### PR TITLE
refactor(backend): enforce logging and validation conventions

### DIFF
--- a/packages/backend/src/domain/services/auth.service.ts
+++ b/packages/backend/src/domain/services/auth.service.ts
@@ -1,5 +1,5 @@
-// This file is deprecated - authentication is now handled by better-auth
-// Keeping this file for backwards compatibility during migration
+// Authentication is handled by better-auth; this module keeps the shared
+// AuthError type that domain code throws when auth invariants are violated.
 
 export class AuthError extends Error {
   constructor(
@@ -10,14 +10,4 @@ export class AuthError extends Error {
     super(message)
     this.name = 'AuthError'
   }
-}
-
-// Legacy auth service - most functionality moved to better-auth
-// Only keeping utility functions that may be used elsewhere
-export const authService = {
-  // Deprecated: Use better-auth session API instead
-  verifyToken(_token: string): { userId: string; isGuest: boolean } | null {
-    console.warn('authService.verifyToken is deprecated. Use better-auth session API.')
-    return null
-  },
 }

--- a/packages/backend/src/domain/services/index.ts
+++ b/packages/backend/src/domain/services/index.ts
@@ -1,4 +1,4 @@
-export { authService, AuthError } from './auth.service.js'
+export { AuthError } from './auth.service.js'
 export { createGameService, type GameService, GameError } from './game.service.js'
 export { createLeaderboardService, type LeaderboardService } from './leaderboard.service.js'
 export { createAdminService, type AdminService } from './admin.service.js'

--- a/packages/backend/src/infrastructure/auth/auth.ts
+++ b/packages/backend/src/infrastructure/auth/auth.ts
@@ -3,6 +3,7 @@ import { username, anonymous, admin } from "better-auth/plugins";
 import { Pool } from "pg";
 import { Resend } from "resend";
 import { env } from "../../config/env.js";
+import { authLogger } from "../logger/logger.js";
 import { inventoryRepository } from "../repositories/inventory.repository.js";
 
 const STARTER_INVENTORY: Array<{ itemType: string; itemKey: string; quantity: number }> = [
@@ -42,12 +43,12 @@ function createAuth() {
           `,
           });
           if (error) {
-            console.error(`[AUTH] Failed to send password reset email to ${user.email}:`, error.message);
+            authLogger.error({ email: user.email, err: error.message }, "failed to send password reset email");
           } else {
-            console.log(`[AUTH] Password reset email sent to ${user.email}, id: ${data?.id}`);
+            authLogger.info({ email: user.email, emailId: data?.id }, "password reset email sent");
           }
         } else {
-          console.log(`[DEV] Password reset for ${user.email}: ${url}`);
+          authLogger.info({ email: user.email, url }, "dev password reset link");
         }
       },
     },
@@ -66,12 +67,12 @@ function createAuth() {
           `,
           });
           if (error) {
-            console.error(`[AUTH] Failed to send verification email to ${user.email}:`, error.message);
+            authLogger.error({ email: user.email, err: error.message }, "failed to send verification email");
           } else {
-            console.log(`[AUTH] Verification email sent to ${user.email}, id: ${data?.id}`);
+            authLogger.info({ email: user.email, emailId: data?.id }, "verification email sent");
           }
         } else {
-          console.log(`[DEV] Email verification for ${user.email}: ${url}`);
+          authLogger.info({ email: user.email, url }, "dev email verification link");
         }
       },
     },
@@ -125,7 +126,7 @@ function createAuth() {
               const userCount = parseInt(result.rows[0].count, 10);
 
               if (userCount === 0) {
-                console.log("[AUTH] First user registration - assigning admin role");
+                authLogger.info("first user registration - assigning admin role");
                 return {
                   data: { ...user, role: "admin" },
                 };
@@ -134,7 +135,7 @@ function createAuth() {
             } catch (error) {
               // Log the error but don't fail the registration
               // Better-auth will handle the user creation, we just won't assign admin role
-              console.error("[AUTH] Error in user creation hook:", error);
+              authLogger.error({ err: error }, "error in user creation hook");
               return { data: user };
             }
           },
@@ -146,9 +147,9 @@ function createAuth() {
             }
             try {
               await inventoryRepository.addMultipleItems(user.id, STARTER_INVENTORY);
-              console.log(`[AUTH] Granted starter inventory to user ${user.id}`);
+              authLogger.info({ userId: user.id }, "granted starter inventory");
             } catch (error) {
-              console.error("[AUTH] Failed to grant starter inventory:", error);
+              authLogger.error({ err: error }, "failed to grant starter inventory");
             }
           },
         },

--- a/packages/backend/src/presentation/middleware/validation.middleware.ts
+++ b/packages/backend/src/presentation/middleware/validation.middleware.ts
@@ -1,0 +1,51 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express'
+import { ZodError, ZodType } from 'zod'
+
+type Source = 'body' | 'query' | 'params'
+
+function buildValidator(source: Source): <T>(schema: ZodType<T>) => RequestHandler {
+  return (schema) => (req, res, next) => {
+    const result = schema.safeParse(req[source])
+    if (!result.success) {
+      const issue = result.error.issues[0]
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: issue?.message ?? 'Invalid request payload',
+          path: issue?.path,
+        },
+      })
+      return
+    }
+    // Replace the raw input with the parsed (coerced) data so downstream
+    // handlers consume the typed value.
+    ;(req as unknown as Record<Source, unknown>)[source] = result.data
+    next()
+  }
+}
+
+export const validateBody = buildValidator('body')
+export const validateQuery = buildValidator('query')
+export const validateParams = buildValidator('params')
+
+export function zodErrorHandler(
+  error: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (error instanceof ZodError) {
+    const issue = error.issues[0]
+    res.status(400).json({
+      success: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: issue?.message ?? 'Invalid request payload',
+        path: issue?.path,
+      },
+    })
+    return
+  }
+  next(error)
+}


### PR DESCRIPTION
- Replace console.* calls in auth infrastructure with Pino authLogger
- Drop deprecated authService.verifyToken stub (dead code, domain purity)
- Add presentation/middleware/validation.middleware.ts with Zod helpers
  (validateBody / validateQuery / validateParams + zodErrorHandler)