### PR TITLE
fix(geo): unblock CI — lockfile + design token violations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3575,6 +3575,17 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@react-three/fiber": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
@@ -4488,6 +4499,13 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -4501,6 +4519,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/multer": {
       "version": "2.0.0",
@@ -8481,6 +8509,12 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -10307,6 +10341,20 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -12468,12 +12516,14 @@
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.25.0",
         "i18next": "^25.7.4",
+        "leaflet": "^1.9.4",
         "lucide-react": "^0.562.0",
         "react": "^19.2.3",
         "react-day-picker": "^9.13.0",
         "react-dom": "^19.2.3",
         "react-hook-form": "^7.71.0",
         "react-i18next": "^16.5.2",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.12.0",
         "socket.io-client": "^4.8.3",
         "sonner": "^2.0.7",
@@ -12487,6 +12537,7 @@
         "@eslint/js": "^9.39.2",
         "@playwright/test": "^1.49.1",
         "@tailwindcss/vite": "^4.1.18",
+        "@types/leaflet": "^1.9.12",
         "@types/node": "^25.0.6",
         "@types/react": "^19.2.8",
         "@types/react-dom": "^19.2.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.71.0",
     "react-i18next": "^16.5.2",
-    "react-leaflet": "^4.2.1",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.12.0",
     "socket.io-client": "^4.8.3",
     "sonner": "^2.0.7",

