### PR TITLE
Add automatic release workflow on main branch pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       version_type:
@@ -21,8 +23,77 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  decide:
+    # Skip pushes made by the workflow's own `chore: bump version` commit.
+    # The bump is committed with GITHUB_TOKEN which won't re-trigger workflows,
+    # so this is belt-and-suspenders against a human/PAT pushing the same shape.
+    if: github.event_name == 'workflow_dispatch' || github.actor != 'github-actions[bot]'
+    name: Decide release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_release: ${{ steps.bump.outputs.should_release }}
+      bump_type: ${{ steps.bump.outputs.bump_type }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine bump type from conventional commits
+        id: bump
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch: bumping ${{ inputs.version_type }}"
+            echo "bump_type=${{ inputs.version_type }}" >> "$GITHUB_OUTPUT"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$PREVIOUS_TAG" ]; then
+            SUBJECTS=$(git log "${PREVIOUS_TAG}..HEAD" --pretty=format:"%s" --no-merges)
+            BODIES=$(git log "${PREVIOUS_TAG}..HEAD" --pretty=format:"%b" --no-merges)
+          else
+            SUBJECTS=$(git log --pretty=format:"%s" --no-merges)
+            BODIES=$(git log --pretty=format:"%b" --no-merges)
+          fi
+
+          if [ -z "$SUBJECTS" ]; then
+            echo "No commits since ${PREVIOUS_TAG:-repo start} — skipping."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Commits since ${PREVIOUS_TAG:-repo start}:"
+          echo "$SUBJECTS" | sed 's/^/  /'
+          echo ""
+
+          # Major: a conventional commit subject marked breaking with `!` or any
+          # commit body containing the BREAKING CHANGE footer.
+          if echo "$SUBJECTS" | grep -qE "^[a-z]+(\([^)]+\))?!:" \
+             || echo "$BODIES" | grep -q "BREAKING CHANGE:"; then
+            BUMP=major
+          elif echo "$SUBJECTS" | grep -qE "^feat(\([^)]+\))?:"; then
+            BUMP=minor
+          elif echo "$SUBJECTS" | grep -qE "^(fix|perf|revert)(\([^)]+\))?:"; then
+            BUMP=patch
+          else
+            echo "Only non-releasable commits (chore/docs/style/refactor/test/ci/build) — skipping."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Bump type: $BUMP"
+          echo "bump_type=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+
   release:
     name: Create Release & Publish Docker Image
+    needs: decide
+    if: needs.decide.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -63,7 +134,7 @@ jobs:
       - name: Bump version
         id: version
         run: |
-          npm run version:${{ inputs.version_type }}
+          npm run version:${{ needs.decide.outputs.bump_type }}
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"


### PR DESCRIPTION
## Summary
This change enhances the release workflow to automatically trigger on pushes to the main branch, in addition to manual workflow dispatch. It introduces intelligent version bump detection based on conventional commits, allowing the workflow to automatically determine the appropriate semantic version increment.

## Key Changes
- **Automatic trigger**: Added `push` event trigger for the main branch alongside existing `workflow_dispatch` trigger
- **New `decide` job**: Introduced a decision job that:
  - Analyzes conventional commits since the last tag to determine if a release is needed
  - Automatically detects the appropriate bump type (major/minor/patch) based on commit messages:
    - **Major**: Breaking changes (marked with `!` or `BREAKING CHANGE:` footer)
    - **Minor**: New features (`feat:`)
    - **Patch**: Bug fixes, performance improvements, or reverts (`fix:`, `perf:`, `revert:`)
    - **Skip**: Non-releasable commits (chore, docs, style, refactor, test, ci, build)
  - Skips releases when no releasable commits are found
  - Prevents duplicate releases from the workflow's own version bump commits
- **Conditional release**: The `release` job now depends on the `decide` job and only runs when `should_release` is true
- **Dynamic version bumping**: The release job now uses the automatically determined bump type instead of requiring manual input

## Implementation Details
- The `decide` job uses git history analysis with conventional commit patterns to intelligently determine release necessity and type
- Includes safeguards to prevent re-triggering on the workflow's own commits (which use `GITHUB_TOKEN`)
- Maintains backward compatibility with manual `workflow_dispatch` triggers that specify version type explicitly

https://claude.ai/code/session_01BTHweZL8Qu5thytDhoz8ob