### PR TITLE
fix(i18n): translate aria-labels, locale-aware formatting, api error mapping

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -35,8 +35,12 @@
     "all": "All",
     "activeFilters": "Active filters",
     "clearAll": "Clear all",
-    "all": "All",
-    "earned": "Earned"
+    "earned": "Earned",
+    "rankBadge": {
+      "first": "1st place",
+      "second": "2nd place",
+      "third": "3rd place"
+    }
   },
   "achievements": {
     "filters": {
@@ -70,6 +74,23 @@
     "unlockedWithName": "Achievement Unlocked: {{name}}"
   },
   "game": {
+    "progressDots": {
+      "label": "Screenshot progress",
+      "item": "Screenshot {{position}}: {{status}}",
+      "itemCurrent": "Screenshot {{position}} (current): {{status}}",
+      "status": {
+        "correct": "correct",
+        "skipped": "skipped",
+        "in_progress": "in progress",
+        "not_visited": "not visited"
+      },
+      "summary": {
+        "found_one": "{{count}} found",
+        "found_other": "{{count}} found",
+        "skipped_one": "{{count}} skipped",
+        "skipped_other": "{{count}} skipped"
+      }
+    },
     "dailyChallenge": "Daily Challenge",
     "startChallenge": "Start Challenge",
     "challengeComplete": "Challenge Complete!",
@@ -513,10 +534,44 @@
         "failed": "Failed",
         "delayed": "Delayed"
       },
+      "relativeTime": {
+        "secondsAgo_one": "{{count}}s ago",
+        "secondsAgo_other": "{{count}}s ago",
+        "minutesAgo_one": "{{count}}m ago",
+        "minutesAgo_other": "{{count}}m ago",
+        "hoursAgo_one": "{{count}}h ago",
+        "hoursAgo_other": "{{count}}h ago"
+      },
       "syncConflict": {
         "title": "Sync Job Already Running",
         "description": "A sync-all job is already in progress or paused. Would you like to cancel it and start a new one?",
         "cancelAndRestart": "Cancel & Restart"
+      }
+    },
+    "fullImport": {
+      "title": "Full RAWG Import",
+      "description": "Import all games with Metacritic score >= threshold (batch processing with pause/resume)",
+      "startImport": "Start full import",
+      "pause": "Pause",
+      "resume": "Resume",
+      "progress": "Progress",
+      "totalAvailable": "Available games",
+      "processed": "Processed",
+      "imported": "Imported",
+      "skipped": "Skipped",
+      "screenshots": "Screenshots",
+      "batch": "Batch",
+      "batchSize": "Batch size",
+      "estimatedTime": "Estimated time",
+      "completedMessage": "Import completed successfully!",
+      "gamesImported": "games imported",
+      "gamesSkippedSuffix": "skipped",
+      "status": {
+        "pending": "Pending",
+        "inProgress": "In progress",
+        "paused": "Paused",
+        "completed": "Completed",
+        "failed": "Failed"
       }
     },
     "games": {
@@ -939,7 +994,9 @@
       "title": "Geo Leaderboard",
       "subtitle": "Ranked independently from the main game.",
       "daily": "Daily",
-      "monthly": "Monthly"
+      "monthly": "Monthly",
+      "topPlayers": "Top players",
+      "noEntries": "No entries yet — be the first."
     },
     "profile": {
       "title": "Geo Crowdsourcer",
@@ -954,5 +1011,34 @@
       "unlockLabel": "Contribute unlocks after",
       "unlockDays": "days played"
     }