--- a/packages/frontend/src/components/admin/GeoAdminActions.tsx
+++ b/packages/frontend/src/components/admin/GeoAdminActions.tsx
@@ -70,7 +70,7 @@ export function GeoAdminActions() {
             </CardHeader>
             <CardContent className="space-y-4">
                 {message && (
-                    <div className="rounded border border-emerald-500/40 bg-emerald-500/10 p-2 text-xs text-emerald-300">
+                    <div className="rounded border border-success/40 bg-success/10 p-2 text-xs text-success">
                         {message}
                     </div>
                 )}

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -156,7 +156,7 @@ export function GeoReviewPanel() {
 
             {loading ? (
                 <div className="flex justify-center py-16">
-                    <Loader2 className="h-6 w-6 animate-spin text-fuchsia-500" />
+                    <Loader2 className="h-6 w-6 animate-spin text-neon-pink" />
                 </div>
             ) : (
                 <div className="grid gap-4 lg:grid-cols-3">
@@ -172,7 +172,7 @@ export function GeoReviewPanel() {
                                     key={c.id}
                                     onClick={() => openDetail(c.id)}
                                     className={`w-full text-left rounded border p-2 text-xs hover:bg-muted/40 ${
-                                        detail?.candidate.id === c.id ? 'border-fuchsia-500' : ''
+                                        detail?.candidate.id === c.id ? 'border-neon-pink' : ''
                                     }`}
                                 >
                                     <div className="flex justify-between items-center">
@@ -226,7 +226,7 @@ export function GeoReviewPanel() {
                                     />
                                     {detail.meta ? (
                                         <div className="flex items-center justify-between gap-3">
-                                            <p className="text-xs text-amber-400">
+                                            <p className="text-xs text-warning">
                                                 {t(
                                                     'admin.geo.alreadyPromoted',
                                                     'Already promoted — delete to re-pin with new coords.',
@@ -260,7 +260,7 @@ export function GeoReviewPanel() {
                                                 size="sm"
                                                 onClick={applyOverride}
                                                 disabled={!pin || saving}
-                                                className="bg-gradient-to-r from-fuchsia-500 to-purple-600 hover:opacity-90"
+                                                className="bg-gradient-to-r from-neon-purple to-neon-pink hover:opacity-90"
                                             >
                                                 {saving && (
                                                     <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />

--- a/packages/frontend/src/components/geo/MapCanvas.tsx
+++ b/packages/frontend/src/components/geo/MapCanvas.tsx
@@ -110,10 +110,7 @@ function Marker({
     color: 'fuchsia' | 'emerald'
     label: string
 }) {
-    const colorClass =
-        color === 'fuchsia'
-            ? 'bg-fuchsia-500 ring-fuchsia-300 shadow-fuchsia-500/50'
-            : 'bg-emerald-500 ring-emerald-300 shadow-emerald-500/50'
+    const colorClass = color === 'fuchsia' ? 'bg-neon-pink' : 'bg-success'
     return (
         <div
             className="pointer-events-none absolute -translate-x-1/2 -translate-y-1/2"
@@ -121,7 +118,7 @@ function Marker({
         >
             <div
                 className={cn(
-                    'h-4 w-4 rounded-full ring-2 shadow-lg',
+                    'h-4 w-4 rounded-full ring-2 ring-white/30 shadow-lg',
                     colorClass,
                 )}
                 aria-hidden

--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -22,12 +22,13 @@ import type { MapCanvasProps } from './MapCanvas'
 const FUCHSIA_DIVICON = createDiv('fuchsia')
 const EMERALD_DIVICON = createDiv('emerald')
 
+// Colors + box-shadow are sourced from the design tokens exposed on :root
+// in src/index.css so this stays in sync with the rest of the UI.
 function createDiv(color: 'fuchsia' | 'emerald'): L.DivIcon {
-    const ring = color === 'fuchsia' ? '#f0abfc' : '#6ee7b7'
-    const fill = color === 'fuchsia' ? '#d946ef' : '#10b981'
+    const fill = color === 'fuchsia' ? 'var(--neon-pink)' : 'var(--success)'
     return L.divIcon({
         className: 'geo-map-marker',
-        html: `<span style="display:block;width:16px;height:16px;border-radius:9999px;background:${fill};box-shadow:0 0 0 2px ${ring},0 4px 12px rgba(0,0,0,0.35);"></span>`,
+        html: `<span style="display:block;width:16px;height:16px;border-radius:9999px;background:${fill};box-shadow:var(--glow-md);"></span>`,
         iconSize: [16, 16],
         iconAnchor: [8, 8],
     })
@@ -70,7 +71,7 @@ export function MapCanvasLeaflet({
                 zoomControl={!disabled}
                 scrollWheelZoom={!disabled}
                 doubleClickZoom={false}
-                style={{ height: '100%', width: '100%', background: '#0b0b10' }}
+                style={{ height: '100%', width: '100%', background: 'var(--background)' }}
             >
                 <ImageOverlay url={imageUrl} bounds={bounds} />
                 {!disabled && onPin && (
@@ -87,7 +88,7 @@ export function MapCanvasLeaflet({
                 {showGuessLine && pinLatLng && canonicalLatLng && (
                     <Polyline
                         positions={[pinLatLng, canonicalLatLng]}
-                        pathOptions={{ color: '#ffffff', weight: 2, dashArray: '6 4', opacity: 0.9 }}
+                        pathOptions={{ color: 'var(--foreground)', weight: 2, dashArray: '6 4', opacity: 0.9 }}
                     />
                 )}
             </MapContainer>

--- a/packages/frontend/src/components/profile/GeoContributorCard.tsx
+++ b/packages/frontend/src/components/profile/GeoContributorCard.tsx
@@ -7,11 +7,13 @@ import { Lock, MapPin, ShieldCheck, Target } from 'lucide-react'
 import type { GeoContributorTier } from '@the-box/types'
 import { cn } from '@/lib/utils'
 
-const TIER_GRADIENT: Record<GeoContributorTier, string> = {
-    bronze: 'from-amber-600 to-amber-800',
-    silver: 'from-slate-300 to-slate-500',
-    gold: 'from-amber-300 to-yellow-500',
-    diamond: 'from-cyan-300 to-blue-500',
+// Tier badges use medal tokens where available; diamond falls back to the
+// neon-cyan scale since no medal-diamond token exists in the contract.
+const TIER_BG: Record<GeoContributorTier, string> = {
+    bronze: 'bg-medal-bronze',
+    silver: 'bg-medal-silver',
+    gold: 'bg-medal-gold',
+    diamond: 'bg-neon-cyan',
 }
 
 const TIER_LABEL: Record<GeoContributorTier, string> = {
@@ -45,7 +47,7 @@ export function GeoContributorCard() {
         <Card>
             <CardHeader className="pb-3">
                 <CardTitle className="text-base flex items-center gap-2">
-                    <MapPin className="h-4 w-4 text-fuchsia-500" />
+                    <MapPin className="h-4 w-4 text-neon-pink" />
                     {t('geo.profile.title', 'Geo Crowdsourcer')}
                 </CardTitle>
             </CardHeader>
@@ -53,8 +55,8 @@ export function GeoContributorCard() {
                 <div className="flex items-center gap-3">
                     <div
                         className={cn(
-                            'h-12 w-12 rounded-full bg-gradient-to-br shadow-lg grid place-items-center',
-                            TIER_GRADIENT[tierShown],
+                            'h-12 w-12 rounded-full shadow-lg grid place-items-center',
+                            TIER_BG[tierShown],
                         )}
                         aria-hidden
                     >
@@ -108,7 +110,7 @@ function UnlockProgress({
             </div>
             <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
                 <div
-                    className="h-full bg-gradient-to-r from-fuchsia-500 to-purple-600 transition-all"
+                    className="h-full bg-gradient-to-r from-neon-purple to-neon-pink transition-all"
                     style={{ width: `${pct}%` }}
                 />
             </div>
@@ -174,7 +176,7 @@ function GeoCrowdsourcerPlaceholder({
         <Card>
             <CardHeader className="pb-3">
                 <CardTitle className="text-base flex items-center gap-2">
-                    <MapPin className="h-4 w-4 text-fuchsia-500" />
+                    <MapPin className="h-4 w-4 text-neon-pink" />
                     {t('geo.profile.title', 'Geo Crowdsourcer')}
                 </CardTitle>
             </CardHeader>

--- a/packages/frontend/src/pages/GeoContributePage.tsx
+++ b/packages/frontend/src/pages/GeoContributePage.tsx
@@ -74,7 +74,7 @@ export default function GeoContributePage() {
     return (
         <div className="container mx-auto max-w-5xl px-4 py-8 space-y-6">
             <header className="space-y-1">
-                <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-fuchsia-400 to-purple-400 bg-clip-text text-transparent">
+                <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
                     {t('geo.contribute.title', 'Tag a screenshot')}
                 </h1>
                 <p className="text-sm text-muted-foreground">
@@ -106,7 +106,7 @@ export default function GeoContributePage() {
 
             {!isLocked && phase === 'loading' && (
                 <div className="flex justify-center py-20">
-                    <Loader2 className="h-8 w-8 animate-spin text-fuchsia-500" />
+                    <Loader2 className="h-8 w-8 animate-spin text-neon-pink" />
                 </div>
             )}
 
@@ -161,13 +161,13 @@ export default function GeoContributePage() {
                                 <Button
                                     onClick={handleSubmit}
                                     disabled={!pendingPin}
-                                    className="bg-gradient-to-r from-fuchsia-500 to-purple-600 hover:opacity-90"
+                                    className="bg-gradient-to-r from-neon-purple to-neon-pink hover:opacity-90"
                                 >
                                     {t('geo.contribute.submit', 'Submit pin')}
                                 </Button>
                             </div>
                             {message && (
-                                <p className="text-xs text-emerald-400">{message}</p>
+                                <p className="text-xs text-success">{message}</p>
                             )}
                         </CardContent>
                     </Card>
@@ -178,7 +178,7 @@ export default function GeoContributePage() {
                 <Card>
                     <CardHeader className="pb-2">
                         <CardTitle className="text-sm flex items-center gap-2">
-                            <HandCoins className="h-4 w-4 text-emerald-400" />
+                            <HandCoins className="h-4 w-4 text-success" />
                             {t('geo.contribute.recent', 'Recent rewards')}
                         </CardTitle>
                     </CardHeader>

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSession } from '@/lib/auth-client'
 import { useGeoStore } from '@/stores/geoStore'
@@ -30,8 +30,10 @@ export default function GeoDailyPage() {
         submitGuess,
     } = useGeoStore()
 
-    const date = useMemo(todayIso, [])
-    const startedAt = useRef<number>(Date.now())
+    const [date] = useState(todayIso)
+    // useRef's initial value runs on every render; lazy-via-useState keeps
+    // Date.now() out of render while staying mount-stable.
+    const [startedAt] = useState(() => Date.now())
 
     useEffect(() => {
         loadDaily(date)
@@ -44,14 +46,14 @@ export default function GeoDailyPage() {
     const canSubmit = phase === 'playing' && !!pendingGuess && !hasGuessed
 
     const handleSubmit = async () => {
-        const duration = Date.now() - startedAt.current
+        const duration = Date.now() - startedAt
         await submitGuess(duration)
     }
 
     return (
         <div className="container mx-auto max-w-5xl px-4 py-8 space-y-6">
             <header className="space-y-1">
-                <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-fuchsia-400 to-purple-400 bg-clip-text text-transparent">
+                <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
                     {t('geo.daily.title', 'Daily Geo Challenge')}
                 </h1>
                 <p className="text-sm text-muted-foreground">
@@ -64,7 +66,7 @@ export default function GeoDailyPage() {
 
             {phase === 'loading' && (
                 <div className="flex justify-center py-20">
-                    <Loader2 className="h-8 w-8 animate-spin text-fuchsia-500" />
+                    <Loader2 className="h-8 w-8 animate-spin text-neon-pink" />
                 </div>
             )}
 
@@ -92,7 +94,7 @@ export default function GeoDailyPage() {
                     <Card>
                         <CardHeader className="pb-2">
                             <CardTitle className="text-base flex items-center gap-2">
-                                <MapPin className="h-4 w-4 text-fuchsia-500" />
+                                <MapPin className="h-4 w-4 text-neon-pink" />
                                 {t('geo.daily.map', 'Map')}
                             </CardTitle>
                         </CardHeader>
@@ -117,7 +119,7 @@ export default function GeoDailyPage() {
                                 <Button
                                     onClick={handleSubmit}
                                     disabled={!canSubmit}
-                                    className="bg-gradient-to-r from-fuchsia-500 to-purple-600 hover:opacity-90"
+                                    className="bg-gradient-to-r from-neon-purple to-neon-pink hover:opacity-90"
                                 >
                                     {phase === 'submitting' && (
                                         <Loader2 className="h-4 w-4 animate-spin mr-2" />
@@ -142,7 +144,7 @@ function ResultBlock({
 }) {
     return (
         <div className="rounded-lg border bg-card/50 p-4 space-y-2">
-            <div className="flex items-center gap-2 text-fuchsia-400 font-medium">
+            <div className="flex items-center gap-2 text-neon-pink font-medium">
                 <Trophy className="h-4 w-4" />
                 <span>Score: {result.score.toLocaleString()}</span>
             </div>

--- a/packages/frontend/src/pages/GeoLeaderboardPage.tsx
+++ b/packages/frontend/src/pages/GeoLeaderboardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSession } from '@/lib/auth-client'
 import { useGeoStore } from '@/stores/geoStore'
@@ -24,8 +24,11 @@ export default function GeoLeaderboardPage() {
         useGeoStore()
 
     const [loading, setLoading] = useState(true)
-    const date = useMemo(todayIso, [])
-    const period = useMemo(currentMonth, [])
+    // Lazy initializers run once at mount, so date/period are effectively
+    // constants for the lifetime of the page without triggering the lint's
+    // "impure function during render" rule.
+    const [date] = useState(todayIso)
+    const [period] = useState(currentMonth)
 
     useEffect(() => {
         connectGeoSocket(session?.user?.id)
@@ -33,7 +36,6 @@ export default function GeoLeaderboardPage() {
 
     useEffect(() => {
         let cancelled = false
-        setLoading(true)
         Promise.all([
             loadLeaderboardDaily(date),
             loadLeaderboardMonthly(period),
@@ -48,7 +50,7 @@ export default function GeoLeaderboardPage() {
     return (
         <div className="container mx-auto max-w-3xl px-4 py-8 space-y-6">
             <header className="space-y-1">
-                <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-fuchsia-400 to-purple-400 bg-clip-text text-transparent">
+                <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
                     {t('geo.leaderboard.title', 'Geo Leaderboard')}
                 </h1>
                 <p className="text-sm text-muted-foreground">
@@ -58,7 +60,7 @@ export default function GeoLeaderboardPage() {
 
             {loading ? (
                 <div className="flex justify-center py-20">
-                    <Loader2 className="h-8 w-8 animate-spin text-fuchsia-500" />
+                    <Loader2 className="h-8 w-8 animate-spin text-neon-pink" />
                 </div>
             ) : (
                 <Tabs defaultValue="daily">
@@ -126,8 +128,8 @@ function LeaderboardRow({ entry }: { entry: GeoLeaderboardEntry }) {
 }
 
 function RankBadge({ rank }: { rank: number }) {
-    if (rank === 1) return <Crown className="h-5 w-5 text-amber-400" aria-label="1st" />
-    if (rank === 2) return <Medal className="h-5 w-5 text-slate-300" aria-label="2nd" />
-    if (rank === 3) return <Trophy className="h-5 w-5 text-amber-700" aria-label="3rd" />
+    if (rank === 1) return <Crown className="h-5 w-5 text-medal-gold" aria-label="1st" />
+    if (rank === 2) return <Medal className="h-5 w-5 text-medal-silver" aria-label="2nd" />
+    if (rank === 3) return <Trophy className="h-5 w-5 text-medal-bronze" aria-label="3rd" />
     return <span className="w-5 text-center text-xs text-muted-foreground">{rank}</span>
 }


### PR DESCRIPTION
Fixes the failing Release workflow on `d69e2c0` (the PR #18 merge commit).

## Root cause

1. **`npm ci` failed** — the lockfile didn't include the `leaflet` + `react-leaflet` deps I added in PR #18. Regenerated. Also bumped `react-leaflet` to `^5.0.0` since 4.x peer-depends on `react@^18` and this project is on React 19.
2. **`npm run lint` then surfaced 56 `design-tokens/no-raw-design-tokens` errors** across the new Geo components. The enforced contract in `docs/ui-tokens.md` bans raw `text-fuchsia-500`, `bg-emerald-500`, etc. plus hex/rgb literals.

## Changes

- `MapCanvas` markers → `bg-neon-pink` / `bg-success`
- `MapCanvasLeaflet` DivIcon, MapContainer, Polyline → source colors from `var(--neon-pink|--success|--glow-md|--background|--foreground)`
- `GeoContributorCard` tier badges → `medal-bronze/silver/gold` tokens + `neon-cyan` for diamond; progress bar → `from-neon-purple to-neon-pink`
- Page headers → `from-neon-purple to-neon-pink` gradient titles, `text-neon-pink` / `text-success` / `text-warning` icons
- `GeoLeaderboardPage` rank badges → `medal-gold/silver/bronze`
- Admin success banner → `border-success/40 bg-success/10 text-success`

Also quieted two react-hooks lints the tokens exposed:
- `useMemo(todayIso, [])` → `useState(todayIso)` (lazy init pattern)
- `useRef<number>(Date.now())` → `useState(() => Date.now())`
- Redundant `setLoading(true)` inside effect dropped

## Test plan

- [x] `npm run lint` — 0 errors (5 pre-existing warnings in ui/button, ui/card, ui/form, ui/badge, achievement/AchievementNotification — all unrelated)
- [x] `npm run build:types` — clean
- [x] `npx tsc --noEmit` on frontend — clean
- [ ] CI green on this branch
- [ ] Merge and confirm the Release workflow recovers on main

https://claude.ai/code/session_019xq9r8kexYQSBcGzbEMRjN