### PR TITLE
feat(admin): explain geo moderation page with intro, labels, and dialog

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -425,6 +425,17 @@
       "geo": "Geo"
     },
     "geo": {
+      "title": "Geo Moderation",
+      "subtitle": "Curate the Geo daily challenge: import sources, schedule challenges, and validate crowdsourced pins.",
+      "intro": {
+        "title": "How this page works",
+        "step1Title": "1. Import sources",
+        "step1Body": "Pull a game's annotated map from a Fandom wiki, then bring in screenshots from Steam. Both run as background jobs — watch progress in the Jobs tab.",
+        "step2Title": "2. Schedule a daily challenge",
+        "step2Body": "Pick the screenshot that the daily Geo round should use. Leave the date blank to schedule for tomorrow (UTC).",
+        "step3Title": "3. Review crowdsourced pins",
+        "step3Body": "Players drop pins guessing where each screenshot was taken. When pins converge, promote a canonical location so the screenshot can ship in a daily challenge."
+      },
       "candidates": "Candidates",
       "empty": "No candidates match this filter.",
       "pins": "pins",
@@ -433,14 +444,56 @@
       "detailHint": "Select a candidate from the list to review its pins and optionally set canonical coordinates.",
       "promote": "Promote to canonical",
       "demote": "Demote canonical",
-      "alreadyPromoted": "Already promoted — delete to re-pin with new coords.",
+      "alreadyPromoted": "Already promoted — demote it to re-pin with new coordinates.",
+      "candidateRow": {
+        "pinCount_one": "{{count}} pin",
+        "pinCount_other": "{{count}} pins",
+        "source": "source: {{source}}"
+      },
+      "statusFilter": {
+        "label": "Filter by status",
+        "collecting": "Collecting",
+        "pending": "Pending",
+        "promoted": "Promoted",
+        "all": "All"
+      },
+      "statusBadge": {
+        "collecting": "Collecting",
+        "pending": "Pending",
+        "promoted": "Promoted",
+        "rejected": "Rejected"
+      },
+      "demoteDialog": {
+        "title": "Demote canonical pin?",
+        "description": "This screenshot will return to the collecting queue. Players' pins are kept; you'll be able to set new canonical coordinates.",
+        "confirm": "Demote",
+        "cancel": "Cancel"
+      },
       "actions": {
         "title": "Ingestion & scheduling",
+        "subtitle": "Run admin-only jobs against the Geo pipeline.",
         "fandom": "Import Fandom map",
+        "fandomDescription": "Download a wiki's interactive-map asset and register it as a Geo map for a game.",
         "steam": "Import Steam screenshots",
+        "steamDescription": "Pull a game's user-submitted screenshots from Steam and register them as candidates against a Geo map.",
         "schedule": "Schedule daily challenge",
-        "enqueue": "Enqueue",
-        "queued": "Job queued: {{id}}"
+        "scheduleDescription": "Assign one promoted candidate to a future date so it appears in the daily Geo round.",
+        "enqueue": "Enqueue job",
+        "queued": "Job queued: {{id}}",
+        "fields": {
+          "gameId": "Game ID",
+          "gameIdHint": "Numeric ID of the game in the local database.",
+          "subdomain": "Wiki subdomain",
+          "subdomainHint": "The Fandom subdomain (e.g. \"eldenring\" for eldenring.fandom.com).",
+          "pageTitle": "Wiki page title",
+          "pageTitleHint": "URL slug of the page hosting the map (e.g. \"Interactive_Map\").",
+          "geoMapId": "Geo map ID",
+          "geoMapIdHint": "ID of the existing Geo map this game's screenshots should attach to.",
+          "steamAppId": "Steam app ID",
+          "steamAppIdHint": "Numeric Steam app ID (e.g. 1245620 for Elden Ring).",
+          "scheduleDate": "Date (optional)",
+          "scheduleDateHint": "Format YYYY-MM-DD. Leave empty to schedule for tomorrow."
+        }
       }
     },
     "growth": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -425,6 +425,17 @@
       "geo": "Géo"
     },
     "geo": {
+      "title": "Modération Géo",
+      "subtitle": "Curatez le défi Géo quotidien : importez les sources, planifiez les défis et validez les épingles communautaires.",
+      "intro": {
+        "title": "Comment cette page fonctionne",
+        "step1Title": "1. Importer les sources",
+        "step1Body": "Récupérez la carte annotée d'un jeu depuis un wiki Fandom, puis importez les captures depuis Steam. Les deux opérations s'exécutent en arrière-plan — surveillez l'avancement dans l'onglet Tâches.",
+        "step2Title": "2. Planifier un défi quotidien",
+        "step2Body": "Choisissez la capture qui sera utilisée pour le défi Géo du jour. Laissez la date vide pour planifier pour demain (UTC).",
+        "step3Title": "3. Valider les épingles",
+        "step3Body": "Les joueurs déposent des épingles pour deviner où chaque capture a été prise. Lorsqu'elles convergent, promouvez un emplacement canonique pour que la capture puisse être utilisée dans un défi quotidien."
+      },
       "candidates": "Candidats",
       "empty": "Aucun candidat ne correspond à ce filtre.",
       "pins": "épingles",
@@ -433,14 +444,56 @@
       "detailHint": "Sélectionnez un candidat dans la liste pour consulter ses épingles et éventuellement définir les coordonnées canoniques.",
       "promote": "Promouvoir en canonique",
       "demote": "Rétrograder la canonique",
-      "alreadyPromoted": "Déjà promu — supprimez pour ré-épingler avec de nouvelles coordonnées.",
+      "alreadyPromoted": "Déjà promu — rétrogradez pour ré-épingler avec de nouvelles coordonnées.",
+      "candidateRow": {
+        "pinCount_one": "{{count}} épingle",
+        "pinCount_other": "{{count}} épingles",
+        "source": "source : {{source}}"
+      },
+      "statusFilter": {
+        "label": "Filtrer par statut",
+        "collecting": "En collecte",
+        "pending": "En attente",
+        "promoted": "Promus",
+        "all": "Tous"
+      },
+      "statusBadge": {
+        "collecting": "En collecte",
+        "pending": "En attente",
+        "promoted": "Promu",
+        "rejected": "Rejeté"
+      },
+      "demoteDialog": {
+        "title": "Rétrograder la canonique ?",
+        "description": "Cette capture retournera dans la file de collecte. Les épingles des joueurs sont conservées ; vous pourrez définir de nouvelles coordonnées canoniques.",
+        "confirm": "Rétrograder",
+        "cancel": "Annuler"
+      },
       "actions": {
         "title": "Ingestion et planification",
+        "subtitle": "Lancez les tâches admin du pipeline Géo.",
         "fandom": "Importer la carte Fandom",
+        "fandomDescription": "Télécharge la carte interactive d'un wiki et l'enregistre comme carte Géo pour un jeu.",
         "steam": "Importer les captures Steam",
+        "steamDescription": "Récupère les captures publiques d'un jeu depuis Steam et les enregistre comme candidats sur une carte Géo.",
         "schedule": "Planifier le défi quotidien",
-        "enqueue": "Lancer",
-        "queued": "Tâche en file : {{id}}"
+        "scheduleDescription": "Assigne un candidat promu à une date future pour qu'il apparaisse dans le défi Géo quotidien.",
+        "enqueue": "Lancer la tâche",
+        "queued": "Tâche en file : {{id}}",
+        "fields": {
+          "gameId": "ID du jeu",
+          "gameIdHint": "Identifiant numérique du jeu dans la base locale.",
+          "subdomain": "Sous-domaine du wiki",
+          "subdomainHint": "Le sous-domaine Fandom (ex. « eldenring » pour eldenring.fandom.com).",
+          "pageTitle": "Titre de la page wiki",
+          "pageTitleHint": "Slug de la page qui héberge la carte (ex. « Interactive_Map »).",
+          "geoMapId": "ID de carte Géo",
+          "geoMapIdHint": "Identifiant de la carte Géo existante à laquelle rattacher les captures.",
+          "steamAppId": "App ID Steam",
+          "steamAppIdHint": "Identifiant Steam numérique du jeu (ex. 1245620 pour Elden Ring).",
+          "scheduleDate": "Date (optionnel)",
+          "scheduleDateHint": "Format AAAA-MM-JJ. Laissez vide pour planifier pour demain."
+        }
       }
     },
     "growth": {

--- a/packages/frontend/src/components/admin/GeoAdminActions.tsx
+++ b/packages/frontend/src/components/admin/GeoAdminActions.tsx
@@ -1,8 +1,15 @@
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Loader2, CalendarClock, Image, ImageDown } from 'lucide-react'
 
 type ActionKind = 'fandom' | 'steam' | 'schedule' | null
