### PR TITLE
feat(home): tribe voice, a11y/perf polish, and achievement teaser

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -242,6 +242,11 @@
       "cta": "Play Geo Daily",
       "secondary": "See the geo leaderboard"
     },
+    "achievements": {
+      "heading": "Achievements waiting to be unlocked",
+      "subheading": "Three trophies you don't have yet. Yet.",
+      "cta": "See all achievements"
+    },
     "completionMessages": {
       "perfect": [
         "Absolute perfection! You're a living legend! 🏆",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -246,27 +246,32 @@
       "perfect": [
         "Absolute perfection! You're a living legend! 🏆",
         "Perfect score! Other players tremble before your mastery! 👑",
-        "AMAZING! You've reached gaming nirvana! 🎮✨"
+        "AMAZING! You've reached gaming nirvana! 🎮✨",
+        "Welcome to the screenshot ninjas. We do this again tomorrow. 👑"
       ],
       "excellent": [
         "Impressive! You really know your stuff! 🌟",
         "Excellent score! You're on the path to glory! 🚀",
-        "Well done champion! This score deserves respect! 💪"
+        "Well done champion! This score deserves respect! 💪",
+        "You played with the screenshot ninjas today. 🔥"
       ],
       "good": [
         "Not bad at all! A very respectable score! 👍",
         "Well played! You've proven you know your classics! 🎯",
-        "Solid performance! Keep it up! ⭐"
+        "Solid performance! Keep it up! ⭐",
+        "Solid. The screenshot ninjas recognize their own. 🤝"
       ],
       "average": [
         "That was... interesting! Next time will be the one! 😅",
         "Well, you tried! It's the taking part that counts, right? 🤷",
-        "You made some... creative choices! Come back tomorrow for revenge! 🎲"
+        "You made some... creative choices! Come back tomorrow for revenge! 🎲",
+        "Not glorious, but even screenshot ninjas have off days. 🎲"
       ],
       "low": [
         "Uh... did you recognize at least one game? Tomorrow will definitely be better! 😬",
         "Looks like you played with your eyes closed! Some training is needed! 🙈",
-        "Courage! Even the pros started somewhere... very low! 💀"
+        "Courage! Even the pros started somewhere... very low! 💀",
+        "Even screenshot ninjas fall sometimes. See you tomorrow. 💀"
       ]
     }
   },

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -246,27 +246,32 @@
       "perfect": [
         "Perfection absolue ! Tu es une légende vivante ! 🏆",
         "Score parfait ! Les autres joueurs tremblent devant ta maîtrise ! 👑",
-        "INCROYABLE ! Tu as atteint le nirvana du gaming ! 🎮✨"
+        "INCROYABLE ! Tu as atteint le nirvana du gaming ! 🎮✨",
+        "Bienvenue chez les ninjas du screenshot. Demain, on remet ça. 👑"
       ],
       "excellent": [
         "Impressionnant ! Tu maîtrises vraiment ton sujet ! 🌟",
         "Excellent score ! Tu es sur la bonne voie pour la gloire ! 🚀",
-        "Bravo champion ! Ce score mérite le respect ! 💪"
+        "Bravo champion ! Ce score mérite le respect ! 💪",
+        "Tu joues dans la cour des ninjas du screenshot aujourd'hui. 🔥"
       ],
       "good": [
         "Pas mal du tout ! Un score très respectable ! 👍",
         "Bien joué ! Tu as prouvé que tu connais tes classiques ! 🎯",
-        "Solide performance ! Continue comme ça ! ⭐"
+        "Solide performance ! Continue comme ça ! ⭐",
+        "Solide. Les ninjas du screenshot reconnaissent les leurs. 🤝"
       ],
       "average": [
         "C'était... intéressant ! La prochaine fois sera la bonne ! 😅",
         "Bon, disons que tu as essayé ! L'important c'est de participer, non ? 🤷",
-        "Tu as fait des choix... créatifs ! Revenez demain pour la revanche ! 🎲"
+        "Tu as fait des choix... créatifs ! Revenez demain pour la revanche ! 🎲",
+        "Pas glorieux, mais même les ninjas du screenshot ont leurs jours sans. 🎲"
       ],
       "low": [
         "Euh... tu as au moins reconnu un jeu ? Demain sera forcément mieux ! 😬",
         "On dirait que tu as joué les yeux fermés ! Un peu d'entraînement s'impose ! 🙈",
-        "Courage ! Même les pros ont commencé quelque part... très bas ! 💀"
+        "Courage ! Même les pros ont commencé quelque part... très bas ! 💀",
+        "Même les ninjas du screenshot tombent parfois. À demain. 💀"
       ]
     }
   },

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -242,6 +242,11 @@
       "cta": "Jouer Geo Daily",
       "secondary": "Voir le classement"
     },
