### PR TITLE
feat(geo): allow users to report ineligible captures

### DIFF
--- a/packages/backend/migrations/20260425_screenshot_reports.ts
+++ b/packages/backend/migrations/20260425_screenshot_reports.ts
@@ -1,0 +1,72 @@
+import type { Knex } from 'knex'
+
+// User-driven reporting of ineligible captures (screenshots).
+// A report can target either a main `screenshots` row or a `geo_screenshot_candidate`
+// row (geo-only sources like Steam imports that don't live in `screenshots`).
+// Once enough unique users report the same target, the corresponding row is
+// flagged inactive and excluded from all selection queries (geo + daily game).
+
+export async function up(knex: Knex): Promise<void> {
+  // Geo candidates need their own active flag; the main screenshots table
+  // already has `is_active` which the daily-challenge picker honors.
+  await knex.schema.alterTable('geo_screenshot_candidate', (table) => {
+    table.boolean('is_active').notNullable().defaultTo(true)
+  })
+
+  await knex.schema.createTable('screenshot_reports', (table) => {
+    table.increments('id').primary()
+    table.text('user_id').notNullable().references('id').inTable('user').onDelete('CASCADE')
+    table
+      .integer('screenshot_id')
+      .nullable()
+      .references('id')
+      .inTable('screenshots')
+      .onDelete('CASCADE')
+    table
+      .integer('geo_screenshot_candidate_id')
+      .nullable()
+      .references('id')
+      .inTable('geo_screenshot_candidate')
+      .onDelete('CASCADE')
+    table
+      .string('reason', 50)
+      .notNullable()
+      .comment('wrong_game | low_quality | not_recognizable | inappropriate | other')
+    table.text('details').nullable()
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+
+    table.index('screenshot_id')
+    table.index('geo_screenshot_candidate_id')
+  })
+
+  // Enforce "exactly one of (screenshot_id, geo_screenshot_candidate_id) is set"
+  // and prevent the same user from reporting the same target twice.
+  await knex.raw(`
+    ALTER TABLE screenshot_reports
+    ADD CONSTRAINT screenshot_reports_target_exclusive
+    CHECK (
+      (screenshot_id IS NOT NULL AND geo_screenshot_candidate_id IS NULL)
+      OR
+      (screenshot_id IS NULL AND geo_screenshot_candidate_id IS NOT NULL)
+    )
+  `)
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX screenshot_reports_unique_screenshot_user
+    ON screenshot_reports (user_id, screenshot_id)
+    WHERE screenshot_id IS NOT NULL
+  `)
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX screenshot_reports_unique_geo_candidate_user
+    ON screenshot_reports (user_id, geo_screenshot_candidate_id)
+    WHERE geo_screenshot_candidate_id IS NOT NULL
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('screenshot_reports')
+  await knex.schema.alterTable('geo_screenshot_candidate', (table) => {
+    table.dropColumn('is_active')
+  })
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo-schedule-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-schedule-logic.ts
@@ -40,8 +40,8 @@ export async function scheduleDailyGeoChallenge(
     }
   }
 
-  // Global random over all promoted metas. Kept as a single query to avoid
-  // loading every row into memory; RANDOM() is fine at pilot scale.
+  // Global random over all promoted metas whose candidate is still active
+  // (i.e. not deactivated by user reports). RANDOM() is fine at pilot scale.
   type Row = { id: number; game_id: number }
   const rows = await db<Row>('geo_screenshot_meta')
     .join(
@@ -49,6 +49,7 @@ export async function scheduleDailyGeoChallenge(
       'geo_screenshot_meta.geo_screenshot_candidate_id',
       'geo_screenshot_candidate.id',
     )
+    .where('geo_screenshot_candidate.is_active', true)
     .orderByRaw('RANDOM()')
     .limit(1)
     .select<Row[]>(

--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -16,6 +16,7 @@ export interface GeoScreenshotCandidateRow {
   external_id: string | null
   status: 'pending' | 'collecting' | 'promoted' | 'rejected'
   pin_count: number
+  is_active: boolean
   created_at: Date
 }
 
@@ -67,7 +68,7 @@ export const geoScreenshotRepository = {
 
   async findRandomUnlabeledForGame(gameId: number): Promise<GeoScreenshotCandidate | null> {
     const row = await db('geo_screenshot_candidate')
-      .where({ game_id: gameId })
+      .where({ game_id: gameId, is_active: true })
       .whereIn('status', ['pending', 'collecting'])
       .orderByRaw('RANDOM()')
       .first<GeoScreenshotCandidateRow>()
@@ -169,6 +170,7 @@ export const geoScreenshotRepository = {
         'geo_screenshot_candidate.id',
       )
       .where('geo_screenshot_candidate.game_id', gameId)
+      .where('geo_screenshot_candidate.is_active', true)
       .count<{ count: string }[]>('geo_screenshot_meta.id as count')
       .first()
     return Number(result?.count ?? 0)
@@ -182,6 +184,7 @@ export const geoScreenshotRepository = {
         'geo_screenshot_candidate.id',
       )
       .where('geo_screenshot_candidate.game_id', gameId)
+      .where('geo_screenshot_candidate.is_active', true)
       .orderByRaw('RANDOM()')
       .select<GeoScreenshotMetaRow>('geo_screenshot_meta.*')
       .first()

--- a/packages/backend/src/infrastructure/repositories/index.ts
+++ b/packages/backend/src/infrastructure/repositories/index.ts
@@ -14,3 +14,7 @@ export { geoScreenshotRepository } from './geo-screenshot.repository.js'
 export { geoChallengeRepository } from './geo-challenge.repository.js'
 export { geoPinRepository } from './geo-pin.repository.js'
 export { geoContributorRepository } from './geo-contributor.repository.js'
+export {
+  screenshotReportRepository,
+  REPORT_DEACTIVATION_THRESHOLD,
+} from './screenshot-report.repository.js'

--- a/packages/backend/src/infrastructure/repositories/screenshot-report.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/screenshot-report.repository.ts
@@ -1,0 +1,155 @@
+import type { Knex } from 'knex'
+import { db } from '../database/connection.js'
+import { repoLogger } from '../logger/logger.js'
+import type { ScreenshotReportReason } from '@the-box/types'
+
+const log = repoLogger.child({ repository: 'screenshot-report' })
+
+export interface ScreenshotReportRow {
+  id: number
+  user_id: string
+  screenshot_id: number | null
+  geo_screenshot_candidate_id: number | null
+  reason: ScreenshotReportReason
+  details: string | null
+  created_at: Date
+}
+
+export interface SubmitReportArgs {
+  userId: string
+  reason: ScreenshotReportReason
+  details?: string
+  screenshotId?: number
+  geoScreenshotCandidateId?: number
+}
+
+export interface SubmitReportOutcome {
+  inserted: boolean
+  reportCount: number
+  deactivated: boolean
+}
+
+// Three independent users flagging the same capture is enough signal to pull
+// it out of rotation; admins can re-enable later if it was a false positive.
+export const REPORT_DEACTIVATION_THRESHOLD = 3
+
+export const screenshotReportRepository = {
+  async submit(args: SubmitReportArgs): Promise<SubmitReportOutcome> {
+    if (
+      (args.screenshotId == null && args.geoScreenshotCandidateId == null) ||
+      (args.screenshotId != null && args.geoScreenshotCandidateId != null)
+    ) {
+      throw new Error('exactly one of screenshotId or geoScreenshotCandidateId is required')
+    }
+
+    return await db.transaction(async (trx: Knex.Transaction) => {
+      // Insert with ON CONFLICT DO NOTHING via the partial unique indexes from
+      // the migration. We can't use knex's onConflict() builder because the
+      // unique index is partial; raw insert + catch dup-key would also work
+      // but the count query gives us idempotent semantics either way.
+      const inserted = await trx('screenshot_reports')
+        .insert({
+          user_id: args.userId,
+          screenshot_id: args.screenshotId ?? null,
+          geo_screenshot_candidate_id: args.geoScreenshotCandidateId ?? null,
+          reason: args.reason,
+          details: args.details ?? null,
+        })
+        .onConflict()
+        .ignore()
+        .returning<{ id: number }[]>('id')
+
+      const didInsert = inserted.length > 0
+
+      const target = args.screenshotId
+        ? { column: 'screenshot_id', value: args.screenshotId }
+        : { column: 'geo_screenshot_candidate_id', value: args.geoScreenshotCandidateId! }
+
+      const countRow = await trx('screenshot_reports')
+        .where(target.column, target.value)
+        .count<{ count: string }[]>('id as count')
+        .first()
+      const reportCount = Number(countRow?.count ?? 0)
+
+      let deactivated = false
+      if (reportCount >= REPORT_DEACTIVATION_THRESHOLD) {
+        deactivated = await deactivateTarget(trx, args)
+      }
+
+      if (didInsert) {
+        log.info(
+          {
+            userId: args.userId,
+            screenshotId: args.screenshotId,
+            geoScreenshotCandidateId: args.geoScreenshotCandidateId,
+            reason: args.reason,
+            reportCount,
+            deactivated,
+          },
+          'screenshot report recorded',
+        )
+      }
+
+      return { inserted: didInsert, reportCount, deactivated }
+    })
+  },
+
+  async countForScreenshot(screenshotId: number): Promise<number> {
+    const row = await db('screenshot_reports')
+      .where({ screenshot_id: screenshotId })
+      .count<{ count: string }[]>('id as count')
+      .first()
+    return Number(row?.count ?? 0)
+  },
+
+  async countForGeoCandidate(candidateId: number): Promise<number> {
+    const row = await db('screenshot_reports')
+      .where({ geo_screenshot_candidate_id: candidateId })
+      .count<{ count: string }[]>('id as count')
+      .first()
+    return Number(row?.count ?? 0)
+  },
+}
+
+// Deactivate both the geo candidate (if applicable) and any linked main
+// screenshot row, so the capture is filtered out of every selection path.
+// Returns whether any row was actually flipped from active → inactive on
+// this call (idempotent for re-runs past the threshold).
+async function deactivateTarget(
+  trx: Knex.Transaction,
+  args: SubmitReportArgs,
+): Promise<boolean> {
+  let flipped = false
+
+  if (args.screenshotId != null) {
+    const updated = await trx('screenshots')
+      .where({ id: args.screenshotId, is_active: true })
+      .update({ is_active: false })
+    if (updated > 0) flipped = true
+  }
+
+  if (args.geoScreenshotCandidateId != null) {
+    const candidate = await trx('geo_screenshot_candidate')
+      .where({ id: args.geoScreenshotCandidateId })
+      .first<{ id: number; screenshot_id: number | null; is_active: boolean }>()
+
+    if (candidate) {
+      if (candidate.is_active) {
+        await trx('geo_screenshot_candidate')
+          .where({ id: candidate.id })
+          .update({ is_active: false })
+        flipped = true
+      }
+      // Cascade: if this candidate references a main screenshot, take that
+      // out of rotation too so the daily-game picker honors the report.
+      if (candidate.screenshot_id != null) {
+        const updated = await trx('screenshots')
+          .where({ id: candidate.screenshot_id, is_active: true })
+          .update({ is_active: false })
+        if (updated > 0) flipped = true
+      }
+    }
+  }
+
+  return flipped
+}

--- a/packages/backend/src/infrastructure/repositories/screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/screenshot.repository.ts
@@ -120,6 +120,7 @@ export const screenshotRepository = {
 
     // Build query with optional metacritic filter
     let query = db('screenshots')
+      .where('screenshots.is_active', true)
       .whereNotIn('screenshots.id', usedIds.length > 0 ? usedIds : [0])
 
     // If minMetacritic is provided, join with games table and filter

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -13,12 +13,22 @@ import {
   geoChallengeRepository,
   geoMapRepository,
   sessionRepository,
+  screenshotReportRepository,
 } from '../../infrastructure/repositories/index.js'
+import type { ScreenshotReportReason } from '@the-box/types'
 import { authMiddleware, optionalAuthMiddleware } from '../middleware/auth.middleware.js'
 import { validateBody, validateParams, validateQuery } from '../middleware/validation.middleware.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
 import { geoQueue } from '../../infrastructure/queue/queues.js'
 import { emitGeoLeaderboardUpdate } from '../../infrastructure/socket/socket.js'
+
+const SCREENSHOT_REPORT_REASONS = [
+  'wrong_game',
+  'low_quality',
+  'not_recognizable',
+  'inappropriate',
+  'other',
+] as const satisfies readonly ScreenshotReportReason[]
 
 const log = routeLogger.child({ route: 'geo' })
 
@@ -57,6 +67,18 @@ const contributePickBodySchema = z.object({
 const historyQuerySchema = z.object({
   days: z.coerce.number().int().positive().max(30).optional(),
 })
+
+const reportBodySchema = z
+  .object({
+    geoScreenshotCandidateId: z.number().int().positive().optional(),
+    screenshotId: z.number().int().positive().optional(),
+    reason: z.enum(SCREENSHOT_REPORT_REASONS),
+    details: z.string().trim().max(500).optional(),
+  })
+  .refine(
+    (v) => Boolean(v.geoScreenshotCandidateId) !== Boolean(v.screenshotId),
+    'exactly one of geoScreenshotCandidateId or screenshotId is required',
+  )
 
 // ---------- Daily challenge ----------
 
@@ -230,6 +252,54 @@ router.post(
     }
   },
 )
+
+// ---------- Report capture as ineligible ----------
+
+// User-facing eligibility flag. Once N distinct users hit this endpoint for
+// the same target the repository auto-deactivates it so it stops appearing in
+// any game mode (geo + daily). Idempotent per (user, target) thanks to the
+// partial unique indexes on screenshot_reports.
+router.post('/report', authMiddleware, validateBody(reportBodySchema), async (req, res, next) => {
+  try {
+    const userId = req.userId!
+    const body = req.body as z.infer<typeof reportBodySchema>
+
+    // Validate that the target actually exists; otherwise we'd be inserting
+    // orphaned rows (or, worse, creating phantom thresholds that admins can't
+    // un-do without exploring the table by hand).
+    if (body.geoScreenshotCandidateId != null) {
+      const candidate = await geoScreenshotRepository.findCandidateById(
+        body.geoScreenshotCandidateId,
+      )
+      if (!candidate) {
+        res.status(404).json({
+          success: false,
+          error: { code: 'CANDIDATE_NOT_FOUND', message: 'capture not found' },
+        })
+        return
+      }
+    }
+
+    const outcome = await screenshotReportRepository.submit({
+      userId,
+      reason: body.reason,
+      details: body.details,
+      screenshotId: body.screenshotId,
+      geoScreenshotCandidateId: body.geoScreenshotCandidateId,
+    })
+
+    res.json({
+      success: true,
+      data: {
+        received: true,
+        deactivated: outcome.deactivated,
+        reportCount: outcome.reportCount,
+      },
+    })
+  } catch (err) {
+    next(err)
+  }
+})
 
 // ---------- Contributor stats ----------
 

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -921,6 +921,27 @@
       "screenshotUnavailable": "Screenshot preview unavailable.",
       "errors": {
         "noChallenge": "No geo challenge is available for today yet. Please check back later."
+      },
+      "report": {
+        "trigger": "Report capture",
+        "title": "Report this capture",
+        "description": "Flag this screenshot if it shouldn't appear in any game. We'll remove it once enough players agree.",
+        "reasonLabel": "Reason",
+        "detailsLabel": "Details (optional)",
+        "detailsPlaceholder": "Anything else we should know?",
+        "submit": "Submit report",
+        "submitting": "Sending…",
+        "successReceived": "Thanks — your report was recorded.",
+        "successDeactivated": "Thanks — this capture has been removed from rotation.",
+        "loginRequired": "You must be signed in to report a capture.",
+        "errorGeneric": "Couldn't send the report. Please try again.",
+        "reasons": {
+          "wrong_game": "Wrong game",
+          "low_quality": "Low-quality image",
+          "not_recognizable": "Not recognizable / no usable landmark",
+          "inappropriate": "Inappropriate content",
+          "other": "Other"
+        }
       }
     },
     "contribute": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -947,6 +947,27 @@
       "screenshotUnavailable": "Aperçu de la capture indisponible.",
       "errors": {
         "noChallenge": "Aucun défi géo n'est encore disponible pour aujourd'hui. Revenez plus tard."
+      },
+      "report": {
+        "trigger": "Signaler la capture",
+        "title": "Signaler cette capture",
+        "description": "Signalez cette capture si elle ne devrait apparaître dans aucun jeu. Elle sera retirée dès que suffisamment de joueurs seront d'accord.",
+        "reasonLabel": "Raison",
+        "detailsLabel": "Précisions (optionnel)",
+        "detailsPlaceholder": "Quelque chose à ajouter ?",
+        "submit": "Envoyer le signalement",
+        "submitting": "Envoi…",
+        "successReceived": "Merci — votre signalement a été enregistré.",
+        "successDeactivated": "Merci — cette capture a été retirée du jeu.",
+        "loginRequired": "Vous devez être connecté pour signaler une capture.",
+        "errorGeneric": "Impossible d'envoyer le signalement. Réessayez plus tard.",
+        "reasons": {
+          "wrong_game": "Mauvais jeu",
+          "low_quality": "Image de mauvaise qualité",
+          "not_recognizable": "Non reconnaissable / aucun repère utile",
+          "inappropriate": "Contenu inapproprié",
+          "other": "Autre"
+        }
       }
     },
     "contribute": {

--- a/packages/frontend/src/components/geo/ReportCaptureDialog.tsx
+++ b/packages/frontend/src/components/geo/ReportCaptureDialog.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Flag, Loader2 } from 'lucide-react'
+import type { ScreenshotReportReason } from '@the-box/types'
+
+const REPORT_REASONS = [
+    'wrong_game',
+    'low_quality',
+    'not_recognizable',
+    'inappropriate',
+    'other',
+] as const satisfies readonly ScreenshotReportReason[]
+import { geoApi, GeoApiError } from '@/lib/api/geo'
+import { toast } from '@/lib/toast'
+import { Button } from '@/components/ui/button'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+
+interface ReportCaptureDialogProps {
+    geoScreenshotCandidateId: number
+    isAuthenticated: boolean
+}
+
+export function ReportCaptureDialog({
+    geoScreenshotCandidateId,
+    isAuthenticated,
+}: ReportCaptureDialogProps) {
+    const { t } = useTranslation()
+    const [open, setOpen] = useState(false)
+    const [submitting, setSubmitting] = useState(false)
+    const [submitted, setSubmitted] = useState(false)
+    const [reason, setReason] = useState<ScreenshotReportReason>('wrong_game')
+    const [details, setDetails] = useState('')
+
+    const handleOpenChange = (next: boolean) => {
+        if (!next) {
+            // Reset on close so re-opening starts fresh.
+            setReason('wrong_game')
+            setDetails('')
+            setSubmitted(false)
+        }
+        setOpen(next)
+    }
+
+    const handleSubmit = async () => {
+        if (!isAuthenticated) {
+            toast.error(t('geo.daily.report.loginRequired'))
+            return
+        }
+        setSubmitting(true)
+        try {
+            const result = await geoApi.reportCapture({
+                geoScreenshotCandidateId,
+                reason,
+                details: details.trim() ? details.trim() : undefined,
+            })
+            toast.success(
+                result.deactivated
+                    ? t('geo.daily.report.successDeactivated')
+                    : t('geo.daily.report.successReceived'),
+            )
+            setSubmitted(true)
+            setOpen(false)
+        } catch (err) {
+            const message =
+                err instanceof GeoApiError
+                    ? err.message
+                    : t('geo.daily.report.errorGeneric')
+            toast.error(message)
+        } finally {
+            setSubmitting(false)
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={submitted}
+                    className="text-xs text-muted-foreground hover:text-destructive"
+                >
+                    <Flag className="h-3.5 w-3.5 mr-1.5" />
+                    {t('geo.daily.report.trigger')}
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>{t('geo.daily.report.title')}</DialogTitle>
+                    <DialogDescription>
+                        {t('geo.daily.report.description')}
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4 py-2">
+                    <div className="space-y-2">
+                        <Label htmlFor="report-reason">
+                            {t('geo.daily.report.reasonLabel')}
+                        </Label>
+                        <Select
+                            value={reason}
+                            onValueChange={(v) =>
+                                setReason(v as ScreenshotReportReason)
+                            }
+                        >
+                            <SelectTrigger id="report-reason">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {REPORT_REASONS.map((r) => (
+                                    <SelectItem key={r} value={r}>
+                                        {t(`geo.daily.report.reasons.${r}`)}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="report-details">
+                            {t('geo.daily.report.detailsLabel')}
+                        </Label>
+                        <textarea
+                            id="report-details"
+                            value={details}
+                            onChange={(e) => setDetails(e.target.value)}
+                            maxLength={500}
+                            rows={3}
+                            placeholder={t('geo.daily.report.detailsPlaceholder')}
+                            className="flex w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 resize-none"
+                        />
+                    </div>
+                </div>
+                <DialogFooter>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => handleOpenChange(false)}
+                        disabled={submitting}
+                    >
+                        {t('common.cancel')}
+                    </Button>
+                    <Button
+                        type="button"
+                        onClick={handleSubmit}
+                        disabled={submitting || !isAuthenticated}
+                        className="gradient-gaming hover:opacity-90"
+                    >
+                        {submitting && (
+                            <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                        )}
+                        {submitting
+                            ? t('geo.daily.report.submitting')
+                            : t('geo.daily.report.submit')}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -9,6 +9,8 @@ import type {
     GeoPoint,
     GeoScreenshotCandidate,
     GeoScreenshotMeta,
+    ScreenshotReportInput,
+    ScreenshotReportResult,
 } from '@the-box/types'
 
 export class GeoApiError extends Error {
@@ -121,5 +123,12 @@ export const geoApi = {
 
     getContributorMe(): Promise<GeoContributorMe> {
         return request<GeoContributorMe>('/api/geo/contributor/me')
+    },
+
+    reportCapture(input: ScreenshotReportInput): Promise<ScreenshotReportResult> {
+        return request<ScreenshotReportResult>('/api/geo/report', {
+            method: 'POST',
+            body: JSON.stringify(input),
+        })
     },
 }

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -4,6 +4,7 @@ import { useSession } from '@/lib/auth-client'
 import { useGeoStore } from '@/stores/geoStore'
 import { connectGeoSocket } from '@/lib/geo-socket'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
+import { ReportCaptureDialog } from '@/components/geo/ReportCaptureDialog'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Loader2, MapPin, Trophy } from 'lucide-react'
@@ -87,10 +88,14 @@ export default function GeoDailyPage() {
             {challenge && meta && candidate && map && (phase === 'playing' || phase === 'submitting' || phase === 'result') && (
                 <div className="grid gap-6 lg:grid-cols-2">
                     <Card>
-                        <CardHeader className="pb-2">
+                        <CardHeader className="pb-2 flex-row items-center justify-between space-y-0">
                             <CardTitle className="text-base">
                                 {t('geo.daily.screenshot', 'Screenshot')}
                             </CardTitle>
+                            <ReportCaptureDialog
+                                geoScreenshotCandidateId={candidate.id}
+                                isAuthenticated={!!session?.user?.id}
+                            />
                         </CardHeader>
                         <CardContent>
                             <ScreenshotFrame imageUrl={candidate.imageUrl} />

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -805,3 +805,33 @@ export interface GeoTierUpEvent {
   previousTier: GeoContributorTier
   newTier: GeoContributorTier
 }
+
+// Capture eligibility reporting. A user can flag a screenshot they believe
+// shouldn't be playable (wrong game, unreadable, inappropriate, etc.). After
+// enough distinct users report the same target it is auto-deactivated for
+// all game modes. The reason union is kept here as a pure type so both
+// frontend and backend agree on the wire shape; each side declares its own
+// runtime list of values (this package emits CJS and is consumed as
+// types-only).
+export type ScreenshotReportReason =
+  | 'wrong_game'
+  | 'low_quality'
+  | 'not_recognizable'
+  | 'inappropriate'
+  | 'other'
+
+export interface ScreenshotReportInput {
+  reason: ScreenshotReportReason
+  details?: string
+  // Exactly one target must be provided.
+  screenshotId?: number
+  geoScreenshotCandidateId?: number
+}
+
+export interface ScreenshotReportResult {
+  received: boolean
+  // True iff this report tipped the target past the threshold and the
+  // capture is now disabled.
+  deactivated: boolean
+  reportCount: number
+}


### PR DESCRIPTION
Adds a "Report capture" affordance on the Geo Daily challenge so players
can flag screenshots that shouldn't be playable (wrong game, unreadable,
inappropriate, etc.). Reports are stored in a new `screenshot_reports`
audit table; once three distinct users report the same capture it is
auto-deactivated and excluded from every game mode.

- Migration: `screenshot_reports` table (one row per user/target) plus a
  new `is_active` flag on `geo_screenshot_candidate` mirroring
  `screenshots.is_active`.
- Selection queries (geo schedule worker, geo daily picker, main daily
  picker) now filter on `is_active = true`, so deactivated captures stop
  appearing in both geo and the main daily challenge — including the
  cascade onto the linked main `screenshots` row when a geo-only
  candidate is taken down.
- New `POST /api/geo/report` endpoint (auth required, idempotent per
  user/target via partial unique indexes).
- Frontend: `ReportCaptureDialog` (reason dropdown + optional details)
  wired into `GeoDailyPage`, with EN/FR copy.