### PR TITLE
feat(frontend): integrate Koe support widget in user menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,12 @@ VITE_API_URL=http://localhost:3000
 # Set to 'true' to use mock services instead of real API (for development/demo)
 VITE_USE_MOCK_API=false
 
+# Koe support widget (https://github.com/Wifsimster/koe)
+# Both vars must be set for the widget to mount. It renders only for
+# authenticated users, alongside the header user menu.
+VITE_KOE_PROJECT_KEY=the-box
+VITE_KOE_API_URL=https://koe.example.com
+
 # ============================================
 # BACKEND CONFIGURATION
 # ============================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -4947,6 +4947,29 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@wifsimster/koe": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wifsimster/koe/-/koe-1.33.0.tgz",
+      "integrity": "sha512-JSWFszJZiw2aqxtLE9b6tu/Ejk9cqDpL7F9oAOkKZDe5tK3CtpGftNCrr9TdbIYdNIrZUGg/E52sA1rw6XAJiw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@wifsimster/koe/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -12437,6 +12460,7 @@
         "@radix-ui/react-tooltip": "^1.1.8",
         "@react-three/fiber": "^9.5.0",
         "@the-box/types": "*",
+        "@wifsimster/koe": "^1.33.0",
         "better-auth": "^1.4.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-tooltip": "^1.1.8",
     "@react-three/fiber": "^9.5.0",
     "@the-box/types": "*",
+    "@wifsimster/koe": "^1.33.0",
     "better-auth": "^1.4.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -21,6 +21,7 @@ import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown } from
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
 import { DailyRewardBadge } from '@/components/daily-login'
+import { KoeSupportWidget } from '@/components/layout/KoeSupportWidget'
 
 interface NavigationLinksProps {
   isMobile?: boolean
@@ -251,6 +252,7 @@ export function Header() {
           )}
         </div>
       </div>
+      <KoeSupportWidget />
     </header>
   )
 }

--- a/packages/frontend/src/components/layout/KoeSupportWidget.tsx
+++ b/packages/frontend/src/components/layout/KoeSupportWidget.tsx
@@ -1,0 +1,38 @@
+import { KoeWidget } from '@wifsimster/koe'
+import '@wifsimster/koe/style.css'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '@/hooks/useAuth'
+
+const KOE_PROJECT_KEY = import.meta.env.VITE_KOE_PROJECT_KEY as string | undefined
+const KOE_API_URL = import.meta.env.VITE_KOE_API_URL as string | undefined
+
+/**
+ * Koe support widget mounted alongside the user menu.
+ * Only renders for authenticated users when the Koe env vars are configured,
+ * so the launcher appears in-context with the rest of the account controls.
+ */
+export function KoeSupportWidget() {
+  const { user, isAuthenticated } = useAuth()
+  const { i18n } = useTranslation()
+
+  if (!KOE_PROJECT_KEY || !KOE_API_URL) return null
+  if (!isAuthenticated || !user?.id) return null
+
+  return (
+    <KoeWidget
+      projectKey={KOE_PROJECT_KEY}
+      apiUrl={KOE_API_URL}
+      user={{
+        id: user.id,
+        name: user.name ?? undefined,
+        email: user.email ?? undefined,
+        metadata: {
+          role: user.role ?? 'user',
+          locale: i18n.language,
+        },
+      }}
+      position="bottom-right"
+      theme={{ mode: 'dark' }}
+    />
+  )
+}


### PR DESCRIPTION
Mount @wifsimster/koe's KoeWidget alongside the header user menu so
authenticated users can file bugs and feature requests from within their
account controls. Config is gated on VITE_KOE_PROJECT_KEY and
VITE_KOE_API_URL, and the widget receives the session user (id, name,
email, role, locale).