### PR TITLE
fix(geo): rename GeoMap component to resolve type collision

### DIFF
--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Loader2, Trash2 } from 'lucide-react'
-import { GeoMap } from '@/components/geo/GeoMap'
+import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { GeoAdminActions } from './GeoAdminActions'
 import type {
     GeoMap,
@@ -208,7 +208,7 @@ export function GeoReviewPanel() {
                                         alt={`Candidate ${detail.candidate.id}`}
                                         className="w-full rounded border max-h-48 object-contain bg-black/20"
                                     />
-                                    <GeoMap
+                                    <GeoMapCanvas
                                         imageUrl={detail.map.imageUrl}
                                         widthPx={detail.map.widthPx}
                                         heightPx={detail.map.heightPx}

--- a/packages/frontend/src/components/geo/GeoMapCanvas.tsx
+++ b/packages/frontend/src/components/geo/GeoMapCanvas.tsx
@@ -6,8 +6,10 @@ import { MapCanvasLeaflet } from './MapCanvasLeaflet'
 // barrel so future swaps don't touch page code.
 const USE_LEAFLET = import.meta.env.VITE_GEO_USE_LEAFLET === 'true'
 
-export type { MapCanvasProps as GeoMapProps } from './MapCanvas'
+// Component name is GeoMapCanvas (not GeoMap) to avoid colliding with the
+// GeoMap type from @the-box/types.
+export type { MapCanvasProps as GeoMapCanvasProps } from './MapCanvas'
 
-export function GeoMap(props: MapCanvasProps) {
+export function GeoMapCanvas(props: MapCanvasProps) {
     return USE_LEAFLET ? <MapCanvasLeaflet {...props} /> : <MapCanvas {...props} />
 }

--- a/packages/frontend/src/pages/GeoContributePage.tsx
+++ b/packages/frontend/src/pages/GeoContributePage.tsx
@@ -4,7 +4,7 @@ import { useSearchParams } from 'react-router-dom'
 import { useSession } from '@/lib/auth-client'
 import { useGeoStore } from '@/stores/geoStore'
 import { connectGeoSocket } from '@/lib/geo-socket'
-import { GeoMap } from '@/components/geo/GeoMap'
+import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { HandCoins, Loader2, Lock, SkipForward } from 'lucide-react'
@@ -142,7 +142,7 @@ export default function GeoContributePage() {
                             </CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-4">
-                            <GeoMap
+                            <GeoMapCanvas
                                 imageUrl={currentCandidateMap.imageUrl}
                                 widthPx={currentCandidateMap.widthPx}
                                 heightPx={currentCandidateMap.heightPx}

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useSession } from '@/lib/auth-client'
 import { useGeoStore } from '@/stores/geoStore'
 import { connectGeoSocket } from '@/lib/geo-socket'
-import { GeoMap } from '@/components/geo/GeoMap'
+import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Loader2, MapPin, Trophy } from 'lucide-react'
@@ -99,7 +99,7 @@ export default function GeoDailyPage() {
                             </CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-4">
-                            <GeoMap
+                            <GeoMapCanvas
                                 imageUrl={map.imageUrl}
                                 widthPx={map.widthPx}
                                 heightPx={map.heightPx}


### PR DESCRIPTION
## Root cause

The Release workflow's `release` job runs `npm run build`, which invokes `tsc -b` on the frontend. That surfaced a `TS2300: Duplicate identifier 'GeoMap'` in `GeoReviewPanel.tsx`:

- I introduced a `GeoMap` wrapper component in the Leaflet slice.
- `GeoReviewPanel.tsx` also imports the `GeoMap` **type** from `@the-box/types` for its `CandidateDetail` interface.

They collide. `tsc -b` catches this at build time; `eslint` + `tsc --noEmit` on the app config didn't, which is why PR #20 passed the local gates but the release job still fails.

## Fix

- Rename `components/geo/GeoMap.tsx` → `components/geo/GeoMapCanvas.tsx`
- Exported component: `GeoMap` → `GeoMapCanvas`
- Exported type alias: `GeoMapProps` → `GeoMapCanvasProps`
- Consumers updated: `GeoDailyPage`, `GeoContributePage`, `GeoReviewPanel`

## Test plan

- [x] `npm run build` — frontend bundle builds cleanly, types package builds clean
- [x] No other consumers of the old name (verified via grep)
- [ ] CI release job green on main after merge

https://claude.ai/code/session_019xq9r8kexYQSBcGzbEMRjN