### PR TITLE
fix(daily-login): close mobile menu when opening reward modal

### DIFF
--- a/packages/frontend/src/components/daily-login/DailyRewardBadge.tsx
+++ b/packages/frontend/src/components/daily-login/DailyRewardBadge.tsx
@@ -13,9 +13,10 @@ import { Gift } from 'lucide-react'
 
 interface DailyRewardBadgeProps {
     className?: string
+    onClick?: () => void
 }
 
-export function DailyRewardBadge({ className }: DailyRewardBadgeProps) {
+export function DailyRewardBadge({ className, onClick }: DailyRewardBadgeProps) {
     const { t } = useTranslation()
     const { status, openModal, isLoading } = useDailyLoginStore()
 
@@ -25,6 +26,11 @@ export function DailyRewardBadge({ className }: DailyRewardBadgeProps) {
     const canClaim = status.canClaim
     const streak = status.currentStreak
 
+    const handleClick = () => {
+        onClick?.()
+        openModal()
+    }
+
     return (
         <TooltipProvider>
             <TooltipRoot>
@@ -32,7 +38,7 @@ export function DailyRewardBadge({ className }: DailyRewardBadgeProps) {
                     <Button
                         variant="ghost"
                         size="sm"
-                        onClick={openModal}
+                        onClick={handleClick}
                         className={cn(
                             'relative flex items-center gap-1.5 px-2 sm:px-3',
                             className

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -122,7 +122,7 @@ export function Header() {
                             </span>
                           )}
                           {/* Daily Reward Badge for mobile */}
-                          <DailyRewardBadge />
+                          <DailyRewardBadge onClick={() => setMobileMenuOpen(false)} />
                         </div>
                         <Button variant="ghost" size="sm" asChild className="w-full justify-start">
                           <Link to={localizedPath('/profile')} onClick={() => setMobileMenuOpen(false)}>


### PR DESCRIPTION
The daily reward modal opened from inside the mobile Sheet menu was
hidden behind the still-open menu, leaving the reward content cut off
on small screens. Close the Sheet before opening the modal so the
reward dialog is fully visible.