### PR TITLE
feat(home): geo header link + design-system pass on the hero page

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -13,6 +13,8 @@
     "back": "Back",
     "home": "Home",
     "leaderboard": "Leaderboard",
+    "geoDaily": "Geo",
+    "alpha": "Alpha",
     "settings": "Settings",
     "login": "Login",
     "register": "Register",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -13,6 +13,8 @@
     "back": "Retour",
     "home": "Accueil",
     "leaderboard": "Classement",
+    "geoDaily": "Geo",
+    "alpha": "Alpha",
     "settings": "Paramètres",
     "login": "Connexion",
     "register": "Inscription",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -209,7 +209,7 @@
   },
   "home": {
     "title": "The Box",
-    "subtitle": "Devinez le jeu vidéo à partir de captures d'écran. Classements en direct, succès et séries de victoires.",
+    "subtitle": "Une capture, un jeu à reconnaître. Voyons si ta culture gaming tient encore debout.",
     "playToday": "Jouer au Défi du Jour",
     "dailyGuess": "Défi Quotidien",
     "guestHint": "Aucun compte requis — jouez instantanément en invité",
@@ -237,10 +237,10 @@
     "geoAlpha": {
       "badge": "Alpha",
       "eyebrow": "Nouveau : Geo Daily",
-      "title": "Trouvez l'endroit. Posez l'épingle.",
-      "subtitle": "Un défi quotidien pour repérer sur la carte l'endroit exact où la capture d'écran a été prise. Elden Ring est en ligne — d'autres mondes arrivent.",
+      "title": "Trouve l'endroit. Pose l'épingle.",
+      "subtitle": "Pour l'instant, c'est Elden Ring. Plante ton épingle pile où la capture a été prise — sinon ça compte pas.",
       "cta": "Jouer Geo Daily",
-      "secondary": "Voir le classement geo"
+      "secondary": "Voir le classement"
     },
     "completionMessages": {
       "perfect": [

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -260,7 +260,7 @@ export function GeoReviewPanel() {
                                                 size="sm"
                                                 onClick={applyOverride}
                                                 disabled={!pin || saving}
-                                                className="bg-linear-to-r from-neon-purple to-neon-pink hover:opacity-90"
+                                                className="gradient-gaming hover:opacity-90"
                                             >
                                                 {saving && (
                                                     <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />

--- a/packages/frontend/src/components/admin/GrowthStats.tsx
+++ b/packages/frontend/src/components/admin/GrowthStats.tsx
@@ -65,7 +65,7 @@ export function GrowthStats() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
+            <div className="text-3xl font-bold gradient-gaming bg-clip-text text-transparent">
               {stats.referrals.claimedTotal}
             </div>
             <p className="text-xs text-muted-foreground mt-1">

--- a/packages/frontend/src/components/game/PercentileBanner.tsx
+++ b/packages/frontend/src/components/game/PercentileBanner.tsx
@@ -52,7 +52,7 @@ export function PercentileBanner({
       <div className="flex flex-col items-center gap-1.5 sm:gap-2">
         <div className="flex items-center gap-1.5 sm:gap-2 text-base sm:text-lg font-bold">
           <TrendingUp className="w-4 h-4 sm:w-5 sm:h-5 text-neon-purple shrink-0" />
-          <span className="bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent text-sm sm:text-base md:text-lg">
+          <span className="gradient-gaming bg-clip-text text-transparent text-sm sm:text-base md:text-lg">
             {t('game.results.percentileTop', { percent: topPercent })}
           </span>
         </div>

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown } from 'lucide-react'
+import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin } from 'lucide-react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
 import { DailyRewardBadge } from '@/components/daily-login'
@@ -49,6 +49,16 @@ function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick }: 
         <Link to={localizedPath('/leaderboard')} onClick={handleClick}>
           <Trophy className={`w-4 h-4 ${iconClass}`} />
           {t('common.leaderboard')}
+        </Link>
+      </Button>
+
+      <Button variant="ghost" size="sm" asChild className={mobileClasses}>
+        <Link to={localizedPath('/geo/daily')} onClick={handleClick}>
+          <MapPin className={`w-4 h-4 ${iconClass}`} />
+          {t('common.geoDaily')}
+          <Badge variant="outline" className="ml-2 h-4 px-1 text-[10px] font-semibold uppercase tracking-wide border-neon-pink/50 text-neon-pink">
+            {t('common.alpha')}
+          </Badge>
         </Link>
       </Button>
     </>

--- a/packages/frontend/src/components/layout/PageHero.tsx
+++ b/packages/frontend/src/components/layout/PageHero.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion'
 import type { LucideIcon } from 'lucide-react'
 import { CubeBackground } from '@/components/backgrounds/CubeBackground'
+import { GradientIcon } from '@/components/ui/gradient-icon'
 
 interface PageHeroProps {
   icon?: LucideIcon
@@ -45,13 +46,17 @@ export function PageHero({ icon: Icon, logo, iconStyle = 'gradient', title, subt
               initial={{ scale: 0.8 }}
               animate={{ scale: 1 }}
               transition={{ duration: 0.5, delay: 0.2 }}
-              className="inline-flex items-center justify-center w-16 h-16 sm:w-20 sm:h-20 md:w-24 md:h-24 mb-4 sm:mb-5 md:mb-6 rounded-xl sm:rounded-2xl bg-linear-to-br from-neon-purple to-neon-pink shadow-lg shadow-neon-purple/30"
+              className="mb-4 sm:mb-5 md:mb-6"
             >
-              <Icon className="w-8 h-8 sm:w-10 sm:h-10 md:w-12 md:h-12 text-white" />
+              <GradientIcon
+                icon={<Icon className="w-8 h-8 sm:w-10 sm:h-10 md:w-12 md:h-12 text-white" />}
+                size="lg"
+                className="w-16 h-16 sm:w-20 sm:h-20 md:w-24 md:h-24 sm:rounded-2xl"
+              />
             </motion.div>
           ) : null}
 
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4 px-2 sm:px-0 bg-linear-to-r from-neon-purple via-neon-pink to-neon-cyan bg-clip-text text-transparent">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4 px-2 sm:px-0 gradient-gaming-title">
             {title}
           </h1>
 

--- a/packages/frontend/src/components/profile/GeoContributorCard.tsx
+++ b/packages/frontend/src/components/profile/GeoContributorCard.tsx
@@ -110,7 +110,7 @@ function UnlockProgress({
             </div>
             <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
                 <div
-                    className="h-full bg-linear-to-r from-neon-purple to-neon-pink transition-all"
+                    className="h-full gradient-gaming transition-all"
                     style={{ width: `${pct}%` }}
                 />
             </div>

--- a/packages/frontend/src/components/ui/gradient-icon.tsx
+++ b/packages/frontend/src/components/ui/gradient-icon.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+type GradientIconSize = 'sm' | 'md' | 'lg'
+
+interface GradientIconProps {
+  /** A rendered icon element, e.g. `<MapPin className="w-6 h-6 text-white" />`. */
+  icon: ReactNode
+  /** Tile size; defaults to `md`. */
+  size?: GradientIconSize
+  /** Additional class names merged via `cn()`. */
+  className?: string
+}
+
+const sizeClass: Record<GradientIconSize, string> = {
+  sm: 'h-8 w-8',
+  md: 'h-12 w-12',
+  lg: 'h-16 w-16',
+}
+
+/**
+ * The recurring "purple→pink rounded square holding an icon" tile used
+ * across hero sections and feature cards. Visual is sourced from the
+ * shared `gradient-gaming` utility so palette tweaks stay centralized.
+ */
+export function GradientIcon({ icon, size = 'md', className }: GradientIconProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center justify-center rounded-xl gradient-gaming shadow-lg shadow-neon-purple/30',
+        sizeClass[size],
+        className,
+      )}
+    >
+      {icon}
+    </div>
+  )
+}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -211,6 +211,16 @@ body {
 .glow-md { box-shadow: var(--glow-md); }
 .glow-lg { box-shadow: var(--glow-lg); }
 
+/* Shared neon gradient utilities. Use `gradient-gaming` for filled
+   surfaces (icon tiles, progress bars) and `gradient-gaming-title` for
+   gradient-text headlines. Keep CVA variants (e.g. Button.gaming) inline. */
+.gradient-gaming {
+  @apply bg-linear-to-r from-neon-purple to-neon-pink;
+}
+.gradient-gaming-title {
+  @apply bg-linear-to-r from-neon-purple via-neon-pink to-neon-cyan bg-clip-text text-transparent;
+}
+
 .glow-hover {
   transition: box-shadow var(--duration-normal) var(--ease-smooth);
 }

--- a/packages/frontend/src/pages/GameHistoryDetailsPage.tsx
+++ b/packages/frontend/src/pages/GameHistoryDetailsPage.tsx
@@ -134,7 +134,7 @@ export default function GameHistoryDetailsPage() {
           <Trophy className="w-8 h-8 sm:w-10 sm:h-10 text-white" />
         </motion.div>
 
-        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-2 sm:mb-3 bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-2 sm:mb-3 gradient-gaming bg-clip-text text-transparent">
           {formatDate(sessionData.challengeDate)}
         </h1>
 

--- a/packages/frontend/src/pages/GeoContributePage.tsx
+++ b/packages/frontend/src/pages/GeoContributePage.tsx
@@ -74,7 +74,7 @@ export default function GeoContributePage() {
     return (
         <div className="container mx-auto max-w-5xl px-4 py-8 space-y-6">
             <header className="space-y-1">
-                <h1 className="text-3xl font-bold tracking-tight bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
+                <h1 className="text-3xl font-bold tracking-tight gradient-gaming bg-clip-text text-transparent">
                     {t('geo.contribute.title', 'Tag a screenshot')}
                 </h1>
                 <p className="text-sm text-muted-foreground">
@@ -161,7 +161,7 @@ export default function GeoContributePage() {
                                 <Button
                                     onClick={handleSubmit}
                                     disabled={!pendingPin}
-                                    className="bg-linear-to-r from-neon-purple to-neon-pink hover:opacity-90"
+                                    className="gradient-gaming hover:opacity-90"
                                 >
                                     {t('geo.contribute.submit', 'Submit pin')}
                                 </Button>

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -53,7 +53,7 @@ export default function GeoDailyPage() {
     return (
         <div className="container mx-auto max-w-5xl px-4 py-8 space-y-6">
             <header className="space-y-1">
-                <h1 className="text-3xl font-bold tracking-tight bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
+                <h1 className="text-3xl font-bold tracking-tight gradient-gaming bg-clip-text text-transparent">
                     {t('geo.daily.title', 'Daily Geo Challenge')}
                 </h1>
                 <p className="text-sm text-muted-foreground">
@@ -119,7 +119,7 @@ export default function GeoDailyPage() {
                                 <Button
                                     onClick={handleSubmit}
                                     disabled={!canSubmit}
-                                    className="bg-linear-to-r from-neon-purple to-neon-pink hover:opacity-90"
+                                    className="gradient-gaming hover:opacity-90"
                                 >
                                     {phase === 'submitting' && (
                                         <Loader2 className="h-4 w-4 animate-spin mr-2" />

--- a/packages/frontend/src/pages/GeoLeaderboardPage.tsx
+++ b/packages/frontend/src/pages/GeoLeaderboardPage.tsx
@@ -50,7 +50,7 @@ export default function GeoLeaderboardPage() {
     return (
         <div className="container mx-auto max-w-3xl px-4 py-8 space-y-6">
             <header className="space-y-1">
-                <h1 className="text-3xl font-bold tracking-tight bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
+                <h1 className="text-3xl font-bold tracking-tight gradient-gaming bg-clip-text text-transparent">
                     {t('geo.leaderboard.title', 'Geo Leaderboard')}
                 </h1>
                 <p className="text-sm text-muted-foreground">

--- a/packages/frontend/src/pages/HistoryPage.tsx
+++ b/packages/frontend/src/pages/HistoryPage.tsx
@@ -280,7 +280,7 @@ export default function HistoryPage() {
             {/* Games List */}
             <Card className="bg-card/50 border-border">
               <CardHeader className="p-4 sm:p-6">
-                <CardTitle className="text-lg sm:text-xl font-extrabold bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent drop-shadow-lg">
+                <CardTitle className="text-lg sm:text-xl font-extrabold gradient-gaming bg-clip-text text-transparent drop-shadow-lg">
                   {t('history.yourGames')}
                 </CardTitle>
                 <p className="text-xs sm:text-sm text-muted-foreground mt-1">

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -1,10 +1,10 @@
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { motion } from 'framer-motion'
-import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { GradientIcon } from '@/components/ui/gradient-icon'
 import { Play, Trophy, Brain, History, Clock, CalendarDays, MapPin, ArrowRight } from 'lucide-react'
 import { CubeBackground } from '@/components/backgrounds/CubeBackground'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
@@ -118,7 +118,7 @@ export default function HomePage() {
             className="h-16 w-16 sm:h-20 sm:w-20 md:h-24 md:w-24 mb-4 sm:mb-5 md:mb-6 mx-auto"
           />
 
-          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-3 sm:mb-4 bg-linear-to-r from-neon-purple via-neon-pink to-neon-cyan bg-clip-text text-transparent">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-3 sm:mb-4 gradient-gaming-title">
             {t('home.title')}
           </h1>
 
@@ -138,13 +138,13 @@ export default function HomePage() {
           {isTodayCompleted && (
             <div className="text-center max-w-xl mx-auto">
               <div className="bg-card/80 backdrop-blur-sm border border-neon-purple/30 rounded-lg p-4 sm:p-6 mb-3">
-                <p className="text-lg sm:text-xl font-bold text-neon-purple mb-3">
+                <p className="text-lg sm:text-xl font-bold text-foreground mb-3">
                   {humorousMessage}
                 </p>
                 <div className="flex items-center justify-center gap-4 sm:gap-6 text-sm sm:text-base mb-4">
                   <div className="flex items-center gap-2">
                     <Trophy className="h-4 w-4 sm:h-5 sm:w-5 text-neon-cyan" />
-                    <span className="font-semibold text-neon-cyan">{todayScore} pts</span>
+                    <span className="font-semibold text-foreground">{todayScore} pts</span>
                   </div>
                   <div className="text-muted-foreground">
                     {screenshotsFound}/10 {t('game.screenshots')}
@@ -157,7 +157,7 @@ export default function HomePage() {
                   <span className="text-xs sm:text-sm text-muted-foreground">
                     {t('home.nextDailyIn')}
                   </span>
-                  <span className="font-mono font-semibold text-neon-pink text-sm sm:text-base">
+                  <span className="font-mono font-semibold text-foreground text-sm sm:text-base">
                     {String(timeRemaining.hours).padStart(2, '0')}:
                     {String(timeRemaining.minutes).padStart(2, '0')}:
                     {String(timeRemaining.seconds).padStart(2, '0')}
@@ -220,7 +220,7 @@ export default function HomePage() {
                   className="w-full h-full object-cover transition-transform hover:scale-105"
                 />
                 <div className="absolute inset-0 bg-linear-to-t from-black/70 via-transparent" />
-                <span className="absolute top-3 left-3 text-[10px] uppercase tracking-wide font-semibold text-neon-cyan bg-black/60 rounded px-2 py-1">
+                <span className="absolute top-3 left-3 text-[10px] uppercase tracking-wide font-semibold text-white bg-black/60 rounded px-2 py-1">
                   {t('home.previewBadge')}
                 </span>
                 <div className="absolute bottom-3 left-3 right-3">
@@ -260,96 +260,12 @@ export default function HomePage() {
           )}
         </motion.div>
 
-        {/* Geo Daily alpha teaser — complements the main daily CTA above */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.5 }}
-          className="max-w-2xl mx-auto mb-8 sm:mb-10 md:mb-12 lg:mb-16"
-        >
-          {/* Outer element is a div+role=button so the secondary leaderboard link can remain focusable without nesting interactive elements. */}
-          <div
-            role="button"
-            tabIndex={0}
-            onClick={() => navigate(localizedPath('/geo/daily'))}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault()
-                navigate(localizedPath('/geo/daily'))
-              }
-            }}
-            className={cn(
-              'group relative block w-full overflow-hidden rounded-2xl text-left cursor-pointer',
-              'border border-neon-purple/40 hover:border-neon-pink/70 transition-colors',
-              'bg-linear-to-br from-neon-purple/20 via-background/60 to-neon-pink/20 backdrop-blur-sm',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-            )}
-          >
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute -top-16 -right-16 h-40 w-40 rounded-full bg-neon-pink/30 blur-3xl opacity-60 group-hover:opacity-80 transition-opacity"
-            />
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute -bottom-20 -left-10 h-40 w-40 rounded-full bg-neon-purple/30 blur-3xl opacity-60 group-hover:opacity-80 transition-opacity"
-            />
-            <div className="relative flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-5 p-5 sm:p-6">
-              <div className="shrink-0 flex h-12 w-12 sm:h-14 sm:w-14 items-center justify-center rounded-xl bg-linear-to-br from-neon-purple to-neon-pink shadow-lg shadow-neon-purple/30">
-                <MapPin className="h-6 w-6 sm:h-7 sm:w-7 text-white" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex flex-wrap items-center gap-2 mb-1.5">
-                  <Badge
-                    variant="outline"
-                    className="border-neon-pink/50 bg-neon-pink/15 text-neon-pink uppercase tracking-wider"
-                  >
-                    {t('home.geoAlpha.badge')}
-                  </Badge>
-                  <span className="text-[11px] sm:text-xs uppercase tracking-wide font-semibold text-neon-cyan">
-                    {t('home.geoAlpha.eyebrow')}
-                  </span>
-                </div>
-                <h2 className="text-lg sm:text-xl md:text-2xl font-bold leading-tight bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
-                  {t('home.geoAlpha.title')}
-                </h2>
-                <p className="mt-1.5 text-xs sm:text-sm text-muted-foreground max-w-xl">
-                  {t('home.geoAlpha.subtitle')}
-                </p>
-                <div className="mt-3 flex flex-wrap items-center gap-3 sm:gap-4">
-                  <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-white group-hover:text-neon-pink transition-colors">
-                    {t('home.geoAlpha.cta')}
-                    <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-                  </span>
-                  <span
-                    role="link"
-                    tabIndex={0}
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      navigate(localizedPath('/geo/leaderboard'))
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault()
-                        event.stopPropagation()
-                        navigate(localizedPath('/geo/leaderboard'))
-                      }
-                    }}
-                    className="text-xs sm:text-sm text-muted-foreground underline-offset-4 hover:text-neon-cyan hover:underline focus-visible:outline-none focus-visible:text-neon-cyan focus-visible:underline cursor-pointer"
-                  >
-                    {t('home.geoAlpha.secondary')}
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </motion.div>
-
         {/* Features Grid */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.6 }}
-          className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-5 md:gap-6 max-w-2xl mx-auto"
+          transition={{ duration: 0.5, delay: 0.5 }}
+          className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-5 md:gap-6 max-w-2xl mx-auto mb-8 sm:mb-10 md:mb-12 lg:mb-16"
         >
           <Card className="bg-card/50 border-border hover:border-neon-purple/50 transition-colors">
             <CardContent className="pt-4 sm:pt-5 md:pt-6 text-center">
@@ -374,6 +290,76 @@ export default function HomePage() {
               </p>
             </CardContent>
           </Card>
+        </motion.div>
+
+        {/*
+          Geo Daily alpha teaser — sits *below* the panorama features grid
+          since it's a single-game pilot and shouldn't compete with the
+          primary daily-play CTA above the fold. The card itself is a
+          single Link covering the main CTA; the secondary leaderboard
+          link is rendered as a sibling so we never nest interactives.
+        */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.6 }}
+          className="max-w-2xl mx-auto"
+        >
+          <div className="group relative overflow-hidden rounded-2xl border border-neon-purple/40 bg-linear-to-br from-neon-purple/20 via-background/60 to-neon-pink/20 backdrop-blur-sm transition-colors hover:border-neon-pink/70 focus-within:border-neon-pink/70">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute -top-16 -right-16 h-40 w-40 rounded-full bg-neon-pink/30 blur-3xl opacity-60 group-hover:opacity-80 transition-opacity"
+            />
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute -bottom-20 -left-10 h-40 w-40 rounded-full bg-neon-purple/30 blur-3xl opacity-60 group-hover:opacity-80 transition-opacity"
+            />
+
+            {/* Primary affordance: a real <Link> wrapping the CTA region. */}
+            <Link
+              to={localizedPath('/geo/daily')}
+              className="relative flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-5 p-5 sm:p-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-2xl"
+            >
+              <GradientIcon
+                icon={<MapPin className="h-6 w-6 sm:h-7 sm:w-7 text-white" />}
+                className="shrink-0 h-12 w-12 sm:h-14 sm:w-14"
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-wrap items-center gap-2 mb-1.5">
+                  <Badge
+                    variant="outline"
+                    className="border-neon-pink/50 bg-neon-pink/15 text-neon-pink uppercase tracking-wider"
+                  >
+                    {t('home.geoAlpha.badge')}
+                  </Badge>
+                  <span className="text-[11px] sm:text-xs uppercase tracking-wide font-semibold text-muted-foreground">
+                    {t('home.geoAlpha.eyebrow')}
+                  </span>
+                </div>
+                <h2 className="text-lg sm:text-xl md:text-2xl font-bold leading-tight gradient-gaming bg-clip-text text-transparent">
+                  {t('home.geoAlpha.title')}
+                </h2>
+                <p className="mt-1.5 text-xs sm:text-sm text-muted-foreground max-w-xl">
+                  {t('home.geoAlpha.subtitle')}
+                </p>
+                <span className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-foreground group-hover:text-neon-pink transition-colors">
+                  {t('home.geoAlpha.cta')}
+                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                </span>
+              </div>
+            </Link>
+
+            {/* Secondary leaderboard link — sibling to the primary <Link>
+                so we don't nest interactive elements. */}
+            <div className="relative px-5 sm:px-6 pb-5 sm:pb-6 -mt-2">
+              <Link
+                to={localizedPath('/geo/leaderboard')}
+                className="inline-block text-xs sm:text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:text-foreground focus-visible:underline"
+              >
+                {t('home.geoAlpha.secondary')}
+              </Link>
+            </div>
+          </div>
         </motion.div>
       </div>
     </>

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -1,19 +1,26 @@
 import { useNavigate, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { motion } from 'framer-motion'
+import { motion, type MotionProps } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { GradientIcon } from '@/components/ui/gradient-icon'
 import { Play, Trophy, Brain, History, Clock, CalendarDays, MapPin, ArrowRight } from 'lucide-react'
-import { CubeBackground } from '@/components/backgrounds/CubeBackground'
+import { lazy, Suspense, useEffect, useState, useMemo } from 'react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useSession } from '@/lib/auth-client'
 import { gameApi } from '@/lib/api/game'
-import { useEffect, useState, useMemo } from 'react'
 import { useNextDailyCountdown } from '@/hooks/useNextDailyCountdown'
 import { WelcomeModal } from '@/components/onboarding/WelcomeModal'
 import { StreakRiskBanner } from '@/components/daily-login/StreakRiskBanner'
+import { prefersReducedMotion } from '@/lib/animations'
+
+// CubeBackground pulls in Three.js + react-three-fiber, so split it into
+// its own chunk and skip rendering entirely when the visitor prefers
+// reduced motion (the chunk also never gets fetched in that case).
+const CubeBackground = lazy(() =>
+  import('@/components/backgrounds/CubeBackground').then((mod) => ({ default: mod.CubeBackground })),
+)
 
 export default function HomePage() {
   const { t } = useTranslation()
@@ -32,6 +39,13 @@ export default function HomePage() {
   } | null>(null)
   const [previewAvailable, setPreviewAvailable] = useState(false)
   const timeRemaining = useNextDailyCountdown()
+
+  // Read once; entrance animations don't need to react mid-session.
+  const reducedMotion = useMemo(() => prefersReducedMotion(), [])
+
+  // Helper: drop `initial`/`animate`/`transition` when reduced motion is
+  // preferred so motion components render statically without changing layout.
+  const motionProps = (props: MotionProps): MotionProps => (reducedMotion ? {} : props)
 
   // Memoize humorous message to prevent re-selection on countdown re-renders
   const humorousMessage = useMemo(() => {
@@ -98,23 +112,34 @@ export default function HomePage() {
 
   return (
     <>
-      <CubeBackground />
+      {reducedMotion ? (
+        // Plain dark backdrop — no Canvas, no chunk fetch.
+        <div className="fixed inset-0 z-0 bg-black" aria-hidden="true" />
+      ) : (
+        <Suspense fallback={null}>
+          <CubeBackground />
+        </Suspense>
+      )}
       <WelcomeModal />
       <div className="container mx-auto px-4 py-8 sm:py-10 md:py-12 lg:py-16 relative z-10">
         <StreakRiskBanner />
         {/* Hero Section */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
+          {...motionProps({
+            initial: { opacity: 0, y: 20 },
+            animate: { opacity: 1, y: 0 },
+            transition: { duration: 0.5 },
+          })}
           className="text-center mb-8 sm:mb-10 md:mb-12 lg:mb-16"
         >
           <motion.img
             src="/logo.svg"
             alt="The Box"
-            initial={{ scale: 0.8 }}
-            animate={{ scale: 1 }}
-            transition={{ duration: 0.5, delay: 0.2 }}
+            {...motionProps({
+              initial: { scale: 0.8 },
+              animate: { scale: 1 },
+              transition: { duration: 0.5, delay: 0.2 },
+            })}
             className="h-16 w-16 sm:h-20 sm:w-20 md:h-24 md:w-24 mb-4 sm:mb-5 md:mb-6 mx-auto"
           />
 
@@ -129,9 +154,11 @@ export default function HomePage() {
 
         {/* CTA Button */}
         <motion.div
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.5, delay: 0.4 }}
+          {...motionProps({
+            initial: { opacity: 0, scale: 0.9 },
+            animate: { opacity: 1, scale: 1 },
+            transition: { duration: 0.5, delay: 0.4 },
+          })}
           className="flex flex-col items-center gap-4 mb-8 sm:mb-10 md:mb-12 lg:mb-16"
         >
           {/* Show completion message if today's challenge is completed */}
@@ -207,9 +234,11 @@ export default function HomePage() {
             <motion.button
               type="button"
               onClick={() => navigate(localizedPath('/play'))}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2 }}
+              {...motionProps({
+                initial: { opacity: 0, y: 10 },
+                animate: { opacity: 1, y: 0 },
+                transition: { delay: 0.2 },
+              })}
               className="mt-6 block w-full max-w-xl overflow-hidden rounded-xl border border-neon-purple/30 bg-card/60 backdrop-blur-sm hover:border-neon-pink/60 transition-colors text-left"
             >
               <div className="relative aspect-video w-full overflow-hidden bg-black/40">
@@ -236,9 +265,11 @@ export default function HomePage() {
           {/* Show yesterday's challenge option if available and not played */}
           {!isLoading && yesterdayChallenge && !yesterdayChallenge.hasPlayed && (
             <motion.div
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2 }}
+              {...motionProps({
+                initial: { opacity: 0, y: 10 },
+                animate: { opacity: 1, y: 0 },
+                transition: { delay: 0.2 },
+              })}
               className="mt-4 text-center"
             >
               <p className="text-xs sm:text-sm text-muted-foreground mb-2">
@@ -262,9 +293,11 @@ export default function HomePage() {
 
         {/* Features Grid */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.5 }}
+          {...motionProps({
+            initial: { opacity: 0, y: 20 },
+            animate: { opacity: 1, y: 0 },
+            transition: { duration: 0.5, delay: 0.5 },
+          })}
           className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-5 md:gap-6 max-w-2xl mx-auto mb-8 sm:mb-10 md:mb-12 lg:mb-16"
         >
           <Card className="bg-card/50 border-border hover:border-neon-purple/50 transition-colors">
@@ -300,9 +333,11 @@ export default function HomePage() {
           link is rendered as a sibling so we never nest interactives.
         */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.6 }}
+          {...motionProps({
+            initial: { opacity: 0, y: 20 },
+            animate: { opacity: 1, y: 0 },
+            transition: { duration: 0.5, delay: 0.6 },
+          })}
           className="max-w-2xl mx-auto"
         >
           <div className="group relative overflow-hidden rounded-2xl border border-neon-purple/40 bg-linear-to-br from-neon-purple/20 via-background/60 to-neon-pink/20 backdrop-blur-sm transition-colors hover:border-neon-pink/70 focus-within:border-neon-pink/70">

--- a/packages/frontend/src/pages/ResetPasswordPage.tsx
+++ b/packages/frontend/src/pages/ResetPasswordPage.tsx
@@ -176,7 +176,7 @@ export default function ResetPasswordPage() {
             <div className="inline-flex items-center justify-center w-16 h-16 mx-auto mb-4 rounded-xl bg-linear-to-br from-neon-purple to-neon-pink shadow-lg shadow-neon-purple/30">
               <KeyRound className="w-8 h-8 text-white" />
             </div>
-            <h1 className="text-2xl font-bold bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
+            <h1 className="text-2xl font-bold gradient-gaming bg-clip-text text-transparent">
               {t('auth.resetPassword')}
             </h1>
             <p className="text-muted-foreground">

--- a/packages/frontend/src/pages/ResultsPage.tsx
+++ b/packages/frontend/src/pages/ResultsPage.tsx
@@ -109,7 +109,7 @@ export default function ResultsPage() {
             <Trophy className="w-8 h-8 sm:w-10 sm:h-10 text-white" />
           </motion.div>
 
-          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-2 sm:mb-3 bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">{t('game.tierComplete')}</h1>
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-2 sm:mb-3 gradient-gaming bg-clip-text text-transparent">{t('game.tierComplete')}</h1>
 
           <motion.div
             initial={{ opacity: 0 }}

--- a/packages/frontend/src/pages/TermsPage.tsx
+++ b/packages/frontend/src/pages/TermsPage.tsx
@@ -27,7 +27,7 @@ export default function TermsPage() {
             <div className="inline-flex items-center justify-center w-16 h-16 mx-auto mb-4 rounded-xl bg-linear-to-br from-neon-purple to-neon-pink shadow-lg shadow-neon-purple/30">
               <FileText className="w-8 h-8 text-white" />
             </div>
-            <h1 className="text-3xl font-bold bg-linear-to-r from-neon-purple to-neon-pink bg-clip-text text-transparent">
+            <h1 className="text-3xl font-bold gradient-gaming bg-clip-text text-transparent">
               {t('legal.termsTitle')}
             </h1>
             <p className="text-sm text-muted-foreground mt-2">


### PR DESCRIPTION
## Summary
Originally a single nav-link change; now a full **home page design-system pass** following a four-persona meeting (UX, design systems, perf/a11y, brand).

## What's included

### Header
- Geo nav link with neon-pink "Alpha" badge in desktop bar + mobile sheet (`MapPin` icon)

### Home page — P0 (correctness)
- **Geo Alpha card a11y rebuild** — replaced `<div role="button">` + nested `<span role="link">` with a real `<Link>`; secondary leaderboard link is now a sibling, no nested interactive elements, manual `onKeyDown` removed
- **Demoted Geo card** below the Panorama / Daily features grid so it stops competing with the primary daily-play CTA
- **`prefers-reduced-motion` respected** on every entrance `motion.*` block via the existing `prefersReducedMotion()` util
- **Contrast pass** — small neon body text (`text-neon-cyan`/`-pink`/`-purple`) on completion message, score, countdown, and preview badge replaced with `text-foreground`; neon retained for icons, gradients, decorative borders

### Home page — P1 (system extraction)
- **`.gradient-gaming` / `.gradient-gaming-title` utilities** in `index.css`; swept across 12 pages and components
- **`<GradientIcon>` primitive** for the recurring purple→pink rounded icon-tile pattern; adopted in `PageHero` and the Geo card
- **`CubeBackground` lazy-loaded** (875 KB chunk now split out); skipped entirely under reduced-motion preference (chunk never fetched)
- **French copy pass** on hero subtitle + Geo card: tightened to one punchy sentence per surface, `tu`-form to match the existing `completionMessages.low` brand voice

## Out of scope (deliberately deferred)
- Iconic motif redesign for "The Box"
- Signed-in vs signed-out home variants
- Feature-grid replacement / achievement teasers
- Light-mode neon palette

## Test plan
- [ ] CI green on push
- [ ] Visual: HomePage hero unchanged in dark mode, Geo card now below features grid
- [ ] Keyboard: Tab through Geo card hits primary CTA once + leaderboard link as separate stop
- [ ] Reduced-motion: enable in OS, reload `/` — no entrance animations, no Three.js scene
- [ ] Geo nav link in header → `/:lang/geo/daily` (desktop + mobile sheet)
- [ ] French strings render natively (`tu` form)

https://claude.ai/code/session_01DDcTigtCJCp8C1J2ABEt2g