### PR TITLE
Disable geo seed in production environments

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,10 +12,6 @@ npx @better-auth/cli migrate
 echo "Running database migrations..."
 npm run db:migrate
 
-# Seed geo mode pilot data (idempotent — no-op once rows exist)
-echo "Seeding geo mode data..."
-npm run db:seed:geo
-
 # Start the backend server
 echo "Starting backend server..."
 cd /app/packages/backend

--- a/packages/backend/seeds/010_geo_elden_ring.ts
+++ b/packages/backend/seeds/010_geo_elden_ring.ts
@@ -50,6 +50,14 @@ const SEED_POINTS = [
 ]
 
 export async function seed(knex: Knex): Promise<void> {
+  // Pilot/dev fixture only — placeholder URLs (placehold.co) must never reach
+  // production, where they'd silently become the auto-scheduled daily
+  // challenge if no real one has been planned yet.
+  if (process.env.NODE_ENV === 'production') {
+    console.log('[geo-seed] skipped: NODE_ENV=production')
+    return
+  }
+
   const now = new Date()
   const today = now.toISOString().slice(0, 10)
 


### PR DESCRIPTION
## Summary
Prevents the geo mode pilot seed data from running in production environments by adding a NODE_ENV check and removing the seed command from the Docker entrypoint.

## Key Changes
- Added production environment guard to the geo seed function that logs and returns early if `NODE_ENV=production`
- Removed the `npm run db:seed:geo` command from the Docker entrypoint script

## Implementation Details
The seed function now includes a safety check at the start that prevents execution in production. This is critical because the seed uses placeholder URLs (placehold.co) that would silently become the auto-scheduled daily challenge if no real one has been planned, which is unacceptable for production. The Docker entrypoint change ensures the seed doesn't run during container startup, relying instead on the in-code guard for additional safety.

https://claude.ai/code/session_014YM6Qsmtk2wvtKz8y1h7rw