### PR TITLE
feat(geo): auto-ingest dataset for curated games (no admin forms)

### DIFF
--- a/packages/backend/migrations/20260425_geo_auto_ingest.ts
+++ b/packages/backend/migrations/20260425_geo_auto_ingest.ts
@@ -1,0 +1,65 @@
+import type { Knex } from 'knex'
+
+// Auto-ingestion support for the Geo Game dataset. Replaces the manual admin
+// forms (typed wiki subdomain / Steam app id / page title) with a curated-set
+// model where:
+//   - operators flip `games.geo_curated = true` for games to onboard,
+//   - a recurring resolver fills in `steam_app_id` / `wiki_subdomain` /
+//     `wiki_page_title` from heuristics (Steam storesearch, Fandom HEAD),
+//   - a recurring tick enqueues per-game Fandom + Steam imports,
+//   - permanent failures land in `geo_ingest_failure` so we stop retrying.
+//
+// All additions are nullable / defaulted so existing rows stay valid.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('games', (table) => {
+    table.integer('steam_app_id').nullable()
+    table.string('wiki_subdomain', 100).nullable()
+    table.string('wiki_page_title', 200).nullable()
+    table
+      .string('geo_metadata_status', 20)
+      .notNullable()
+      .defaultTo('pending')
+      .comment('pending | resolved | unresolved')
+    table.boolean('geo_curated').notNullable().defaultTo(false)
+    table.timestamp('geo_metadata_resolved_at', { useTz: true }).nullable()
+
+    table.index(['geo_curated', 'geo_metadata_status'], 'idx_games_geo_curation')
+  })
+
+  await knex.schema.createTable('geo_ingest_failure', (table) => {
+    table
+      .integer('game_id')
+      .notNullable()
+      .references('id')
+      .inTable('games')
+      .onDelete('CASCADE')
+    table.string('source', 30).notNullable().comment('fandom | steam | metadata')
+    table.string('reason', 500).notNullable()
+    table.integer('attempt_count').notNullable().defaultTo(1)
+    table
+      .timestamp('last_attempt_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now())
+    table
+      .timestamp('retry_after', { useTz: true })
+      .notNullable()
+      .comment('Tick skips this game/source until now() >= retry_after')
+
+    table.primary(['game_id', 'source'])
+    table.index('retry_after', 'idx_geo_ingest_failure_retry_after')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('geo_ingest_failure')
+  await knex.schema.alterTable('games', (table) => {
+    table.dropIndex(['geo_curated', 'geo_metadata_status'], 'idx_games_geo_curation')
+    table.dropColumn('geo_metadata_resolved_at')
+    table.dropColumn('geo_curated')
+    table.dropColumn('geo_metadata_status')
+    table.dropColumn('wiki_page_title')
+    table.dropColumn('wiki_subdomain')
+    table.dropColumn('steam_app_id')
+  })
+}

--- a/packages/backend/src/domain/services/geo-metadata.service.ts
+++ b/packages/backend/src/domain/services/geo-metadata.service.ts
@@ -1,0 +1,77 @@
+// Pure helpers used by the geo metadata resolver. No I/O — keeps the
+// behaviour testable without a network. The resolver worker layers
+// HTTP probes on top of these.
+
+const DEFAULT_WIKI_PAGE_TITLES = [
+  'Interactive_Map',
+  'World_Map',
+  'Map',
+  'Maps',
+  'Atlas',
+] as const
+
+/**
+ * Derive Fandom subdomain candidates from a game slug. Most Fandom wikis
+ * follow `<slug>.fandom.com`, but slugs use kebab-case while wikis are
+ * usually concatenated. We yield a small ordered list of likely candidates;
+ * the resolver HEAD-checks them and picks the first one that responds.
+ */
+export function wikiSubdomainCandidates(slug: string): string[] {
+  const cleaned = slug.toLowerCase().trim()
+  if (!cleaned) return []
+
+  const collapsed = cleaned.replace(/[^a-z0-9]/g, '')
+  const dashed = cleaned.replace(/[^a-z0-9-]/g, '')
+  // Prefer collapsed (eldenring) over dashed (elden-ring) — Fandom convention.
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const c of [collapsed, dashed, cleaned]) {
+    if (c && !seen.has(c)) {
+      seen.add(c)
+      out.push(c)
+    }
+  }
+  return out
+}
+
+export function defaultWikiPageTitles(): readonly string[] {
+  return DEFAULT_WIKI_PAGE_TITLES
+}
+
+/**
+ * Parse the Steam appid from a store URL, e.g.
+ *   https://store.steampowered.com/app/1245620/ELDEN_RING/
+ * Used when RAWG `stores[]` is available; safe to call on arbitrary strings
+ * (returns null if no match).
+ */
+export function parseSteamAppIdFromUrl(url: string | null | undefined): number | null {
+  if (!url) return null
+  const m = url.match(/store\.steampowered\.com\/app\/(\d+)/i)
+  if (!m) return null
+  const id = Number(m[1])
+  return Number.isFinite(id) && id > 0 ? id : null
+}
+
+/**
+ * Very lightweight title normalization for matching Steam storesearch
+ * results to a known game name — strip punctuation, lowercase, collapse
+ * whitespace. Not a full fuzzy match; only used for "is this the right
+ * appid" disambiguation.
+ */
+export function normalizeGameTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[™®]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+/**
+ * Compute the next retry-after timestamp for a tombstoned (game, source)
+ * pair using exponential backoff capped at 30 days. Attempt 1 = 1 day,
+ * attempt 2 = 2 days, attempt 3 = 4 days, …, capped at 30.
+ */
+export function tombstoneRetryAfter(attemptCount: number, now: Date = new Date()): Date {
+  const days = Math.min(2 ** Math.max(0, attemptCount - 1), 30)
+  return new Date(now.getTime() + days * 24 * 60 * 60 * 1000)
+}

--- a/packages/backend/src/domain/services/index.ts
+++ b/packages/backend/src/domain/services/index.ts
@@ -57,6 +57,13 @@ export {
   GEO_CONTRIBUTE_HOURLY_LIMIT,
   GEO_CONTRIBUTE_MIN_DAYS_PLAYED,
 } from './geo-game.service.js'
+export {
+  wikiSubdomainCandidates,
+  defaultWikiPageTitles,
+  parseSteamAppIdFromUrl,
+  normalizeGameTitle,
+  tombstoneRetryAfter,
+} from './geo-metadata.service.js'
 
 // ---------------------------------------------------------------------------
 // Composition root for domain services.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -447,7 +447,11 @@ async function start(): Promise<void> {
     try {
       const existing = await geoQueue.getRepeatableJobs()
       for (const job of existing) {
-        if (job.name === 'schedule-daily-challenge') {
+        if (
+          job.name === 'schedule-daily-challenge' ||
+          job.name === 'resolve-metadata' ||
+          job.name === 'ingest-tick'
+        ) {
           await geoQueue.removeRepeatableByKey(job.key)
         }
       }
@@ -460,6 +464,30 @@ async function start(): Promise<void> {
         }
       )
       logger.info('scheduled recurring schedule-daily-challenge geo job (daily at 00:05 UTC)')
+
+      // Auto-resolve metadata for curated games every 30 min: HEADs Fandom +
+      // Steam storesearch and fills in steam_app_id / wiki_subdomain.
+      await geoQueue.add(
+        'resolve-metadata',
+        { kind: 'resolve-metadata' },
+        {
+          repeat: { every: 30 * 60 * 1000 },
+          jobId: 'geo-resolve-metadata-recurring',
+        }
+      )
+      logger.info('scheduled recurring resolve-metadata geo job (every 30 min)')
+
+      // Ingest tick every 15 min: enqueues per-game fandom/steam imports
+      // for curated games that are missing maps or low on candidates.
+      await geoQueue.add(
+        'ingest-tick',
+        { kind: 'ingest-tick' },
+        {
+          repeat: { every: 15 * 60 * 1000 },
+          jobId: 'geo-ingest-tick-recurring',
+        }
+      )
+      logger.info('scheduled recurring ingest-tick geo job (every 15 min)')
     } catch (error) {
       logger.warn({ error: String(error) }, 'failed to schedule recurring geo daily challenge job')
     }

--- a/packages/backend/src/infrastructure/queue/queues.ts
+++ b/packages/backend/src/infrastructure/queue/queues.ts
@@ -39,6 +39,8 @@ export type GeoJobData =
       maxItems?: number
     }
   | { kind: 'schedule-daily-challenge'; date?: string }