+  },
+  "apiErrors": {
+    "default": "Something went wrong. Please try again.",
+    "NETWORK_ERROR": "Network error. Please check your connection.",
+    "VALIDATION_ERROR": "The information you entered is invalid.",
+    "UNAUTHORIZED": "Please sign in to continue.",
+    "FORBIDDEN": "You don't have permission to do that.",
+    "NOT_FOUND": "Resource not found.",
+    "INTERNAL_ERROR": "Server error. Please try again later.",
+    "NO_CHALLENGE": "No challenge is available today.",
+    "INVALID_ID": "Invalid identifier.",
+    "MISSING_PARAMS": "Some required information is missing.",
+    "INVALID_SESSION_ID": "Invalid session.",
+    "SESSION_NOT_FOUND": "Session not found or not completed.",
+    "SESSION_ALREADY_COMPLETED": "You have already completed this challenge.",
+    "CHALLENGE_ALREADY_COMPLETED": "You have already completed this challenge.",
+    "INVALID_SCORE": "Score must be a valid number.",
+    "INVALID_YEAR": "Invalid year. Must be between 2020 and 2100.",
+    "INVALID_MONTH": "Invalid month. Must be between 1 and 12.",
+    "FUTURE_MONTH": "Cannot view leaderboard for future months.",
+    "INVALID_DATE": "Invalid date format. Use YYYY-MM-DD.",
+    "INVALID_USERNAME": "Invalid username.",
+    "USER_NOT_FOUND": "User not found.",
+    "NO_FILE": "No file uploaded.",
+    "INVALID_CONSENT": "Consent must be a boolean.",
+    "REFERRAL_ALREADY_CLAIMED": "Referral has already been claimed.",
+    "CHALLENGE_NOT_FOUND": "Challenge not found.",
+    "SCREENSHOT_NOT_FOUND": "Screenshot not found.",
+    "CONTRIBUTE_RATE_LIMIT": "Hourly pin limit reached — come back later."
   }
 }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -32,11 +32,15 @@
     "unknown": "Inconnu",
     "backTo": "Retour à",
     "filters": "Filtres",
-    "all": "Tout",
+    "all": "Tous",
     "activeFilters": "Filtres actifs",
     "clearAll": "Tout effacer",
-    "all": "Tous",
-    "earned": "Obtenu"
+    "earned": "Obtenu",
+    "rankBadge": {
+      "first": "1re place",
+      "second": "2e place",
+      "third": "3e place"
+    }
   },
   "achievements": {
     "filters": {
@@ -70,6 +74,23 @@
     "unlockedWithName": "Succès Débloqué : {{name}}"
   },
   "game": {
+    "progressDots": {
+      "label": "Progression des captures",
+      "item": "Capture {{position}} : {{status}}",
+      "itemCurrent": "Capture {{position}} (actuelle) : {{status}}",
+      "status": {
+        "correct": "trouvée",
+        "skipped": "passée",
+        "in_progress": "en cours",
+        "not_visited": "non visitée"
+      },
+      "summary": {
+        "found_one": "{{count}} trouvée",
+        "found_other": "{{count}} trouvées",
+        "skipped_one": "{{count}} passée",
+        "skipped_other": "{{count}} passées"
+      }
+    },
     "dailyChallenge": "Défi Quotidien",
     "startChallenge": "Commencer le Défi",
     "challengeComplete": "Défi Terminé !",
@@ -512,6 +533,14 @@
         "completed": "Terminé",
         "failed": "Échoué",
         "delayed": "Retardé"
+      },
+      "relativeTime": {
+        "secondsAgo_one": "il y a {{count}}s",
+        "secondsAgo_other": "il y a {{count}}s",
+        "minutesAgo_one": "il y a {{count}}min",
+        "minutesAgo_other": "il y a {{count}}min",
+        "hoursAgo_one": "il y a {{count}}h",
+        "hoursAgo_other": "il y a {{count}}h"
       },
       "syncConflict": {
         "title": "Synchronisation déjà en cours",
@@ -965,7 +994,9 @@
       "title": "Classement Géo",
       "subtitle": "Classé indépendamment du jeu principal.",
       "daily": "Journalier",
-      "monthly": "Mensuel"
+      "monthly": "Mensuel",
+      "topPlayers": "Meilleurs joueurs",
+      "noEntries": "Aucune entrée pour l'instant — soyez le premier."
     },
     "profile": {
       "title": "Contributeur Géo",
@@ -980,5 +1011,34 @@
       "unlockLabel": "Contribution débloquée après",
       "unlockDays": "jours joués"
     }
+  },
+  "apiErrors": {
+    "default": "Une erreur est survenue. Veuillez réessayer.",
+    "NETWORK_ERROR": "Erreur réseau. Vérifiez votre connexion.",
+    "VALIDATION_ERROR": "Les informations saisies sont invalides.",
+    "UNAUTHORIZED": "Veuillez vous connecter pour continuer.",
+    "FORBIDDEN": "Vous n'avez pas la permission d'effectuer cette action.",
+    "NOT_FOUND": "Ressource introuvable.",
+    "INTERNAL_ERROR": "Erreur serveur. Veuillez réessayer plus tard.",
+    "NO_CHALLENGE": "Aucun défi n'est disponible aujourd'hui.",
+    "INVALID_ID": "Identifiant invalide.",
+    "MISSING_PARAMS": "Des informations requises sont manquantes.",
+    "INVALID_SESSION_ID": "Session invalide.",
+    "SESSION_NOT_FOUND": "Session introuvable ou non terminée.",
+    "SESSION_ALREADY_COMPLETED": "Vous avez déjà terminé ce défi.",
+    "CHALLENGE_ALREADY_COMPLETED": "Vous avez déjà terminé ce défi.",
+    "INVALID_SCORE": "Le score doit être un nombre valide.",
+    "INVALID_YEAR": "Année invalide. Doit être comprise entre 2020 et 2100.",
+    "INVALID_MONTH": "Mois invalide. Doit être compris entre 1 et 12.",
+    "FUTURE_MONTH": "Impossible d'afficher le classement pour des mois futurs.",
+    "INVALID_DATE": "Format de date invalide. Utilisez AAAA-MM-JJ.",
+    "INVALID_USERNAME": "Nom d'utilisateur invalide.",
+    "USER_NOT_FOUND": "Utilisateur introuvable.",
+    "NO_FILE": "Aucun fichier téléversé.",
+    "INVALID_CONSENT": "Le consentement doit être un booléen.",
+    "REFERRAL_ALREADY_CLAIMED": "Le parrainage a déjà été utilisé.",
+    "CHALLENGE_NOT_FOUND": "Défi introuvable.",
+    "SCREENSHOT_NOT_FOUND": "Capture introuvable.",
+    "CONTRIBUTE_RATE_LIMIT": "Limite horaire d'épingles atteinte — revenez plus tard."
   }
 }

