### PR TITLE
feat(admin): show thumbnail, game name, and reason breakdown in reports panel

### DIFF
--- a/packages/backend/src/infrastructure/repositories/screenshot-report.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/screenshot-report.repository.ts
@@ -110,11 +110,11 @@ export const screenshotReportRepository = {
     return Number(row?.count ?? 0)
   },
 
-  // Admin-facing aggregate: one row per reported target, with total count and
-  // most recent reason/details. Used to power the moderation queue. Filtering
-  // by `onlyDeactivated` lets admins focus on captures already pulled from
-  // rotation; the default returns everything so they can intervene before the
-  // threshold trips when needed.
+  // Admin-facing aggregate: one row per reported target, enriched with the
+  // capture preview (image + game name) and a reason breakdown so moderators
+  // can act on a report without leaving the panel. `onlyDeactivated` focuses
+  // the queue on captures already pulled from rotation; the default returns
+  // everything so admins can intervene before the threshold trips.
   async listAggregated(args: {
     limit?: number
     onlyDeactivated?: boolean
@@ -123,12 +123,19 @@ export const screenshotReportRepository = {
 
     const rows = await db('screenshot_reports as r')
       .leftJoin('screenshots as s', 's.id', 'r.screenshot_id')
+      .leftJoin('games as sg', 'sg.id', 's.game_id')
       .leftJoin('geo_screenshot_candidate as g', 'g.id', 'r.geo_screenshot_candidate_id')
+      .leftJoin('games as gg', 'gg.id', 'g.game_id')
       .select<RawAdminReportRow[]>(
         db.raw('r.screenshot_id as screenshot_id'),
         db.raw('r.geo_screenshot_candidate_id as geo_screenshot_candidate_id'),
         db.raw('s.is_active as screenshot_is_active'),
         db.raw('g.is_active as geo_candidate_is_active'),
+        // COALESCE to the geo URL when this is a geo-only candidate (no
+        // linked main screenshot row).
+        db.raw('COALESCE(s.image_url, g.image_url) as image_url'),
+        db.raw('COALESCE(s.thumbnail_url, g.thumbnail_url) as thumbnail_url'),
+        db.raw('COALESCE(sg.name, gg.name) as game_name'),
         db.raw('count(r.id)::int as count'),
         db.raw('max(r.created_at) as last_reported_at'),
       )
@@ -137,15 +144,48 @@ export const screenshotReportRepository = {
         'r.geo_screenshot_candidate_id',
         's.is_active',
         'g.is_active',
+        's.image_url',
+        'g.image_url',
+        's.thumbnail_url',
+        'g.thumbnail_url',
+        'sg.name',
+        'gg.name',
       )
       .orderBy('count', 'desc')
       .limit(limit)
+
+    // Reason breakdown is fetched in a single follow-up query and merged in
+    // memory; cheaper than a window function and keeps the SQL readable.
+    const reasonRows = await db('screenshot_reports')
+      .select<ReasonBreakdownRow[]>(
+        db.raw('screenshot_id as screenshot_id'),
+        db.raw('geo_screenshot_candidate_id as geo_screenshot_candidate_id'),
+        'reason',
+        db.raw('count(*)::int as count'),
+      )
+      .groupBy('screenshot_id', 'geo_screenshot_candidate_id', 'reason')
+
+    const reasonsByKey = new Map<string, Partial<Record<ScreenshotReportReason, number>>>()
+    for (const r of reasonRows) {
+      const reason = r.reason as ScreenshotReportReason
+      const key =
+        r.screenshot_id != null
+          ? `s:${r.screenshot_id}`
+          : `g:${r.geo_screenshot_candidate_id}`
+      const bucket = reasonsByKey.get(key) ?? {}
+      bucket[reason] = Number(r.count)
+      reasonsByKey.set(key, bucket)
+    }
 
     let summaries = rows.map<AdminReportSummary>((row) => {
       const active =
         row.screenshot_id != null
           ? !!row.screenshot_is_active
           : !!row.geo_candidate_is_active
+      const key =
+        row.screenshot_id != null
+          ? `s:${row.screenshot_id}`
+          : `g:${row.geo_screenshot_candidate_id}`
       return {
         screenshotId: row.screenshot_id ?? undefined,
         geoScreenshotCandidateId: row.geo_screenshot_candidate_id ?? undefined,
@@ -155,6 +195,10 @@ export const screenshotReportRepository = {
             ? row.last_reported_at.toISOString()
             : String(row.last_reported_at),
         isActive: active,
+        imageUrl: row.image_url ?? undefined,
+        thumbnailUrl: row.thumbnail_url ?? undefined,
+        gameName: row.game_name ?? undefined,
+        reasons: reasonsByKey.get(key) ?? {},
       }
     })
 
@@ -215,6 +259,11 @@ export interface AdminReportSummary {
   reportCount: number
   lastReportedAt: string
   isActive: boolean
+  imageUrl?: string
+  thumbnailUrl?: string
+  gameName?: string
+  // Partial map: only reasons that have at least one report appear as keys.
+  reasons: Partial<Record<ScreenshotReportReason, number>>
 }
 
 interface RawAdminReportRow {
@@ -222,8 +271,18 @@ interface RawAdminReportRow {
   geo_screenshot_candidate_id: number | null
   screenshot_is_active: boolean | null
   geo_candidate_is_active: boolean | null
+  image_url: string | null
+  thumbnail_url: string | null
+  game_name: string | null
   count: number
   last_reported_at: Date
+}
+
+interface ReasonBreakdownRow {
+  screenshot_id: number | null
+  geo_screenshot_candidate_id: number | null
+  reason: ScreenshotReportReason
+  count: number
 }
 
 // Deactivate both the geo candidate (if applicable) and any linked main

--- a/packages/frontend/src/components/admin/ReportsModerationPanel.tsx
+++ b/packages/frontend/src/components/admin/ReportsModerationPanel.tsx
@@ -5,7 +5,8 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { toast } from '@/lib/toast'
-import { Loader2, RefreshCw, Undo2, Flag } from 'lucide-react'
+import { Loader2, RefreshCw, Undo2, Flag, ImageOff } from 'lucide-react'
+import type { ScreenshotReportReason } from '@the-box/types'
 
 interface ReportSummary {
     screenshotId?: number
@@ -13,6 +14,10 @@ interface ReportSummary {
     reportCount: number
     lastReportedAt: string
     isActive: boolean
+    imageUrl?: string
+    thumbnailUrl?: string
+    gameName?: string
+    reasons: Partial<Record<ScreenshotReportReason, number>>
 }
 
 async function fetchReports(onlyDeactivated: boolean): Promise<ReportSummary[]> {
@@ -124,36 +129,66 @@ export function ReportsModerationPanel() {
                         {reports.map((row) => (
                             <li
                                 key={rowKey(row)}
-                                className="flex items-center justify-between gap-3 py-3"
+                                className="flex items-start justify-between gap-3 py-3"
                             >
-                                <div className="flex flex-col gap-1 min-w-0">
-                                    <div className="flex items-center gap-2 flex-wrap">
-                                        <Badge
-                                            variant={
-                                                row.screenshotId ? 'default' : 'secondary'
-                                            }
-                                        >
-                                            {row.screenshotId
-                                                ? t('admin.reports.targetMain')
-                                                : t('admin.reports.targetGeo')}
-                                        </Badge>
-                                        <span className="text-sm font-mono">
-                                            #{row.screenshotId ?? row.geoScreenshotCandidateId}
-                                        </span>
-                                        {!row.isActive && (
-                                            <Badge variant="destructive">
-                                                {t('admin.reports.deactivated')}
+                                <div className="flex items-start gap-3 min-w-0 flex-1">
+                                    <ReportThumbnail
+                                        src={row.thumbnailUrl ?? row.imageUrl}
+                                        alt={row.gameName ?? ''}
+                                    />
+                                    <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                            <Badge
+                                                variant={
+                                                    row.screenshotId ? 'default' : 'secondary'
+                                                }
+                                            >
+                                                {row.screenshotId
+                                                    ? t('admin.reports.targetMain')
+                                                    : t('admin.reports.targetGeo')}
                                             </Badge>
-                                        )}
-                                    </div>
-                                    <div className="text-xs text-muted-foreground">
-                                        {t('admin.reports.count', {
-                                            count: row.reportCount,
-                                        })}
-                                        {' · '}
-                                        {t('admin.reports.lastReported', {
-                                            when: formatWhen(row.lastReportedAt, i18n.language),
-                                        })}
+                                            <span className="text-sm font-mono">
+                                                #{row.screenshotId ?? row.geoScreenshotCandidateId}
+                                            </span>
+                                            {row.gameName && (
+                                                <span className="text-sm font-medium truncate">
+                                                    {row.gameName}
+                                                </span>
+                                            )}
+                                            {!row.isActive && (
+                                                <Badge variant="destructive">
+                                                    {t('admin.reports.deactivated')}
+                                                </Badge>
+                                            )}
+                                        </div>
+                                        <div className="flex flex-wrap gap-1">
+                                            {(Object.entries(row.reasons) as [
+                                                ScreenshotReportReason,
+                                                number,
+                                            ][])
+                                                .sort((a, b) => b[1] - a[1])
+                                                .map(([reason, n]) => (
+                                                    <Badge
+                                                        key={reason}
+                                                        variant="outline"
+                                                        className="text-[10px] font-normal"
+                                                    >
+                                                        {t(`report.reasons.${reason}`)} · {n}
+                                                    </Badge>
+                                                ))}
+                                        </div>
+                                        <div className="text-xs text-muted-foreground">
+                                            {t('admin.reports.count', {
+                                                count: row.reportCount,
+                                            })}
+                                            {' · '}
+                                            {t('admin.reports.lastReported', {
+                                                when: formatWhen(
+                                                    row.lastReportedAt,
+                                                    i18n.language,
+                                                ),
+                                            })}
+                                        </div>
                                     </div>
                                 </div>
                                 {!row.isActive && (
@@ -188,6 +223,26 @@ function rowKey(row: ReportSummary): string {
     return row.screenshotId
         ? `s:${row.screenshotId}`
         : `g:${row.geoScreenshotCandidateId}`
+}
+
+function ReportThumbnail({ src, alt }: { src?: string; alt: string }) {
+    const [errored, setErrored] = useState(false)
+    if (!src || errored) {
+        return (
+            <div className="h-16 w-24 shrink-0 rounded-md bg-muted/40 flex items-center justify-center">
+                <ImageOff className="h-4 w-4 text-muted-foreground" />
+            </div>
+        )
+    }
+    return (
+        <img
+            src={src}
+            alt={alt}
+            loading="lazy"
+            onError={() => setErrored(true)}
+            className="h-16 w-24 shrink-0 rounded-md object-cover border border-border"
+        />
+    )
 }
 
 function formatWhen(iso: string, locale: string): string {


### PR DESCRIPTION
Moderators couldn't actually moderate from the previous Reports tab — all they saw was a count and a timestamp. This adds the context they need to triage without leaving the panel.

## Summary
- **Backend** (`screenshot-report.repository.ts`): the aggregation query now joins both `screenshots` (with its `games` row) and `geo_screenshot_candidate` (with its `games` row) so each summary carries `imageUrl`, `thumbnailUrl`, and `gameName`. URLs are coalesced so geo-only candidates (no linked main screenshot) still resolve. A second query groups by `(target, reason)` and the results are merged in memory into a `reasons: Partial<Record<ScreenshotReportReason, number>>` map. Two queries (instead of a window function) keeps the SQL readable at moderation-scale row counts.
- **Frontend** (`ReportsModerationPanel.tsx`): renders a 96×64 thumbnail (or a placeholder icon when missing / errored), the game name next to the target id, and an outline badge per reason with its count, sorted descending.

## Test plan
- [ ] As an admin, visit `/admin?tab=reports` — each row shows a thumbnail, game name, and reason badges.
- [ ] Geo-only candidates (no linked `screenshots` row) still render their thumbnail (uses the candidate's own `image_url`).
- [ ] Image error fallback shows the placeholder icon when an image fails to load.
- [ ] Reason badges are sorted by count (most-frequent first).
- [ ] `npm run build` and `npm run lint` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxkaEaCkcxw75zf32g4fgs)_