### PR TITLE
feat(admin): make admin pages mobile-first responsive

### DIFF
--- a/packages/frontend/src/components/admin/EmailSettings.tsx
+++ b/packages/frontend/src/components/admin/EmailSettings.tsx
@@ -94,33 +94,35 @@ export function EmailSettings() {
 
       <CardContent className="space-y-4">
         <div className="space-y-3">
-          <div className="flex items-center justify-between p-3 rounded-lg bg-muted/50">
-            <span className="text-sm font-medium">{t('admin.email.status')}</span>
-            <div className="flex items-center gap-2">
+          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-muted/50">
+            <span className="text-sm font-medium shrink-0">{t('admin.email.status')}</span>
+            <div className="flex items-center gap-2 min-w-0">
               {config?.configured ? (
                 <>
-                  <CheckCircle2 className="h-5 w-5 text-success" />
-                  <span className="text-sm text-success">{t('admin.email.configured')}</span>
+                  <CheckCircle2 className="h-5 w-5 text-success shrink-0" />
+                  <span className="text-sm text-success truncate">{t('admin.email.configured')}</span>
                 </>
               ) : (
                 <>
-                  <XCircle className="h-5 w-5 text-error" />
-                  <span className="text-sm text-error">{t('admin.email.notConfigured')}</span>
+                  <XCircle className="h-5 w-5 text-error shrink-0" />
+                  <span className="text-sm text-error truncate">{t('admin.email.notConfigured')}</span>
                 </>
               )}
             </div>
           </div>
 
-          <div className="flex items-center justify-between p-3 rounded-lg bg-muted/50">
-            <span className="text-sm font-medium">{t('admin.email.apiKey')}</span>
-            <span className="text-sm text-muted-foreground">
+          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-muted/50">
+            <span className="text-sm font-medium shrink-0">{t('admin.email.apiKey')}</span>
+            <span className="text-sm text-muted-foreground truncate">
               {config?.hasApiKey ? t('admin.email.apiKeySet') : t('admin.email.apiKeyNotSet')}
             </span>
           </div>
 
-          <div className="flex items-center justify-between p-3 rounded-lg bg-muted/50">
-            <span className="text-sm font-medium">{t('admin.email.fromAddress')}</span>
-            <span className="text-sm font-mono text-foreground">{config?.emailFrom || '-'}</span>
+          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-muted/50">
+            <span className="text-sm font-medium shrink-0">{t('admin.email.fromAddress')}</span>
+            <span className="text-sm font-mono text-foreground truncate text-right">
+              {config?.emailFrom || '-'}
+            </span>
           </div>
         </div>
 

--- a/packages/frontend/src/components/admin/GameForm.tsx
+++ b/packages/frontend/src/components/admin/GameForm.tsx
@@ -162,7 +162,7 @@ export function GameForm({
       <CardContent className="px-0 pb-0">
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
-            <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-4 sm:grid-cols-2">
               <FormField
                 control={form.control}
                 name="name"
@@ -218,7 +218,7 @@ export function GameForm({
               )}
             />
 
-            <div className="grid gap-4 md:grid-cols-4">
+            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-4">
               <FormField
                 control={form.control}
                 name="releaseYear"
@@ -279,7 +279,7 @@ export function GameForm({
               />
             </div>
 
-            <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-4 sm:grid-cols-2">
               <FormField
                 control={form.control}
                 name="genres"

--- a/packages/frontend/src/components/admin/GameList.tsx
+++ b/packages/frontend/src/components/admin/GameList.tsx
@@ -153,16 +153,16 @@ export function GameList() {
 
   return (
     <Card className="bg-card/50 backdrop-blur-sm">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0">
-        <CardTitle className="flex items-center gap-2">
-          {t('admin.games.title')}
+      <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 space-y-0">
+        <CardTitle className="flex items-center gap-2 min-w-0">
+          <span className="truncate">{t('admin.games.title')}</span>
           {gamesPagination.total > 0 && (
-            <span className="text-sm font-normal text-muted-foreground">
+            <span className="text-sm font-normal text-muted-foreground shrink-0">
               ({gamesPagination.total})
             </span>
           )}
         </CardTitle>
-        <Button variant="gaming" onClick={() => setIsFormOpen(true)}>
+        <Button variant="gaming" onClick={() => setIsFormOpen(true)} className="shrink-0">
           <Plus className="h-4 w-4" />
           {t('admin.games.addGame')}
         </Button>

--- a/packages/frontend/src/components/admin/GameTable.tsx
+++ b/packages/frontend/src/components/admin/GameTable.tsx
@@ -75,112 +75,197 @@ export function GameTable({
 }: GameTableProps) {
   const { t } = useTranslation()
 
+  const metacriticClass = (score: number) =>
+    score >= 75 ? 'text-success/80' : score >= 50 ? 'text-warning/80' : 'text-error/80'
+
   return (
-    <div className="rounded-lg border border-white/10 overflow-hidden">
-      <Table>
-        <TableHeader>
-          <TableRow className="hover:bg-transparent border-white/10">
-            <SortableHeader field="name" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.name')}</SortableHeader>
-            <SortableHeader field="slug" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.slug')}</SortableHeader>
-            <SortableHeader field="releaseYear" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.releaseYear')}</SortableHeader>
-            <SortableHeader field="developer" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.developer')}</SortableHeader>
-            <SortableHeader field="metacritic" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.metacritic')}</SortableHeader>
-            <TableHead>{t('admin.games.table.genres')}</TableHead>
-            <TableHead className="text-right">{t('admin.games.table.actions')}</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          <AnimatePresence mode="popLayout">
-            {games.map((game, index) => (
-              <motion.tr
-                key={game.id}
-                variants={tableRow}
-                initial="initial"
-                animate="animate"
-                exit="exit"
-                custom={index}
-                layout
-                transition={{ delay: index * 0.02 }}
-                className="border-b border-white/5 transition-colors group"
-                whileHover={{
-                  backgroundColor: 'var(--table-row-hover)',
-                }}
-              >
-                <TableCell className="font-medium group-hover:text-primary/70 transition-colors">
-                  {game.name}
-                </TableCell>
-                <TableCell className="text-muted-foreground">{game.slug}</TableCell>
-                <TableCell>{game.releaseYear || '-'}</TableCell>
-                <TableCell>{game.developer || '-'}</TableCell>
-                <TableCell>
-                  {game.metacritic != null ? (
-                    <span
-                      className={
-                        game.metacritic >= 75
-                          ? 'text-success/80'
-                          : game.metacritic >= 50
-                            ? 'text-warning/80'
-                            : 'text-error/80'
-                      }
-                    >
-                      {game.metacritic}
-                    </span>
-                  ) : (
-                    '-'
-                  )}
-                </TableCell>
-                <TableCell>
-                  {game.genres?.length ? (
-                    <span className="text-sm text-muted-foreground">
-                      {game.genres.slice(0, 2).join(', ')}
-                      {game.genres.length > 2 && ` +${game.genres.length - 2}`}
-                    </span>
-                  ) : (
-                    '-'
-                  )}
-                </TableCell>
-                <TableCell className="text-right">
-                  <div className="flex justify-end gap-1 opacity-70 group-hover:opacity-100 transition-opacity">
-                    <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => onViewScreenshots(game)}
-                        title={t('admin.games.viewScreenshots')}
-                        className="hover:bg-primary/20 hover:text-primary/70"
-                      >
-                        <Image className="h-4 w-4" />
-                      </Button>
-                    </motion.div>
-                    <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => onEdit(game)}
-                        title={t('admin.games.editGame')}
-                        className="hover:bg-neon-blue/20 hover:text-neon-blue/70"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                    </motion.div>
-                    <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => onDelete(game)}
-                        className="text-destructive hover:text-destructive hover:bg-error/20"
-                        title={t('admin.games.deleteGame')}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </motion.div>
-                  </div>
-                </TableCell>
-              </motion.tr>
-            ))}
-          </AnimatePresence>
-        </TableBody>
-      </Table>
-    </div>
+    <>
+      {/* Mobile cards */}
+      <div className="md:hidden space-y-3">
+        <AnimatePresence mode="popLayout">
+          {games.map((game, index) => (
+            <motion.div
+              key={game.id}
+              variants={tableRow}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              custom={index}
+              layout
+              transition={{ delay: index * 0.02 }}
+              className="rounded-lg border border-white/10 bg-card/50 p-3 space-y-3"
+            >
+              <div className="flex items-start gap-3">
+                <div className="min-w-0 flex-1 space-y-0.5">
+                  <h3 className="font-medium text-sm truncate">{game.name}</h3>
+                  <p className="text-xs text-muted-foreground truncate">{game.slug}</p>
+                </div>
+                {game.metacritic != null && (
+                  <span
+                    className={`shrink-0 text-xs font-semibold tabular-nums ${metacriticClass(game.metacritic)}`}
+                    aria-label={t('admin.games.table.metacritic')}
+                  >
+                    {game.metacritic}
+                  </span>
+                )}
+              </div>
+
+              <dl className="grid grid-cols-2 gap-2 text-xs">
+                <div className="space-y-0.5 min-w-0">
+                  <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    {t('admin.games.table.releaseYear')}
+                  </dt>
+                  <dd className="tabular-nums">{game.releaseYear || '-'}</dd>
+                </div>
+                <div className="space-y-0.5 min-w-0">
+                  <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    {t('admin.games.table.developer')}
+                  </dt>
+                  <dd className="truncate">{game.developer || '-'}</dd>
+                </div>
+                <div className="col-span-2 space-y-0.5 min-w-0">
+                  <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    {t('admin.games.table.genres')}
+                  </dt>
+                  <dd className="text-muted-foreground truncate">
+                    {game.genres?.length
+                      ? `${game.genres.slice(0, 2).join(', ')}${game.genres.length > 2 ? ` +${game.genres.length - 2}` : ''}`
+                      : '-'}
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="flex justify-end gap-1 pt-1 border-t border-white/5">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onViewScreenshots(game)}
+                  title={t('admin.games.viewScreenshots')}
+                  className="hover:bg-primary/20 hover:text-primary/70"
+                >
+                  <Image className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onEdit(game)}
+                  title={t('admin.games.editGame')}
+                  className="hover:bg-neon-blue/20 hover:text-neon-blue/70"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onDelete(game)}
+                  className="text-destructive hover:text-destructive hover:bg-error/20"
+                  title={t('admin.games.deleteGame')}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+
+      {/* Table (md+) */}
+      <div className="hidden md:block rounded-lg border border-white/10 overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent border-white/10">
+              <SortableHeader field="name" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.name')}</SortableHeader>
+              <SortableHeader field="slug" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.slug')}</SortableHeader>
+              <SortableHeader field="releaseYear" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.releaseYear')}</SortableHeader>
+              <SortableHeader field="developer" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.developer')}</SortableHeader>
+              <SortableHeader field="metacritic" sortField={sortField} sortOrder={sortOrder} onSort={onSort}>{t('admin.games.table.metacritic')}</SortableHeader>
+              <TableHead>{t('admin.games.table.genres')}</TableHead>
+              <TableHead className="text-right">{t('admin.games.table.actions')}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <AnimatePresence mode="popLayout">
+              {games.map((game, index) => (
+                <motion.tr
+                  key={game.id}
+                  variants={tableRow}
+                  initial="initial"
+                  animate="animate"
+                  exit="exit"
+                  custom={index}
+                  layout
+                  transition={{ delay: index * 0.02 }}
+                  className="border-b border-white/5 transition-colors group"
+                  whileHover={{
+                    backgroundColor: 'var(--table-row-hover)',
+                  }}
+                >
+                  <TableCell className="font-medium group-hover:text-primary/70 transition-colors">
+                    {game.name}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{game.slug}</TableCell>
+                  <TableCell>{game.releaseYear || '-'}</TableCell>
+                  <TableCell>{game.developer || '-'}</TableCell>
+                  <TableCell>
+                    {game.metacritic != null ? (
+                      <span className={metacriticClass(game.metacritic)}>{game.metacritic}</span>
+                    ) : (
+                      '-'
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {game.genres?.length ? (
+                      <span className="text-sm text-muted-foreground">
+                        {game.genres.slice(0, 2).join(', ')}
+                        {game.genres.length > 2 && ` +${game.genres.length - 2}`}
+                      </span>
+                    ) : (
+                      '-'
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1 opacity-70 group-hover:opacity-100 transition-opacity">
+                      <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onViewScreenshots(game)}
+                          title={t('admin.games.viewScreenshots')}
+                          className="hover:bg-primary/20 hover:text-primary/70"
+                        >
+                          <Image className="h-4 w-4" />
+                        </Button>
+                      </motion.div>
+                      <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onEdit(game)}
+                          title={t('admin.games.editGame')}
+                          className="hover:bg-neon-blue/20 hover:text-neon-blue/70"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      </motion.div>
+                      <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onDelete(game)}
+                          className="text-destructive hover:text-destructive hover:bg-error/20"
+                          title={t('admin.games.deleteGame')}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </motion.div>
+                    </div>
+                  </TableCell>
+                </motion.tr>
+              ))}
+            </AnimatePresence>
+          </TableBody>
+        </Table>
+      </div>
+    </>
   )
 }

--- a/packages/frontend/src/components/admin/JobQueuePanel.tsx
+++ b/packages/frontend/src/components/admin/JobQueuePanel.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { AnimatedProgress } from '@/components/ui/animated-progress'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { useAdminStore } from '@/stores/adminStore'
 import { Trash2, Loader2, Clock, Play, CheckCircle2, XCircle, Pause, RefreshCw, ChevronRight, ChevronLeft } from 'lucide-react'
 import type { JobStatus } from '@/types'
@@ -89,6 +90,10 @@ export function JobQueuePanel({ onMinimizedChange }: JobQueuePanelProps = {}) {
     const { jobs, isLoading, fetchJobs, clearCompleted, cancelJob, connectSocket, disconnectSocket } = useAdminStore()
     const [filterTab, setFilterTab] = useState<'all' | 'active' | 'completed' | 'failed' | 'delayed'>('all')
     const [isMinimized, setIsMinimized] = useState(true)
+    const isMobile = useIsMobile()
+    // Full viewport on phones, fixed dock on tablets+. Keep as a string so the
+    // value flows straight into Framer Motion's animate config.
+    const expandedWidth = isMobile ? '100vw' : '480px'
 
     const handleToggleMinimize = () => {
         const newState = !isMinimized
@@ -147,14 +152,29 @@ export function JobQueuePanel({ onMinimizedChange }: JobQueuePanelProps = {}) {
     const failedJobs = jobs.filter((j) => j.status === 'failed')
 
     return (
-        <motion.div
-            className="fixed right-0 top-14 sm:top-16 h-[calc(100vh-3.5rem)] sm:h-[calc(100vh-4rem)] border-l bg-card shadow-lg flex flex-col z-50 pointer-events-auto"
-            initial={false}
-            animate={{
-                width: isMinimized ? '0px' : '480px'
-            }}
-            transition={{ duration: 0.3, ease: 'easeInOut' }}
-        >
+        <>
+            {/* Mobile backdrop — overlays page content when the panel is open on phones. */}
+            <AnimatePresence>
+                {!isMinimized && isMobile && (
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.2 }}
+                        onClick={handleToggleMinimize}
+                        className="fixed inset-0 top-14 sm:top-16 bg-background/60 backdrop-blur-sm z-40"
+                        aria-hidden="true"
+                    />
+                )}
+            </AnimatePresence>
+            <motion.div
+                className="fixed right-0 top-14 sm:top-16 h-[calc(100vh-3.5rem)] sm:h-[calc(100vh-4rem)] max-w-[100vw] border-l bg-card shadow-lg flex flex-col z-50 pointer-events-auto"
+                initial={false}
+                animate={{
+                    width: isMinimized ? '0px' : expandedWidth
+                }}
+                transition={{ duration: 0.3, ease: 'easeInOut' }}
+            >
             {/* Minimize/Expand Button */}
             <Button
                 variant="ghost"
@@ -334,6 +354,7 @@ export function JobQueuePanel({ onMinimizedChange }: JobQueuePanelProps = {}) {
                 </>
             )
             }
-        </motion.div >
+            </motion.div>
+        </>
     )
 }

--- a/packages/frontend/src/components/admin/ReportsModerationPanel.tsx
+++ b/packages/frontend/src/components/admin/ReportsModerationPanel.tsx
@@ -93,12 +93,12 @@ export function ReportsModerationPanel() {
 
     return (
         <Card>
-            <CardHeader className="flex-row items-center justify-between space-y-0">
-                <CardTitle className="flex items-center gap-2 text-base">
-                    <Flag className="h-4 w-4 text-neon-pink" />
-                    {t('admin.reports.title')}
+            <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 space-y-0">
+                <CardTitle className="flex items-center gap-2 text-base min-w-0">
+                    <Flag className="h-4 w-4 text-neon-pink shrink-0" />
+                    <span className="truncate">{t('admin.reports.title')}</span>
                 </CardTitle>
-                <div className="flex items-center gap-3">
+                <div className="flex items-center justify-between sm:justify-end gap-3 shrink-0">
                     <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer select-none">
                         <Checkbox
                             checked={onlyDeactivated}
@@ -129,7 +129,7 @@ export function ReportsModerationPanel() {
                         {reports.map((row) => (
                             <li
                                 key={rowKey(row)}
-                                className="flex items-start justify-between gap-3 py-3"
+                                className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 py-3"
                             >
                                 <div className="flex items-start gap-3 min-w-0 flex-1">
                                     <ReportThumbnail

--- a/packages/frontend/src/components/admin/UserList.tsx
+++ b/packages/frontend/src/components/admin/UserList.tsx
@@ -247,7 +247,7 @@ export function UserList() {
             <p className="text-muted-foreground">{t('admin.users.noUsers')}</p>
           </div>
         ) : (
-          /* Table */
+          /* Table (md+) / Cards (mobile) */
           <>
             <div className="relative">
               {usersLoading && (
@@ -255,7 +255,109 @@ export function UserList() {
                   <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                 </div>
               )}
-              <div className="rounded-lg border border-white/10 overflow-hidden">
+
+              {/* Mobile cards */}
+              <div className="md:hidden space-y-3">
+                <AnimatePresence mode="popLayout">
+                  {users.map((user, index) => (
+                    <motion.div
+                      key={user.id}
+                      variants={tableRow}
+                      initial="initial"
+                      animate="animate"
+                      exit="exit"
+                      custom={index}
+                      layout
+                      transition={{ delay: index * 0.02 }}
+                      className="rounded-lg border border-white/10 bg-card/50 p-3 space-y-3"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="font-medium text-sm break-all">{user.email}</div>
+                          <div className="text-xs text-muted-foreground truncate mt-0.5">
+                            {user.displayName || user.username}
+                            {user.isGuest && (
+                              <span className="ml-2">({t('admin.users.guest')})</span>
+                            )}
+                          </div>
+                        </div>
+                        <Select
+                          value={user.isAdmin ? 'admin' : 'user'}
+                          onValueChange={(value) => {
+                            setRoleChangingUser({ user, newRole: value })
+                            handleRoleChange(user, value)
+                          }}
+                          disabled={isSubmitting}
+                        >
+                          <SelectTrigger className="h-8 w-24 shrink-0" aria-label={t('admin.users.role.user')}>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="user">{t('admin.users.role.user')}</SelectItem>
+                            <SelectItem value="admin">{t('admin.users.role.admin')}</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <dl className="grid grid-cols-3 gap-2 text-xs">
+                        <div className="space-y-0.5">
+                          <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                            {t('admin.users.totalScore')}
+                          </dt>
+                          <dd className="font-medium tabular-nums">
+                            {(user.totalScore ?? 0).toLocaleString(i18n.language)}
+                          </dd>
+                        </div>
+                        <div className="space-y-0.5">
+                          <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                            {t('admin.users.currentStreak')}
+                          </dt>
+                          <dd className="font-medium tabular-nums">{user.currentStreak ?? 0}</dd>
+                        </div>
+                        <div className="space-y-0.5">
+                          <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                            {t('admin.users.createdAt')}
+                          </dt>
+                          <dd className="text-muted-foreground">{formatDate(user.createdAt)}</dd>
+                        </div>
+                      </dl>
+
+                      <div className="flex justify-end gap-1 pt-1 border-t border-white/5">
+                        {user.isAdmin ? (
+                          <Button
+                            variant="unban"
+                            size="icon"
+                            onClick={() => setUnbanningUser(user)}
+                            aria-label={t('admin.users.unbanUser')}
+                          >
+                            <Unlock className="h-4 w-4" />
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="ban"
+                            size="icon"
+                            onClick={() => setBanningUser(user)}
+                            aria-label={t('admin.users.banUser')}
+                          >
+                            <Ban className="h-4 w-4" />
+                          </Button>
+                        )}
+                        <Button
+                          variant="dangerGhost"
+                          size="icon"
+                          onClick={() => setDeletingUser(user)}
+                          aria-label={t('admin.users.deleteUser')}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+              </div>
+
+              {/* Table (md+) */}
+              <div className="hidden md:block rounded-lg border border-white/10 overflow-hidden">
                 <Table>
                   <TableHeader>
                     <TableRow className="hover:bg-transparent border-white/10">

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useSession } from '@/lib/auth-client'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { useAdminStore } from '@/stores/adminStore'
 import { JobList } from '@/components/admin/JobList'
 import { GameList } from '@/components/admin/GameList'
@@ -26,7 +27,11 @@ export default function AdminPage() {
   const { lang } = useParams()
   const [searchParams, setSearchParams] = useSearchParams()
   const { data: session, isPending } = useSession()
+  const isMobile = useIsMobile()
   const [isPanelMinimized, setIsPanelMinimized] = useState(true)
+  // On mobile the JobQueuePanel overlays the page instead of pushing it,
+  // so only reserve right padding on viewports where the panel docks.
+  const sidebarOffset = !isMobile && !isPanelMinimized ? '480px' : '0'
 
   const {
     fetchRecurringJobs,
@@ -110,7 +115,7 @@ export default function AdminPage() {
       className="flex min-h-screen"
     >
       {/* Main Content Area */}
-      <div className="flex-1 transition-all duration-300" style={{ paddingRight: isPanelMinimized ? '0' : '480px' }}>
+      <div className="flex-1 transition-all duration-300" style={{ paddingRight: sidebarOffset }}>
         <div className="container mx-auto px-3 sm:px-4 py-4 sm:py-8">
           <motion.div
             variants={fadeInLeft}


### PR DESCRIPTION
- AdminPage: only reserve sidebar offset on viewports where the
  JobQueuePanel docks; on phones the panel overlays content instead
  of pushing a hard-coded 480px gutter onto a narrow screen.
- JobQueuePanel: expanded width is viewport-aware (full width on
  phones, 480px on tablets+) and tapping the new backdrop closes
  the panel on mobile.
- UserList & GameTable: keep the data table on md+ but render a
  card list on phones so 7-column rows stop overflowing.
- GameList header, EmailSettings status rows, ReportsModerationPanel
  header/rows, and GameForm grids: tighten breakpoints and add
  truncation so they reflow cleanly on narrow widths.