--- a/packages/frontend/src/components/admin/FullImportCard.tsx
+++ b/packages/frontend/src/components/admin/FullImportCard.tsx
@@ -10,7 +10,7 @@ import { useAdminStore } from '@/stores/adminStore'
 import { Database, Play, Pause, Loader2, RefreshCw } from 'lucide-react'
 
 export function FullImportCard() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const {
     currentImport,
     fullImportLoading,
@@ -142,23 +142,23 @@ export function FullImportCard() {
             <div className="grid grid-cols-2 gap-3 text-sm">
               <div className="flex justify-between">
                 <span className="text-muted-foreground">{t('admin.fullImport.totalAvailable')}:</span>
-                <span>{currentImport.totalGamesAvailable?.toLocaleString() || '...'}</span>
+                <span>{currentImport.totalGamesAvailable?.toLocaleString(i18n.language) || '...'}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-muted-foreground">{t('admin.fullImport.processed')}:</span>
-                <span>{currentImport.gamesProcessed.toLocaleString()}</span>
+                <span>{currentImport.gamesProcessed.toLocaleString(i18n.language)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-muted-foreground">{t('admin.fullImport.imported')}:</span>
-                <span className="text-success">{currentImport.gamesImported.toLocaleString()}</span>
+                <span className="text-success">{currentImport.gamesImported.toLocaleString(i18n.language)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-muted-foreground">{t('admin.fullImport.skipped')}:</span>
-                <span className="text-warning">{currentImport.gamesSkipped.toLocaleString()}</span>
+                <span className="text-warning">{currentImport.gamesSkipped.toLocaleString(i18n.language)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-muted-foreground">{t('admin.fullImport.screenshots')}:</span>
-                <span>{currentImport.screenshotsDownloaded.toLocaleString()}</span>
+                <span>{currentImport.screenshotsDownloaded.toLocaleString(i18n.language)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-muted-foreground">{t('admin.fullImport.batch')}:</span>

--- a/packages/frontend/src/components/admin/JobQueuePanel.tsx
+++ b/packages/frontend/src/components/admin/JobQueuePanel.tsx
@@ -34,7 +34,11 @@ const progressVariants: Record<JobStatus, 'default' | 'success' | 'warning' | 'e
     delayed: 'warning',
 }
 
-function formatDate(dateString: string): string {
+function formatDate(
+    dateString: string,
+    t: ReturnType<typeof useTranslation>['t'],
+    language: string,
+): string {
     const date = new Date(dateString)
     const now = new Date()
     const diff = now.getTime() - date.getTime()
@@ -42,15 +46,15 @@ function formatDate(dateString: string): string {
     const minutes = Math.floor(seconds / 60)
     const hours = Math.floor(minutes / 60)
 
-    if (seconds < 60) return `${seconds}s ago`
-    if (minutes < 60) return `${minutes}m ago`
-    if (hours < 24) return `${hours}h ago`
-    return date.toLocaleDateString()
+    if (seconds < 60) return t('admin.jobs.relativeTime.secondsAgo', { count: seconds })
+    if (minutes < 60) return t('admin.jobs.relativeTime.minutesAgo', { count: minutes })
+    if (hours < 24) return t('admin.jobs.relativeTime.hoursAgo', { count: hours })
+    return date.toLocaleDateString(language)
 }
 
-function formatNextRunDate(dateString: string): string {
+function formatNextRunDate(dateString: string, language: string): string {
     const date = new Date(dateString)
-    return date.toLocaleDateString('fr-FR', {
+    return date.toLocaleDateString(language, {
         day: '2-digit',
         month: '2-digit',
         year: 'numeric',
@@ -81,7 +85,7 @@ interface JobQueuePanelProps {
 }
 
 export function JobQueuePanel({ onMinimizedChange }: JobQueuePanelProps = {}) {
-    const { t } = useTranslation()
+    const { t, i18n } = useTranslation()
     const { jobs, isLoading, fetchJobs, clearCompleted, cancelJob, connectSocket, disconnectSocket } = useAdminStore()
     const [filterTab, setFilterTab] = useState<'all' | 'active' | 'completed' | 'failed' | 'delayed'>('all')
     const [isMinimized, setIsMinimized] = useState(true)
@@ -256,12 +260,12 @@ export function JobQueuePanel({ onMinimizedChange }: JobQueuePanelProps = {}) {
                                                         )}
                                                     </div>
                                                     <div className="text-[10px] text-muted-foreground">
-                                                        {formatDate(job.createdAt)}
+                                                        {formatDate(job.createdAt, t, i18n.language)}
                                                     </div>
                                                 </div>
                                                 <Badge variant={statusBadgeVariants[job.status]} className="text-[10px] h-5">
                                                     {job.id.startsWith('repeat:') && job.status === 'delayed' && job.nextRunAt
-                                                        ? formatNextRunDate(job.nextRunAt)
+                                                        ? formatNextRunDate(job.nextRunAt, i18n.language)
                                                         : t(`admin.jobs.status.${job.status}`)}
                                                 </Badge>
                                             </div>

--- a/packages/frontend/src/components/admin/UserList.tsx
+++ b/packages/frontend/src/components/admin/UserList.tsx
@@ -75,7 +75,7 @@ function UserSortableHeader({
 }
 
 export function UserList() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const {
     users,
     usersLoading,
@@ -196,7 +196,7 @@ export function UserList() {
 
   const formatDate = (dateString: string) => {
     try {
-      return new Date(dateString).toLocaleDateString()
+      return new Date(dateString).toLocaleDateString(i18n.language)
     } catch {
       return dateString
     }
@@ -312,7 +312,7 @@ export function UserList() {
                               </SelectContent>
                             </Select>
                           </TableCell>
-                          <TableCell>{(user.totalScore ?? 0).toLocaleString()}</TableCell>
+                          <TableCell>{(user.totalScore ?? 0).toLocaleString(i18n.language)}</TableCell>
                           <TableCell>{user.currentStreak ?? 0}</TableCell>
                           <TableCell className="text-muted-foreground">
                             {formatDate(user.createdAt)}

--- a/packages/frontend/src/components/game/ProgressDots.tsx
+++ b/packages/frontend/src/components/game/ProgressDots.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion'
+import { useTranslation } from 'react-i18next'
 import { useGameStore } from '@/stores/gameStore'
 import { cn } from '@/lib/utils'
 import type { PositionStatus } from '@/types'
@@ -11,6 +12,7 @@ import type { PositionStatus } from '@/types'
  * - primary: current page (with ring + glow)
  */
 export function ProgressDots() {
+  const { t } = useTranslation()
   const {
     positionStates,
     currentPosition,
@@ -36,7 +38,7 @@ export function ProgressDots() {
   return (
     <div
       role="tablist"
-      aria-label="Screenshot progress"
+      aria-label={t('game.progressDots.label')}
       className="flex gap-1.5 sm:gap-2 bg-black/60 backdrop-blur-md rounded-full px-2.5 sm:px-3 py-1.5 sm:py-2 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] shadow-lg max-w-full"
     >
       {Array.from({ length: totalScreenshots }, (_, i) => {
@@ -60,7 +62,10 @@ export function ProgressDots() {
             )}
             animate={isCurrent ? { scale: [1, 1.08, 1] } : { scale: 1 }}
             transition={{ duration: 0.6, repeat: isCurrent ? Infinity : 0, repeatDelay: 1.5 }}
-            aria-label={`Screenshot ${pos}${isCurrent ? ' (current)' : ''}: ${status}`}
+            aria-label={t(isCurrent ? 'game.progressDots.itemCurrent' : 'game.progressDots.item', {
+              position: pos,
+              status: t(`game.progressDots.status.${status}`),
+            })}
             aria-current={isCurrent ? 'true' : undefined}
           >
             <span
@@ -86,6 +91,7 @@ export function ProgressDots() {
  * Compact progress indicator showing current/total with dots
  */
 export function ProgressDotsCompact() {
+  const { t } = useTranslation()
   const { positionStates, currentPosition, totalScreenshots } = useGameStore()
 
   // Count by status
@@ -106,12 +112,12 @@ export function ProgressDotsCompact() {
       </span>
       {counts.correct > 0 && (
         <span className="text-success text-sm">
-          {counts.correct} found
+          {t('game.progressDots.summary.found', { count: counts.correct })}
         </span>
       )}
       {counts.skipped > 0 && (
         <span className="text-warning text-sm">
-          {counts.skipped} skipped
+          {t('game.progressDots.summary.skipped', { count: counts.skipped })}
         </span>
       )}
     </div>

--- a/packages/frontend/src/lib/api-errors.ts
+++ b/packages/frontend/src/lib/api-errors.ts
@@ -1,0 +1,35 @@
+import i18n from './i18n'
+import { ApiError } from './errors'
+
+type WithCode = { code?: string | null }
+type WithMessage = { message?: string | null }
+
+export function getApiErrorTranslationKey(code?: string | null): string {
+  if (!code) return 'apiErrors.default'
+  // Only map to the namespaced key if it's a known code; otherwise fall back to default
+  const exists = i18n.exists(`apiErrors.${code}`)
+  return exists ? `apiErrors.${code}` : 'apiErrors.default'
+}
+
+export function getApiErrorMessage(error: unknown, fallback?: string): string {
+  if (error instanceof ApiError) {
+    if (error.code) {
+      const key = getApiErrorTranslationKey(error.code)
+      if (key !== 'apiErrors.default') return i18n.t(key)
+    }
+    if (error.message) return error.message
+  }
+
+  if (error && typeof error === 'object') {
+    const e = error as WithCode & WithMessage
+    if (e.code) {
+      const key = getApiErrorTranslationKey(e.code)
+      if (key !== 'apiErrors.default') return i18n.t(key)
+    }
+    if (typeof e.message === 'string' && e.message) return e.message
+  }
+
+  if (typeof error === 'string' && error) return error
+
+  return fallback ?? i18n.t('apiErrors.default')
+}

--- a/packages/frontend/src/pages/GameHistoryDetailsPage.tsx
+++ b/packages/frontend/src/pages/GameHistoryDetailsPage.tsx
@@ -10,6 +10,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Trophy, ArrowLeft, CheckCircle, XCircle, Clock, Loader2 } from 'lucide-react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { gameApi } from '@/lib/api/game'
+import { getApiErrorMessage } from '@/lib/api-errors'
 import type { GameSessionDetailsResponse } from '@/types'
 import { calculateSpeedMultiplier } from '@/lib/utils'
 
@@ -25,7 +26,7 @@ export default function GameHistoryDetailsPage() {
   /* eslint-disable react-hooks/set-state-in-effect -- Necessary pattern for data fetching */
   useEffect(() => {
     if (!sessionId) {
-      setError('Session ID is required')
+      setError(t('apiErrors.INVALID_SESSION_ID'))
       setLoading(false)
       return
     }
@@ -36,12 +37,12 @@ export default function GameHistoryDetailsPage() {
         setError(null)
       })
       .catch(err => {
-        setError(err.message || 'Failed to load game session details')
+        setError(getApiErrorMessage(err))
       })
       .finally(() => {
         setLoading(false)
       })
-  }, [sessionId])
+  }, [sessionId, t])
   /* eslint-enable react-hooks/set-state-in-effect */
 
   if (loading) {

--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -375,8 +375,9 @@ export default function GamePage() {
       })
     } catch (err) {
       console.error('Failed to start game:', err)
-      // Check if it's the "already completed" error
-      if (err instanceof Error && err.message.includes('already completed')) {
+      // Check if it's the "already completed" error via the structured code
+      const code = err && typeof err === 'object' && 'code' in err ? (err as { code?: string }).code : undefined
+      if (code === 'CHALLENGE_ALREADY_COMPLETED' || code === 'SESSION_ALREADY_COMPLETED') {
         setError(t('game.alreadyCompleted'))
       } else {
         setError(t('game.errorStarting'))

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -13,7 +13,7 @@ function todayIso(): string {
 }
 
 export default function GeoDailyPage() {
-    const { t } = useTranslation()
+    const { t, i18n } = useTranslation()
     const { data: session } = useSession()
     const {
         phase,
@@ -134,7 +134,7 @@ export default function GeoDailyPage() {
                                 </Button>
                             </div>
 
-                            {result && <ResultBlock result={result} t={t} />}
+                            {result && <ResultBlock result={result} t={t} language={i18n.language} />}
                         </CardContent>
                     </Card>
                 </div>
@@ -146,16 +146,18 @@ export default function GeoDailyPage() {
 function ResultBlock({
     result,
     t,
+    language,
 }: {
     result: NonNullable<ReturnType<typeof useGeoStore.getState>['result']>
     t: ReturnType<typeof useTranslation>['t']
+    language: string
 }) {
     return (
         <div className="rounded-lg border bg-card/50 p-4 space-y-2">
             <div className="flex items-center gap-2 text-neon-pink font-medium">
                 <Trophy className="h-4 w-4" />
                 <span>
-                    {t('geo.daily.score', 'Score')}: {result.score.toLocaleString()}
+                    {t('geo.daily.score', 'Score')}: {result.score.toLocaleString(language)}
                 </span>
             </div>
             <div className="text-xs text-muted-foreground">

--- a/packages/frontend/src/pages/GeoLeaderboardPage.tsx
+++ b/packages/frontend/src/pages/GeoLeaderboardPage.tsx
@@ -85,11 +85,12 @@ export default function GeoLeaderboardPage() {
 }
 
 function LeaderboardList({ entries }: { entries: GeoLeaderboardEntry[] }) {
+    const { t } = useTranslation()
     if (entries.length === 0) {
         return (
             <Card>
                 <CardContent className="py-10 text-center text-sm text-muted-foreground">
-                    No entries yet — be the first.
+                    {t('geo.leaderboard.noEntries')}
                 </CardContent>
             </Card>
         )
@@ -97,7 +98,7 @@ function LeaderboardList({ entries }: { entries: GeoLeaderboardEntry[] }) {
     return (
         <Card>
             <CardHeader className="pb-2">
-                <CardTitle className="text-base">Top players</CardTitle>
+                <CardTitle className="text-base">{t('geo.leaderboard.topPlayers')}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-2">
                 {entries.map((e) => (
@@ -109,6 +110,7 @@ function LeaderboardList({ entries }: { entries: GeoLeaderboardEntry[] }) {
 }
 
 function LeaderboardRow({ entry }: { entry: GeoLeaderboardEntry }) {
+    const { i18n } = useTranslation()
     return (
         <div className="flex items-center gap-3 rounded-lg border bg-card/30 px-3 py-2">
             <RankBadge rank={entry.rank} />
@@ -121,15 +123,16 @@ function LeaderboardRow({ entry }: { entry: GeoLeaderboardEntry }) {
                 <p className="text-xs text-muted-foreground truncate">@{entry.username}</p>
             </div>
             <span className="text-sm font-semibold tabular-nums">
-                {entry.score.toLocaleString()}
+                {entry.score.toLocaleString(i18n.language)}
             </span>
         </div>
     )
 }
 
 function RankBadge({ rank }: { rank: number }) {
-    if (rank === 1) return <Crown className="h-5 w-5 text-medal-gold" aria-label="1st" />
-    if (rank === 2) return <Medal className="h-5 w-5 text-medal-silver" aria-label="2nd" />
-    if (rank === 3) return <Trophy className="h-5 w-5 text-medal-bronze" aria-label="3rd" />
+    const { t } = useTranslation()
+    if (rank === 1) return <Crown className="h-5 w-5 text-medal-gold" aria-label={t('common.rankBadge.first')} />
+    if (rank === 2) return <Medal className="h-5 w-5 text-medal-silver" aria-label={t('common.rankBadge.second')} />
+    if (rank === 3) return <Trophy className="h-5 w-5 text-medal-bronze" aria-label={t('common.rankBadge.third')} />
     return <span className="w-5 text-center text-xs text-muted-foreground">{rank}</span>
 }

--- a/packages/frontend/src/stores/geoStore.ts
+++ b/packages/frontend/src/stores/geoStore.ts
@@ -11,6 +11,8 @@ import type {
     GeoTierUpEvent,
 } from '@the-box/types'
 import { geoApi, GeoApiError, type GeoContributorMe } from '../lib/api/geo'
+import { getApiErrorMessage } from '../lib/api-errors'
+import i18n from '../lib/i18n'
 
 type Phase = 'idle' | 'loading' | 'playing' | 'submitting' | 'result' | 'error'
 
@@ -101,7 +103,7 @@ export const useGeoStore = create<GeoState>((set, get) => ({
         } catch (err) {
             set({
                 phase: 'error',
-                errorMessage: err instanceof GeoApiError ? err.message : 'Failed to load challenge',
+                errorMessage: getApiErrorMessage(err, i18n.t('apiErrors.default')),
                 errorCode: err instanceof GeoApiError ? err.code : null,
             })
         }
@@ -127,8 +129,7 @@ export const useGeoStore = create<GeoState>((set, get) => ({
         } catch (err) {
             set({
                 phase: 'error',
-                errorMessage:
-                    err instanceof GeoApiError ? err.message : 'Failed to submit guess',
+                errorMessage: getApiErrorMessage(err),
             })
             return null
         }
@@ -157,12 +158,7 @@ export const useGeoStore = create<GeoState>((set, get) => ({
         } catch (err) {
             set({
                 phase: 'error',
-                errorMessage:
-                    err instanceof GeoApiError
-                        ? err.code === 'CONTRIBUTE_RATE_LIMIT'
-                            ? 'Hourly pin limit reached — come back later.'
-                            : err.message
-                        : 'Failed to load a candidate',
+                errorMessage: getApiErrorMessage(err),
             })
         }
     },
@@ -188,8 +184,7 @@ export const useGeoStore = create<GeoState>((set, get) => ({
             return true
         } catch (err) {
             set({
-                errorMessage:
-                    err instanceof GeoApiError ? err.message : 'Failed to submit pin',
+                errorMessage: getApiErrorMessage(err),
             })
             return false
         }


### PR DESCRIPTION
- Replace hardcoded aria-labels in GeoLeaderboardPage RankBadge and
  ProgressDots with translated keys (common.rankBadge.*,
  game.progressDots.*).
- Translate ProgressDotsCompact "found"/"skipped" via plural keys.
- Pass i18n.language to all toLocaleString / toLocaleDateString calls
  in admin (UserList, FullImportCard, JobQueuePanel) and geo pages
  (GeoLeaderboardPage, GeoDailyPage) so number/date formatting follows
  the active locale instead of browser default.
- Add api-errors helper that maps backend error codes to translated
  messages (apiErrors.*), wired through geoStore, GameHistoryDetailsPage
  and GamePage. Replaces fragile substring matching on English error
  messages (e.g. "already completed") with structured code checks
  (CHALLENGE_ALREADY_COMPLETED / SESSION_ALREADY_COMPLETED).
- Replace hardcoded "Top players" / "No entries yet" / French-only
  formatNextRunDate with translated strings.
- Localize JobQueuePanel relative time (Ns/Nm/Nh ago) via plural keys.
- Fix duplicate "all" key in common namespace (fr resolved to "Tous"
  silently overriding the first "Tout").
- Fill in missing en/admin.fullImport.* keys (previously fr-only).

Translation files now have 864 keys each, fully in sync.