@@ -21,6 +28,34 @@ async function postJson(path: string, body: unknown): Promise<{ jobId: string }>
     return json.data
 }
 
+interface FieldProps {
+    id: string
+    label: string
+    hint: string
+    placeholder?: string
+    value: string
+    onChange: (v: string) => void
+    inputMode?: 'numeric' | 'text'
+}
+
+function Field({ id, label, hint, placeholder, value, onChange, inputMode }: FieldProps) {
+    return (
+        <div className="space-y-1">
+            <Label htmlFor={id} className="text-xs">
+                {label}
+            </Label>
+            <Input
+                id={id}
+                placeholder={placeholder}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                inputMode={inputMode}
+            />
+            <p className="text-[11px] text-muted-foreground leading-snug">{hint}</p>
+        </div>
+    )
+}
+
 /**
  * Minimal ops controls for the admin: enqueue ingestion + scheduling jobs
  * onto the geo-jobs BullMQ queue. Deliberately no job-status polling here
@@ -28,6 +63,7 @@ async function postJson(path: string, body: unknown): Promise<{ jobId: string }>
  */
 export function GeoAdminActions() {
     const { t } = useTranslation()
+    const formId = useId()
     const [running, setRunning] = useState<ActionKind>(null)
     const [message, setMessage] = useState<string | null>(null)
     const [error, setError] = useState<string | null>(null)
@@ -45,15 +81,16 @@ export function GeoAdminActions() {
     // Schedule form
     const [scheduleDate, setScheduleDate] = useState('')
 
-    const runAction = async (kind: Exclude<ActionKind, null>, fn: () => Promise<{ jobId: string }>) => {
+    const runAction = async (
+        kind: Exclude<ActionKind, null>,
+        fn: () => Promise<{ jobId: string }>,
+    ) => {
         setRunning(kind)
         setError(null)
         setMessage(null)
         try {
             const { jobId } = await fn()
-            setMessage(
-                t('admin.geo.actions.queued', 'Job queued: {{id}}', { id: jobId }),
-            )
+            setMessage(t('admin.geo.actions.queued', { id: jobId }))
         } catch (e) {
             setError(String(e))
         } finally {
@@ -64,11 +101,12 @@ export function GeoAdminActions() {
     return (
         <Card>
             <CardHeader className="pb-2">
-                <CardTitle className="text-sm">
-                    {t('admin.geo.actions.title', 'Ingestion & scheduling')}
-                </CardTitle>
+                <CardTitle className="text-sm">{t('admin.geo.actions.title')}</CardTitle>
+                <CardDescription className="text-xs">
+                    {t('admin.geo.actions.subtitle')}
+                </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className="space-y-6">
                 {message && (
                     <div className="rounded border border-success/40 bg-success/10 p-2 text-xs text-success">
                         {message}
@@ -80,26 +118,42 @@ export function GeoAdminActions() {
                     </div>
                 )}
 
-                <section className="space-y-2">
-                    <h3 className="text-xs font-semibold flex items-center gap-2">
-                        <Image className="h-3.5 w-3.5" aria-hidden />
-                        {t('admin.geo.actions.fandom', 'Import Fandom map')}
-                    </h3>
-                    <div className="grid grid-cols-3 gap-2">
-                        <Input
-                            placeholder="gameId"
+                {/* Fandom */}
+                <section className="space-y-3">
+                    <div className="space-y-0.5">
+                        <h3 className="text-sm font-semibold flex items-center gap-2">
+                            <Image className="h-3.5 w-3.5" aria-hidden />
+                            {t('admin.geo.actions.fandom')}
+                        </h3>
+                        <p className="text-xs text-muted-foreground">
+                            {t('admin.geo.actions.fandomDescription')}
+                        </p>
+                    </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                        <Field
+                            id={`${formId}-fandom-gameid`}
+                            label={t('admin.geo.actions.fields.gameId')}
+                            hint={t('admin.geo.actions.fields.gameIdHint')}
+                            placeholder="123"
                             value={fandomGameId}
-                            onChange={(e) => setFandomGameId(e.target.value)}
+                            onChange={setFandomGameId}
+                            inputMode="numeric"
                         />
-                        <Input
-                            placeholder="subdomain"
+                        <Field
+                            id={`${formId}-fandom-sub`}
+                            label={t('admin.geo.actions.fields.subdomain')}
+                            hint={t('admin.geo.actions.fields.subdomainHint')}
+                            placeholder="eldenring"
                             value={fandomSubdomain}
-                            onChange={(e) => setFandomSubdomain(e.target.value)}
+                            onChange={setFandomSubdomain}
                         />
-                        <Input
-                            placeholder="pageTitle"
+                        <Field
+                            id={`${formId}-fandom-page`}
+                            label={t('admin.geo.actions.fields.pageTitle')}
+                            hint={t('admin.geo.actions.fields.pageTitleHint')}
+                            placeholder="Interactive_Map"
                             value={fandomPage}
-                            onChange={(e) => setFandomPage(e.target.value)}
+                            onChange={setFandomPage}
                         />
                     </div>
                     <Button
@@ -123,30 +177,48 @@ export function GeoAdminActions() {
                         {running === 'fandom' && (
                             <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
                         )}
-                        {t('admin.geo.actions.enqueue', 'Enqueue')}
+                        {t('admin.geo.actions.enqueue')}
                     </Button>
                 </section>
 
-                <section className="space-y-2">
-                    <h3 className="text-xs font-semibold flex items-center gap-2">
-                        <ImageDown className="h-3.5 w-3.5" aria-hidden />
-                        {t('admin.geo.actions.steam', 'Import Steam screenshots')}
-                    </h3>
-                    <div className="grid grid-cols-3 gap-2">
-                        <Input
-                            placeholder="gameId"
+                {/* Steam */}
+                <section className="space-y-3">
+                    <div className="space-y-0.5">
+                        <h3 className="text-sm font-semibold flex items-center gap-2">
+                            <ImageDown className="h-3.5 w-3.5" aria-hidden />
+                            {t('admin.geo.actions.steam')}
+                        </h3>
+                        <p className="text-xs text-muted-foreground">
+                            {t('admin.geo.actions.steamDescription')}
+                        </p>
+                    </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                        <Field
+                            id={`${formId}-steam-gameid`}
+                            label={t('admin.geo.actions.fields.gameId')}
+                            hint={t('admin.geo.actions.fields.gameIdHint')}
+                            placeholder="123"
                             value={steamGameId}
-                            onChange={(e) => setSteamGameId(e.target.value)}
+                            onChange={setSteamGameId}
+                            inputMode="numeric"
                         />
-                        <Input
-                            placeholder="geoMapId"
+                        <Field
+                            id={`${formId}-steam-mapid`}
+                            label={t('admin.geo.actions.fields.geoMapId')}
+                            hint={t('admin.geo.actions.fields.geoMapIdHint')}
+                            placeholder="456"
                             value={steamMapId}
-                            onChange={(e) => setSteamMapId(e.target.value)}
+                            onChange={setSteamMapId}
+                            inputMode="numeric"
                         />
-                        <Input
-                            placeholder="steamAppId"
+                        <Field
+                            id={`${formId}-steam-appid`}
+                            label={t('admin.geo.actions.fields.steamAppId')}
+                            hint={t('admin.geo.actions.fields.steamAppIdHint')}
+                            placeholder="1245620"
                             value={steamAppId}
-                            onChange={(e) => setSteamAppId(e.target.value)}
+                            onChange={setSteamAppId}
+                            inputMode="numeric"
                         />
                     </div>
                     <Button
@@ -167,20 +239,29 @@ export function GeoAdminActions() {
                         {running === 'steam' && (
                             <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
                         )}
-                        {t('admin.geo.actions.enqueue', 'Enqueue')}
+                        {t('admin.geo.actions.enqueue')}
                     </Button>
                 </section>
 
-                <section className="space-y-2">
-                    <h3 className="text-xs font-semibold flex items-center gap-2">
-                        <CalendarClock className="h-3.5 w-3.5" aria-hidden />
-                        {t('admin.geo.actions.schedule', 'Schedule daily challenge')}
-                    </h3>
-                    <div className="grid grid-cols-3 gap-2">
-                        <Input
-                            placeholder="YYYY-MM-DD (optional)"
+                {/* Schedule */}
+                <section className="space-y-3">
+                    <div className="space-y-0.5">
+                        <h3 className="text-sm font-semibold flex items-center gap-2">
+                            <CalendarClock className="h-3.5 w-3.5" aria-hidden />
+                            {t('admin.geo.actions.schedule')}
+                        </h3>
+                        <p className="text-xs text-muted-foreground">
+                            {t('admin.geo.actions.scheduleDescription')}
+                        </p>
+                    </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                        <Field
+                            id={`${formId}-schedule-date`}
+                            label={t('admin.geo.actions.fields.scheduleDate')}
+                            hint={t('admin.geo.actions.fields.scheduleDateHint')}
+                            placeholder="2026-05-01"
                             value={scheduleDate}
-                            onChange={(e) => setScheduleDate(e.target.value)}
+                            onChange={setScheduleDate}
                         />
                     </div>
                     <Button
@@ -198,7 +279,7 @@ export function GeoAdminActions() {
                         {running === 'schedule' && (
                             <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
                         )}
-                        {t('admin.geo.actions.enqueue', 'Enqueue')}
+                        {t('admin.geo.actions.enqueue')}
                     </Button>
                 </section>
             </CardContent>

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -3,7 +3,15 @@ import { useTranslation } from 'react-i18next'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Loader2, Trash2 } from 'lucide-react'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import { Loader2, Trash2, Info, MapPin } from 'lucide-react'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { GeoAdminActions } from './GeoAdminActions'
 import type {
@@ -20,6 +28,9 @@ interface CandidateDetail {
     map: GeoMap | null
     meta: GeoScreenshotMeta | null
 }
+
+type StatusFilter = 'collecting' | 'pending' | 'promoted' | 'all'
+const STATUS_FILTERS: StatusFilter[] = ['collecting', 'pending', 'promoted', 'all']
 
 async function fetchCandidates(status?: string): Promise<GeoScreenshotCandidate[]> {
     const qs = status ? `?status=${encodeURIComponent(status)}` : ''
@@ -62,15 +73,14 @@ async function deleteMeta(metaId: number): Promise<void> {
 
 export function GeoReviewPanel() {
     const { t } = useTranslation()
-    const [statusFilter, setStatusFilter] = useState<'pending' | 'collecting' | 'promoted' | 'all'>(
-        'collecting',
-    )
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>('collecting')
     const [candidates, setCandidates] = useState<GeoScreenshotCandidate[]>([])
     const [detail, setDetail] = useState<CandidateDetail | null>(null)
     const [pin, setPin] = useState<GeoPoint | null>(null)
     const [loading, setLoading] = useState(true)
     const [saving, setSaving] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const [demoteOpen, setDemoteOpen] = useState(false)
 
     useEffect(() => {
         let cancelled = false
@@ -112,10 +122,8 @@ export function GeoReviewPanel() {
         }
     }
 
-    const handleDeleteMeta = async () => {
+    const confirmDemote = async () => {
         if (!detail?.meta) return
-        // Destructive on a public canonical — confirm explicitly.
-        if (!window.confirm('Demote this meta? It will become a collecting candidate again.')) return
         setError(null)
         setSaving(true)
         try {
@@ -124,6 +132,7 @@ export function GeoReviewPanel() {
             const fresh = await fetchCandidateDetail(detail.candidate.id)
             setDetail(fresh)
             setPin(null)
+            setDemoteOpen(false)
         } catch (e) {
             setError(String(e))
         } finally {
@@ -131,19 +140,65 @@ export function GeoReviewPanel() {
         }
     }
 
+    const statusLabel = (status: string): string => {
+        // Translate known statuses; fall back to the raw value for unknown statuses
+        // (rejected, archived, etc.) so we never silently hide data.
+        const key = `admin.geo.statusBadge.${status}`
+        const translated = t(key)
+        return translated === key ? status : translated
+    }
+
     return (
         <div className="space-y-4">
+            {/* Page header */}
+            <header className="space-y-1">
+                <h2 className="text-xl font-semibold tracking-tight flex items-center gap-2">
+                    <MapPin className="h-5 w-5 text-neon-pink" />
+                    {t('admin.geo.title')}
+                </h2>
+                <p className="text-sm text-muted-foreground">{t('admin.geo.subtitle')}</p>
+            </header>
+
+            {/* Workflow explainer */}
+            <Card className="border-neon-pink/30 bg-linear-to-r from-neon-pink/5 via-neon-purple/5 to-transparent">
+                <CardHeader className="pb-2">
+                    <CardTitle className="text-sm flex items-center gap-2">
+                        <Info className="h-4 w-4 text-neon-pink" />
+                        {t('admin.geo.intro.title')}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <ol className="grid gap-3 sm:grid-cols-3 text-sm">
+                        {(['step1', 'step2', 'step3'] as const).map((step) => (
+                            <li key={step} className="space-y-1">
+                                <p className="font-semibold text-foreground">
+                                    {t(`admin.geo.intro.${step}Title`)}
+                                </p>
+                                <p className="text-xs text-muted-foreground leading-relaxed">
+                                    {t(`admin.geo.intro.${step}Body`)}
+                                </p>
+                            </li>
+                        ))}
+                    </ol>
+                </CardContent>
+            </Card>
+
             <GeoAdminActions />
 
-            <div className="flex items-center gap-2">
-                {(['collecting', 'pending', 'promoted', 'all'] as const).map((s) => (
+            {/* Status filter */}
+            <div
+                className="flex flex-wrap items-center gap-2"
+                role="group"
+                aria-label={t('admin.geo.statusFilter.label')}
+            >
+                {STATUS_FILTERS.map((s) => (
                     <Button
                         key={s}
                         size="sm"
                         variant={statusFilter === s ? 'default' : 'outline'}
                         onClick={() => setStatusFilter(s)}
                     >
-                        {s}
+                        {t(`admin.geo.statusFilter.${s}`)}
                     </Button>
                 ))}
             </div>
@@ -163,7 +218,7 @@ export function GeoReviewPanel() {
                     <Card className="lg:col-span-1">
                         <CardHeader className="pb-2">
                             <CardTitle className="text-sm">
-                                {t('admin.geo.candidates', 'Candidates')} ({candidates.length})
+                                {t('admin.geo.candidates')} ({candidates.length})
                             </CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-2 max-h-[520px] overflow-auto">
@@ -177,16 +232,18 @@ export function GeoReviewPanel() {
                                 >
                                     <div className="flex justify-between items-center">
                                         <span className="font-mono">#{c.id}</span>
-                                        <Badge variant="outline">{c.status}</Badge>
+                                        <Badge variant="outline">{statusLabel(c.status)}</Badge>
                                     </div>
                                     <div className="mt-1 text-muted-foreground">
-                                        {c.pinCount} pins · {c.source}
+                                        {t('admin.geo.candidateRow.pinCount', { count: c.pinCount })}
+                                        {' · '}
+                                        {t('admin.geo.candidateRow.source', { source: c.source })}
                                     </div>
                                 </button>
                             ))}
                             {candidates.length === 0 && (
                                 <p className="text-xs text-muted-foreground">
-                                    {t('admin.geo.empty', 'No candidates match this filter.')}
+                                    {t('admin.geo.empty')}
                                 </p>
                             )}
                         </CardContent>
@@ -196,8 +253,8 @@ export function GeoReviewPanel() {
                         <CardHeader className="pb-2">
                             <CardTitle className="text-sm">
                                 {detail
-                                    ? `#${detail.candidate.id} · ${detail.pins.length} ${t('admin.geo.pins', 'pins')}`
-                                    : t('admin.geo.pickOne', 'Pick a candidate')}
+                                    ? `#${detail.candidate.id} · ${t('admin.geo.candidateRow.pinCount', { count: detail.pins.length })}`
+                                    : t('admin.geo.pickOne')}
                             </CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-3">
@@ -227,23 +284,16 @@ export function GeoReviewPanel() {
                                     {detail.meta ? (
                                         <div className="flex items-center justify-between gap-3">
                                             <p className="text-xs text-warning">
-                                                {t(
-                                                    'admin.geo.alreadyPromoted',
-                                                    'Already promoted — delete to re-pin with new coords.',
-                                                )}
+                                                {t('admin.geo.alreadyPromoted')}
                                             </p>
                                             <Button
                                                 size="sm"
                                                 variant="destructive"
-                                                onClick={handleDeleteMeta}
+                                                onClick={() => setDemoteOpen(true)}
                                                 disabled={saving}
                                             >
-                                                {saving ? (
-                                                    <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
-                                                ) : (
-                                                    <Trash2 className="h-3.5 w-3.5 mr-2" />
-                                                )}
-                                                {t('admin.geo.demote', 'Demote canonical')}
+                                                <Trash2 className="h-3.5 w-3.5 mr-2" />
+                                                {t('admin.geo.demote')}
                                             </Button>
                                         </div>
                                     ) : (
@@ -251,10 +301,7 @@ export function GeoReviewPanel() {
                                             <span className="text-xs text-muted-foreground">
                                                 {pin
                                                     ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
-                                                    : t(
-                                                          'admin.geo.pickPoint',
-                                                          'Click the map to set canonical coordinates',
-                                                      )}
+                                                    : t('admin.geo.pickPoint')}
                                             </span>
                                             <Button
                                                 size="sm"
@@ -265,23 +312,48 @@ export function GeoReviewPanel() {
                                                 {saving && (
                                                     <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
                                                 )}
-                                                {t('admin.geo.promote', 'Promote to canonical')}
+                                                {t('admin.geo.promote')}
                                             </Button>
                                         </div>
                                     )}
                                 </>
                             ) : (
                                 <p className="text-xs text-muted-foreground">
-                                    {t(
-                                        'admin.geo.detailHint',
-                                        'Select a candidate from the list to review its pins and optionally set canonical coordinates.',
-                                    )}
+                                    {t('admin.geo.detailHint')}
                                 </p>
                             )}
                         </CardContent>
                     </Card>
                 </div>
             )}
+
+            <Dialog open={demoteOpen} onOpenChange={(open) => !saving && setDemoteOpen(open)}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>{t('admin.geo.demoteDialog.title')}</DialogTitle>
+                        <DialogDescription>
+                            {t('admin.geo.demoteDialog.description')}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setDemoteOpen(false)}
+                            disabled={saving}
+                        >
+                            {t('admin.geo.demoteDialog.cancel')}
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmDemote}
+                            disabled={saving}
+                        >
+                            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />}
+                            {t('admin.geo.demoteDialog.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     )
 }


### PR DESCRIPTION
The /admin?tab=geo page previously dropped admins straight into a list
of statuses, raw form fields ("gameId", "subdomain"), and an English
window.confirm. There was no indication of what the page does or how
the import → schedule → review workflow fits together.

GeoReviewPanel:
- Add page header with title + subtitle.
- Add a 3-step workflow card (Import sources → Schedule → Review pins)
  so admins understand what the tab is for before scrolling.
- Localize the status filter buttons (collecting / pending / promoted /
  all) and the candidate-row status badge.
- Replace `window.confirm` for canonical demotion with a translated
  Dialog that explains exactly what happens (returns to collecting
  queue, players' pins kept).
- Use the new pluralized pinCount key so "1 pin" / "N pins" follows
  i18next plural rules.

GeoAdminActions:
- Wrap each ingestion section in a description + reusable Field
  component that pairs Label + Input + helper text, so admins know
  what each field expects (e.g. "The Fandom subdomain (e.g. eldenring
  for eldenring.fandom.com)").
- Add `inputMode="numeric"` to numeric ID fields for mobile keyboards.

Translations:
- 50+ new keys under admin.geo.* covering intro, statusFilter,
  statusBadge, demoteDialog, candidateRow, and per-field labels +
  hints. EN and FR fully in sync at 922 keys each.