### PR TITLE
fix(build): order workspace builds so types builds before consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "npm run dev --workspaces --if-present",
     "dev:backend": "npm run dev -w @the-box/backend",
     "dev:frontend": "npm run dev -w @the-box/frontend",
-    "build": "npm run build --workspaces --if-present",
+    "build": "npm run build:types && npm run build:backend && npm run build:frontend",
     "build:types": "npm run build -w @the-box/types",
     "build:backend": "npm run build -w @the-box/backend",
     "build:frontend": "npm run build -w @the-box/frontend",


### PR DESCRIPTION
## Summary

Follow-up to #25: the first CI run on main failed because `npm run build --workspaces --if-present` enumerates workspaces alphabetically (`backend → frontend → types`), so `@the-box/types` was being built **last**. Backend and frontend then failed with `Cannot find module '@the-box/types'`.

Fix: explicit build order in the root `build` script, matching what the `Dockerfile` already does (`build:types → build:backend → build:frontend`).

## Why this wasn't caught before

The previous `release.yml` ran `npm run build:types` explicitly before `npm run build`, masking the bug in the root script. When I rewrote the workflow in #25 I removed that step as "redundant" — it wasn't.

## Verified locally

```
npm run build   # now passes
npm run lint    # passes (5 pre-existing warnings, 0 errors)
npm test        # no-op (no test scripts in any workspace)
```

## Test plan

- [ ] CI on this PR goes green on `Lint / Build / Test`

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5FVcp4B8cUCceUcrYUuDf)_