+    "achievements": {
+      "heading": "Des succès qui n'attendent que toi",
+      "subheading": "Trois trophées que tu n'as pas encore. Encore.",
+      "cta": "Voir tous les succès"
+    },
     "completionMessages": {
       "perfect": [
         "Perfection absolue ! Tu es une légende vivante ! 🏆",

--- a/packages/frontend/src/components/home/HomeAchievementTeaser.tsx
+++ b/packages/frontend/src/components/home/HomeAchievementTeaser.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useMemo, type ReactNode } from 'react'
+import { motion, type MotionProps } from 'framer-motion'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import { Lock, Trophy, ArrowRight } from 'lucide-react'
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from '@/components/ui/carousel'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Badge } from '@/components/ui/badge'
+import { GradientIcon } from '@/components/ui/gradient-icon'
+import { useAchievementStore } from '@/stores/achievementStore'
+import { useSession } from '@/lib/auth-client'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { prefersReducedMotion } from '@/lib/animations'
+import { cn } from '@/lib/utils'
+import type { Achievement, AchievementWithProgress } from '@the-box/types'
+
+// Shape we render in the teaser. We coerce both `Achievement` (catalog,
+// guests) and `AchievementWithProgress` (authenticated user view) to this.
+interface TeaserAchievement {
+  id: number
+  key: string
+  name: string
+  description: string
+  iconUrl: string | null
+  points: number
+  tier: number
+}
+
+const TEASER_COUNT = 3
+
+// Match AchievementGrid's `sortByDifficulty`: tier ASC, then points ASC.
+// "First N unearned" needs a deterministic order so re-renders don't shuffle.
+function pickTeaserAchievements<T extends TeaserAchievement>(list: T[]): T[] {
+  return [...list]
+    .sort((a, b) => (a.tier !== b.tier ? a.tier - b.tier : a.points - b.points))
+    .slice(0, TEASER_COUNT)
+}
+
+interface TeaserCardProps {
+  achievement: TeaserAchievement
+  lockedLabel: string
+}
+
+function TeaserCard({ achievement, lockedLabel }: TeaserCardProps) {
+  return (
+    <div className="group relative h-full overflow-hidden rounded-xl border border-neon-purple/30 bg-card/60 backdrop-blur-sm transition-colors hover:border-neon-pink/60">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -top-12 -right-12 h-32 w-32 rounded-full bg-neon-pink/20 blur-3xl opacity-50 group-hover:opacity-70 transition-opacity"
+      />
+      <div className="relative flex flex-col items-center text-center p-5 sm:p-6 gap-3">
+        <div className="relative">
+          <GradientIcon
+            icon={
+              <span className="text-2xl leading-none" aria-hidden="true">
+                {achievement.iconUrl ?? '🏆'}
+              </span>
+            }
+            className="opacity-80 grayscale-[0.4] group-hover:grayscale-0 group-hover:opacity-100 transition"
+          />
+          <span className="absolute -bottom-1.5 -right-1.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-background/90 border border-neon-purple/40 text-muted-foreground">
+            <Lock className="h-3 w-3" aria-label={lockedLabel} />
+          </span>
+        </div>
+        <h3 className="text-sm sm:text-base font-semibold leading-tight text-foreground">
+          {achievement.name}
+        </h3>
+        <p className="text-xs sm:text-sm text-muted-foreground line-clamp-3">
+          {achievement.description}
+        </p>
+        <Badge
+          variant="outline"
+          className="border-neon-purple/40 bg-neon-purple/10 text-[11px] uppercase tracking-wide text-neon-purple"
+        >
+          {achievement.points} pts
+        </Badge>
+      </div>
+    </div>
+  )
+}
+
+function TeaserSkeleton() {
+  return (
+    <div className="rounded-xl border border-white/10 bg-card/40 p-5 sm:p-6 flex flex-col items-center gap-3">
+      <Skeleton className="h-12 w-12 rounded-xl" />
+      <Skeleton className="h-4 w-3/4" variant="text" />
+      <Skeleton className="h-3 w-full" variant="text" />
+      <Skeleton className="h-3 w-5/6" variant="text" />
+      <Skeleton className="h-5 w-16" />
+    </div>
+  )
+}
+
+export function HomeAchievementTeaser() {
+  const { t } = useTranslation()
+  const { data: session } = useSession()
+  const { localizedPath } = useLocalizedPath()
+  const userId = session?.user?.id
+
+  const reducedMotion = useMemo(() => prefersReducedMotion(), [])
+  const motionProps = (props: MotionProps): MotionProps =>
+    reducedMotion ? {} : props
+
+  const {
+    achievements,
+    userAchievements,
+    isLoading,
+    isLoadingUserAchievements,
+    fetchAchievements,
+    fetchUserAchievements,
+  } = useAchievementStore()
+
+  // Authenticated → fetch progress so we can prefer locked/unearned items.
+  // Guest → fetch the public catalog and treat all as locked.
+  useEffect(() => {
+    if (userId) {
+      if (userAchievements.length === 0 && !isLoadingUserAchievements) {
+        fetchUserAchievements().catch(() => {})
+      }
+    } else if (achievements.length === 0 && !isLoading) {
+      fetchAchievements().catch(() => {})
+    }
+    // We intentionally only re-run on auth changes: the store already
+    // guards against parallel fetches and we don't want to refetch on
+    // every render of the home page.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId])
+
+  const loading = userId ? isLoadingUserAchievements : isLoading
+
+  // Stable per-render-session pick. `useMemo` keyed on the underlying
+  // arrays; since the store caches results, this is a single computation
+  // unless the user logs in/out mid-session.
+  const teaser = useMemo<TeaserAchievement[]>(() => {
+    if (userId) {
+      const unearned = userAchievements.filter(
+        (a: AchievementWithProgress) =>
+          !a.isHidden &&
+          !a.earned &&
+          !(a.progressMax != null && a.progress >= a.progressMax),
+      )
+      // If somehow the user has earned everything, fall back to the full
+      // catalog so the teaser still renders (slim chance, but harmless).
+      const pool = unearned.length >= TEASER_COUNT
+        ? unearned
+        : userAchievements.filter((a) => !a.isHidden)
+      return pickTeaserAchievements(pool).map((a) => ({
+        id: a.id,
+        key: a.key,
+        name: a.name,
+        description: a.description,
+        iconUrl: a.iconUrl,
+        points: a.points,
+        tier: a.tier,
+      }))
+    }
+    const pool = achievements.filter((a: Achievement) => !a.isHidden)
+    return pickTeaserAchievements(pool).map((a) => ({
+      id: a.id,
+      key: a.key,
+      name: a.name,
+      description: a.description,
+      iconUrl: a.iconUrl,
+      points: a.points,
+      tier: a.tier,
+    }))
+  }, [userId, userAchievements, achievements])
+
+  // Fail soft: if the API errored or returned nothing, render nothing.
+  // Loading state still shows skeletons (so the section doesn't pop in).
+  if (!loading && teaser.length === 0) {
+    return null
+  }
+
+  const lockedLabel = t('achievements.filters.locked')
+
+  // Render either skeletons or real cards through the same layout shells
+  // so mobile/desktop parity is identical between states.
+  const items: ReactNode[] = loading
+    ? Array.from({ length: TEASER_COUNT }).map((_, i) => (
+        <TeaserSkeleton key={`sk-${i}`} />
+      ))
+    : teaser.map((a) => (
+        <TeaserCard key={a.id} achievement={a} lockedLabel={lockedLabel} />
+      ))
+
+  return (
+    <motion.section
+      {...motionProps({
+        initial: { opacity: 0, y: 20 },
+        animate: { opacity: 1, y: 0 },
+        transition: { duration: 0.5, delay: 0.5 },
+      })}
+      aria-labelledby="home-achievements-heading"
+      className="max-w-4xl mx-auto mb-8 sm:mb-10 md:mb-12 lg:mb-16"
+    >
+      <div className="flex items-end justify-between gap-4 mb-4 sm:mb-6">
+        <div className="flex items-center gap-3 min-w-0">
+          <GradientIcon
+            size="sm"
+            icon={<Trophy className="h-4 w-4 text-white" />}
+            className="shrink-0"
+          />
+          <div className="min-w-0">
+            <h2
+              id="home-achievements-heading"
+              className="text-lg sm:text-xl md:text-2xl font-bold leading-tight gradient-gaming-title"
+            >
+              {t('home.achievements.heading')}
+            </h2>
+            <p className="text-xs sm:text-sm text-muted-foreground mt-0.5">
+              {t('home.achievements.subheading')}
+            </p>
+          </div>
+        </div>
+        <Link
+          to={localizedPath('/profile')}
+          className="hidden sm:inline-flex items-center gap-1.5 text-sm font-semibold text-foreground hover:text-neon-pink transition-colors shrink-0"
+        >
+          {t('home.achievements.cta')}
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      {/* Mobile: swipeable carousel, 1 card visible. */}
+      <div className="md:hidden">
+        <Carousel
+          opts={{ align: 'start', loop: false }}
+          className="w-full"
+          aria-label={t('home.achievements.heading')}
+        >
+          <CarouselContent className="-ml-3">
+            {items.map((node, i) => (
+              <CarouselItem
+                key={i}
+                className={cn('pl-3 basis-[85%]')}
+              >
+                <div className="h-full">{node}</div>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+        </Carousel>
+      </div>
+
+      {/* Desktop md+: static 3-column grid. */}
+      <div className="hidden md:grid grid-cols-3 gap-5 lg:gap-6">
+        {items.map((node, i) => (
+          <div key={i} className="h-full">
+            {node}
+          </div>
+        ))}
+      </div>
+
+      {/* Mobile-only CTA below the carousel; desktop CTA sits in the header. */}
+      <div className="mt-4 sm:hidden text-center">
+        <Link
+          to={localizedPath('/profile')}
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground hover:text-neon-pink transition-colors"
+        >
+          {t('home.achievements.cta')}
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+    </motion.section>
+  )
+}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -218,7 +218,22 @@ body {
   @apply bg-linear-to-r from-neon-purple to-neon-pink;
 }
 .gradient-gaming-title {
+  /* Fallback color for environments where the gradient/clip can't render
+     (print, forced-colors, missing custom-property support). The browser
+     uses this color whenever `text-transparent` / `-webkit-text-fill-color`
+     resolves to a paint that's unavailable. */
+  color: var(--color-foreground, white);
   @apply bg-linear-to-r from-neon-purple via-neon-pink to-neon-cyan bg-clip-text text-transparent;
+}
+
+/* Windows High Contrast / forced-colors mode: drop the gradient entirely
+   and let the OS pick a readable foreground/background pair. */
+@media (forced-colors: active) {
+  .gradient-gaming-title {
+    background: none;
+    color: CanvasText;
+    -webkit-text-fill-color: CanvasText;
+  }
 }
 
 .glow-hover {

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -2,10 +2,9 @@ import { useNavigate, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { motion, type MotionProps } from 'framer-motion'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { GradientIcon } from '@/components/ui/gradient-icon'
-import { Play, Trophy, Brain, History, Clock, CalendarDays, MapPin, ArrowRight } from 'lucide-react'
+import { Play, Trophy, History, Clock, CalendarDays, MapPin, ArrowRight } from 'lucide-react'
 import { lazy, Suspense, useEffect, useState, useMemo } from 'react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useSession } from '@/lib/auth-client'
@@ -13,6 +12,7 @@ import { gameApi } from '@/lib/api/game'
 import { useNextDailyCountdown } from '@/hooks/useNextDailyCountdown'
 import { WelcomeModal } from '@/components/onboarding/WelcomeModal'
 import { StreakRiskBanner } from '@/components/daily-login/StreakRiskBanner'
+import { HomeAchievementTeaser } from '@/components/home/HomeAchievementTeaser'
 import { prefersReducedMotion } from '@/lib/animations'
 
 // CubeBackground pulls in Three.js + react-three-fiber, so split it into
@@ -294,39 +294,12 @@ export default function HomePage() {
           )}
         </motion.div>
 
-        {/* Features Grid */}
-        <motion.div
-          {...motionProps({
-            initial: { opacity: 0, y: 20 },
-            animate: { opacity: 1, y: 0 },
-            transition: { duration: 0.5, delay: 0.5 },
-          })}
-          className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-5 md:gap-6 max-w-2xl mx-auto mb-8 sm:mb-10 md:mb-12 lg:mb-16"
-        >
-          <Card className="bg-card/50 border-border hover:border-neon-purple/50 transition-colors">
-            <CardContent className="pt-4 sm:pt-5 md:pt-6 text-center">
-              <div className="h-10 w-10 sm:h-12 sm:w-12 mx-auto mb-3 sm:mb-4 rounded-lg bg-neon-purple/20 flex items-center justify-center">
-                <Brain className="h-5 w-5 sm:h-6 sm:w-6 text-neon-purple" />
-              </div>
-              <h3 className="text-sm sm:text-base font-semibold mb-1.5 sm:mb-2">{t('home.features.panorama')}</h3>
-              <p className="text-xs sm:text-sm text-muted-foreground">
-                {t('home.features.panoramaDesc')}
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-card/50 border-border hover:border-neon-pink/50 transition-colors">
-            <CardContent className="pt-4 sm:pt-5 md:pt-6 text-center">
-              <div className="h-10 w-10 sm:h-12 sm:w-12 mx-auto mb-3 sm:mb-4 rounded-lg bg-neon-pink/20 flex items-center justify-center">
-                <Trophy className="h-5 w-5 sm:h-6 sm:w-6 text-neon-pink" />
-              </div>
-              <h3 className="text-sm sm:text-base font-semibold mb-1.5 sm:mb-2">{t('home.features.daily')}</h3>
-              <p className="text-xs sm:text-sm text-muted-foreground">
-                {t('home.features.dailyDesc')}
-              </p>
-            </CardContent>
-          </Card>
-        </motion.div>
+        {/* Achievement teaser — replaces the static "Panorama / Daily"
+            features grid with aspirational social proof: three locked
+            achievements pulled from the catalog (or the visitor's own
+            unearned set when authenticated). Fail-soft: renders nothing
+            if the API errors. */}
+        <HomeAchievementTeaser />
 
         {/*
           Geo Daily alpha teaser — sits *below* the panorama features grid

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -246,6 +246,9 @@ export default function HomePage() {
                   src="/api/game/preview/image"
                   alt={t('home.previewAlt')}
                   loading="lazy"
+                  decoding="async"
+                  width={1280}
+                  height={720}
                   className="w-full h-full object-cover transition-transform hover:scale-105"
                 />
                 <div className="absolute inset-0 bg-linear-to-t from-black/70 via-transparent" />


### PR DESCRIPTION
## Summary
Three follow-ups from the design-system meeting that the team approved:

### 1. Tribe-identity completion messages (Léo)
- One extra entry per bucket (perfect/excellent/good/average/low) in both `fr` and `en` introducing **"screenshot ninjas" / "ninjas du screenshot"** as a community moniker
- Builds belonging instead of only individual praise — same brand voice as the existing `low` bucket

### 2. Home a11y / perf residuals (Priya)
- **CLS**: explicit `width={1280}` `height={720}` + `decoding="async"` on the preview image
- **Gradient `<h1>` contrast**: fallback `color: var(--color-foreground, white)` + `@media (forced-colors: active)` rule on `.gradient-gaming-title` so Windows High Contrast and screen-readers always get readable text
- **Countdown hook hydration**: confirmed the app is SPA-only (`createRoot`, not `hydrateRoot`) — no hydration phase, no fix needed. Documented in the meeting notes.

### 3. Achievement teaser carousel (Maya)
- Replaced the static "Panorama / Daily" features grid with **3 unearned achievements** pulled from the existing API
  - **Authenticated users** see their own non-hidden, non-earned achievements (sorted by tier ASC, points ASC — same rule as `AchievementGrid`)
  - **Guests** see 3 from the public catalog rendered locked
- New slim `TeaserCard` co-located in `components/home/HomeAchievementTeaser.tsx` — does not replace `AchievementCard` anywhere else
- Dual layout: Embla carousel below `md` (swipeable), static 3-column grid at `md+`
- Fails soft: empty / error → renders nothing, home never breaks
- "See all achievements" CTA routes to `/profile` (achievements live there; no dedicated route)

## Out of scope (deferred)
- Iconic motif redesign for "The Box"
- Signed-in vs signed-out home variants
- Light-mode neon palette (light mode is not on the roadmap)
- Analytics / CTR tracking on the new teaser

## Test plan
- [ ] CI green
- [ ] Visual: home renders Geo card → Achievement teaser (3 cards) where the features grid used to be
- [ ] Reduced-motion: enable in OS, reload `/` — teaser cards appear without entrance animations
- [ ] Mobile (`<768px`): teaser is a swipeable carousel
- [ ] Guest visit: 3 locked sample achievements visible
- [ ] Authenticated visit: 3 personal unearned achievements visible
- [ ] Backend down for `/api/achievements`: page still renders (teaser quietly omitted)

https://claude.ai/code/session_01DDcTigtCJCp8C1J2ABEt2g

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDcTigtCJCp8C1J2ABEt2g)_