### PR TITLE
refactor(game): improve daily play mobile UI/UX

### DIFF
--- a/packages/frontend/src/components/game/GuessInput.tsx
+++ b/packages/frontend/src/components/game/GuessInput.tsx
@@ -1,10 +1,10 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Tooltip } from '@/components/ui/tooltip'
-import { Alert } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
 import { useGameStore } from '@/stores/gameStore'
 import { SkipForward, SkipBack, Loader2, Send, Calendar, Building2, Code2 } from 'lucide-react'
 import { createGuessSubmissionService } from '@/services'
@@ -148,6 +148,11 @@ export function GuessInput() {
     }
   }
 
+  const hasRevealedHints =
+    (hintYearUsed && availableHints?.year) ||
+    (hintPublisherUsed && availableHints?.publisher) ||
+    (hintDeveloperUsed && availableHints?.developer)
+
   return (
     <div className="relative">
       {/* Screen reader announcements */}
@@ -158,6 +163,43 @@ export function GuessInput() {
         {isShaking && t('game.guessIncorrect', { defaultValue: 'Incorrect guess. Try again.' })}
       </div>
 
+      {/* Revealed hint chips - compact inline display above input */}
+      <AnimatePresence>
+        {hasRevealedHints && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="flex flex-wrap justify-center gap-1.5 pb-2">
+              {hintYearUsed && availableHints?.year && (
+                <Badge variant="info" className="gap-1 py-1 px-2.5 text-xs font-medium">
+                  <Calendar className="h-3 w-3" aria-hidden="true" />
+                  <span className="sr-only">{t('game.hints.yearHint')}: </span>
+                  <span>{availableHints.year}</span>
+                </Badge>
+              )}
+              {hintPublisherUsed && availableHints?.publisher && (
+                <Badge variant="info" className="gap-1 py-1 px-2.5 text-xs font-medium max-w-[60vw] truncate">
+                  <Building2 className="h-3 w-3 shrink-0" aria-hidden="true" />
+                  <span className="sr-only">{t('game.hints.publisherHint')}: </span>
+                  <span className="truncate">{availableHints.publisher}</span>
+                </Badge>
+              )}
+              {hintDeveloperUsed && availableHints?.developer && (
+                <Badge variant="info" className="gap-1 py-1 px-2.5 text-xs font-medium max-w-[60vw] truncate">
+                  <Code2 className="h-3 w-3 shrink-0" aria-hidden="true" />
+                  <span className="sr-only">{t('game.hints.developerHint')}: </span>
+                  <span className="truncate">{availableHints.developer}</span>
+                </Badge>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       {/* Input with submit button */}
       <div className="flex gap-1.5 sm:gap-2">
         {/* Previous button - shown when there are skipped positions before current */}
@@ -165,11 +207,11 @@ export function GuessInput() {
           <Tooltip content={t('game.navigation.previous')}>
             <Button
               variant="outline"
-              size="lg"
+              size="icon"
               onClick={handlePrevious}
               disabled={gamePhase !== 'playing' || isSubmitting}
               aria-label={t('game.navigation.previous')}
-              className="h-12 sm:h-14 px-3 sm:px-4 md:px-6 min-w-12 sm:min-w-14 touch-manipulation"
+              className="h-12 w-12 sm:h-14 sm:w-14 shrink-0 touch-manipulation"
             >
               <SkipBack className="h-4 w-4 sm:h-5 sm:w-5" />
             </Button>
@@ -177,7 +219,7 @@ export function GuessInput() {
         )}
 
         <motion.div
-          className="relative flex-1"
+          className="relative flex-1 min-w-0"
           animate={isShaking ? { x: [-10, 10, -10, 10, 0] } : {}}
           transition={{ duration: 0.4 }}
         >
@@ -187,8 +229,12 @@ export function GuessInput() {
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={t('game.guessPlaceholder')}
+            enterKeyHint="send"
+            autoCapitalize="words"
+            autoCorrect="off"
+            spellCheck={false}
             className={cn(
-              'h-12 sm:h-14 text-sm sm:text-base md:text-lg bg-gradient-to-r from-background/40 to-card/30 backdrop-blur-md md:backdrop-blur-xl border-2 border-primary/30 shadow-[var(--glow-md)] focus:border-primary focus:shadow-[var(--glow-lg)] pl-3 sm:pl-4 pr-11 sm:pr-14 transition-all duration-300',
+              'h-12 sm:h-14 text-base md:text-lg bg-gradient-to-r from-background/40 to-card/30 backdrop-blur-md md:backdrop-blur-xl border-2 border-primary/30 shadow-[var(--glow-md)] focus:border-primary focus:shadow-[var(--glow-lg)] pl-3 sm:pl-4 pr-12 sm:pr-14 transition-all duration-300',
               isSuccess && 'border-success shadow-[var(--glow-success)] animate-pulse',
               !isSuccess && isShaking && 'border-error shadow-[var(--glow-error)]'
             )}
@@ -198,12 +244,12 @@ export function GuessInput() {
           {/* Submit button inside input */}
           <Button
             variant="ghost"
-            size="sm"
+            size="icon"
             onClick={handleSubmit}
             disabled={!query.trim() || isSubmitting || gamePhase !== 'playing'}
             aria-label={t('game.submit', { defaultValue: 'Submit guess' })}
             className={cn(
-              'absolute right-1.5 sm:right-2 top-1/2 -translate-y-1/2 h-8 w-8 sm:h-10 sm:w-10 p-0 touch-manipulation transition-all duration-300',
+              'absolute right-1.5 sm:right-2 top-1/2 -translate-y-1/2 h-9 w-9 sm:h-10 sm:w-10 p-0 touch-manipulation transition-all duration-300',
               query.trim()
                 ? 'bg-gradient-to-r from-neon-pink to-neon-purple hover:from-neon-pink/90 hover:to-neon-purple/90'
                 : 'hover:bg-accent'
@@ -222,46 +268,17 @@ export function GuessInput() {
           <Tooltip content={t('game.navigation.skip')}>
             <Button
               variant="outline"
-              size="lg"
+              size="icon"
               onClick={handleSkip}
               disabled={gamePhase !== 'playing' || isSubmitting}
               aria-label={t('game.navigation.skip')}
-              className="h-12 sm:h-14 px-3 sm:px-4 md:px-6 min-w-12 sm:min-w-14 touch-manipulation"
+              className="h-12 w-12 sm:h-14 sm:w-14 shrink-0 touch-manipulation"
             >
               <SkipForward className="h-4 w-4 sm:h-5 sm:w-5" />
             </Button>
           </Tooltip>
         )}
       </div>
-
-      {/* Hint displays - shown when hints are used */}
-      {hintYearUsed && availableHints?.year && (
-        <Alert className="mt-1.5 sm:mt-2 py-1.5 sm:py-2">
-          <Calendar className="h-3 w-3 sm:h-4 sm:w-4" />
-          <span className="text-xs sm:text-sm">
-            {t('game.hints.yearHint')}: <strong>{availableHints.year}</strong>
-          </span>
-        </Alert>
-      )}
-
-      {hintPublisherUsed && availableHints?.publisher && (
-        <Alert className="mt-1.5 sm:mt-2 py-1.5 sm:py-2">
-          <Building2 className="h-3 w-3 sm:h-4 sm:w-4" />
-          <span className="text-xs sm:text-sm">
-            {t('game.hints.publisherHint')}: <strong>{availableHints.publisher}</strong>
-          </span>
-        </Alert>
-      )}
-
-      {hintDeveloperUsed && availableHints?.developer && (
-        <Alert className="mt-1.5 sm:mt-2 py-1.5 sm:py-2">
-          <Code2 className="h-3 w-3 sm:h-4 sm:w-4" />
-          <span className="text-xs sm:text-sm">
-            {t('game.hints.developerHint')}: <strong>{availableHints.developer}</strong>
-          </span>
-        </Alert>
-      )}
-
     </div>
   )
 }

--- a/packages/frontend/src/components/game/HintButtons.tsx
+++ b/packages/frontend/src/components/game/HintButtons.tsx
@@ -103,7 +103,7 @@ export function HintButtons() {
           size="sm"
           onClick={handleHintYear}
           disabled={!hasIncorrectGuess || hintYearUsed || !yearAvailable || gamePhase !== 'playing'}
-          className="relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300"
+          className="relative h-11 w-11 sm:h-10 sm:w-auto sm:px-4 p-0 touch-manipulation transition-all duration-300"
         >
           <Calendar className={cn('h-4 w-4 transition-colors duration-300', hintYearUsed && 'text-warning')} />
           {!hintYearUsed && hasIncorrectGuess && yearAvailable && (
@@ -142,7 +142,7 @@ export function HintButtons() {
           size="sm"
           onClick={handleHintPublisher}
           disabled={!hasIncorrectGuess || hintPublisherUsed || !publisherAvailable || gamePhase !== 'playing'}
-          className="relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300"
+          className="relative h-11 w-11 sm:h-10 sm:w-auto sm:px-4 p-0 touch-manipulation transition-all duration-300"
         >
           <Building2 className={cn('h-4 w-4 transition-colors duration-300', hintPublisherUsed && 'text-warning')} />
           {!hintPublisherUsed && hasIncorrectGuess && publisherAvailable && (
@@ -181,7 +181,7 @@ export function HintButtons() {
           size="sm"
           onClick={handleHintDeveloper}
           disabled={!hasIncorrectGuess || hintDeveloperUsed || !developerAvailable || gamePhase !== 'playing'}
-          className="relative h-9 sm:h-10 px-3 sm:px-4 touch-manipulation transition-all duration-300"
+          className="relative h-11 w-11 sm:h-10 sm:w-auto sm:px-4 p-0 touch-manipulation transition-all duration-300"
         >
           <Code2 className={cn('h-4 w-4 transition-colors duration-300', hintDeveloperUsed && 'text-warning')} />
           {!hintDeveloperUsed && hasIncorrectGuess && developerAvailable && (

--- a/packages/frontend/src/components/game/ProgressDots.tsx
+++ b/packages/frontend/src/components/game/ProgressDots.tsx
@@ -34,7 +34,11 @@ export function ProgressDots() {
   }
 
   return (
-    <div className="flex gap-1 sm:gap-2 md:gap-1.5 bg-black/60 backdrop-blur-md rounded-full px-2 sm:px-4 md:px-3 py-1.5 sm:py-2.5 md:py-2 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] shadow-lg">
+    <div
+      role="tablist"
+      aria-label="Screenshot progress"
+      className="flex gap-1.5 sm:gap-2 bg-black/60 backdrop-blur-md rounded-full px-2.5 sm:px-3 py-1.5 sm:py-2 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] shadow-lg max-w-full"
+    >
       {Array.from({ length: totalScreenshots }, (_, i) => {
         const pos = i + 1
         const state = positionStates[pos]
@@ -45,22 +49,32 @@ export function ProgressDots() {
         return (
           <motion.button
             key={pos}
+            role="tab"
             onClick={() => handleDotClick(pos)}
             disabled={!isClickable}
             className={cn(
-              "min-w-6 min-h-6 w-6 h-6 sm:w-10 sm:h-10 md:w-7 md:h-7 rounded-full transition-all duration-300 shrink-0 touch-manipulation flex items-center justify-center font-semibold text-[10px] sm:text-sm md:text-[10px]",
-              getStatusColor(status),
-              isCurrent && "bg-primary ring-2 ring-ring scale-110",
-              isClickable && "cursor-pointer hover:scale-125 hover:shadow-lg active:scale-95",
+              // Outer tap area guarantees ~44px target on mobile without crowding the visual
+              "relative shrink-0 p-1.5 sm:p-1 -m-1 touch-manipulation rounded-full",
+              isClickable && "cursor-pointer active:scale-95",
               !isClickable && "cursor-default"
             )}
-            style={isCurrent ? { boxShadow: 'var(--glow-md)' } : undefined}
             animate={isCurrent ? { scale: [1, 1.08, 1] } : { scale: 1 }}
             transition={{ duration: 0.6, repeat: isCurrent ? Infinity : 0, repeatDelay: 1.5 }}
             aria-label={`Screenshot ${pos}${isCurrent ? ' (current)' : ''}: ${status}`}
             aria-current={isCurrent ? 'true' : undefined}
           >
-            <span className="text-primary-foreground drop-shadow-md">{pos}</span>
+            <span
+              className={cn(
+                "flex items-center justify-center rounded-full font-semibold text-[11px] sm:text-xs transition-all duration-300",
+                "h-7 w-7 sm:h-8 sm:w-8",
+                getStatusColor(status),
+                isCurrent && "bg-primary ring-2 ring-ring",
+                isClickable && "hover:brightness-125"
+              )}
+              style={isCurrent ? { boxShadow: 'var(--glow-md)' } : undefined}
+            >
+              <span className="text-primary-foreground drop-shadow-md tabular-nums">{pos}</span>
+            </span>
           </motion.button>
         )
       })}

--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -517,7 +517,10 @@ export default function GamePage() {
             className="relative w-full h-full"
           >
             {/* Mobile Menu and Home Button (Top Left) */}
-            <div className="absolute top-1 left-2 sm:top-2 sm:left-4 z-40 flex items-center gap-1 sm:gap-2">
+            <div
+              className="absolute left-2 sm:left-4 z-40 flex items-center gap-1 sm:gap-2"
+              style={{ top: 'max(0.5rem, env(safe-area-inset-top))' }}
+            >
               {/* Mobile Menu Button - shown on mobile, hidden on md and up */}
               <div className="md:hidden">
                 <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
@@ -602,8 +605,11 @@ export default function GamePage() {
             </div>
 
             {/* Score and End Game Button (Top Right) */}
-            <div className="absolute top-2 right-2 sm:top-3 sm:right-4 z-40 flex flex-col items-stretch min-w-32 sm:min-w-36">
-              <div className="bg-black/60 backdrop-blur-md rounded-t-xl px-5 sm:px-6 py-2 sm:py-2.5 border border-white/10 shadow-2xl">
+            <div
+              className="absolute right-2 sm:right-4 z-40 flex flex-col items-stretch min-w-28 sm:min-w-36"
+              style={{ top: 'max(0.5rem, env(safe-area-inset-top))' }}
+            >
+              <div className="bg-black/60 backdrop-blur-md rounded-t-xl px-4 sm:px-6 py-1.5 sm:py-2.5 border border-white/10 shadow-2xl">
                 <ScoreDisplay />
               </div>
               <EndGameButton />
@@ -654,7 +660,12 @@ export default function GamePage() {
             {/* Guess Input (Bottom Center) */}
             {/* Slides up when keyboard is open on mobile */}
             <motion.div
-              className="absolute left-0 right-0 z-20 bg-linear-to-t from-background/95 via-background/90 to-transparent pt-2 sm:pt-3 md:pt-4 pb-2 sm:pb-3 md:pb-4 px-2 sm:px-3 md:px-4"
+              className="absolute left-0 right-0 z-20 bg-linear-to-t from-background/95 via-background/90 to-transparent pt-3 md:pt-4 px-2 sm:px-3 md:px-4"
+              style={{
+                paddingBottom: isKeyboardOpen
+                  ? '0.5rem'
+                  : 'max(0.5rem, env(safe-area-inset-bottom))',
+              }}
               initial={isMobile ? undefined : false}
               animate={{
                 bottom: isKeyboardOpen ? keyboardHeight : 0,
@@ -665,7 +676,7 @@ export default function GamePage() {
                 {/* Hint Buttons (Above Progress Dots) */}
                 <HintButtons />
                 {/* Progress Dots (Above Input) */}
-                <div className="flex justify-center items-center gap-2 sm:gap-3 md:gap-4">
+                <div className="flex justify-center items-center">
                   <ProgressDots />
                 </div>
                 <GuessInput />


### PR DESCRIPTION
Tighten the daily-challenge layout so it works on small phones:

- Replace the three stacked hint Alert cards with a compact row of
  shadcn Badge chips above the input. This reclaims ~60-90px of
  vertical space that the input was losing when 1-3 hints were used.
- Swap the Prev/Skip Buttons to size="icon" (square 48/56px) so they
  obey the shadcn sizing scale and stop shrinking the input on narrow
  screens.
- Bump ProgressDots tap targets to ~44px (WCAG 2.5.5 / Apple HIG) via
  outer padding without growing the visual dot.
- Bump HintButtons to 44x44 on mobile (matching touch guidelines).
- Respect iPhone notches / Android gesture bars via
  env(safe-area-inset-top) on top bar and env(safe-area-inset-bottom)
  on the bottom input container.
- Compact the top-right score pill (smaller min-width, less padding
  on mobile) so it stops crowding the menu/home buttons.
- Add enterKeyHint="send" plus autoCapitalize/autoCorrect/spellCheck
  hints to the guess Input for better mobile keyboard behavior.