### PR TITLE
refactor(ui): improve shadcn compliance across primitives and flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2451,6 +2451,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
@@ -3142,6 +3172,67 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
@@ -3380,6 +3471,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -12283,6 +12389,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -12290,6 +12397,7 @@
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
 
 <head>
   <meta charset="UTF-8" />

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -24,6 +25,7 @@
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -530,7 +530,9 @@
         "title": "Screenshots for {{name}}",
         "noScreenshots": "No screenshots for this game",
         "difficulty": "Difficulty",
-        "close": "Close"
+        "close": "Close",
+        "previous": "Previous screenshot",
+        "next": "Next screenshot"
       }
     },
     "users": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -530,7 +530,9 @@
         "title": "Captures de {{name}}",
         "noScreenshots": "Aucune capture pour ce jeu",
         "difficulty": "Difficulté",
-        "close": "Fermer"
+        "close": "Fermer",
+        "previous": "Capture précédente",
+        "next": "Capture suivante"
       }
     },
     "users": {

--- a/packages/frontend/src/components/admin/ScreenshotsDialog.tsx
+++ b/packages/frontend/src/components/admin/ScreenshotsDialog.tsx
@@ -108,18 +108,20 @@ export function ScreenshotsDialog({ game, open, onOpenChange }: ScreenshotsDialo
               {screenshots.length > 1 && (
                 <>
                   <Button
-                    variant="ghost"
+                    variant="overlay"
                     size="icon"
-                    className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white h-10 w-10"
+                    className="absolute left-2 top-1/2 -translate-y-1/2 h-10 w-10"
                     onClick={goToPrevious}
+                    aria-label={t('admin.games.screenshotsDialog.previous')}
                   >
                     <ChevronLeft className="h-6 w-6" />
                   </Button>
                   <Button
-                    variant="ghost"
+                    variant="overlay"
                     size="icon"
-                    className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white h-10 w-10"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 h-10 w-10"
                     onClick={goToNext}
+                    aria-label={t('admin.games.screenshotsDialog.next')}
                   >
                     <ChevronRight className="h-6 w-6" />
                   </Button>

--- a/packages/frontend/src/components/admin/UserList.tsx
+++ b/packages/frontend/src/components/admin/UserList.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Pagination } from '@/components/ui/pagination'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   Table,
   TableBody,
@@ -294,18 +295,22 @@ export function UserList() {
                           </TableCell>
                           <TableCell>{user.displayName || user.username}</TableCell>
                           <TableCell>
-                            <select
+                            <Select
                               value={user.isAdmin ? 'admin' : 'user'}
-                              onChange={(e) => {
-                                setRoleChangingUser({ user, newRole: e.target.value })
-                                handleRoleChange(user, e.target.value)
+                              onValueChange={(value) => {
+                                setRoleChangingUser({ user, newRole: value })
+                                handleRoleChange(user, value)
                               }}
                               disabled={isSubmitting}
-                              className="bg-background border border-white/10 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500/50"
                             >
-                              <option value="user">{t('admin.users.role.user')}</option>
-                              <option value="admin">{t('admin.users.role.admin')}</option>
-                            </select>
+                              <SelectTrigger className="h-8 w-28" aria-label={t('admin.users.role.user')}>
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="user">{t('admin.users.role.user')}</SelectItem>
+                                <SelectItem value="admin">{t('admin.users.role.admin')}</SelectItem>
+                              </SelectContent>
+                            </Select>
                           </TableCell>
                           <TableCell>{(user.totalScore ?? 0).toLocaleString()}</TableCell>
                           <TableCell>{user.currentStreak ?? 0}</TableCell>
@@ -317,11 +322,10 @@ export function UserList() {
                               {user.isAdmin ? (
                                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
                                   <Button
-                                    variant="ghost"
+                                    variant="unban"
                                     size="icon"
                                     onClick={() => setUnbanningUser(user)}
-                                    title={t('admin.users.unbanUser')}
-                                    className="hover:bg-green-500/20 hover:text-green-300"
+                                    aria-label={t('admin.users.unbanUser')}
                                   >
                                     <Unlock className="h-4 w-4" />
                                   </Button>
@@ -329,11 +333,10 @@ export function UserList() {
                               ) : (
                                 <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
                                   <Button
-                                    variant="ghost"
+                                    variant="ban"
                                     size="icon"
                                     onClick={() => setBanningUser(user)}
-                                    title={t('admin.users.banUser')}
-                                    className="hover:bg-orange-500/20 hover:text-orange-300"
+                                    aria-label={t('admin.users.banUser')}
                                   >
                                     <Ban className="h-4 w-4" />
                                   </Button>
@@ -341,11 +344,10 @@ export function UserList() {
                               )}
                               <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
                                 <Button
-                                  variant="ghost"
+                                  variant="dangerGhost"
                                   size="icon"
                                   onClick={() => setDeletingUser(user)}
-                                  className="text-destructive hover:text-destructive hover:bg-red-500/20"
-                                  title={t('admin.users.deleteUser')}
+                                  aria-label={t('admin.users.deleteUser')}
                                 >
                                   <Trash2 className="h-4 w-4" />
                                 </Button>

--- a/packages/frontend/src/components/game/GuessInput.tsx
+++ b/packages/frontend/src/components/game/GuessInput.tsx
@@ -10,6 +10,7 @@ import { SkipForward, SkipBack, Loader2, Send, Calendar, Building2, Code2 } from
 import { createGuessSubmissionService } from '@/services'
 import { useGameGuess } from '@/hooks/useGameGuess'
 import { toast } from '@/lib/toast'
+import { cn } from '@/lib/utils'
 
 /**
  * Game guess input component with simple text input
@@ -167,6 +168,7 @@ export function GuessInput() {
               size="lg"
               onClick={handlePrevious}
               disabled={gamePhase !== 'playing' || isSubmitting}
+              aria-label={t('game.navigation.previous')}
               className="h-12 sm:h-14 px-3 sm:px-4 md:px-6 min-w-12 sm:min-w-14 touch-manipulation"
             >
               <SkipBack className="h-4 w-4 sm:h-5 sm:w-5" />
@@ -185,12 +187,11 @@ export function GuessInput() {
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={t('game.guessPlaceholder')}
-            className={`h-12 sm:h-14 text-sm sm:text-base md:text-lg bg-gradient-to-r from-background/40 to-card/30 backdrop-blur-md md:backdrop-blur-xl border-2 border-primary/30 shadow-[0_0_20px_rgba(168,85,247,0.3)] focus:border-primary focus:shadow-[0_0_30px_rgba(168,85,247,0.5)] pl-3 sm:pl-4 pr-11 sm:pr-14 transition-all duration-300 ${isSuccess
-              ? 'border-green-500 shadow-[0_0_30px_rgba(34,197,94,0.6)] animate-pulse'
-              : isShaking
-                ? 'border-red-500 shadow-[0_0_20px_rgba(239,68,68,0.5)]'
-                : ''
-              }`}
+            className={cn(
+              'h-12 sm:h-14 text-sm sm:text-base md:text-lg bg-gradient-to-r from-background/40 to-card/30 backdrop-blur-md md:backdrop-blur-xl border-2 border-primary/30 shadow-[0_0_20px_rgba(168,85,247,0.3)] focus:border-primary focus:shadow-[0_0_30px_rgba(168,85,247,0.5)] pl-3 sm:pl-4 pr-11 sm:pr-14 transition-all duration-300',
+              isSuccess && 'border-green-500 shadow-[0_0_30px_rgba(34,197,94,0.6)] animate-pulse',
+              !isSuccess && isShaking && 'border-red-500 shadow-[0_0_20px_rgba(239,68,68,0.5)]'
+            )}
             disabled={gamePhase !== 'playing'}
           />
 
@@ -200,15 +201,18 @@ export function GuessInput() {
             size="sm"
             onClick={handleSubmit}
             disabled={!query.trim() || isSubmitting || gamePhase !== 'playing'}
-            className={`absolute right-1.5 sm:right-2 top-1/2 -translate-y-1/2 h-8 w-8 sm:h-10 sm:w-10 p-0 touch-manipulation transition-all duration-300 ${query.trim()
-              ? 'bg-gradient-to-r from-neon-pink to-neon-purple hover:from-neon-pink/90 hover:to-neon-purple/90'
-              : 'hover:bg-accent'
-              }`}
+            aria-label={t('game.submit', { defaultValue: 'Submit guess' })}
+            className={cn(
+              'absolute right-1.5 sm:right-2 top-1/2 -translate-y-1/2 h-8 w-8 sm:h-10 sm:w-10 p-0 touch-manipulation transition-all duration-300',
+              query.trim()
+                ? 'bg-gradient-to-r from-neon-pink to-neon-purple hover:from-neon-pink/90 hover:to-neon-purple/90'
+                : 'hover:bg-accent'
+            )}
           >
             {isSubmitting ? (
-              <Loader2 className={`h-4 w-4 sm:h-5 sm:w-5 animate-spin ${query.trim() ? 'text-white' : ''}`} />
+              <Loader2 className={cn('h-4 w-4 sm:h-5 sm:w-5 animate-spin', query.trim() && 'text-white')} />
             ) : (
-              <Send className={`h-4 w-4 sm:h-5 sm:w-5 ${query.trim() ? 'text-white' : ''}`} />
+              <Send className={cn('h-4 w-4 sm:h-5 sm:w-5', query.trim() && 'text-white')} />
             )}
           </Button>
         </motion.div>
@@ -221,6 +225,7 @@ export function GuessInput() {
               size="lg"
               onClick={handleSkip}
               disabled={gamePhase !== 'playing' || isSubmitting}
+              aria-label={t('game.navigation.skip')}
               className="h-12 sm:h-14 px-3 sm:px-4 md:px-6 min-w-12 sm:min-w-14 touch-manipulation"
             >
               <SkipForward className="h-4 w-4 sm:h-5 sm:w-5" />

--- a/packages/frontend/src/components/game/HintButtons.tsx
+++ b/packages/frontend/src/components/game/HintButtons.tsx
@@ -7,6 +7,15 @@ import { useGameStore } from '@/stores/gameStore'
 import { useDailyLoginStore } from '@/stores/dailyLoginStore'
 import { Calendar, Building2, Code2 } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
+import { cn } from '@/lib/utils'
+
+type HintVariant = 'outline' | 'hintUsed' | 'hintFree'
+
+function hintVariant(used: boolean, freeCount: number): HintVariant {
+  if (used) return 'hintUsed'
+  if (freeCount > 0) return 'hintFree'
+  return 'outline'
+}
 
 /**
  * Hint buttons component for daily challenge
@@ -90,18 +99,13 @@ export function HintButtons() {
                 : t('game.hints.yearTooltip', { defaultValue: 'Release Year Hint (-20%)' })
       }>
         <Button
-          variant="outline"
+          variant={hintVariant(hintYearUsed, yearHintsInInventory)}
           size="sm"
           onClick={handleHintYear}
           disabled={!hasIncorrectGuess || hintYearUsed || !yearAvailable || gamePhase !== 'playing'}
-          className={`relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300 ${hintYearUsed
-            ? 'bg-yellow-500/20 border-yellow-500 hover:bg-yellow-500/30'
-            : yearHintsInInventory > 0
-              ? 'border-green-500/50 hover:border-green-500'
-              : ''
-            }`}
+          className="relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300"
         >
-          <Calendar className={`h-4 w-4 transition-colors duration-300 ${hintYearUsed ? 'text-yellow-400' : ''}`} />
+          <Calendar className={cn('h-4 w-4 transition-colors duration-300', hintYearUsed && 'text-yellow-400')} />
           {!hintYearUsed && hasIncorrectGuess && yearAvailable && (
             yearHintsInInventory > 0 ? (
               <Badge
@@ -134,18 +138,13 @@ export function HintButtons() {
                 : t('game.hints.publisherTooltip', { defaultValue: 'Publisher Hint (-20%)' })
       }>
         <Button
-          variant="outline"
+          variant={hintVariant(hintPublisherUsed, publisherHintsInInventory)}
           size="sm"
           onClick={handleHintPublisher}
           disabled={!hasIncorrectGuess || hintPublisherUsed || !publisherAvailable || gamePhase !== 'playing'}
-          className={`relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300 ${hintPublisherUsed
-            ? 'bg-yellow-500/20 border-yellow-500 hover:bg-yellow-500/30'
-            : publisherHintsInInventory > 0
-              ? 'border-green-500/50 hover:border-green-500'
-              : ''
-            }`}
+          className="relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300"
         >
-          <Building2 className={`h-4 w-4 transition-colors duration-300 ${hintPublisherUsed ? 'text-yellow-400' : ''}`} />
+          <Building2 className={cn('h-4 w-4 transition-colors duration-300', hintPublisherUsed && 'text-yellow-400')} />
           {!hintPublisherUsed && hasIncorrectGuess && publisherAvailable && (
             publisherHintsInInventory > 0 ? (
               <Badge
@@ -178,18 +177,13 @@ export function HintButtons() {
                 : t('game.hints.developerTooltip', { defaultValue: 'Developer Hint (-20%)' })
       }>
         <Button
-          variant="outline"
+          variant={hintVariant(hintDeveloperUsed, developerHintsInInventory)}
           size="sm"
           onClick={handleHintDeveloper}
           disabled={!hasIncorrectGuess || hintDeveloperUsed || !developerAvailable || gamePhase !== 'playing'}
-          className={`relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300 ${hintDeveloperUsed
-            ? 'bg-yellow-500/20 border-yellow-500 hover:bg-yellow-500/30'
-            : developerHintsInInventory > 0
-              ? 'border-green-500/50 hover:border-green-500'
-              : ''
-            }`}
+          className="relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300"
         >
-          <Code2 className={`h-4 w-4 transition-colors duration-300 ${hintDeveloperUsed ? 'text-yellow-400' : ''}`} />
+          <Code2 className={cn('h-4 w-4 transition-colors duration-300', hintDeveloperUsed && 'text-yellow-400')} />
           {!hintDeveloperUsed && hasIncorrectGuess && developerAvailable && (
             developerHintsInInventory > 0 ? (
               <Badge

--- a/packages/frontend/src/components/game/HintButtons.tsx
+++ b/packages/frontend/src/components/game/HintButtons.tsx
@@ -105,12 +105,12 @@ export function HintButtons() {
           disabled={!hasIncorrectGuess || hintYearUsed || !yearAvailable || gamePhase !== 'playing'}
           className="relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300"
         >
-          <Calendar className={cn('h-4 w-4 transition-colors duration-300', hintYearUsed && 'text-yellow-400')} />
+          <Calendar className={cn('h-4 w-4 transition-colors duration-300', hintYearUsed && 'text-warning')} />
           {!hintYearUsed && hasIncorrectGuess && yearAvailable && (
             yearHintsInInventory > 0 ? (
               <Badge
-                variant="outline"
-                className="absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 flex items-center justify-center text-[10px] font-bold bg-green-500/20 border-green-500 text-green-400"
+                variant="success"
+                className="absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 flex items-center justify-center text-[10px] font-bold"
               >
                 {yearHintsInInventory}
               </Badge>
@@ -144,12 +144,12 @@ export function HintButtons() {
           disabled={!hasIncorrectGuess || hintPublisherUsed || !publisherAvailable || gamePhase !== 'playing'}
           className="relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300"
         >
-          <Building2 className={cn('h-4 w-4 transition-colors duration-300', hintPublisherUsed && 'text-yellow-400')} />
+          <Building2 className={cn('h-4 w-4 transition-colors duration-300', hintPublisherUsed && 'text-warning')} />
           {!hintPublisherUsed && hasIncorrectGuess && publisherAvailable && (
             publisherHintsInInventory > 0 ? (
               <Badge
-                variant="outline"
-                className="absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 flex items-center justify-center text-[10px] font-bold bg-green-500/20 border-green-500 text-green-400"
+                variant="success"
+                className="absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 flex items-center justify-center text-[10px] font-bold"
               >
                 {publisherHintsInInventory}
               </Badge>
@@ -183,12 +183,12 @@ export function HintButtons() {
           disabled={!hasIncorrectGuess || hintDeveloperUsed || !developerAvailable || gamePhase !== 'playing'}
           className="relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300"
         >
-          <Code2 className={cn('h-4 w-4 transition-colors duration-300', hintDeveloperUsed && 'text-yellow-400')} />
+          <Code2 className={cn('h-4 w-4 transition-colors duration-300', hintDeveloperUsed && 'text-warning')} />
           {!hintDeveloperUsed && hasIncorrectGuess && developerAvailable && (
             developerHintsInInventory > 0 ? (
               <Badge
-                variant="outline"
-                className="absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 flex items-center justify-center text-[10px] font-bold bg-green-500/20 border-green-500 text-green-400"
+                variant="success"
+                className="absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 flex items-center justify-center text-[10px] font-bold"
               >
                 {developerHintsInInventory}
               </Badge>

--- a/packages/frontend/src/components/ui/alert.tsx
+++ b/packages/frontend/src/components/ui/alert.tsx
@@ -9,13 +9,13 @@ const alertVariants = cva(
       variant: {
         default: "bg-background text-foreground",
         destructive:
-          "border-red-500/30 bg-red-500/10 text-red-400 [&>svg]:text-red-400",
+          "border-destructive/30 bg-destructive/10 text-destructive [&>svg]:text-destructive",
         warning:
-          "border-yellow-500/30 bg-yellow-500/10 text-yellow-400 [&>svg]:text-yellow-400",
+          "border-warning/30 bg-warning/10 text-warning [&>svg]:text-warning",
         success:
-          "border-green-500/30 bg-green-500/10 text-green-400 [&>svg]:text-green-400",
+          "border-success/30 bg-success/10 text-success [&>svg]:text-success",
         info:
-          "border-blue-500/30 bg-blue-500/10 text-blue-400 [&>svg]:text-blue-400",
+          "border-neon-blue/30 bg-neon-blue/10 text-neon-blue [&>svg]:text-neon-blue",
       },
     },
     defaultVariants: {

--- a/packages/frontend/src/components/ui/alert.tsx
+++ b/packages/frontend/src/components/ui/alert.tsx
@@ -30,6 +30,7 @@ const Alert = React.forwardRef<
 >(({ className, variant, ...props }, ref) => (
   <div
     ref={ref}
+    data-slot="alert"
     role="alert"
     className={cn(alertVariants({ variant }), className)}
     {...props}
@@ -43,6 +44,7 @@ const AlertTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h5
     ref={ref}
+    data-slot="alert-title"
     className={cn("mb-1 font-medium leading-none tracking-tight", className)}
     {...props}
   />
@@ -55,6 +57,7 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
+    data-slot="alert-description"
     className={cn("text-sm [&_p]:leading-relaxed", className)}
     {...props}
   />

--- a/packages/frontend/src/components/ui/animated-progress.tsx
+++ b/packages/frontend/src/components/ui/animated-progress.tsx
@@ -13,7 +13,7 @@ interface AnimatedProgressProps {
 }
 
 const variantColors = {
-  default: 'from-purple-500 to-pink-500',
+  default: 'from-neon-purple to-neon-pink',
   success: 'from-green-500 to-emerald-400',
   warning: 'from-yellow-500 to-orange-400',
   error: 'from-red-500 to-rose-400',

--- a/packages/frontend/src/components/ui/animated-tabs.tsx
+++ b/packages/frontend/src/components/ui/animated-tabs.tsx
@@ -53,7 +53,7 @@ export function AnimatedTabs({
             {isActive && variant === 'default' && (
               <motion.div
                 layoutId="activeTab"
-                className="absolute inset-0 bg-linear-to-r from-purple-500/20 to-pink-500/20 rounded-lg border border-purple-500/40"
+                className="absolute inset-0 bg-linear-to-r from-neon-purple/20 to-neon-pink/20 rounded-lg border border-neon-purple/40"
                 style={{ boxShadow: '0 0 20px oklch(0.7 0.25 300 / 0.2)' }}
                 transition={springConfig.snappy}
               />
@@ -61,7 +61,7 @@ export function AnimatedTabs({
             {isActive && variant === 'pills' && (
               <motion.div
                 layoutId="activeTabPill"
-                className="absolute inset-0 bg-linear-to-r from-purple-500 to-pink-500 rounded-lg"
+                className="absolute inset-0 bg-linear-to-r from-neon-purple to-neon-pink rounded-lg"
                 style={{ boxShadow: '0 0 20px oklch(0.7 0.25 300 / 0.4)' }}
                 transition={springConfig.snappy}
               />
@@ -69,7 +69,7 @@ export function AnimatedTabs({
             {isActive && variant === 'underline' && (
               <motion.div
                 layoutId="activeTabUnderline"
-                className="absolute bottom-0 left-0 right-0 h-0.5 bg-linear-to-r from-purple-500 to-pink-500"
+                className="absolute bottom-0 left-0 right-0 h-0.5 bg-linear-to-r from-neon-purple to-neon-pink"
                 style={{ boxShadow: '0 0 10px oklch(0.7 0.25 300 / 0.5)' }}
                 transition={springConfig.snappy}
               />

--- a/packages/frontend/src/components/ui/avatar.tsx
+++ b/packages/frontend/src/components/ui/avatar.tsx
@@ -9,6 +9,7 @@ const Avatar = React.forwardRef<
 >(({ className, ...props }, ref) => (
     <AvatarPrimitive.Root
         ref={ref}
+        data-slot="avatar"
         className={cn(
             "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
             className
@@ -24,6 +25,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
     <AvatarPrimitive.Image
         ref={ref}
+        data-slot="avatar-image"
         className={cn("aspect-square h-full w-full", className)}
         {...props}
     />
@@ -36,6 +38,7 @@ const AvatarFallback = React.forwardRef<
 >(({ className, ...props }, ref) => (
     <AvatarPrimitive.Fallback
         ref={ref}
+        data-slot="avatar-fallback"
         className={cn(
             "flex h-full w-full items-center justify-center rounded-full bg-muted",
             className

--- a/packages/frontend/src/components/ui/badge.tsx
+++ b/packages/frontend/src/components/ui/badge.tsx
@@ -15,13 +15,13 @@ const badgeVariants = cva(
           "border-transparent bg-error text-white hover:bg-error/80",
         outline: "text-foreground",
         success:
-          "border-green-500/30 bg-green-500/20 text-green-400",
+          "border-success/30 bg-success/20 text-success",
         warning:
-          "border-yellow-500/30 bg-yellow-500/20 text-yellow-400",
+          "border-warning/30 bg-warning/20 text-warning",
         info:
-          "border-blue-500/30 bg-blue-500/20 text-blue-400",
+          "border-neon-blue/30 bg-neon-blue/20 text-neon-blue",
         admin:
-          "border-red-500 bg-transparent text-red-400 rounded-md",
+          "border-destructive bg-transparent text-destructive rounded-md",
       },
     },
     defaultVariants: {

--- a/packages/frontend/src/components/ui/badge.tsx
+++ b/packages/frontend/src/components/ui/badge.tsx
@@ -36,7 +36,7 @@ export interface BadgeProps
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    <div data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
   )
 }
 

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -24,6 +24,18 @@ const buttonVariants = cva(
           "bg-linear-to-r from-neon-purple to-neon-pink text-white shadow-lg hover:shadow-[0_0_25px_oklch(0.7_0.25_300_/_0.5)] hover:scale-[1.03] active:scale-[0.98]",
         warning:
           "text-orange-400 bg-orange-500/10 border border-orange-500/30 hover:bg-orange-500/20 hover:scale-[1.02] active:scale-[0.98]",
+        hintUsed:
+          "border border-yellow-500 bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 hover:scale-[1.02] active:scale-[0.98]",
+        hintFree:
+          "border border-green-500/50 bg-transparent hover:border-green-500 hover:bg-muted hover:text-foreground hover:scale-[1.02] active:scale-[0.98]",
+        ban:
+          "hover:bg-orange-500/20 hover:text-orange-300 active:scale-[0.98]",
+        unban:
+          "hover:bg-green-500/20 hover:text-green-300 active:scale-[0.98]",
+        dangerGhost:
+          "text-destructive hover:bg-red-500/20 hover:text-destructive active:scale-[0.98]",
+        overlay:
+          "bg-black/50 text-white hover:bg-black/70 active:scale-[0.98]",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/packages/frontend/src/components/ui/button.tsx
+++ b/packages/frontend/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-error text-white shadow-sm hover:bg-error/90 hover:scale-[1.02] active:scale-[0.98]",
         outline:
-          "border border-border bg-transparent hover:bg-muted hover:text-foreground hover:border-purple-500/30 hover:scale-[1.02] active:scale-[0.98]",
+          "border border-border bg-transparent hover:bg-muted hover:text-foreground hover:border-primary/30 hover:scale-[1.02] active:scale-[0.98]",
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 hover:scale-[1.02] active:scale-[0.98]",
         ghost:
@@ -25,17 +25,17 @@ const buttonVariants = cva(
         warning:
           "text-orange-400 bg-orange-500/10 border border-orange-500/30 hover:bg-orange-500/20 hover:scale-[1.02] active:scale-[0.98]",
         hintUsed:
-          "border border-yellow-500 bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 hover:scale-[1.02] active:scale-[0.98]",
+          "border border-warning bg-warning/20 text-warning hover:bg-warning/30 hover:scale-[1.02] active:scale-[0.98]",
         hintFree:
-          "border border-green-500/50 bg-transparent hover:border-green-500 hover:bg-muted hover:text-foreground hover:scale-[1.02] active:scale-[0.98]",
+          "border border-success/50 bg-transparent hover:border-success hover:bg-muted hover:text-foreground hover:scale-[1.02] active:scale-[0.98]",
         ban:
-          "hover:bg-orange-500/20 hover:text-orange-300 active:scale-[0.98]",
+          "hover:bg-warning/20 hover:text-warning active:scale-[0.98]",
         unban:
-          "hover:bg-green-500/20 hover:text-green-300 active:scale-[0.98]",
+          "hover:bg-success/20 hover:text-success active:scale-[0.98]",
         dangerGhost:
-          "text-destructive hover:bg-red-500/20 hover:text-destructive active:scale-[0.98]",
+          "text-destructive hover:bg-destructive/20 hover:text-destructive active:scale-[0.98]",
         overlay:
-          "bg-black/50 text-white hover:bg-black/70 active:scale-[0.98]",
+          "bg-background/60 text-foreground backdrop-blur-sm hover:bg-background/80 active:scale-[0.98]",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/packages/frontend/src/components/ui/checkbox.tsx
+++ b/packages/frontend/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer h-4 w-4 shrink-0 rounded-sm border border-input shadow-xs",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className={cn("flex items-center justify-center text-current")}
+      >
+        <Check className="h-3.5 w-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/packages/frontend/src/components/ui/collapsible.tsx
+++ b/packages/frontend/src/components/ui/collapsible.tsx
@@ -1,11 +1,22 @@
 "use client"
 
+import * as React from "react"
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
 
-const Collapsible = CollapsiblePrimitive.Root
+function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
 
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return <CollapsiblePrimitive.CollapsibleTrigger data-slot="collapsible-trigger" {...props} />
+}
 
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return <CollapsiblePrimitive.CollapsibleContent data-slot="collapsible-content" {...props} />
+}
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/packages/frontend/src/components/ui/dropdown-menu.tsx
+++ b/packages/frontend/src/components/ui/dropdown-menu.tsx
@@ -25,6 +25,7 @@ function DropdownMenuSubTrigger({
 }) {
     return (
         <DropdownMenuPrimitive.SubTrigger
+            data-slot="dropdown-menu-sub-trigger"
             className={cn(
                 "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
                 inset && "pl-8",
@@ -44,6 +45,7 @@ function DropdownMenuSubContent({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
     return (
         <DropdownMenuPrimitive.SubContent
+            data-slot="dropdown-menu-sub-content"
             className={cn(
                 "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
                 className
@@ -61,6 +63,7 @@ function DropdownMenuContent({
     return (
         <DropdownMenuPrimitive.Portal>
             <DropdownMenuPrimitive.Content
+                data-slot="dropdown-menu-content"
                 sideOffset={sideOffset}
                 className={cn(
                     "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md",
@@ -83,6 +86,7 @@ function DropdownMenuItem({
 }) {
     return (
         <DropdownMenuPrimitive.Item
+            data-slot="dropdown-menu-item"
             className={cn(
                 "relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
                 inset && "pl-8",
@@ -101,6 +105,7 @@ function DropdownMenuCheckboxItem({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
     return (
         <DropdownMenuPrimitive.CheckboxItem
+            data-slot="dropdown-menu-checkbox-item"
             className={cn(
                 "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
                 className
@@ -125,6 +130,7 @@ function DropdownMenuRadioItem({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
     return (
         <DropdownMenuPrimitive.RadioItem
+            data-slot="dropdown-menu-radio-item"
             className={cn(
                 "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
                 className
@@ -150,6 +156,7 @@ function DropdownMenuLabel({
 }) {
     return (
         <DropdownMenuPrimitive.Label
+            data-slot="dropdown-menu-label"
             className={cn(
                 "px-2 py-1.5 text-sm font-semibold",
                 inset && "pl-8",
@@ -166,6 +173,7 @@ function DropdownMenuSeparator({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
     return (
         <DropdownMenuPrimitive.Separator
+            data-slot="dropdown-menu-separator"
             className={cn("-mx-1 my-1 h-px bg-border", className)}
             {...props}
         />

--- a/packages/frontend/src/components/ui/form.tsx
+++ b/packages/frontend/src/components/ui/form.tsx
@@ -77,7 +77,7 @@ const FormItem = React.forwardRef<
 
   return (
     <FormItemContext.Provider value={{ id }}>
-      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+      <div ref={ref} data-slot="form-item" className={cn("space-y-2", className)} {...props} />
     </FormItemContext.Provider>
   )
 })
@@ -92,6 +92,7 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
+      data-slot="form-label"
       className={cn(error && "text-destructive", className)}
       htmlFor={formItemId}
       {...props}
@@ -109,6 +110,7 @@ const FormControl = React.forwardRef<
   return (
     <Slot
       ref={ref}
+      data-slot="form-control"
       id={formItemId}
       aria-describedby={
         !error
@@ -131,6 +133,7 @@ const FormDescription = React.forwardRef<
   return (
     <p
       ref={ref}
+      data-slot="form-description"
       id={formDescriptionId}
       className={cn("text-sm text-muted-foreground", className)}
       {...props}
@@ -153,6 +156,7 @@ const FormMessage = React.forwardRef<
   return (
     <p
       ref={ref}
+      data-slot="form-message"
       id={formMessageId}
       className={cn("text-sm font-medium text-destructive", className)}
       {...props}

--- a/packages/frontend/src/components/ui/label.tsx
+++ b/packages/frontend/src/components/ui/label.tsx
@@ -15,6 +15,7 @@ const Label = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}
+    data-slot="label"
     className={cn(labelVariants(), className)}
     {...props}
   />

--- a/packages/frontend/src/components/ui/loading-spinner.tsx
+++ b/packages/frontend/src/components/ui/loading-spinner.tsx
@@ -24,7 +24,7 @@ export function LoadingSpinner({
   if (variant === 'minimal') {
     return (
       <motion.div
-        className={cn('rounded-full border-2 border-purple-500/30 border-t-purple-500', className)}
+        className={cn('rounded-full border-2 border-neon-purple/30 border-t-neon-purple', className)}
         style={{ width: s, height: s }}
         animate={{ rotate: 360 }}
         transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
@@ -39,26 +39,26 @@ export function LoadingSpinner({
     >
       {/* Outer ring - slow rotation */}
       <motion.div
-        className="absolute inset-0 rounded-full border-2 border-purple-500/20"
+        className="absolute inset-0 rounded-full border-2 border-neon-purple/20"
         animate={{ rotate: 360 }}
         transition={{ duration: 3, repeat: Infinity, ease: 'linear' }}
       />
       {/* Middle ring - medium rotation */}
       <motion.div
-        className="absolute inset-[2px] rounded-full border-2 border-transparent border-t-purple-500/50 border-r-pink-500/50"
+        className="absolute inset-[2px] rounded-full border-2 border-transparent border-t-neon-purple/50 border-r-neon-pink/50"
         animate={{ rotate: -360 }}
         transition={{ duration: 1.5, repeat: Infinity, ease: 'linear' }}
       />
       {/* Inner arc - fast rotation with glow */}
       <motion.div
-        className="absolute inset-1 rounded-full border-2 border-transparent border-t-purple-500"
+        className="absolute inset-1 rounded-full border-2 border-transparent border-t-neon-purple"
         animate={{ rotate: 360 }}
         transition={{ duration: 0.8, repeat: Infinity, ease: 'linear' }}
         style={{ boxShadow: '0 0 10px oklch(0.7 0.25 300 / 0.5)' }}
       />
       {/* Center pulsing glow */}
       <motion.div
-        className="absolute inset-[30%] rounded-full bg-purple-500/30"
+        className="absolute inset-[30%] rounded-full bg-neon-purple/30"
         animate={{
           scale: [1, 1.3, 1],
           opacity: [0.5, 0.8, 0.5],
@@ -80,7 +80,7 @@ export function LoadingDots({ className }: { className?: string }) {
       {[0, 1, 2].map((i) => (
         <motion.div
           key={i}
-          className="w-1.5 h-1.5 rounded-full bg-purple-500"
+          className="w-1.5 h-1.5 rounded-full bg-neon-purple"
           animate={{
             scale: [1, 1.2, 1],
             opacity: [0.5, 1, 0.5],

--- a/packages/frontend/src/components/ui/scroll-area.tsx
+++ b/packages/frontend/src/components/ui/scroll-area.tsx
@@ -8,10 +8,11 @@ const ScrollArea = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
+    data-slot="scroll-area"
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport data-slot="scroll-area-viewport" className="h-full w-full rounded-[inherit]">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />
@@ -26,6 +27,7 @@ const ScrollBar = React.forwardRef<
 >(({ className, orientation = "vertical", ...props }, ref) => (
   <ScrollAreaPrimitive.ScrollAreaScrollbar
     ref={ref}
+    data-slot="scroll-area-scrollbar"
     orientation={orientation}
     className={cn(
       "flex touch-none select-none transition-colors",

--- a/packages/frontend/src/components/ui/select.tsx
+++ b/packages/frontend/src/components/ui/select.tsx
@@ -1,0 +1,174 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      className={cn(
+        "flex h-9 w-full items-center justify-between rounded-md border border-input bg-card px-3 py-2 text-sm shadow-xs transition-colors",
+        "placeholder:text-muted-foreground",
+        "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "[&>span]:line-clamp-1",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}
+    >
+      <ChevronUp className="h-4 w-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}
+    >
+      <ChevronDown className="h-4 w-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
+        "focus:bg-accent focus:text-accent-foreground",
+        "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/packages/frontend/src/components/ui/separator.tsx
+++ b/packages/frontend/src/components/ui/separator.tsx
@@ -12,6 +12,7 @@ const Separator = React.forwardRef<
   ) => (
     <SeparatorPrimitive.Root
       ref={ref}
+      data-slot="separator"
       decorative={decorative}
       orientation={orientation}
       className={cn(

--- a/packages/frontend/src/components/ui/sheet.tsx
+++ b/packages/frontend/src/components/ui/sheet.tsx
@@ -17,6 +17,7 @@ const SheetOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
+    data-slot="sheet-overlay"
     className={cn(
       "fixed inset-0 z-50 bg-black/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
@@ -58,6 +59,7 @@ const SheetContent = React.forwardRef<
     <SheetOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      data-slot="sheet-content"
       className={cn(sheetVariants({ side }), className)}
       aria-describedby={undefined}
       {...props}
@@ -77,6 +79,7 @@ const SheetHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
+    data-slot="sheet-header"
     className={cn(
       "flex flex-col space-y-2 text-center sm:text-left",
       className
@@ -91,6 +94,7 @@ const SheetFooter = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
+    data-slot="sheet-footer"
     className={cn(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
       className
@@ -106,6 +110,7 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
+    data-slot="sheet-title"
     className={cn("text-lg font-semibold text-foreground", className)}
     {...props}
   />
@@ -118,6 +123,7 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
+    data-slot="sheet-description"
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />

--- a/packages/frontend/src/components/ui/skeleton.tsx
+++ b/packages/frontend/src/components/ui/skeleton.tsx
@@ -11,6 +11,7 @@ export function Skeleton({
 }: SkeletonProps) {
   return (
     <div
+      data-slot="skeleton"
       className={cn(
         'skeleton',
         variant === 'circular' && 'rounded-full',

--- a/packages/frontend/src/components/ui/tooltip.tsx
+++ b/packages/frontend/src/components/ui/tooltip.tsx
@@ -15,6 +15,7 @@ const TooltipContent = React.forwardRef<
   <TooltipPrimitive.Portal>
     <TooltipPrimitive.Content
       ref={ref}
+      data-slot="tooltip-content"
       sideOffset={sideOffset}
       className={cn(
         "z-50 overflow-hidden rounded-md bg-card border border-border px-3 py-1.5 text-xs text-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -3,6 +3,7 @@
 @custom-variant dark (&:is(.dark \*));
 
 :root {
+  color-scheme: dark;
   --radius: 0.625rem;
   /* Dark violet theme (default since dark-only) */
   --background: oklch(0.129 0.042 283.713);

--- a/packages/frontend/src/pages/RegisterPage.tsx
+++ b/packages/frontend/src/pages/RegisterPage.tsx
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import { motion } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Form,
   FormControl,
@@ -265,11 +266,10 @@ export default function RegisterPage() {
                 />
 
                 <label className="flex items-start gap-3 cursor-pointer select-none group">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={marketingConsent}
-                    onChange={(e) => setMarketingConsent(e.target.checked)}
-                    className="mt-0.5 h-4 w-4 shrink-0 rounded border-white/20 bg-background/50 accent-neon-purple cursor-pointer"
+                    onCheckedChange={(checked) => setMarketingConsent(checked === true)}
+                    className="mt-0.5"
                   />
                   <span className="text-xs text-muted-foreground leading-relaxed group-hover:text-foreground/80 transition-colors">
                     {t('auth.marketingConsent')}


### PR DESCRIPTION
- Replace hardcoded purple-500/pink-500 with neon-purple/neon-pink
  tokens in animated-tabs, animated-progress, loading-spinner so
  primitives respect the design-token layer instead of raw colors.
- Add Button variants (hintUsed, hintFree, ban, unban, dangerGhost,
  overlay) to absorb className overrides previously scattered across
  HintButtons, UserList and ScreenshotsDialog.
- Add shadcn Select and Checkbox primitives (backed by @radix-ui/
  react-select and @radix-ui/react-checkbox) and migrate the admin
  role selector and register page consent checkbox off of native
  HTML controls.
- Replace title attributes with aria-label on icon-only Buttons in
  UserList, ScreenshotsDialog and GuessInput; add screenshot
  navigation translations.
- Swap template-string className ternaries for cn() in GuessInput
  and HintButtons.