### PR TITLE
Fix dialog centering by using inline translate style

### DIFF
--- a/packages/frontend/src/components/ui/dialog.tsx
+++ b/packages/frontend/src/components/ui/dialog.tsx
@@ -38,11 +38,16 @@ function DialogContent({
       <DialogPrimitive.Content
         aria-describedby={undefined}
         data-slot="dialog-content"
+        // Inline translate bypasses @wifsimster/koe's unlayered Tailwind v3
+        // preflight, whose `*,:before,:after{--tw-translate-x:0;--tw-translate-y:0}`
+        // outranks our @layer utilities and would otherwise pin the dialog's
+        // top-left corner to viewport center.
+        style={{ translate: '-50% -50%' }}
         className={cn(
           // 100dvh handles iOS Safari's shrinking viewport with the keyboard open;
           // overflow-y-auto lets dense content (e.g. the 7-day reward calendar) scroll
           // instead of pushing the close affordance off-screen on narrow phones.
-          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] sm:max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-3 sm:gap-4 border border-border bg-card p-4 sm:p-6 shadow-lg duration-200 motion-safe:data-[state=open]:animate-in motion-safe:data-[state=closed]:animate-out motion-safe:data-[state=closed]:fade-out-0 motion-safe:data-[state=open]:fade-in-0 motion-safe:data-[state=closed]:zoom-out-95 motion-safe:data-[state=open]:zoom-in-95 motion-safe:data-[state=closed]:slide-out-to-left-1/2 motion-safe:data-[state=closed]:slide-out-to-top-[48%] motion-safe:data-[state=open]:slide-in-from-left-1/2 motion-safe:data-[state=open]:slide-in-from-top-[48%] rounded-lg",
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] sm:max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto gap-3 sm:gap-4 border border-border bg-card p-4 sm:p-6 shadow-lg duration-200 motion-safe:data-[state=open]:animate-in motion-safe:data-[state=closed]:animate-out motion-safe:data-[state=closed]:fade-out-0 motion-safe:data-[state=open]:fade-in-0 motion-safe:data-[state=closed]:zoom-out-95 motion-safe:data-[state=open]:zoom-in-95 motion-safe:data-[state=closed]:slide-out-to-left-1/2 motion-safe:data-[state=closed]:slide-out-to-top-[48%] motion-safe:data-[state=open]:slide-in-from-left-1/2 motion-safe:data-[state=open]:slide-in-from-top-[48%] rounded-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
Fixes dialog positioning by replacing Tailwind translate utility classes with an inline `translate` style property to work around CSS specificity issues with the `@wifsimster/koe` package's Tailwind v3 preflight.

## Changes
- Added inline `style={{ translate: '-50% -50%' }}` to `DialogPrimitive.Content` to center the dialog
- Removed `translate-x-[-50%] translate-y-[-50%]` Tailwind classes from the className
- Added explanatory comment documenting why the inline style is necessary

## Implementation Details
The `@wifsimster/koe` package's unlayered Tailwind v3 preflight includes `*,:before,:after{--tw-translate-x:0;--tw-translate-y:0}` which has higher CSS specificity than our `@layer utilities` declarations. This causes the Tailwind translate utilities to be overridden, pinning the dialog to the viewport center instead of centering it properly.

By using an inline style with the CSS `translate` property directly, we bypass this specificity issue while maintaining the same visual centering behavior. The inline style takes precedence over the preflight's CSS variable declarations.

https://claude.ai/code/session_01BTHweZL8Qu5thytDhoz8ob