+  | { kind: 'resolve-metadata'; batchSize?: number }
+  | { kind: 'ingest-tick'; batchSize?: number }
 
 export const geoQueue = new Queue<GeoJobData>('geo-jobs', {
   connection: redisConnectionOptions,

--- a/packages/backend/src/infrastructure/queue/workers/geo-fandom-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-fandom-import-logic.ts
@@ -1,5 +1,9 @@
 import { queueLogger } from '../../logger/logger.js'
-import { geoMapRepository } from '../../repositories/index.js'
+import {
+  geoIngestFailureRepository,
+  geoMapRepository,
+} from '../../repositories/index.js'
+import { tombstoneRetryAfter } from '../../../domain/services/geo-metadata.service.js'
 
 const log = queueLogger.child({ worker: 'geo-fandom-import' })
 
@@ -72,6 +76,7 @@ export async function importFandomMap(
   const imageTitle = page?.images?.find((i) => looksLikeMap(i.title))?.title ?? page?.images?.[0]?.title
 
   if (!imageTitle) {
+    await recordFandomTombstone(gameId, 'no images on page')
     return { imported: false, reason: 'no images on page' }
   }
 
@@ -80,6 +85,7 @@ export async function importFandomMap(
   const infoPage = firstPage(infoRes)
   const info = infoPage?.imageinfo?.[0]
   if (!info?.url || !info.width || !info.height) {
+    await recordFandomTombstone(gameId, 'image info missing url or dimensions')
     return { imported: false, reason: 'image info missing url or dimensions' }
   }
 
@@ -94,8 +100,19 @@ export async function importFandomMap(
     attribution: `${wikiSubdomain}.fandom.com — ${imageTitle}`,
   })
 
+  await geoIngestFailureRepository.clear(gameId, 'fandom')
   log.info({ gameId, mapId: map.id }, 'imported fandom map')
   return { imported: true, geoMapId: map.id }
+}
+
+async function recordFandomTombstone(gameId: number, reason: string): Promise<void> {
+  const attempt = (await geoIngestFailureRepository.getAttemptCount(gameId, 'fandom')) + 1
+  await geoIngestFailureRepository.record({
+    gameId,
+    source: 'fandom',
+    reason,
+    retryAfter: tombstoneRetryAfter(attempt),
+  })
 }
 
 function firstPage(resp: MediaWikiQueryResponse): MediaWikiPage | undefined {

--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -1,0 +1,138 @@
+import { db } from '../../database/connection.js'
+import { queueLogger } from '../../logger/logger.js'
+import { geoQueue } from '../queues.js'
+import { geoMapRepository } from '../../repositories/index.js'
+
+const log = queueLogger.child({ worker: 'geo-ingest-tick' })
+
+const DEFAULT_BATCH = 25
+const STEAM_TARGET_CANDIDATES = 30 // stop fetching Steam shots once we have this many
+
+interface TickRow {
+  id: number
+  steam_app_id: number | null
+  wiki_subdomain: string | null
+  wiki_page_title: string | null
+  active_map_id: number | null
+  candidate_count: number
+}
+
+export interface IngestTickResult {
+  scanned: number
+  fandomEnqueued: number
+  steamEnqueued: number
+}
+
+/**
+ * One pass over curated, resolved games. For each:
+ *   - if no active geo_map → enqueue `import-fandom-map` (skipped if a
+ *     fandom tombstone is still active);
+ *   - if a map exists but candidate count is below STEAM_TARGET_CANDIDATES
+ *     and a steam_app_id is known → enqueue `import-steam-screenshots`
+ *     (skipped if a steam tombstone is still active).
+ *
+ * Idempotency: the import workers themselves short-circuit on duplicates
+ * (`findActiveByGameId` for fandom, `(source, external_id)` unique for
+ * steam), so it's safe to enqueue every tick — at worst we waste a few
+ * external HTTP calls.
+ */
+export async function runGeoIngestTick(
+  batchSize = DEFAULT_BATCH,
+): Promise<IngestTickResult> {
+  const rows = await db
+    .raw<{ rows: TickRow[] }>(
+      `
+      SELECT
+        g.id,
+        g.steam_app_id,
+        g.wiki_subdomain,
+        g.wiki_page_title,
+        m.id AS active_map_id,
+        COALESCE(c.cnt, 0) AS candidate_count
+      FROM games g
+      LEFT JOIN LATERAL (
+        SELECT id FROM geo_map
+        WHERE game_id = g.id AND is_active = true
+        ORDER BY created_at DESC
+        LIMIT 1
+      ) m ON true
+      LEFT JOIN (
+        SELECT game_id, COUNT(*)::int AS cnt
+        FROM geo_screenshot_candidate
+        WHERE is_active IS NOT FALSE
+        GROUP BY game_id
+      ) c ON c.game_id = g.id
+      WHERE g.geo_curated = true
+        AND g.geo_metadata_status = 'resolved'
+      ORDER BY g.id
+      LIMIT ?
+      `,
+      [batchSize],
+    )
+    .then((res) => (res as unknown as { rows: TickRow[] }).rows)
+
+  let fandomEnqueued = 0
+  let steamEnqueued = 0
+
+  for (const row of rows) {
+    if (!row.active_map_id && row.wiki_subdomain && row.wiki_page_title) {
+      const skip = await tombstoneBlocks(row.id, 'fandom')
+      if (!skip) {
+        await geoQueue.add(
+          'import-fandom-map',
+          {
+            kind: 'import-fandom-map',
+            gameId: row.id,
+            wikiSubdomain: row.wiki_subdomain,
+            pageTitle: row.wiki_page_title,
+          },
+          { jobId: `auto-fandom:${row.id}` },
+        )
+        fandomEnqueued++
+      }
+    }
+
+    if (
+      row.active_map_id &&
+      row.candidate_count < STEAM_TARGET_CANDIDATES &&
+      row.steam_app_id
+    ) {
+      const skip = await tombstoneBlocks(row.id, 'steam')
+      if (!skip) {
+        // Re-fetch the active map id off the repo so we don't pass a stale
+        // value (the SELECT above can be racing a recent fandom-import).
+        const map = await geoMapRepository.findActiveByGameId(row.id)
+        if (map) {
+          await geoQueue.add(
+            'import-steam-screenshots',
+            {
+              kind: 'import-steam-screenshots',
+              gameId: row.id,
+              geoMapId: map.id,
+              steamAppId: row.steam_app_id,
+            },
+            { jobId: `auto-steam:${row.id}:${map.id}` },
+          )
+          steamEnqueued++
+        }
+      }
+    }
+  }
+
+  log.info(
+    { scanned: rows.length, fandomEnqueued, steamEnqueued },
+    'geo-ingest-tick run',
+  )
+  return { scanned: rows.length, fandomEnqueued, steamEnqueued }
+}
+
+async function tombstoneBlocks(
+  gameId: number,
+  source: 'fandom' | 'steam',
+): Promise<boolean> {
+  const row = await db('geo_ingest_failure')
+    .where({ game_id: gameId, source })
+    .andWhere('retry_after', '>', db.fn.now())
+    .first<{ game_id: number }>()
+  return Boolean(row)
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
@@ -1,0 +1,161 @@
+import { db } from '../../database/connection.js'
+import { queueLogger } from '../../logger/logger.js'
+import { geoIngestFailureRepository } from '../../repositories/index.js'
+import {
+  defaultWikiPageTitles,
+  normalizeGameTitle,
+  tombstoneRetryAfter,
+  wikiSubdomainCandidates,
+} from '../../../domain/services/geo-metadata.service.js'
+
+const log = queueLogger.child({ worker: 'geo-metadata-resolve' })
+
+const DEFAULT_USER_AGENT =
+  'the-box-geo-importer/1.0 (+https://github.com/Wifsimster/the-box)'
+const STEAM_STORESEARCH = 'https://store.steampowered.com/api/storesearch/'
+const FANDOM_BASE = (sub: string) => `https://${sub}.fandom.com`
+
+interface CuratedGameRow {
+  id: number
+  name: string
+  slug: string
+  steam_app_id: number | null
+  wiki_subdomain: string | null
+  wiki_page_title: string | null
+}
+
+export interface ResolveMetadataResult {
+  scanned: number
+  resolved: number
+  unresolved: number
+  skipped: number
+}
+
+/**
+ * Resolve missing Steam app id, wiki subdomain, and wiki page title for
+ * curated games (`geo_curated = true`, `geo_metadata_status = 'pending'`).
+ *
+ * Strategy:
+ *   1. Steam app id: hit Steam's `storesearch` API by game name; pick the
+ *      first hit whose normalized title matches.
+ *   2. Wiki subdomain + page title: try each `<slug-variant>.fandom.com`
+ *      with each likely page title (Interactive_Map, World_Map, Map, …);
+ *      first HEAD that returns 200 wins.
+ *
+ * On full success → status='resolved'. On partial (e.g. wiki found but no
+ * Steam) we still mark resolved and let the per-source importers handle
+ * missing inputs. On total failure → status='unresolved' + tombstone with
+ * exponential backoff so we don't loop.
+ */
+export async function resolveGeoMetadataBatch(
+  batchSize = 25,
+): Promise<ResolveMetadataResult> {
+  const rows = await db<CuratedGameRow>('games')
+    .where('geo_curated', true)
+    .where('geo_metadata_status', 'pending')
+    .orderBy('id')
+    .limit(batchSize)
+    .select<CuratedGameRow[]>(
+      'id',
+      'name',
+      'slug',
+      'steam_app_id',
+      'wiki_subdomain',
+      'wiki_page_title',
+    )
+
+  let resolved = 0
+  let unresolved = 0
+  let skipped = 0
+
+  for (const row of rows) {
+    try {
+      const steamAppId = row.steam_app_id ?? (await resolveSteamAppId(row.name))
+      const wiki = row.wiki_subdomain
+        ? { subdomain: row.wiki_subdomain, pageTitle: row.wiki_page_title ?? 'Interactive_Map' }
+        : await resolveFandomPage(row.slug)
+
+      const haveAnything = Boolean(steamAppId) || Boolean(wiki)
+      if (!haveAnything) {
+        const attempt =
+          (await geoIngestFailureRepository.getAttemptCount(row.id, 'metadata')) + 1
+        await geoIngestFailureRepository.record({
+          gameId: row.id,
+          source: 'metadata',
+          reason: 'no Steam appid and no Fandom wiki found',
+          retryAfter: tombstoneRetryAfter(attempt),
+        })
+        await db('games')
+          .where({ id: row.id })
+          .update({ geo_metadata_status: 'unresolved' })
+        unresolved++
+        continue
+      }
+
+      await db('games')
+        .where({ id: row.id })
+        .update({
+          steam_app_id: steamAppId,
+          wiki_subdomain: wiki?.subdomain ?? row.wiki_subdomain,
+          wiki_page_title: wiki?.pageTitle ?? row.wiki_page_title,
+          geo_metadata_status: 'resolved',
+          geo_metadata_resolved_at: new Date(),
+        })
+      await geoIngestFailureRepository.clear(row.id, 'metadata')
+      resolved++
+      log.info(
+        { gameId: row.id, steamAppId, wiki },
+        'resolved geo metadata',
+      )
+    } catch (err) {
+      log.warn({ gameId: row.id, err: String(err) }, 'metadata resolution error')
+      skipped++
+    }
+  }
+
+  return { scanned: rows.length, resolved, unresolved, skipped }
+}
+
+async function resolveSteamAppId(name: string): Promise<number | null> {
+  try {
+    const url = `${STEAM_STORESEARCH}?term=${encodeURIComponent(name)}&l=en&cc=us`
+    const res = await fetch(url, {
+      headers: { 'User-Agent': DEFAULT_USER_AGENT, Accept: 'application/json' },
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as { items?: Array<{ id: number; name: string }> }
+    if (!body.items?.length) return null
+    const target = normalizeGameTitle(name)
+    const hit = body.items.find((it) => normalizeGameTitle(it.name) === target) ?? body.items[0]
+    return hit?.id ?? null
+  } catch (err) {
+    log.warn({ name, err: String(err) }, 'steam storesearch failed')
+    return null
+  }
+}
+
+async function resolveFandomPage(
+  slug: string,
+): Promise<{ subdomain: string; pageTitle: string } | null> {
+  const subs = wikiSubdomainCandidates(slug)
+  const titles = defaultWikiPageTitles()
+
+  for (const sub of subs) {
+    for (const title of titles) {
+      const url = `${FANDOM_BASE(sub)}/wiki/${encodeURIComponent(title)}`
+      try {
+        const res = await fetch(url, {
+          method: 'HEAD',
+          headers: { 'User-Agent': DEFAULT_USER_AGENT },
+          redirect: 'follow',
+        })
+        if (res.ok) {
+          return { subdomain: sub, pageTitle: title }
+        }
+      } catch {
+        // network glitch on a probe is fine — keep trying.
+      }
+    }
+  }
+  return null
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo-steam-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-steam-import-logic.ts
@@ -1,5 +1,9 @@
 import { queueLogger } from '../../logger/logger.js'
-import { geoScreenshotRepository } from '../../repositories/index.js'
+import {
+  geoIngestFailureRepository,
+  geoScreenshotRepository,
+} from '../../repositories/index.js'
+import { tombstoneRetryAfter } from '../../../domain/services/geo-metadata.service.js'
 
 const log = queueLogger.child({ worker: 'geo-steam-import' })
 
@@ -85,6 +89,19 @@ export async function importSteamScreenshots(
       log.warn({ err: String(e), externalId }, 'failed to insert candidate')
       skipped++
     }
+  }
+
+  if (shots.length === 0) {
+    const attempt =
+      (await geoIngestFailureRepository.getAttemptCount(gameId, 'steam')) + 1
+    await geoIngestFailureRepository.record({
+      gameId,
+      source: 'steam',
+      reason: 'steam appdetails returned no screenshots',
+      retryAfter: tombstoneRetryAfter(attempt),
+    })
+  } else if (inserted > 0) {
+    await geoIngestFailureRepository.clear(gameId, 'steam')
   }
 
   log.info({ gameId, steamAppId, fetched: shots.length, inserted, skipped }, 'imported steam screenshots')

--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -6,6 +6,8 @@ import { evaluateConsensusForCandidate } from './geo-consensus-logic.js'
 import { importFandomMap } from './geo-fandom-import-logic.js'
 import { importSteamScreenshots } from './geo-steam-import-logic.js'
 import { scheduleDailyGeoChallenge } from './geo-schedule-logic.js'
+import { resolveGeoMetadataBatch } from './geo-metadata-resolve-logic.js'
+import { runGeoIngestTick } from './geo-ingest-tick-logic.js'
 import { geoContributorService } from '../../../domain/services/index.js'
 import { emitGeoTierUp } from '../../socket/socket.js'
 
@@ -54,6 +56,14 @@ export const geoWorker = new Worker<GeoJobData>(
 
     if (data.kind === 'schedule-daily-challenge') {
       return await scheduleDailyGeoChallenge(data.date)
+    }
+
+    if (data.kind === 'resolve-metadata') {
+      return await resolveGeoMetadataBatch(data.batchSize)
+    }
+
+    if (data.kind === 'ingest-tick') {
+      return await runGeoIngestTick(data.batchSize)
     }
 
     throw new Error(`unknown geo job kind: ${JSON.stringify(data)}`)

--- a/packages/backend/src/infrastructure/repositories/geo-ingest-failure.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-ingest-failure.repository.ts
@@ -1,0 +1,67 @@
+import { db } from '../database/connection.js'
+import { repoLogger } from '../logger/logger.js'
+
+const log = repoLogger.child({ repository: 'geo-ingest-failure' })
+
+export type GeoIngestSource = 'fandom' | 'steam' | 'metadata'
+
+export interface GeoIngestFailureRow {
+  game_id: number
+  source: GeoIngestSource
+  reason: string
+  attempt_count: number
+  last_attempt_at: Date
+  retry_after: Date
+}
+
+export const geoIngestFailureRepository = {
+  /**
+   * Record a permanent (or temporarily unrecoverable) failure for a given
+   * (game, source). On conflict bumps `attempt_count` and refreshes
+   * `retry_after`. The tick query LEFT JOINs this table and skips rows
+   * where `retry_after > now()`.
+   */
+  async record(input: {
+    gameId: number
+    source: GeoIngestSource
+    reason: string
+    retryAfter: Date
+  }): Promise<void> {
+    log.info(
+      { gameId: input.gameId, source: input.source, reason: input.reason },
+      'record',
+    )
+    await db.raw(
+      `INSERT INTO geo_ingest_failure (game_id, source, reason, attempt_count, last_attempt_at, retry_after)
+       VALUES (?, ?, ?, 1, NOW(), ?)
+       ON CONFLICT (game_id, source) DO UPDATE SET
+         reason = EXCLUDED.reason,
+         attempt_count = geo_ingest_failure.attempt_count + 1,
+         last_attempt_at = NOW(),
+         retry_after = EXCLUDED.retry_after`,
+      [input.gameId, input.source, input.reason.slice(0, 500), input.retryAfter],
+    )
+  },
+
+  async clear(gameId: number, source: GeoIngestSource): Promise<void> {
+    await db('geo_ingest_failure').where({ game_id: gameId, source }).del()
+  },
+
+  async findActive(gameId: number, source: GeoIngestSource): Promise<GeoIngestFailureRow | null> {
+    const row = await db('geo_ingest_failure')
+      .where({ game_id: gameId, source })
+      .first<GeoIngestFailureRow>()
+    return row ?? null
+  },
+
+  async getAttemptCount(gameId: number, source: GeoIngestSource): Promise<number> {
+    const row = await this.findActive(gameId, source)
+    return row?.attempt_count ?? 0
+  },
+
+  async listAll(): Promise<GeoIngestFailureRow[]> {
+    return db('geo_ingest_failure')
+      .orderBy('last_attempt_at', 'desc')
+      .select<GeoIngestFailureRow[]>('*')
+  },
+}

--- a/packages/backend/src/infrastructure/repositories/index.ts
+++ b/packages/backend/src/infrastructure/repositories/index.ts
@@ -18,3 +18,8 @@ export {
   screenshotReportRepository,
   REPORT_DEACTIVATION_THRESHOLD,
 } from './screenshot-report.repository.js'
+export {
+  geoIngestFailureRepository,
+  type GeoIngestFailureRow,
+  type GeoIngestSource,
+} from './geo-ingest-failure.repository.js'

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -32,6 +32,7 @@ import {
   geoScreenshotRepository,
   geoPinRepository,
   geoMapRepository,
+  geoIngestFailureRepository,
   screenshotReportRepository,
 } from '../../infrastructure/repositories/index.js'
 import { GEO_CONSENSUS_VERSION } from '../../domain/services/index.js'
@@ -1381,18 +1382,98 @@ router.post('/geo/candidates/:id/override', async (req, res, next) => {
   }
 })
 
-// Enqueue on-demand ingestion + scheduling jobs onto the geo-jobs queue.
-// Returns the BullMQ job id so the admin UI can poll for completion.
+// Auto-ingestion is driven by recurring `resolve-metadata` and `ingest-tick`
+// jobs (see index.ts). The endpoints below give the admin a read-only view of
+// the dataset's health plus a small set of manual-override actions: flagging
+// games as curated (in/out of the auto pipeline) and forcing a re-import for
+// a single game when the heuristics get something wrong.
 
-const importFandomBodySchema = z.object({
-  gameId: z.number().int().positive(),
-  wikiSubdomain: z.string().min(1).max(100),
-  pageTitle: z.string().min(1).max(200),
+router.get('/geo/health', async (_req, res, next) => {
+  try {
+    const [counts, lastFandom, lastSteam, nextChallenge, queueCounts] =
+      await Promise.all([
+        db
+          .raw<{
+            rows: Array<{
+              curated: string
+              resolved: string
+              with_map: string
+              total: string
+            }>
+          }>(
+            `
+            SELECT
+              COUNT(*) FILTER (WHERE g.geo_curated)::text AS curated,
+              COUNT(*) FILTER (WHERE g.geo_curated AND g.geo_metadata_status = 'resolved')::text AS resolved,
+              COUNT(*) FILTER (
+                WHERE g.geo_curated
+                  AND EXISTS (
+                    SELECT 1 FROM geo_map m
+                    WHERE m.game_id = g.id AND m.is_active = true
+                  )
+              )::text AS with_map,
+              COUNT(*)::text AS total
+            FROM games g
+            `,
+          )
+          .then(
+            (r) => (r as unknown as { rows: Array<{ curated: string; resolved: string; with_map: string; total: string }> }).rows[0]!,
+          ),
+        db('geo_map')
+          .where('source', 'fandom')
+          .orderBy('created_at', 'desc')
+          .first<{ created_at: Date }>('created_at'),
+        db('geo_screenshot_candidate')
+          .where('source', 'steam')
+          .orderBy('created_at', 'desc')
+          .first<{ created_at: Date }>('created_at'),
+        db('geo_challenge')
+          .where('challenge_date', '>=', new Date().toISOString().slice(0, 10))
+          .orderBy('challenge_date', 'asc')
+          .first<{ id: number; challenge_date: string }>('id', 'challenge_date'),
+        geoQueue.getJobCounts('active', 'waiting', 'delayed', 'failed'),
+      ])
+
+    const failures = await geoIngestFailureRepository.listAll()
+
+    res.json({
+      success: true,
+      data: {
+        coverage: {
+          curated: Number(counts.curated),
+          resolved: Number(counts.resolved),
+          withMap: Number(counts.with_map),
+          total: Number(counts.total),
+        },
+        lastFandomImportAt: lastFandom?.created_at ?? null,
+        lastSteamImportAt: lastSteam?.created_at ?? null,
+        nextChallenge: nextChallenge
+          ? { id: nextChallenge.id, date: nextChallenge.challenge_date }
+          : null,
+        queue: queueCounts,
+        failures: failures.map((f) => ({
+          gameId: f.game_id,
+          source: f.source,
+          reason: f.reason,
+          attemptCount: f.attempt_count,
+          lastAttemptAt: f.last_attempt_at,
+          retryAfter: f.retry_after,
+        })),
+      },
+    })
+  } catch (err) {
+    next(err)
+  }
 })
 
-router.post('/geo/import/fandom', async (req, res, next) => {
+const curatedBodySchema = z.object({
+  gameId: z.number().int().positive(),
+  curated: z.boolean(),
+})
+
+router.post('/geo/curated', async (req, res, next) => {
   try {
-    const parse = importFandomBodySchema.safeParse(req.body)
+    const parse = curatedBodySchema.safeParse(req.body)
     if (!parse.success) {
       res.status(400).json({
         success: false,
@@ -1400,9 +1481,66 @@ router.post('/geo/import/fandom', async (req, res, next) => {
       })
       return
     }
-    const job = await geoQueue.add('import-fandom-map', {
-      kind: 'import-fandom-map',
-      ...parse.data,
+
+    // Flipping curated→true also resets metadata_status so the resolver
+    // picks the game up on its next tick, even if a previous attempt left
+    // it as 'unresolved'.
+    const update: Record<string, unknown> = { geo_curated: parse.data.curated }
+    if (parse.data.curated) {
+      update.geo_metadata_status = 'pending'
+    }
+    const updated = await db('games')
+      .where({ id: parse.data.gameId })
+      .update(update)
+
+    if (updated === 0) {
+      res.status(404).json({ success: false, error: { code: 'NOT_FOUND' } })
+      return
+    }
+
+    if (parse.data.curated) {
+      await geoIngestFailureRepository.clear(parse.data.gameId, 'metadata')
+    }
+
+    res.json({ success: true, data: { gameId: parse.data.gameId, curated: parse.data.curated } })
+  } catch (err) {
+    next(err)
+  }
+})
+
+const reimportBodySchema = z.object({
+  gameId: z.number().int().positive(),
+})
+
+router.post('/geo/reimport', async (req, res, next) => {
+  try {
+    const parse = reimportBodySchema.safeParse(req.body)
+    if (!parse.success) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: parse.error.issues[0]?.message },
+      })
+      return
+    }
+    // Wipe tombstones + force a metadata re-resolve. The recurring ingest
+    // tick will re-enqueue per-source imports as soon as resolution lands.
+    await Promise.all([
+      geoIngestFailureRepository.clear(parse.data.gameId, 'fandom'),
+      geoIngestFailureRepository.clear(parse.data.gameId, 'steam'),
+      geoIngestFailureRepository.clear(parse.data.gameId, 'metadata'),
+    ])
+    await db('games')
+      .where({ id: parse.data.gameId })
+      .update({
+        geo_metadata_status: 'pending',
+        wiki_subdomain: null,
+        wiki_page_title: null,
+        steam_app_id: null,
+      })
+
+    const job = await geoQueue.add('resolve-metadata', {
+      kind: 'resolve-metadata',
+      batchSize: 1,
     })
     res.json({ success: true, data: { jobId: job.id } })
   } catch (err) {
@@ -1410,53 +1548,13 @@ router.post('/geo/import/fandom', async (req, res, next) => {
   }
 })
 
-const importSteamBodySchema = z.object({
-  gameId: z.number().int().positive(),
-  geoMapId: z.number().int().positive(),
-  steamAppId: z.number().int().positive(),
-  maxItems: z.number().int().positive().max(200).optional(),
-})
-
-router.post('/geo/import/steam', async (req, res, next) => {
+router.post('/geo/schedule', async (_req, res, next) => {
+  // Manual fallback: trigger the daily-challenge scheduler immediately.
+  // The recurring 00:05 UTC job is the primary path; this is an escape
+  // hatch when ops needs to refill the calendar mid-day.
   try {
-    const parse = importSteamBodySchema.safeParse(req.body)
-    if (!parse.success) {
-      res.status(400).json({
-        success: false,
-        error: { code: 'VALIDATION_ERROR', message: parse.error.issues[0]?.message },
-      })
-      return
-    }
-    const job = await geoQueue.add('import-steam-screenshots', {
-      kind: 'import-steam-screenshots',
-      ...parse.data,
-    })
-    res.json({ success: true, data: { jobId: job.id } })
-  } catch (err) {
-    next(err)
-  }
-})
-
-const scheduleBodySchema = z.object({
-  date: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD')
-    .optional(),
-})
-
-router.post('/geo/schedule', async (req, res, next) => {
-  try {
-    const parse = scheduleBodySchema.safeParse(req.body ?? {})
-    if (!parse.success) {
-      res.status(400).json({
-        success: false,
-        error: { code: 'VALIDATION_ERROR', message: parse.error.issues[0]?.message },
-      })
-      return
-    }
     const job = await geoQueue.add('schedule-daily-challenge', {
       kind: 'schedule-daily-challenge',
-      date: parse.data.date,
     })
     res.json({ success: true, data: { jobId: job.id } })
   } catch (err) {

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -484,30 +484,57 @@
         "confirm": "Demote",
         "cancel": "Cancel"
       },
-      "actions": {
-        "title": "Ingestion & scheduling",
-        "subtitle": "Run admin-only jobs against the Geo pipeline.",
-        "fandom": "Import Fandom map",
-        "fandomDescription": "Download a wiki's interactive-map asset and register it as a Geo map for a game.",
-        "steam": "Import Steam screenshots",
-        "steamDescription": "Pull a game's user-submitted screenshots from Steam and register them as candidates against a Geo map.",
-        "schedule": "Schedule daily challenge",
-        "scheduleDescription": "Assign one promoted candidate to a future date so it appears in the daily Geo round.",
-        "enqueue": "Enqueue job",
-        "queued": "Job queued: {{id}}",
-        "fields": {
-          "gameId": "Game ID",
-          "gameIdHint": "Numeric ID of the game in the local database.",
-          "subdomain": "Wiki subdomain",
-          "subdomainHint": "The Fandom subdomain (e.g. \"eldenring\" for eldenring.fandom.com).",
-          "pageTitle": "Wiki page title",
-          "pageTitleHint": "URL slug of the page hosting the map (e.g. \"Interactive_Map\").",
-          "geoMapId": "Geo map ID",
-          "geoMapIdHint": "ID of the existing Geo map this game's screenshots should attach to.",
-          "steamAppId": "Steam app ID",
-          "steamAppIdHint": "Numeric Steam app ID (e.g. 1245620 for Elden Ring).",
-          "scheduleDate": "Date (optional)",
-          "scheduleDateHint": "Format YYYY-MM-DD. Leave empty to schedule for tomorrow."
+      "health": {
+        "title": "Geo dataset health",
+        "subtitle": "The pipeline auto-ingests maps and screenshots for games flagged as curated. No manual action required.",
+        "loading": "Loading dataset state…",
+        "error": "Failed to load dataset state.",
+        "refresh": "Refresh",
+        "status": {
+          "healthy": "Healthy",
+          "warning": "Watch",
+          "critical": "Failing"
+        },
+        "coverage": {
+          "label": "Map coverage",
+          "value": "{{withMap}} / {{curated}} curated games have a map ({{total}} games total)"
+        },
+        "metrics": {
+          "resolved": "Resolved metadata",
+          "lastFandom": "Last Fandom map",
+          "lastSteam": "Last Steam screenshots",
+          "nextChallenge": "Next scheduled challenge",
+          "never": "Never",
+          "noScheduled": "None"
+        },
+        "queue": {
+          "title": "geo-jobs queue",
+          "active": "active",
+          "waiting": "waiting",
+          "delayed": "delayed",
+          "failed": "failed"
+        },
+        "failures": {
+          "title": "Recent failures",
+          "empty": "No active failures. 🎉",
+          "row": "Game #{{gameId}} · {{source}} · {{reason}} (attempt {{attempt}})"
+        },
+        "advanced": {
+          "title": "Advanced",
+          "subtitle": "Rare manual overrides — only if the auto-ingest gets something wrong.",
+          "curatedToggle": "Toggle curation",
+          "curatedOn": "Mark as curated",
+          "curatedOff": "Remove from curation",
+          "reimport": "Force re-ingestion",
+          "scheduleNow": "Schedule challenge now",
+          "gameIdLabel": "Game ID",
+          "gameIdHint": "Numeric ID of the game in the local database."
+        },
+        "actions": {
+          "queued": "Job queued: {{id}}",
+          "curatedSet": "Game #{{id}}: curated = {{curated}}",
+          "reimportQueued": "Re-ingestion queued for game #{{id}} (job {{jobId}})",
+          "scheduled": "Scheduling triggered (job {{id}})"
         }
       }
     },

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -484,30 +484,57 @@
         "confirm": "Rétrograder",
         "cancel": "Annuler"
       },
-      "actions": {
-        "title": "Ingestion et planification",
-        "subtitle": "Lancez les tâches admin du pipeline Géo.",
-        "fandom": "Importer la carte Fandom",
-        "fandomDescription": "Télécharge la carte interactive d'un wiki et l'enregistre comme carte Géo pour un jeu.",
-        "steam": "Importer les captures Steam",
-        "steamDescription": "Récupère les captures publiques d'un jeu depuis Steam et les enregistre comme candidats sur une carte Géo.",
-        "schedule": "Planifier le défi quotidien",
-        "scheduleDescription": "Assigne un candidat promu à une date future pour qu'il apparaisse dans le défi Géo quotidien.",
-        "enqueue": "Lancer la tâche",
-        "queued": "Tâche en file : {{id}}",
-        "fields": {
-          "gameId": "ID du jeu",
-          "gameIdHint": "Identifiant numérique du jeu dans la base locale.",
-          "subdomain": "Sous-domaine du wiki",
-          "subdomainHint": "Le sous-domaine Fandom (ex. « eldenring » pour eldenring.fandom.com).",
-          "pageTitle": "Titre de la page wiki",
-          "pageTitleHint": "Slug de la page qui héberge la carte (ex. « Interactive_Map »).",
-          "geoMapId": "ID de carte Géo",
-          "geoMapIdHint": "Identifiant de la carte Géo existante à laquelle rattacher les captures.",
-          "steamAppId": "App ID Steam",
-          "steamAppIdHint": "Identifiant Steam numérique du jeu (ex. 1245620 pour Elden Ring).",
-          "scheduleDate": "Date (optionnel)",
-          "scheduleDateHint": "Format AAAA-MM-JJ. Laissez vide pour planifier pour demain."
+      "health": {
+        "title": "Santé du dataset Géo",
+        "subtitle": "Le pipeline ingère automatiquement cartes et captures pour les jeux marqués comme curatés. Aucune action manuelle requise.",
+        "loading": "Chargement de l'état du dataset…",
+        "error": "Échec du chargement de l'état du dataset.",
+        "refresh": "Actualiser",
+        "status": {
+          "healthy": "Sain",
+          "warning": "À surveiller",
+          "critical": "Échec"
+        },
+        "coverage": {
+          "label": "Couverture des cartes",
+          "value": "{{withMap}} / {{curated}} jeux curatés ont une carte ({{total}} jeux au total)"
+        },
+        "metrics": {
+          "resolved": "Métadonnées résolues",
+          "lastFandom": "Dernière carte Fandom",
+          "lastSteam": "Dernières captures Steam",
+          "nextChallenge": "Prochain défi planifié",
+          "never": "Jamais",
+          "noScheduled": "Aucun"
+        },
+        "queue": {
+          "title": "File geo-jobs",
+          "active": "actifs",
+          "waiting": "en attente",
+          "delayed": "différés",
+          "failed": "échoués"
+        },
+        "failures": {
+          "title": "Échecs récents",
+          "empty": "Aucun échec actif. 🎉",
+          "row": "Jeu #{{gameId}} · {{source}} · {{reason}} (tentative {{attempt}})"
+        },
+        "advanced": {
+          "title": "Avancé",
+          "subtitle": "Actions manuelles rares — uniquement si l'auto-ingestion se trompe.",
+          "curatedToggle": "Activer/désactiver la curation",
+          "curatedOn": "Marquer comme curaté",
+          "curatedOff": "Retirer de la curation",
+          "reimport": "Forcer la ré-ingestion",
+          "scheduleNow": "Planifier le défi maintenant",
+          "gameIdLabel": "ID du jeu",
+          "gameIdHint": "Identifiant numérique du jeu dans la base locale."
+        },
+        "actions": {
+          "queued": "Tâche en file : {{id}}",
+          "curatedSet": "Jeu #{{id}} : curation = {{curated}}",
+          "reimportQueued": "Ré-ingestion lancée pour le jeu #{{id}} (tâche {{jobId}})",
+          "scheduled": "Planification lancée (tâche {{id}})"
         }
       }
     },

--- a/packages/frontend/src/components/admin/GeoAdminActions.tsx
+++ b/packages/frontend/src/components/admin/GeoAdminActions.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react'
+import { useCallback, useEffect, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
     Card,
@@ -10,103 +10,161 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Loader2, CalendarClock, Image, ImageDown } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Progress } from '@/components/ui/progress'
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+    Loader2,
+    RefreshCw,
+    ChevronsUpDown,
+    AlertTriangle,
+} from 'lucide-react'
 
-type ActionKind = 'fandom' | 'steam' | 'schedule' | null
+interface HealthData {
+    coverage: { curated: number; resolved: number; withMap: number; total: number }
+    lastFandomImportAt: string | null
+    lastSteamImportAt: string | null
+    nextChallenge: { id: number; date: string } | null
+    queue: { active: number; waiting: number; delayed: number; failed: number }
+    failures: Array<{
+        gameId: number
+        source: string
+        reason: string
+        attemptCount: number
+        lastAttemptAt: string
+        retryAfter: string
+    }>
+}
 
-async function postJson(path: string, body: unknown): Promise<{ jobId: string }> {
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
     const res = await fetch(path, {
-        method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
+        ...init,
     })
     const json = await res.json().catch(() => ({}))
     if (!res.ok || !json?.success) {
         throw new Error(json?.error?.code ?? `request failed: ${res.status}`)
     }
-    return json.data
+    return json.data as T
 }
 
-interface FieldProps {
-    id: string
-    label: string
-    hint: string
-    placeholder?: string
-    value: string
-    onChange: (v: string) => void
-    inputMode?: 'numeric' | 'text'
-}
-
-function Field({ id, label, hint, placeholder, value, onChange, inputMode }: FieldProps) {
-    return (
-        <div className="space-y-1">
-            <Label htmlFor={id} className="text-xs">
-                {label}
-            </Label>
-            <Input
-                id={id}
-                placeholder={placeholder}
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-                inputMode={inputMode}
-            />
-            <p className="text-[11px] text-muted-foreground leading-snug">{hint}</p>
-        </div>
-    )
+function relative(iso: string | null, neverLabel: string): string {
+    if (!iso) return neverLabel
+    const d = new Date(iso)
+    const diffMs = Date.now() - d.getTime()
+    const mins = Math.round(diffMs / 60_000)
+    if (mins < 60) return `il y a ${mins} min`
+    const hours = Math.round(mins / 60)
+    if (hours < 48) return `il y a ${hours} h`
+    return d.toISOString().slice(0, 10)
 }
 
 /**
- * Minimal ops controls for the admin: enqueue ingestion + scheduling jobs
- * onto the geo-jobs BullMQ queue. Deliberately no job-status polling here
- * — admins watch progress via the existing Job Queue tab.
+ * Read-only "Geo dataset health" panel. The full ingestion pipeline runs
+ * automatically (recurring `resolve-metadata` and `ingest-tick` jobs) for
+ * games flagged as curated. The collapsible "Advanced" section exposes the
+ * three rare overrides admins might still need: toggling curation, forcing
+ * a re-ingestion, and triggering the daily-challenge scheduler immediately.
  */
 export function GeoAdminActions() {
     const { t } = useTranslation()
     const formId = useId()
-    const [running, setRunning] = useState<ActionKind>(null)
-    const [message, setMessage] = useState<string | null>(null)
+    const [health, setHealth] = useState<HealthData | null>(null)
+    const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [busy, setBusy] = useState<'reimport' | 'curated' | 'schedule' | null>(null)
+    const [message, setMessage] = useState<string | null>(null)
+    const [advancedGameId, setAdvancedGameId] = useState('')
 
-    // Fandom form
-    const [fandomGameId, setFandomGameId] = useState('')
-    const [fandomSubdomain, setFandomSubdomain] = useState('eldenring')
-    const [fandomPage, setFandomPage] = useState('Interactive_Map')
-
-    // Steam form
-    const [steamGameId, setSteamGameId] = useState('')
-    const [steamMapId, setSteamMapId] = useState('')
-    const [steamAppId, setSteamAppId] = useState('')
-
-    // Schedule form
-    const [scheduleDate, setScheduleDate] = useState('')
-
-    const runAction = async (
-        kind: Exclude<ActionKind, null>,
-        fn: () => Promise<{ jobId: string }>,
-    ) => {
-        setRunning(kind)
+    const reload = useCallback(async () => {
+        setLoading(true)
         setError(null)
-        setMessage(null)
         try {
-            const { jobId } = await fn()
-            setMessage(t('admin.geo.actions.queued', { id: jobId }))
+            const data = await fetchJson<HealthData>('/api/admin/geo/health')
+            setHealth(data)
         } catch (e) {
             setError(String(e))
         } finally {
-            setRunning(null)
+            setLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        void reload()
+        const interval = window.setInterval(() => void reload(), 30_000)
+        return () => window.clearInterval(interval)
+    }, [reload])
+
+    const runAdvanced = async (
+        kind: 'reimport' | 'curated' | 'schedule',
+        fn: () => Promise<string>,
+    ) => {
+        setBusy(kind)
+        setMessage(null)
+        setError(null)
+        try {
+            const msg = await fn()
+            setMessage(msg)
+            await reload()
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setBusy(null)
         }
     }
+
+    const coveragePct = health?.coverage.curated
+        ? Math.round((100 * health.coverage.withMap) / health.coverage.curated)
+        : 0
+    const failingNow = (health?.queue.failed ?? 0) > 0 || (health?.failures.length ?? 0) > 0
+    const status: 'healthy' | 'warning' | 'critical' = error
+        ? 'critical'
+        : failingNow
+          ? 'warning'
+          : 'healthy'
 
     return (
         <Card>
             <CardHeader className="pb-2">
-                <CardTitle className="text-sm">{t('admin.geo.actions.title')}</CardTitle>
-                <CardDescription className="text-xs">
-                    {t('admin.geo.actions.subtitle')}
-                </CardDescription>
+                <div className="flex items-center justify-between gap-2">
+                    <div>
+                        <CardTitle className="text-sm">{t('admin.geo.health.title')}</CardTitle>
+                        <CardDescription className="text-xs">
+                            {t('admin.geo.health.subtitle')}
+                        </CardDescription>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Badge
+                            variant={
+                                status === 'healthy'
+                                    ? 'default'
+                                    : status === 'warning'
+                                      ? 'secondary'
+                                      : 'destructive'
+                            }
+                        >
+                            {t(`admin.geo.health.status.${status}`)}
+                        </Badge>
+                        <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => void reload()}
+                            disabled={loading}
+                            aria-label={t('admin.geo.health.refresh')}
+                        >
+                            <RefreshCw
+                                className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`}
+                            />
+                        </Button>
+                    </div>
+                </div>
             </CardHeader>
-            <CardContent className="space-y-6">
+            <CardContent className="space-y-4">
                 {message && (
                     <div className="rounded border border-success/40 bg-success/10 p-2 text-xs text-success">
                         {message}
@@ -117,172 +175,228 @@ export function GeoAdminActions() {
                         {error}
                     </div>
                 )}
+                {loading && !health && (
+                    <p className="text-xs text-muted-foreground">
+                        {t('admin.geo.health.loading')}
+                    </p>
+                )}
 
-                {/* Fandom */}
-                <section className="space-y-3">
-                    <div className="space-y-0.5">
-                        <h3 className="text-sm font-semibold flex items-center gap-2">
-                            <Image className="h-3.5 w-3.5" aria-hidden />
-                            {t('admin.geo.actions.fandom')}
-                        </h3>
-                        <p className="text-xs text-muted-foreground">
-                            {t('admin.geo.actions.fandomDescription')}
-                        </p>
-                    </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                        <Field
-                            id={`${formId}-fandom-gameid`}
-                            label={t('admin.geo.actions.fields.gameId')}
-                            hint={t('admin.geo.actions.fields.gameIdHint')}
-                            placeholder="123"
-                            value={fandomGameId}
-                            onChange={setFandomGameId}
-                            inputMode="numeric"
-                        />
-                        <Field
-                            id={`${formId}-fandom-sub`}
-                            label={t('admin.geo.actions.fields.subdomain')}
-                            hint={t('admin.geo.actions.fields.subdomainHint')}
-                            placeholder="eldenring"
-                            value={fandomSubdomain}
-                            onChange={setFandomSubdomain}
-                        />
-                        <Field
-                            id={`${formId}-fandom-page`}
-                            label={t('admin.geo.actions.fields.pageTitle')}
-                            hint={t('admin.geo.actions.fields.pageTitleHint')}
-                            placeholder="Interactive_Map"
-                            value={fandomPage}
-                            onChange={setFandomPage}
-                        />
-                    </div>
-                    <Button
-                        size="sm"
-                        onClick={() =>
-                            runAction('fandom', () =>
-                                postJson('/api/admin/geo/import/fandom', {
-                                    gameId: Number(fandomGameId),
-                                    wikiSubdomain: fandomSubdomain,
-                                    pageTitle: fandomPage,
-                                }),
-                            )
-                        }
-                        disabled={
-                            running !== null ||
-                            !fandomGameId ||
-                            !fandomSubdomain ||
-                            !fandomPage
-                        }
-                    >
-                        {running === 'fandom' && (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
-                        )}
-                        {t('admin.geo.actions.enqueue')}
-                    </Button>
-                </section>
+                {health && (
+                    <>
+                        <section className="space-y-2">
+                            <div className="flex items-center justify-between text-xs">
+                                <span className="font-medium">
+                                    {t('admin.geo.health.coverage.label')}
+                                </span>
+                                <span className="text-muted-foreground">{coveragePct}%</span>
+                            </div>
+                            <Progress value={coveragePct} className="h-2" />
+                            <p className="text-[11px] text-muted-foreground">
+                                {t('admin.geo.health.coverage.value', {
+                                    withMap: health.coverage.withMap,
+                                    curated: health.coverage.curated,
+                                    total: health.coverage.total,
+                                })}
+                            </p>
+                        </section>
 
-                {/* Steam */}
-                <section className="space-y-3">
-                    <div className="space-y-0.5">
-                        <h3 className="text-sm font-semibold flex items-center gap-2">
-                            <ImageDown className="h-3.5 w-3.5" aria-hidden />
-                            {t('admin.geo.actions.steam')}
-                        </h3>
-                        <p className="text-xs text-muted-foreground">
-                            {t('admin.geo.actions.steamDescription')}
-                        </p>
-                    </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                        <Field
-                            id={`${formId}-steam-gameid`}
-                            label={t('admin.geo.actions.fields.gameId')}
-                            hint={t('admin.geo.actions.fields.gameIdHint')}
-                            placeholder="123"
-                            value={steamGameId}
-                            onChange={setSteamGameId}
-                            inputMode="numeric"
-                        />
-                        <Field
-                            id={`${formId}-steam-mapid`}
-                            label={t('admin.geo.actions.fields.geoMapId')}
-                            hint={t('admin.geo.actions.fields.geoMapIdHint')}
-                            placeholder="456"
-                            value={steamMapId}
-                            onChange={setSteamMapId}
-                            inputMode="numeric"
-                        />
-                        <Field
-                            id={`${formId}-steam-appid`}
-                            label={t('admin.geo.actions.fields.steamAppId')}
-                            hint={t('admin.geo.actions.fields.steamAppIdHint')}
-                            placeholder="1245620"
-                            value={steamAppId}
-                            onChange={setSteamAppId}
-                            inputMode="numeric"
-                        />
-                    </div>
-                    <Button
-                        size="sm"
-                        onClick={() =>
-                            runAction('steam', () =>
-                                postJson('/api/admin/geo/import/steam', {
-                                    gameId: Number(steamGameId),
-                                    geoMapId: Number(steamMapId),
-                                    steamAppId: Number(steamAppId),
-                                }),
-                            )
-                        }
-                        disabled={
-                            running !== null || !steamGameId || !steamMapId || !steamAppId
-                        }
-                    >
-                        {running === 'steam' && (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
-                        )}
-                        {t('admin.geo.actions.enqueue')}
-                    </Button>
-                </section>
+                        <section className="grid grid-cols-2 gap-3 text-xs">
+                            <Metric
+                                label={t('admin.geo.health.metrics.resolved')}
+                                value={`${health.coverage.resolved} / ${health.coverage.curated}`}
+                            />
+                            <Metric
+                                label={t('admin.geo.health.metrics.nextChallenge')}
+                                value={
+                                    health.nextChallenge?.date ??
+                                    t('admin.geo.health.metrics.noScheduled')
+                                }
+                            />
+                            <Metric
+                                label={t('admin.geo.health.metrics.lastFandom')}
+                                value={relative(
+                                    health.lastFandomImportAt,
+                                    t('admin.geo.health.metrics.never'),
+                                )}
+                            />
+                            <Metric
+                                label={t('admin.geo.health.metrics.lastSteam')}
+                                value={relative(
+                                    health.lastSteamImportAt,
+                                    t('admin.geo.health.metrics.never'),
+                                )}
+                            />
+                        </section>
 
-                {/* Schedule */}
-                <section className="space-y-3">
-                    <div className="space-y-0.5">
-                        <h3 className="text-sm font-semibold flex items-center gap-2">
-                            <CalendarClock className="h-3.5 w-3.5" aria-hidden />
-                            {t('admin.geo.actions.schedule')}
-                        </h3>
-                        <p className="text-xs text-muted-foreground">
-                            {t('admin.geo.actions.scheduleDescription')}
+                        <section className="flex flex-wrap gap-2">
+                            <span className="text-[11px] text-muted-foreground">
+                                {t('admin.geo.health.queue.title')} —
+                            </span>
+                            <Badge variant="outline">
+                                {health.queue.active} {t('admin.geo.health.queue.active')}
+                            </Badge>
+                            <Badge variant="outline">
+                                {health.queue.waiting} {t('admin.geo.health.queue.waiting')}
+                            </Badge>
+                            <Badge variant="outline">
+                                {health.queue.delayed} {t('admin.geo.health.queue.delayed')}
+                            </Badge>
+                            <Badge
+                                variant={health.queue.failed ? 'destructive' : 'outline'}
+                            >
+                                {health.queue.failed} {t('admin.geo.health.queue.failed')}
+                            </Badge>
+                        </section>
+
+                        <section className="space-y-1.5">
+                            <h4 className="text-xs font-semibold flex items-center gap-1.5">
+                                <AlertTriangle className="h-3 w-3" aria-hidden />
+                                {t('admin.geo.health.failures.title')}
+                            </h4>
+                            {health.failures.length === 0 ? (
+                                <p className="text-[11px] text-muted-foreground">
+                                    {t('admin.geo.health.failures.empty')}
+                                </p>
+                            ) : (
+                                <ul className="space-y-1 text-[11px] text-muted-foreground">
+                                    {health.failures.slice(0, 8).map((f) => (
+                                        <li
+                                            key={`${f.gameId}-${f.source}`}
+                                            className="leading-snug"
+                                        >
+                                            {t('admin.geo.health.failures.row', {
+                                                gameId: f.gameId,
+                                                source: f.source,
+                                                reason: f.reason,
+                                                attempt: f.attemptCount,
+                                            })}
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </section>
+                    </>
+                )}
+
+                <Collapsible>
+                    <CollapsibleTrigger asChild>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="w-full justify-between text-xs"
+                        >
+                            {t('admin.geo.health.advanced.title')}
+                            <ChevronsUpDown className="h-3 w-3" aria-hidden />
+                        </Button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="space-y-3 pt-2">
+                        <p className="text-[11px] text-muted-foreground">
+                            {t('admin.geo.health.advanced.subtitle')}
                         </p>
-                    </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                        <Field
-                            id={`${formId}-schedule-date`}
-                            label={t('admin.geo.actions.fields.scheduleDate')}
-                            hint={t('admin.geo.actions.fields.scheduleDateHint')}
-                            placeholder="2026-05-01"
-                            value={scheduleDate}
-                            onChange={setScheduleDate}
-                        />
-                    </div>
-                    <Button
-                        size="sm"
-                        onClick={() =>
-                            runAction('schedule', () =>
-                                postJson(
-                                    '/api/admin/geo/schedule',
-                                    scheduleDate ? { date: scheduleDate } : {},
-                                ),
-                            )
-                        }
-                        disabled={running !== null}
-                    >
-                        {running === 'schedule' && (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
-                        )}
-                        {t('admin.geo.actions.enqueue')}
-                    </Button>
-                </section>
+                        <div className="space-y-1">
+                            <Label htmlFor={`${formId}-advanced-gameid`} className="text-xs">
+                                {t('admin.geo.health.advanced.gameIdLabel')}
+                            </Label>
+                            <Input
+                                id={`${formId}-advanced-gameid`}
+                                inputMode="numeric"
+                                value={advancedGameId}
+                                onChange={(e) => setAdvancedGameId(e.target.value)}
+                                placeholder="123"
+                            />
+                            <p className="text-[11px] text-muted-foreground">
+                                {t('admin.geo.health.advanced.gameIdHint')}
+                            </p>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={busy !== null || !advancedGameId}
+                                onClick={() =>
+                                    runAdvanced('curated', async () => {
+                                        const id = Number(advancedGameId)
+                                        const data = await fetchJson<{
+                                            gameId: number
+                                            curated: boolean
+                                        }>('/api/admin/geo/curated', {
+                                            method: 'POST',
+                                            body: JSON.stringify({ gameId: id, curated: true }),
+                                        })
+                                        return t('admin.geo.health.actions.curatedSet', {
+                                            id: data.gameId,
+                                            curated: data.curated,
+                                        })
+                                    })
+                                }
+                            >
+                                {busy === 'curated' && (
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                                )}
+                                {t('admin.geo.health.advanced.curatedOn')}
+                            </Button>
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={busy !== null || !advancedGameId}
+                                onClick={() =>
+                                    runAdvanced('reimport', async () => {
+                                        const id = Number(advancedGameId)
+                                        const data = await fetchJson<{ jobId: string }>(
+                                            '/api/admin/geo/reimport',
+                                            {
+                                                method: 'POST',
+                                                body: JSON.stringify({ gameId: id }),
+                                            },
+                                        )
+                                        return t('admin.geo.health.actions.reimportQueued', {
+                                            id,
+                                            jobId: data.jobId,
+                                        })
+                                    })
+                                }
+                            >
+                                {busy === 'reimport' && (
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                                )}
+                                {t('admin.geo.health.advanced.reimport')}
+                            </Button>
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={busy !== null}
+                                onClick={() =>
+                                    runAdvanced('schedule', async () => {
+                                        const data = await fetchJson<{ jobId: string }>(
+                                            '/api/admin/geo/schedule',
+                                            { method: 'POST', body: '{}' },
+                                        )
+                                        return t('admin.geo.health.actions.scheduled', {
+                                            id: data.jobId,
+                                        })
+                                    })
+                                }
+                            >
+                                {busy === 'schedule' && (
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                                )}
+                                {t('admin.geo.health.advanced.scheduleNow')}
+                            </Button>
+                        </div>
+                    </CollapsibleContent>
+                </Collapsible>
             </CardContent>
         </Card>
+    )
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+    return (
+        <div className="rounded border border-border/50 bg-muted/20 p-2">
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                {label}
+            </p>
+            <p className="font-mono text-xs">{value}</p>
+        </div>
     )
 }


### PR DESCRIPTION
Replaces the three manual admin forms (Fandom map import, Steam screenshot
import, daily-challenge schedule) with a fully automatic pipeline driven by
two new recurring jobs on the geo-jobs queue:

- resolve-metadata (every 30 min): for games flagged geo_curated, fills in
  steam_app_id from Steam storesearch and wiki_subdomain/wiki_page_title via
  HEAD probes against <slug>.fandom.com.
- ingest-tick (every 15 min): for curated, resolved games, enqueues
  import-fandom-map when no active map exists, and import-steam-screenshots
  when candidate count is below threshold.

Permanent failures land in a new geo_ingest_failure tombstone table with
exponential backoff (1d, 2d, 4d, …, capped at 30d), so the tick stops
hammering games that have no Fandom wiki or empty Steam screenshots.

Admin UI (GeoAdminActions.tsx) becomes a read-only "Santé du dataset Géo"
card showing coverage, last-import timestamps, queue depth, next scheduled
challenge, and recent failures. A small "Avancé" collapsible exposes three
rare overrides: mark a game as curated, force re-ingestion, and trigger the
scheduler immediately.

Schema:
- games gains steam_app_id, wiki_subdomain, wiki_page_title,
  geo_metadata_status, geo_curated, geo_metadata_resolved_at.
- new geo_ingest_failure (game_id, source) PK with retry_after.

Endpoints:
- GET  /api/admin/geo/health     (coverage + queue + failures)
- POST /api/admin/geo/curated    ({gameId, curated})
- POST /api/admin/geo/reimport   ({gameId})
- POST /api/admin/geo/schedule   (no body — manual fallback)
- removed: /api/admin/geo/import/fandom and /import/steam