### PR TITLE
feat(email): add inactive-user reminder win-back worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,15 @@ EMAIL_FROM=noreply@yourdomain.com
 RELANCE_EMAIL_ENABLED=true
 RELANCE_EMAIL_CRON=0 17 * * *
 
+# Inactive-user reminder — long-horizon win-back email for users who have
+# not played AND not refreshed a session in INACTIVE_USER_REMINDER_DAYS
+# days. Default cron is weekly (Mondays 16:00 UTC) to avoid piling
+# reminders onto already-lapsed users. Worker enforces a 30-day per-user
+# cooldown internally and aborts if more than 5000 candidates match.
+INACTIVE_USER_REMINDER_ENABLED=true
+INACTIVE_USER_REMINDER_CRON=0 16 * * 1
+INACTIVE_USER_REMINDER_DAYS=14
+
 # ============================================
 # RAWG API (OPTIONAL - for admin game imports)
 # ============================================

--- a/packages/backend/migrations/20260422_inactive_user_reminder_email_log.ts
+++ b/packages/backend/migrations/20260422_inactive_user_reminder_email_log.ts
@@ -1,0 +1,18 @@
+import type { Knex } from 'knex'
+
+/**
+ * Tracks when the long-horizon "we miss you" win-back email was last sent
+ * to a user so the recurring worker can enforce a multi-week cooldown
+ * between re-engagement attempts for the same lapsed user.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.timestamp('last_inactive_reminder_email_at').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.dropColumn('last_inactive_reminder_email_at')
+  })
+}

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -22,6 +22,13 @@ export const env = {
   RELANCE_EMAIL_ENABLED: process.env['RELANCE_EMAIL_ENABLED'] || 'true',
   RELANCE_EMAIL_CRON: process.env['RELANCE_EMAIL_CRON'] || '0 17 * * *',
 
+  // Long-horizon win-back email for users inactive (no play, no session
+  // refresh) for N days. Runs weekly to avoid piling reminders onto
+  // already-gone users; per-user cooldown inside the worker is 30 days.
+  INACTIVE_USER_REMINDER_ENABLED: process.env['INACTIVE_USER_REMINDER_ENABLED'] || 'true',
+  INACTIVE_USER_REMINDER_CRON: process.env['INACTIVE_USER_REMINDER_CRON'] || '0 16 * * 1',
+  INACTIVE_USER_REMINDER_DAYS: process.env['INACTIVE_USER_REMINDER_DAYS'] || '14',
+
   // Public-facing frontend URL (used in marketing email CTAs)
   FRONTEND_URL: process.env['FRONTEND_URL'] || 'https://the-box.battistella.ovh',
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -298,6 +298,7 @@ async function start(): Promise<void> {
       'recalculate-scores',
       'streak-risk-email',
       'relance-email',
+      'inactive-user-reminder',
     ]
     try {
       const repeatableJobs = await importQueue.getRepeatableJobs()
@@ -413,6 +414,28 @@ async function start(): Promise<void> {
       logger.info({ pattern: env.RELANCE_EMAIL_CRON }, 'scheduled recurring relance-email job')
     } catch (error) {
       logger.warn({ error: String(error) }, 'failed to schedule recurring relance-email job')
+    }
+
+    // Schedule recurring inactive-user-reminder — long-horizon win-back for
+    // users who have not played AND have not refreshed an auth session in
+    // N days. Default schedule is weekly (Mondays 16:00 UTC) to avoid
+    // piling reminders on already-gone users; the worker also enforces a
+    // 30-day per-user cooldown internally.
+    try {
+      await importQueue.add(
+        'inactive-user-reminder',
+        {},
+        {
+          repeat: { pattern: env.INACTIVE_USER_REMINDER_CRON, tz: 'UTC' },
+          jobId: 'inactive-user-reminder-recurring',
+        }
+      )
+      logger.info(
+        { pattern: env.INACTIVE_USER_REMINDER_CRON, days: env.INACTIVE_USER_REMINDER_DAYS },
+        'scheduled recurring inactive-user-reminder job'
+      )
+    } catch (error) {
+      logger.warn({ error: String(error) }, 'failed to schedule recurring inactive-user-reminder job')
     }
 
     // Log final repeatable jobs configuration with next run times

--- a/packages/backend/src/infrastructure/queue/workers/import.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/import.worker.ts
@@ -11,6 +11,7 @@ import { processRecalculateScoresJob } from './recalculate-scores-logic.js'
 import { clearDailyData } from './clear-daily-data-logic.js'
 import { sendStreakRiskEmails } from './streak-risk-email-logic.js'
 import { sendRelanceEmails } from './relance-email-logic.js'
+import { sendInactiveUserReminderEmails } from './inactive-user-reminder-logic.js'
 
 const log = queueLogger
 
@@ -314,6 +315,20 @@ export const importWorker = new Worker<JobData, JobResult>(
         }
 
         log.info({ jobId: id, result }, 'relance-email job completed')
+        return jobResult
+      }
+
+      if (name === 'inactive-user-reminder') {
+        const result = await sendInactiveUserReminderEmails((current, total) => {
+          const progress = total > 0 ? Math.round((current / total) * 100) : 0
+          job.updateProgress(progress)
+        })
+
+        const jobResult: JobResult = {
+          message: result.message,
+        }
+
+        log.info({ jobId: id, result }, 'inactive-user-reminder job completed')
         return jobResult
       }
 

--- a/packages/backend/src/infrastructure/queue/workers/inactive-user-reminder-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/inactive-user-reminder-logic.ts
@@ -1,0 +1,208 @@
+import { db } from '../../database/connection.js'
+import { resend } from '../../auth/auth.js'
+import { env } from '../../../config/env.js'
+import { queueLogger } from '../../logger/logger.js'
+
+const log = queueLogger.child({ worker: 'inactive-user-reminder' })
+
+const GUEST_EMAIL_DOMAIN = 'guest.thebox.local'
+
+// Per-user cooldown. Once someone has received a win-back nudge, we wait
+// a full month before trying again — a longer window than the daily
+// workers because re-engaging a silent user is a slow game and we don't
+// want to become the reason they unsubscribe.
+const MIN_DAYS_BETWEEN_EMAILS = 30
+
+// Matches the relance worker: keep us out of the welcome flow for
+// brand-new signups.
+const MIN_ACCOUNT_AGE_HOURS = 48
+
+// Safety cap. If the candidate set blows past this, the query is wrong
+// (wrong env, failed migration, broken clock) and mailing the whole base
+// would be worse than aborting.
+const MAX_CANDIDATES_PER_RUN = 5000
+
+export interface InactiveUserReminderResult {
+  candidates: number
+  sent: number
+  skipped: number
+  failed: number
+  aborted?: boolean
+  message: string
+}
+
+interface InactiveCandidate {
+  id: string
+  email: string
+  display_name: string | null
+  name: string
+  last_played_at: Date | null
+}
+
+/**
+ * Returns users who:
+ *   - have opted in to marketing emails,
+ *   - own a non-guest account at least 48h old,
+ *   - have played at least once (welcome funnel owns never-played users),
+ *   - have not played in the last N days,
+ *   - have not had any Better Auth session refreshed in the last N days
+ *     (so someone who still logs in to browse the leaderboard is spared),
+ *   - were not already nudged by this worker within the cooldown window.
+ *
+ * All date math runs against the database clock in UTC, matching the
+ * other recurring workers.
+ */
+async function findCandidates(inactivityDays: number): Promise<InactiveCandidate[]> {
+  const rows = await db('user as u')
+    .select<InactiveCandidate[]>(
+      'u.id',
+      'u.email',
+      'u.display_name',
+      'u.name',
+      'u.last_played_at'
+    )
+    .where('u.email_marketing_consent', true)
+    .whereNot('u.email', 'like', `%@${GUEST_EMAIL_DOMAIN}`)
+    .whereRaw(`u."createdAt" < NOW() - INTERVAL '${MIN_ACCOUNT_AGE_HOURS} hours'`)
+    .whereNotNull('u.last_played_at')
+    .whereRaw(`u.last_played_at < NOW() - INTERVAL '${inactivityDays} days'`)
+    .whereRaw(
+      `NOT EXISTS (
+         SELECT 1 FROM "session" s
+         WHERE s."userId" = u.id
+           AND s."updatedAt" > NOW() - INTERVAL '${inactivityDays} days'
+       )`
+    )
+    .whereRaw(
+      `(u.last_inactive_reminder_email_at IS NULL
+        OR u.last_inactive_reminder_email_at < NOW() - INTERVAL '${MIN_DAYS_BETWEEN_EMAILS} days')`
+    )
+
+  return rows
+}
+
+function daysSince(date: Date | null): number {
+  if (!date) return 0
+  const ms = Date.now() - new Date(date).getTime()
+  return Math.max(1, Math.floor(ms / (1000 * 60 * 60 * 24)))
+}
+
+function buildHtml(displayName: string, days: number, playUrl: string, unsubscribeUrl: string): string {
+  return `
+    <div style="background:#0b0612;padding:24px 0;font-family:-apple-system,Segoe UI,Arial,sans-serif;">
+      <div style="max-width:520px;margin:0 auto;background:#140a26;border:1px solid #2a1644;border-radius:14px;padding:28px 24px;color:#ece8f5;">
+        <div style="font-size:13px;letter-spacing:2px;color:#c084fc;text-transform:uppercase;margin-bottom:8px;">The Box</div>
+        <h1 style="margin:0 0 16px;font-size:22px;line-height:1.3;color:#ffffff;">
+          Ça fait ${days} jours, ${displayName}…
+        </h1>
+        <p style="margin:0 0 14px;font-size:15px;line-height:1.55;color:#cfc6e6;">
+          Ton dernier passage dans la Box remonte à <strong style="color:#f0abfc;">${days} jours</strong>. Les défis du jour continuent de tomber sans toi — et on aimerait bien te revoir.
+        </p>
+        <p style="margin:0 0 24px;font-size:15px;line-height:1.55;color:#cfc6e6;">
+          Un nouveau panorama t'attend dès maintenant. Quelques secondes suffisent pour retrouver la main.
+        </p>
+        <div style="text-align:center;margin:28px 0;">
+          <a href="${playUrl}" style="display:inline-block;padding:14px 28px;background:linear-gradient(135deg,#a855f7,#ec4899);color:#fff;text-decoration:none;border-radius:10px;font-weight:700;font-size:15px;">
+            Relancer une partie
+          </a>
+        </div>
+        <p style="margin:0;font-size:12px;line-height:1.5;color:#7a6f93;">
+          Astuce : ton inventaire d'indices est toujours là, intact, prêt à servir sur le prochain défi.
+        </p>
+        <hr style="margin:28px 0 16px;border:none;border-top:1px solid #2a1644;" />
+        <p style="margin:0;font-size:11px;color:#6b6189;line-height:1.5;">
+          Tu reçois cet e-mail car tu as accepté les rappels par e-mail. <a href="${unsubscribeUrl}" style="color:#a78bfa;">Se désabonner</a>.
+        </p>
+      </div>
+    </div>
+  `
+}
+
+function buildText(displayName: string, days: number, playUrl: string, unsubscribeUrl: string): string {
+  return [
+    `Salut ${displayName},`,
+    '',
+    `Ça fait ${days} jours qu'on ne t'a pas vu(e) dans la Box. Un nouveau défi t'attend — et ton inventaire d'indices est toujours là, intact.`,
+    '',
+    `Reprends une partie : ${playUrl}`,
+    '',
+    `Se désabonner : ${unsubscribeUrl}`,
+    '— The Box',
+  ].join('\n')
+}
+
+async function sendOne(user: InactiveCandidate): Promise<'sent' | 'skipped' | 'failed'> {
+  const displayName = user.display_name ?? user.name
+  const days = daysSince(user.last_played_at)
+  const playUrl = `${env.FRONTEND_URL}/fr/play`
+  const unsubscribeUrl = `${env.FRONTEND_URL}/fr/profile`
+
+  if (!resend) {
+    log.info({ userId: user.id }, '[DEV] inactive-user-reminder email skipped — no Resend key configured')
+    return 'skipped'
+  }
+
+  try {
+    const { error } = await resend.emails.send({
+      from: `The Box <${env.EMAIL_FROM}>`,
+      to: user.email,
+      subject: `${displayName}, ça fait ${days} jours — on t'attend dans la Box`,
+      html: buildHtml(displayName, days, playUrl, unsubscribeUrl),
+      text: buildText(displayName, days, playUrl, unsubscribeUrl),
+    })
+
+    if (error) {
+      log.warn({ userId: user.id, error: error.message }, 'inactive-user-reminder email send failed')
+      return 'failed'
+    }
+
+    await db('user').where('id', user.id).update({ last_inactive_reminder_email_at: new Date() })
+    return 'sent'
+  } catch (err) {
+    log.error({ userId: user.id, error: String(err) }, 'inactive-user-reminder email unexpected error')
+    return 'failed'
+  }
+}
+
+export async function sendInactiveUserReminderEmails(
+  onProgress?: (current: number, total: number) => void
+): Promise<InactiveUserReminderResult> {
+  if (env.INACTIVE_USER_REMINDER_ENABLED !== 'true') {
+    const message = 'inactive-user-reminder disabled via INACTIVE_USER_REMINDER_ENABLED=false'
+    log.info(message)
+    return { candidates: 0, sent: 0, skipped: 0, failed: 0, message }
+  }
+
+  const inactivityDays = Number.parseInt(env.INACTIVE_USER_REMINDER_DAYS, 10)
+  if (!Number.isFinite(inactivityDays) || inactivityDays < 1) {
+    const message = `inactive-user-reminder aborted: invalid INACTIVE_USER_REMINDER_DAYS=${env.INACTIVE_USER_REMINDER_DAYS}`
+    log.warn(message)
+    return { candidates: 0, sent: 0, skipped: 0, failed: 0, aborted: true, message }
+  }
+
+  const candidates = await findCandidates(inactivityDays)
+  log.info({ count: candidates.length, inactivityDays }, 'inactive-user-reminder candidates identified')
+
+  if (candidates.length > MAX_CANDIDATES_PER_RUN) {
+    const message = `inactive-user-reminder aborted: ${candidates.length} candidates exceed safety cap (${MAX_CANDIDATES_PER_RUN})`
+    log.warn({ count: candidates.length, cap: MAX_CANDIDATES_PER_RUN }, message)
+    return { candidates: candidates.length, sent: 0, skipped: 0, failed: 0, aborted: true, message }
+  }
+
+  let sent = 0
+  let skipped = 0
+  let failed = 0
+
+  for (let i = 0; i < candidates.length; i++) {
+    const outcome = await sendOne(candidates[i]!)
+    if (outcome === 'sent') sent++
+    else if (outcome === 'skipped') skipped++
+    else failed++
+    onProgress?.(i + 1, candidates.length)
+  }
+
+  const message = `inactive-user-reminder emails: ${sent} sent, ${skipped} skipped, ${failed} failed (of ${candidates.length} candidates, threshold ${inactivityDays}d)`
+  log.info({ candidates: candidates.length, sent, skipped, failed, inactivityDays }, message)
+
+  return { candidates: candidates.length, sent, skipped, failed, message }
+}


### PR DESCRIPTION
Sends a re-engagement email to users inactive for INACTIVE_USER_REMINDER_DAYS
days (default 14) — no gameplay AND no Better Auth session refresh in the
window. Distinct from streak-risk and relance, which only cover 1-day
lapses. Weekly cron, 30-day per-user cooldown, 5000-row safety cap,
requires email_marketing_consent, skips guest and <48h-old accounts.