### PR TITLE
feat(mobile): PWA manifest and resilient socket reconnect on cellular

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -4,8 +4,13 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+  <link rel="manifest" href="/manifest.webmanifest" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
   <meta name="theme-color" content="#0a0a0f" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="The Box" />
+  <link rel="apple-touch-icon" href="/logo.svg" />
   <title>The Box — Daily Video Game Guessing Challenge</title>
   <meta name="description" content="Daily video game guessing challenges. Identify games from panoramic screenshots, climb live leaderboards, unlock achievements. Play instantly as a guest — no account needed." />
   <link rel="canonical" href="https://the-box.battistella.ovh/" />

--- a/packages/frontend/public/manifest.webmanifest
+++ b/packages/frontend/public/manifest.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "The Box — Daily Video Game Guessing Challenge",
+  "short_name": "The Box",
+  "description": "Identify video games from 360° panoramic screenshots. New daily challenge, live leaderboards, achievements.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0a0a0f",
+  "theme_color": "#0a0a0f",
+  "lang": "fr",
+  "categories": ["games", "entertainment"],
+  "icons": [
+    {
+      "src": "/logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/packages/frontend/src/lib/geo-socket.ts
+++ b/packages/frontend/src/lib/geo-socket.ts
@@ -18,7 +18,11 @@ function createSocket(): Socket {
         reconnection: true,
         reconnectionDelay: 1000,
         reconnectionDelayMax: 5000,
-        reconnectionAttempts: 5,
+        // Cellular networks drop and recover all day — keep trying. Default
+        // randomizationFactor (0.5) already jitters the backoff so a fleet
+        // recovering from the same outage doesn't stampede the server.
+        reconnectionAttempts: Infinity,
+        randomizationFactor: 0.5,
     })
 }
 

--- a/packages/frontend/src/lib/socket.ts
+++ b/packages/frontend/src/lib/socket.ts
@@ -22,7 +22,11 @@ export function getAdminSocket(): Socket {
             reconnection: true,
             reconnectionDelay: 1000,
             reconnectionDelayMax: 5000,
-            reconnectionAttempts: 5,
+            // Cellular networks drop and recover all day — keep trying. Default
+            // randomizationFactor (0.5) already jitters the backoff so a fleet
+            // recovering from the same outage doesn't stampede the server.
+            reconnectionAttempts: Infinity,
+            randomizationFactor: 0.5,
         })
 
         socket.on('connect', () => {


### PR DESCRIPTION
Two more mobile-first quick wins after PR #28.

## Summary

- **PWA manifest scaffold** — `public/manifest.webmanifest` + linked from `index.html`. Standalone display, portrait lock, theme colour `#0a0a0f`, apple-touch-icon + `apple-mobile-web-app-*` meta. The site is now installable to the home screen on Android and iOS. No install-prompt UI yet — that is Chloé's product-owned post-first-game surface and needs design first.
- **Resilient Socket.IO on cellular** — dropped the `reconnectionAttempts: 5` cap on both admin and `/geo` clients. On 4G drop-reconnect cycles the old cap killed realtime after ~30 s of flakiness. Default `Infinity` with explicit `randomizationFactor: 0.5` lets us recover when coverage returns without stampeding the server.

## Test plan

- [ ] `npm run build` typechecks
- [ ] On Android Chrome, visit the deployed site and confirm the "Add to Home Screen" menu entry is available and installs into standalone mode.
- [ ] On iOS Safari, confirm "Add to Home Screen" produces a standalone launch (no browser chrome).
- [ ] Mid-game, toggle airplane mode off and on — realtime leaderboard updates should resume once coverage returns, not go permanently silent.

https://claude.ai/code/session_01Q8GtFzDCtdJLzjiH4DhJ14

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8GtFzDCtdJLzjiH4DhJ14)_