### PR TITLE
feat(captures): raise per-game default to 5 and add topup-screenshots backfill

### DIFF
--- a/packages/backend/migrations/20260425_screenshots_per_game_default_five.ts
+++ b/packages/backend/migrations/20260425_screenshots_per_game_default_five.ts
@@ -1,0 +1,17 @@
+import type { Knex } from 'knex'
+
+// Per-game capture count was raised from 3 to 5. The column default backs new
+// import-state rows when the API caller doesn't supply a value, so it has to
+// move with the application code.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('import_states', (table) => {
+    table.integer('screenshots_per_game').notNullable().defaultTo(5).alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('import_states', (table) => {
+    table.integer('screenshots_per_game').notNullable().defaultTo(3).alter()
+  })
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,9 +14,9 @@
     "db:seed": "knex seed:run --knexfile knexfile.ts",
     "db:seed:geo": "knex seed:run --knexfile knexfile.ts --specific=010_geo_elden_ring.ts",
     "db:make-migration": "knex migrate:make --knexfile knexfile.ts -x ts",
-    "fetch:games": "tsx src/tools/screenshot-fetcher.ts fetch --games 200 --screenshots-per-game 3",
+    "fetch:games": "tsx src/tools/screenshot-fetcher.ts fetch --games 200 --screenshots-per-game 5",
     "fetch:download": "tsx src/tools/screenshot-fetcher.ts download",
-    "fetch:all": "tsx src/tools/screenshot-fetcher.ts all --games 200 --screenshots-per-game 3",
+    "fetch:all": "tsx src/tools/screenshot-fetcher.ts all --games 200 --screenshots-per-game 5",
     "e2e:seed": "tsx scripts/e2e-seed.ts"
   },
   "dependencies": {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -340,7 +340,7 @@ async function start(): Promise<void> {
         {
           batchSize: 100,
           minMetacritic: 70,
-          screenshotsPerGame: 3,
+          screenshotsPerGame: 5,
           updateExistingMetadata: true,
         },
         {

--- a/packages/backend/src/infrastructure/queue/workers/batch-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/batch-import-logic.ts
@@ -275,7 +275,7 @@ export async function startBatchImport(config: {
   const importState = await importStateRepository.create({
     batchSize: config.batchSize ?? 100,
     minMetacritic: config.minMetacritic ?? 70,
-    screenshotsPerGame: config.screenshotsPerGame ?? 3,
+    screenshotsPerGame: config.screenshotsPerGame ?? 5,
   })
 
   // Fetch total count from RAWG

--- a/packages/backend/src/infrastructure/queue/workers/import.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/import.worker.ts
@@ -12,6 +12,7 @@ import { clearDailyData } from './clear-daily-data-logic.js'
 import { sendStreakRiskEmails } from './streak-risk-email-logic.js'
 import { sendRelanceEmails } from './relance-email-logic.js'
 import { sendInactiveUserReminderEmails } from './inactive-user-reminder-logic.js'
+import { processTopupBatch, scheduleTopupNextBatch } from './topup-screenshots-logic.js'
 
 const log = queueLogger
 
@@ -25,7 +26,7 @@ export const importWorker = new Worker<JobData, JobResult>(
     try {
       if (name === 'import-games') {
         const targetGames = data.targetGames || 200
-        const screenshotsPerGame = data.screenshotsPerGame || 3
+        const screenshotsPerGame = data.screenshotsPerGame || 5
         const minMetacritic = data.minMetacritic ?? 70
 
         const result = await fetchGamesFromRAWG(
@@ -315,6 +316,46 @@ export const importWorker = new Worker<JobData, JobResult>(
         }
 
         log.info({ jobId: id, result }, 'relance-email job completed')
+        return jobResult
+      }
+
+      if (name === 'topup-screenshots') {
+        const { topupStateId } = data
+        if (!topupStateId) {
+          throw new Error('topupStateId is required for topup-screenshots job')
+        }
+
+        const result = await processTopupBatch(topupStateId, (current, total) => {
+          const progress = total > 0 ? Math.round((current / total) * 100) : 0
+          job.updateProgress(progress)
+        })
+
+        let nextBatchScheduled = false
+        if (!result.isComplete && !result.isPaused) {
+          const nextJob = await scheduleTopupNextBatch(topupStateId)
+          nextBatchScheduled = !!nextJob
+        }
+
+        const jobResult: JobResult = {
+          gamesProcessed: result.gamesProcessed,
+          gamesToppedUp: result.gamesToppedUp,
+          gamesSkipped: result.gamesSkipped,
+          screenshotsProcessed: result.screenshotsDownloaded,
+          failedCount: result.failedCount,
+          topupStateId: result.topupStateId,
+          batchNumber: result.currentBatch,
+          totalBatches: result.totalBatches ?? undefined,
+          totalGamesAvailable: result.totalGamesAvailable ?? undefined,
+          isComplete: result.isComplete,
+          nextBatchScheduled,
+          message: result.isPaused
+            ? `Topup paused after ${result.gamesProcessed} games`
+            : result.isComplete
+              ? `Topup complete! ${result.gamesToppedUp} games topped up, +${result.screenshotsDownloaded} screenshots`
+              : `Topup batch ${result.currentBatch}: ${result.gamesToppedUp} topped up, +${result.screenshotsDownloaded} screenshots`,
+        }
+
+        log.info({ jobId: id, result: jobResult }, 'topup-screenshots job completed')
         return jobResult
       }
 

--- a/packages/backend/src/infrastructure/queue/workers/sync-all-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/sync-all-logic.ts
@@ -280,7 +280,7 @@ export async function startSyncAll(config: SyncAllConfig): Promise<{ syncState: 
     importType: 'sync-all',
     batchSize: config.batchSize ?? 100,
     minMetacritic: config.minMetacritic ?? 70,
-    screenshotsPerGame: config.screenshotsPerGame ?? 3,
+    screenshotsPerGame: config.screenshotsPerGame ?? 5,
   })
 
   // Fetch total count from RAWG

--- a/packages/backend/src/infrastructure/queue/workers/topup-screenshots-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/topup-screenshots-logic.ts
@@ -1,0 +1,527 @@
+/**
+ * Top-Up Screenshots Logic
+ *
+ * Adds missing screenshots to existing games whose active capture count is
+ * below `targetScreenshotsPerGame`. Re-uses RAWG as the source and assumes the
+ * existing per-game files are the leading slice of RAWG's screenshot list (the
+ * convention enforced by every other importer in this repo). Pause/resume is
+ * driven by `import_states.last_processed_offset`, which we use as the last
+ * game id we walked past.
+ */
+
+import fs from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { Job as BullJob } from 'bullmq'
+import { env } from '../../../config/env.js'
+import { queueLogger } from '../../logger/logger.js'
+import { db } from '../../database/connection.js'
+import { screenshotRepository } from '../../repositories/screenshot.repository.js'
+import { importStateRepository } from '../../repositories/import-state.repository.js'
+import { importQueue } from '../queues.js'
+import type { ImportState, JobData } from '@the-box/types'
+
+const log = queueLogger.child({ module: 'topup-screenshots' })
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT_DIR = path.resolve(__dirname, '..', '..', '..', '..')
+const UPLOADS_DIR = path.resolve(ROOT_DIR, '..', '..', 'uploads', 'screenshots')
+
+const IMPORT_TYPE = 'topup-screenshots'
+
+// Lowest priority so we yield to user-facing imports / daily challenges
+const TOPUP_JOB_PRIORITY = 1000
+
+interface RAWGScreenshot {
+  id: number
+  image: string
+  width: number
+  height: number
+}
+
+interface RAWGPaginatedResponse<T> {
+  count: number
+  next: string | null
+  previous: string | null
+  results: T[]
+}
+
+export type TopupProgressCallback = (
+  current: number,
+  total: number,
+  message: string,
+  state: ImportState
+) => void
+
+export interface TopupResult {
+  gamesProcessed: number
+  gamesToppedUp: number
+  gamesSkipped: number
+  screenshotsDownloaded: number
+  failedCount: number
+  isPaused: boolean
+  isComplete: boolean
+  topupStateId: number
+  currentBatch: number
+  totalBatches: number | null
+  totalGamesAvailable: number | null
+}
+
+export interface TopupConfig {
+  batchSize?: number
+  targetScreenshotsPerGame?: number
+}
+
+interface CandidateGame {
+  id: number
+  slug: string
+  rawg_id: number
+  active_count: number
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+class RateLimiter {
+  private requests: number[] = []
+  private readonly windowMs = 60_000
+  private readonly maxRequests: number
+  private readonly delayMs: number
+
+  constructor(maxRequestsPerMinute = 20, delayMs = 3000) {
+    this.maxRequests = maxRequestsPerMinute
+    this.delayMs = delayMs
+  }
+
+  async acquire(): Promise<void> {
+    const now = Date.now()
+    this.requests = this.requests.filter((t) => now - t < this.windowMs)
+
+    if (this.requests.length >= this.maxRequests) {
+      const oldest = this.requests[0]!
+      const wait = this.windowMs - (now - oldest) + 100
+      log.warn(`  Rate limit reached, waiting ${Math.round(wait / 1000)}s...`)
+      await sleep(wait)
+    }
+
+    if (this.requests.length > 0) {
+      const last = this.requests[this.requests.length - 1]!
+      const since = now - last
+      if (since < this.delayMs) await sleep(this.delayMs - since)
+    }
+
+    this.requests.push(Date.now())
+  }
+}
+
+class RAWGTopupClient {
+  private baseUrl = 'https://api.rawg.io/api'
+  private rateLimiter = new RateLimiter(20, 3000)
+  constructor(private apiKey: string) {}
+
+  async fetchGameScreenshots(rawgId: number): Promise<RAWGPaginatedResponse<RAWGScreenshot>> {
+    await this.rateLimiter.acquire()
+    const url = new URL(`${this.baseUrl}/games/${rawgId}/screenshots`)
+    url.searchParams.set('key', this.apiKey)
+
+    const response = await fetch(url.toString())
+    if (!response.ok) {
+      if (response.status === 429) {
+        log.warn('  RAWG API rate limit (429), waiting 60s...')
+        await sleep(60_000)
+        return this.fetchGameScreenshots(rawgId)
+      }
+      throw new Error(`RAWG API error: ${response.status} ${response.statusText}`)
+    }
+    return response.json() as Promise<RAWGPaginatedResponse<RAWGScreenshot>>
+  }
+}
+
+async function downloadImage(url: string, outputPath: string, retries = 3): Promise<boolean> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const response = await fetch(url)
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const buffer = Buffer.from(await response.arrayBuffer())
+      await fs.mkdir(path.dirname(outputPath), { recursive: true })
+      await fs.writeFile(outputPath, buffer)
+      return true
+    } catch (error) {
+      if (attempt === retries - 1) {
+        log.error({ url, error: String(error) }, 'failed to download image')
+        return false
+      }
+      await sleep(1000 * Math.pow(2, attempt))
+    }
+  }
+  return false
+}
+
+async function countCandidates(target: number): Promise<number> {
+  const result = await db('games as g')
+    .leftJoin('screenshots as s', function () {
+      this.on('s.game_id', '=', 'g.id').andOn('s.is_active', '=', db.raw('true'))
+    })
+    .whereNotNull('g.rawg_id')
+    .groupBy('g.id')
+    .havingRaw('COUNT(s.id) < ?', [target])
+    .count<{ count: string }[]>('g.id')
+
+  // count() with groupBy returns one row per group, so total is rows.length
+  return result.length
+}
+
+async function fetchCandidateBatch(
+  target: number,
+  limit: number,
+  afterGameId: number
+): Promise<CandidateGame[]> {
+  const rows = await db('games as g')
+    .leftJoin('screenshots as s', function () {
+      this.on('s.game_id', '=', 'g.id').andOn('s.is_active', '=', db.raw('true'))
+    })
+    .whereNotNull('g.rawg_id')
+    .andWhere('g.id', '>', afterGameId)
+    .groupBy('g.id', 'g.slug', 'g.rawg_id')
+    .havingRaw('COUNT(s.id) < ?', [target])
+    .orderBy('g.id', 'asc')
+    .limit(limit)
+    .select<{ id: number; slug: string; rawg_id: number; active_count: string | number }[]>(
+      'g.id',
+      'g.slug',
+      'g.rawg_id',
+      db.raw('COUNT(s.id) as active_count')
+    )
+
+  return rows.map((r) => ({
+    id: r.id,
+    slug: r.slug,
+    rawg_id: r.rawg_id,
+    active_count: typeof r.active_count === 'string' ? parseInt(r.active_count, 10) : r.active_count,
+  }))
+}
+
+export async function getActiveTopupScreenshots(): Promise<ImportState | null> {
+  return importStateRepository.findActiveByType(IMPORT_TYPE)
+}
+
+export async function getTopupScreenshotsState(id: number): Promise<ImportState | null> {
+  return importStateRepository.findById(id)
+}
+
+export async function startTopupScreenshots(
+  config: TopupConfig
+): Promise<{ topupState: ImportState; job: BullJob<JobData> }> {
+  const apiKey = env.RAWG_API_KEY
+  if (!apiKey) throw new Error('RAWG_API_KEY environment variable is required')
+
+  const active = await getActiveTopupScreenshots()
+  if (active) throw new Error('A topup-screenshots job is already in progress or paused')
+
+  const target = config.targetScreenshotsPerGame ?? 5
+  const batchSize = config.batchSize ?? 50
+
+  const topupState = await importStateRepository.create({
+    importType: IMPORT_TYPE,
+    batchSize,
+    screenshotsPerGame: target,
+  })
+
+  const totalGamesAvailable = await countCandidates(target)
+  const totalBatches = Math.max(1, Math.ceil(totalGamesAvailable / batchSize))
+
+  await importStateRepository.update(topupState.id, {
+    totalGamesAvailable,
+    totalBatchesEstimated: totalBatches,
+    status: 'in_progress',
+    startedAt: new Date(),
+  })
+
+  const updatedState = await importStateRepository.findById(topupState.id)
+
+  log.info('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
+  log.info(`TOPUP SCREENSHOTS STARTED - ID: ${topupState.id}`)
+  log.info('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
+  log.info({
+    topupStateId: topupState.id,
+    targetScreenshotsPerGame: target,
+    batchSize,
+    totalGamesAvailable,
+    totalBatches,
+  }, `Target: ${target} screenshots/game, ${totalGamesAvailable} games need topup`)
+
+  if (totalGamesAvailable === 0) {
+    await importStateRepository.setStatus(topupState.id, 'completed')
+    log.info('No games need topup; marking complete immediately')
+  }
+
+  const job = await importQueue.add(
+    'topup-screenshots',
+    {
+      topupStateId: topupState.id,
+      targetScreenshotsPerGame: target,
+      batchSize,
+    },
+    { priority: TOPUP_JOB_PRIORITY }
+  )
+
+  return { topupState: updatedState!, job }
+}
+
+export async function scheduleTopupNextBatch(topupStateId: number): Promise<BullJob<JobData> | null> {
+  const state = await importStateRepository.findById(topupStateId)
+  if (!state) {
+    log.warn({ topupStateId }, 'topup state not found, cannot schedule next batch')
+    return null
+  }
+  if (state.status !== 'in_progress') {
+    log.info({ topupStateId, status: state.status }, 'topup not in progress, not scheduling next batch')
+    return null
+  }
+
+  return importQueue.add(
+    'topup-screenshots',
+    {
+      topupStateId: state.id,
+      targetScreenshotsPerGame: state.screenshotsPerGame,
+      batchSize: state.batchSize,
+    },
+    { priority: TOPUP_JOB_PRIORITY }
+  )
+}
+
+export async function pauseTopupScreenshots(topupStateId: number): Promise<ImportState> {
+  const state = await importStateRepository.findById(topupStateId)
+  if (!state) throw new Error(`Topup state ${topupStateId} not found`)
+  if (state.status !== 'in_progress') {
+    throw new Error(`Cannot pause topup with status: ${state.status}`)
+  }
+  log.info({ topupStateId, gamesProcessed: state.gamesProcessed }, 'topup pause requested')
+  const updated = await importStateRepository.setStatus(topupStateId, 'paused')
+  return updated!
+}
+
+export async function resumeTopupScreenshots(
+  topupStateId: number
+): Promise<{ topupState: ImportState; job: BullJob<JobData> }> {
+  const state = await importStateRepository.findById(topupStateId)
+  if (!state) throw new Error(`Topup state ${topupStateId} not found`)
+  if (state.status !== 'paused') {
+    throw new Error(`Cannot resume topup with status: ${state.status}`)
+  }
+  log.info({ topupStateId, gamesProcessed: state.gamesProcessed }, 'topup resume requested')
+  const updated = await importStateRepository.setStatus(topupStateId, 'in_progress')
+
+  const job = await importQueue.add(
+    'topup-screenshots',
+    {
+      topupStateId: state.id,
+      targetScreenshotsPerGame: state.screenshotsPerGame,
+      batchSize: state.batchSize,
+      isResume: true,
+    },
+    { priority: TOPUP_JOB_PRIORITY }
+  )
+
+  return { topupState: updated!, job }
+}
+
+export async function cancelTopupScreenshots(topupStateId: number): Promise<ImportState> {
+  const state = await importStateRepository.findById(topupStateId)
+  if (!state) throw new Error(`Topup state ${topupStateId} not found`)
+  if (state.status === 'completed' || state.status === 'failed') {
+    throw new Error(`Cannot cancel topup with status: ${state.status}`)
+  }
+  log.warn({ topupStateId }, 'topup cancelled by admin')
+  const updated = await importStateRepository.setStatus(topupStateId, 'failed')
+  return updated!
+}
+
+function buildResult(state: ImportState, isPaused: boolean, isComplete: boolean): TopupResult {
+  return {
+    gamesProcessed: state.gamesProcessed,
+    gamesToppedUp: state.gamesImported, // reuse field for "games we touched"
+    gamesSkipped: state.gamesSkipped,
+    screenshotsDownloaded: state.screenshotsDownloaded,
+    failedCount: state.failedCount,
+    isPaused,
+    isComplete,
+    topupStateId: state.id,
+    currentBatch: state.currentBatch,
+    totalBatches: state.totalBatchesEstimated,
+    totalGamesAvailable: state.totalGamesAvailable,
+  }
+}
+
+export async function processTopupBatch(
+  topupStateId: number,
+  onProgress?: TopupProgressCallback
+): Promise<TopupResult> {
+  const apiKey = env.RAWG_API_KEY
+  if (!apiKey) throw new Error('RAWG_API_KEY environment variable is required')
+
+  const state = await importStateRepository.findById(topupStateId)
+  if (!state) throw new Error(`Topup state ${topupStateId} not found`)
+
+  if (state.status === 'paused') {
+    log.info({ topupStateId }, 'topup paused, skipping batch')
+    return buildResult(state, true, false)
+  }
+
+  const target = state.screenshotsPerGame
+  const client = new RAWGTopupClient(apiKey)
+  const afterGameId = state.lastProcessedOffset
+  const candidates = await fetchCandidateBatch(target, state.batchSize, afterGameId)
+
+  log.info('──────────────────────────────────────────────────────────────────────────')
+  log.info(`TOPUP BATCH ${state.currentBatch + 1}/${state.totalBatchesEstimated ?? '?'} STARTING`)
+  log.info('──────────────────────────────────────────────────────────────────────────')
+  log.info({
+    topupStateId,
+    candidates: candidates.length,
+    afterGameId,
+    target,
+  }, `Processing ${candidates.length} candidate games (after id ${afterGameId})`)
+
+  if (candidates.length === 0) {
+    await importStateRepository.setStatus(topupStateId, 'completed')
+    const finalState = await importStateRepository.findById(topupStateId)
+    log.info({ topupStateId }, 'no more candidate games, topup complete')
+    return buildResult(finalState!, false, true)
+  }
+
+  await fs.mkdir(UPLOADS_DIR, { recursive: true })
+
+  let gamesProcessed = 0
+  let gamesToppedUp = 0
+  let gamesSkipped = 0
+  let screenshotsDownloaded = 0
+  let failedCount = 0
+  let lastGameId = afterGameId
+
+  for (const candidate of candidates) {
+    // Honor pause requests between games
+    const mid = await importStateRepository.findById(topupStateId)
+    if (mid?.status === 'paused') {
+      log.info({ topupStateId, lastGameId }, 'topup pause signal received, stopping batch')
+      break
+    }
+
+    gamesProcessed++
+    lastGameId = candidate.id
+    const needed = target - candidate.active_count
+
+    try {
+      const screenshotResp = await client.fetchGameScreenshots(candidate.rawg_id)
+      const available = screenshotResp.results
+
+      if (available.length <= candidate.active_count) {
+        gamesSkipped++
+        log.info(
+          { gameId: candidate.id, slug: candidate.slug, available: available.length, current: candidate.active_count },
+          'no new screenshots available on RAWG'
+        )
+        continue
+      }
+
+      // Trust the existing convention: existing files map to the leading
+      // RAWG screenshots, so the new ones are the next slice.
+      const toAdd = available.slice(candidate.active_count, candidate.active_count + needed)
+      let addedForGame = 0
+
+      for (let i = 0; i < toAdd.length; i++) {
+        const raw = toAdd[i]!
+        const positionNumber = candidate.active_count + i + 1
+        const filename = `screenshot_${positionNumber}.jpg`
+        const localPath = `/uploads/screenshots/${candidate.slug}/${filename}`
+        const absolutePath = path.join(UPLOADS_DIR, candidate.slug, filename)
+
+        const ok = await downloadImage(raw.image, absolutePath)
+        if (!ok) {
+          failedCount++
+          continue
+        }
+
+        const difficulty = (((positionNumber - 1) % 3) + 1) as 1 | 2 | 3
+        await screenshotRepository.create({
+          gameId: candidate.id,
+          imageUrl: localPath,
+          difficulty,
+        })
+
+        screenshotsDownloaded++
+        addedForGame++
+        await sleep(100)
+      }
+
+      if (addedForGame > 0) {
+        gamesToppedUp++
+        log.info(
+          { gameId: candidate.id, slug: candidate.slug, added: addedForGame },
+          `topped up "${candidate.slug}" (+${addedForGame})`
+        )
+      } else {
+        gamesSkipped++
+      }
+    } catch (error) {
+      failedCount++
+      log.error({ gameId: candidate.id, slug: candidate.slug, error: String(error) }, 'topup failed for game')
+    }
+
+    onProgress?.(
+      state.gamesProcessed + gamesProcessed,
+      state.totalGamesAvailable ?? 0,
+      `Topped up: ${candidate.slug}`,
+      state
+    )
+  }
+
+  const newState = await importStateRepository.updateProgress(topupStateId, {
+    lastProcessedOffset: lastGameId,
+    gamesProcessed: state.gamesProcessed + gamesProcessed,
+    gamesImported: state.gamesImported + gamesToppedUp,
+    gamesSkipped: state.gamesSkipped + gamesSkipped,
+    screenshotsDownloaded: state.screenshotsDownloaded + screenshotsDownloaded,
+    failedCount: state.failedCount + failedCount,
+    currentBatch: state.currentBatch + 1,
+  })
+
+  // Re-read to pick up status changes that may have happened during batch
+  const refreshed = (await importStateRepository.findById(topupStateId))!
+
+  if (refreshed.status === 'paused') {
+    log.info({ topupStateId }, 'batch ended in paused state')
+    return buildResult(refreshed, true, false)
+  }
+
+  // If the batch returned fewer rows than batchSize, we've hit the end
+  const isComplete = candidates.length < state.batchSize
+  if (isComplete) {
+    await importStateRepository.setStatus(topupStateId, 'completed')
+    const finalState = await importStateRepository.findById(topupStateId)
+    log.info(
+      {
+        topupStateId,
+        totalProcessed: finalState!.gamesProcessed,
+        totalToppedUp: finalState!.gamesImported,
+        totalScreenshots: finalState!.screenshotsDownloaded,
+      },
+      'topup-screenshots complete'
+    )
+    return buildResult(finalState!, false, true)
+  }
+
+  log.info(
+    {
+      batch: refreshed.currentBatch,
+      gamesProcessed,
+      gamesToppedUp,
+      gamesSkipped,
+      screenshotsDownloaded,
+      failedCount,
+    },
+    'topup batch complete; will schedule next'
+  )
+  return buildResult(newState ?? refreshed, false, false)
+}

--- a/packages/backend/src/infrastructure/repositories/import-state.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/import-state.repository.ts
@@ -69,7 +69,7 @@ export const importStateRepository = {
         import_type: data.importType ?? 'full-import',
         batch_size: data.batchSize ?? 100,
         min_metacritic: data.minMetacritic ?? 70,
-        screenshots_per_game: data.screenshotsPerGame ?? 3,
+        screenshots_per_game: data.screenshotsPerGame ?? 5,
         status: 'pending',
       })
       .returning<ImportStateRow[]>('*')

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -24,6 +24,14 @@ import {
   getActiveRecalculateScores,
   getRecalculateScoresState,
 } from '../../infrastructure/queue/workers/recalculate-scores-logic.js'
+import {
+  startTopupScreenshots,
+  pauseTopupScreenshots,
+  resumeTopupScreenshots,
+  cancelTopupScreenshots,
+  getActiveTopupScreenshots,
+  getTopupScreenshotsState,
+} from '../../infrastructure/queue/workers/topup-screenshots-logic.js'
 import { resend } from '../../infrastructure/auth/auth.js'
 import { env } from '../../config/env.js'
 import { db } from '../../infrastructure/database/connection.js'
@@ -535,7 +543,7 @@ router.post('/jobs/import-games', async (req, res, next) => {
   try {
     const data = {
       targetGames: req.body?.targetGames || 200,
-      screenshotsPerGame: req.body?.screenshotsPerGame || 3,
+      screenshotsPerGame: req.body?.screenshotsPerGame || 5,
       minMetacritic: req.body?.minMetacritic ?? 70,
     }
     const job = await jobService.createJob('import-games', data)
@@ -610,7 +618,7 @@ router.post('/jobs/import-games/trigger', async (req, res, next) => {
   try {
     const data = {
       targetGames: req.body?.targetGames || 50,
-      screenshotsPerGame: req.body?.screenshotsPerGame || 3,
+      screenshotsPerGame: req.body?.screenshotsPerGame || 5,
       minMetacritic: req.body?.minMetacritic ?? 70,
     }
     const job = await jobService.createJob('import-games', data)
@@ -643,7 +651,7 @@ router.post('/jobs/import-screenshots/trigger', async (_req, res, next) => {
 // Start a new full import
 const startFullImportSchema = z.object({
   batchSize: z.number().min(10).max(500).default(100),
-  screenshotsPerGame: z.number().min(1).max(10).default(3),
+  screenshotsPerGame: z.number().min(1).max(10).default(5),
   minMetacritic: z.number().min(0).max(100).default(70),
 })
 
@@ -783,7 +791,7 @@ router.post('/jobs/full-import/:id/resume', async (req, res, next) => {
 // Start a new sync-all job
 const startSyncAllSchema = z.object({
   batchSize: z.number().min(10).max(500).default(100),
-  screenshotsPerGame: z.number().min(1).max(10).default(3),
+  screenshotsPerGame: z.number().min(1).max(10).default(5),
   minMetacritic: z.number().min(0).max(100).default(70),
   updateExistingMetadata: z.boolean().default(true),
 })
@@ -1084,6 +1092,132 @@ router.post('/jobs/recalculate-scores/:id/resume', async (req, res, next) => {
           success: false,
           error: { code: 'INVALID_STATE', message: error.message },
         })
+        return
+      }
+    }
+    next(error)
+  }
+})
+
+// === Top-Up Screenshots (Backfill existing games) ===
+
+const startTopupScreenshotsSchema = z.object({
+  batchSize: z.number().min(10).max(500).default(50),
+  targetScreenshotsPerGame: z.number().min(1).max(10).default(5),
+})
+
+router.post('/jobs/topup-screenshots/start', async (req, res, next) => {
+  try {
+    const active = await getActiveTopupScreenshots()
+    if (active) {
+      res.status(409).json({
+        success: false,
+        error: { code: 'TOPUP_IN_PROGRESS', message: 'A topup-screenshots job is already in progress or paused' },
+        data: { topupState: active },
+      })
+      return
+    }
+
+    const config = startTopupScreenshotsSchema.parse(req.body)
+    const { topupState, job } = await startTopupScreenshots(config)
+
+    res.status(201).json({
+      success: true,
+      data: { topupState, job: { id: job.id, name: job.name } },
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: error.issues[0]?.message },
+      })
+      return
+    }
+    next(error)
+  }
+})
+
+router.get('/jobs/topup-screenshots/current', async (_req, res, next) => {
+  try {
+    const topupState = await getActiveTopupScreenshots()
+    res.json({ success: true, data: { topupState } })
+  } catch (error) {
+    next(error)
+  }
+})
+
+router.get('/jobs/topup-screenshots/:id', async (req, res, next) => {
+  try {
+    const id = parseInt(req.params['id']!, 10)
+    const topupState = await getTopupScreenshotsState(id)
+
+    if (!topupState) {
+      res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Topup state not found' },
+      })
+      return
+    }
+
+    res.json({ success: true, data: { topupState } })
+  } catch (error) {
+    next(error)
+  }
+})
+
+router.post('/jobs/topup-screenshots/:id/pause', async (req, res, next) => {
+  try {
+    const id = parseInt(req.params['id']!, 10)
+    const topupState = await pauseTopupScreenshots(id)
+    res.json({ success: true, data: { topupState } })
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes('not found')) {
+        res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: error.message } })
+        return
+      }
+      if (error.message.includes('Cannot pause')) {
+        res.status(400).json({ success: false, error: { code: 'INVALID_STATE', message: error.message } })
+        return
+      }
+    }
+    next(error)
+  }
+})
+
+router.post('/jobs/topup-screenshots/:id/resume', async (req, res, next) => {
+  try {
+    const id = parseInt(req.params['id']!, 10)
+    const { topupState, job } = await resumeTopupScreenshots(id)
+    res.json({ success: true, data: { topupState, job: { id: job.id, name: job.name } } })
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes('not found')) {
+        res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: error.message } })
+        return
+      }
+      if (error.message.includes('Cannot resume')) {
+        res.status(400).json({ success: false, error: { code: 'INVALID_STATE', message: error.message } })
+        return
+      }
+    }
+    next(error)
+  }
+})
+
+router.post('/jobs/topup-screenshots/:id/cancel', async (req, res, next) => {
+  try {
+    const id = parseInt(req.params['id']!, 10)
+    const topupState = await cancelTopupScreenshots(id)
+    res.json({ success: true, data: { topupState } })
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes('not found')) {
+        res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: error.message } })
+        return
+      }
+      if (error.message.includes('Cannot cancel')) {
+        res.status(400).json({ success: false, error: { code: 'INVALID_STATE', message: error.message } })
         return
       }
     }

--- a/packages/backend/src/tools/screenshot-fetcher.ts
+++ b/packages/backend/src/tools/screenshot-fetcher.ts
@@ -5,9 +5,9 @@
  * and saves them locally for seeding the database.
  *
  * Usage:
- *   npx tsx src/tools/screenshot-fetcher.ts fetch --games 200 --screenshots-per-game 3
+ *   npx tsx src/tools/screenshot-fetcher.ts fetch --games 200 --screenshots-per-game 5
  *   npx tsx src/tools/screenshot-fetcher.ts download
- *   npx tsx src/tools/screenshot-fetcher.ts all --games 200 --screenshots-per-game 3
+ *   npx tsx src/tools/screenshot-fetcher.ts all --games 200 --screenshots-per-game 5
  */
 
 import fs from 'fs/promises'
@@ -394,7 +394,7 @@ async function main(): Promise<void> {
   }
 
   const targetGames = parseInt(flags['games'] || '200')
-  const screenshotsPerGame = parseInt(flags['screenshots-per-game'] || '3')
+  const screenshotsPerGame = parseInt(flags['screenshots-per-game'] || '5')
 
   switch (command) {
     case 'fetch': {
@@ -433,10 +433,10 @@ Commands:
 
 Options:
   --games <number>               Number of games to fetch (default: 200)
-  --screenshots-per-game <number> Screenshots per game (default: 3)
+  --screenshots-per-game <number> Screenshots per game (default: 5)
 
 Examples:
-  npx tsx src/tools/screenshot-fetcher.ts fetch --games 200 --screenshots-per-game 3
+  npx tsx src/tools/screenshot-fetcher.ts fetch --games 200 --screenshots-per-game 5
   npx tsx src/tools/screenshot-fetcher.ts download
   npx tsx src/tools/screenshot-fetcher.ts all --games 50 --screenshots-per-game 5
 

--- a/packages/frontend/src/components/admin/FullImportCard.tsx
+++ b/packages/frontend/src/components/admin/FullImportCard.tsx
@@ -23,7 +23,7 @@ export function FullImportCard() {
 
   // Configuration state
   const [batchSize, setBatchSize] = useState(100)
-  const [screenshotsPerGame, setScreenshotsPerGame] = useState(3)
+  const [screenshotsPerGame, setScreenshotsPerGame] = useState(5)
   const [minMetacritic, setMinMetacritic] = useState(70)
 
   // Fetch current import on mount
@@ -215,7 +215,7 @@ export function FullImportCard() {
                 <Input
                   type="number"
                   value={screenshotsPerGame}
-                  onChange={(e) => setScreenshotsPerGame(parseInt(e.target.value) || 3)}
+                  onChange={(e) => setScreenshotsPerGame(parseInt(e.target.value) || 5)}
                   min={1}
                   max={10}
                 />

--- a/packages/frontend/src/components/admin/JobTriggerCard.tsx
+++ b/packages/frontend/src/components/admin/JobTriggerCard.tsx
@@ -18,7 +18,7 @@ export function JobTriggerCard({ type }: JobTriggerCardProps) {
 
   const [isLoading, setIsLoading] = useState(false)
   const [targetGames, setTargetGames] = useState(50)
-  const [screenshotsPerGame, setScreenshotsPerGame] = useState(3)
+  const [screenshotsPerGame, setScreenshotsPerGame] = useState(5)
   const [minMetacritic, setMinMetacritic] = useState(70)
 
   const isGamesImport = type === 'import-games'
@@ -82,7 +82,7 @@ export function JobTriggerCard({ type }: JobTriggerCardProps) {
               <Input
                 type="number"
                 value={screenshotsPerGame}
-                onChange={(e) => setScreenshotsPerGame(parseInt(e.target.value) || 3)}
+                onChange={(e) => setScreenshotsPerGame(parseInt(e.target.value) || 5)}
                 min={1}
                 max={10}
               />

--- a/packages/frontend/src/components/admin/TopupScreenshotsCard.tsx
+++ b/packages/frontend/src/components/admin/TopupScreenshotsCard.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Progress } from '@/components/ui/progress'
+import { Badge } from '@/components/ui/badge'
+import { useAdminStore } from '@/stores/adminStore'
+import { Images, Play, Pause, Loader2, RefreshCw, X } from 'lucide-react'
+
+export function TopupScreenshotsCard() {
+  const { t, i18n } = useTranslation()
+  const {
+    currentTopupScreenshots,
+    topupScreenshotsLoading,
+    topupScreenshotsError,
+    fetchCurrentTopupScreenshots,
+    startTopupScreenshots,
+    pauseTopupScreenshots,
+    resumeTopupScreenshots,
+    cancelTopupScreenshots,
+  } = useAdminStore()
+
+  const [batchSize, setBatchSize] = useState(50)
+  const [targetScreenshotsPerGame, setTargetScreenshotsPerGame] = useState(5)
+
+  useEffect(() => {
+    fetchCurrentTopupScreenshots()
+  }, [fetchCurrentTopupScreenshots])
+
+  const progress = currentTopupScreenshots?.totalGamesAvailable
+    ? Math.round((currentTopupScreenshots.gamesProcessed / currentTopupScreenshots.totalGamesAvailable) * 100)
+    : 0
+
+  const handleStart = async () => {
+    try {
+      await startTopupScreenshots({ batchSize, targetScreenshotsPerGame })
+    } catch (error) {
+      console.error('Failed to start topup-screenshots:', error)
+    }
+  }
+
+  const handlePause = async () => {
+    try {
+      await pauseTopupScreenshots()
+    } catch (error) {
+      console.error('Failed to pause topup-screenshots:', error)
+    }
+  }
+
+  const handleResume = async () => {
+    try {
+      await resumeTopupScreenshots()
+    } catch (error) {
+      console.error('Failed to resume topup-screenshots:', error)
+    }
+  }
+
+  const handleCancel = async () => {
+    try {
+      await cancelTopupScreenshots()
+    } catch (error) {
+      console.error('Failed to cancel topup-screenshots:', error)
+    }
+  }
+
+  const getStatusBadge = () => {
+    if (!currentTopupScreenshots) return null
+
+    const variants: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+      pending: 'outline',
+      in_progress: 'default',
+      paused: 'secondary',
+      completed: 'default',
+      failed: 'destructive',
+    }
+
+    return (
+      <Badge variant={variants[currentTopupScreenshots.status] || 'outline'}>
+        {currentTopupScreenshots.status}
+      </Badge>
+    )
+  }
+
+  const canStart =
+    !currentTopupScreenshots ||
+    currentTopupScreenshots.status === 'completed' ||
+    currentTopupScreenshots.status === 'failed'
+  const canPause = currentTopupScreenshots?.status === 'in_progress'
+  const canResume = currentTopupScreenshots?.status === 'paused'
+  const canCancel =
+    currentTopupScreenshots?.status === 'in_progress' || currentTopupScreenshots?.status === 'paused'
+
+  return (
+    <Card className="bg-card/50 backdrop-blur-sm border-neon-purple/30">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Images className="h-6 w-6 text-neon-purple" />
+            <div>
+              <CardTitle>
+                {t('admin.topupScreenshots.title', 'Top-Up Screenshots')}
+              </CardTitle>
+              <CardDescription>
+                {t(
+                  'admin.topupScreenshots.description',
+                  'Backfill existing games up to the target number of captures by pulling missing screenshots from RAWG.'
+                )}
+              </CardDescription>
+            </div>
+          </div>
+          {getStatusBadge()}
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {currentTopupScreenshots &&
+          (currentTopupScreenshots.status === 'in_progress' || currentTopupScreenshots.status === 'paused') && (
+            <div className="space-y-3 p-4 rounded-lg bg-background/50">
+              <div className="space-y-1">
+                <div className="flex justify-between text-sm">
+                  <span>{t('admin.fullImport.progress', 'Progress')}</span>
+                  <span>{progress}%</span>
+                </div>
+                <Progress value={progress} className="h-2" />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    {t('admin.topupScreenshots.candidates', 'Candidates')}:
+                  </span>
+                  <span>
+                    {currentTopupScreenshots.totalGamesAvailable?.toLocaleString(i18n.language) || '...'}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    {t('admin.fullImport.processed', 'Processed')}:
+                  </span>
+                  <span>{currentTopupScreenshots.gamesProcessed.toLocaleString(i18n.language)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    {t('admin.topupScreenshots.toppedUp', 'Topped up')}:
+                  </span>
+                  <span className="text-success">
+                    {currentTopupScreenshots.gamesImported.toLocaleString(i18n.language)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    {t('admin.fullImport.skipped', 'Skipped')}:
+                  </span>
+                  <span className="text-warning">
+                    {currentTopupScreenshots.gamesSkipped.toLocaleString(i18n.language)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    {t('admin.fullImport.screenshots', 'Screenshots')}:
+                  </span>
+                  <span>
+                    {currentTopupScreenshots.screenshotsDownloaded.toLocaleString(i18n.language)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    {t('admin.fullImport.batch', 'Batch')}:
+                  </span>
+                  <span>
+                    {currentTopupScreenshots.currentBatch} /{' '}
+                    {currentTopupScreenshots.totalBatchesEstimated || '?'}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+
+        {currentTopupScreenshots?.status === 'completed' && (
+          <div className="p-4 rounded-lg bg-success/10 border border-success/30">
+            <p className="text-success font-medium">
+              {t('admin.topupScreenshots.completed', 'Top-up complete')}
+            </p>
+            <p className="text-sm text-muted-foreground mt-1">
+              {currentTopupScreenshots.gamesImported.toLocaleString()} {t('admin.topupScreenshots.gamesToppedUp', 'games topped up')},{' '}
+              {currentTopupScreenshots.screenshotsDownloaded.toLocaleString()}{' '}
+              {t('admin.topupScreenshots.newScreenshots', 'new screenshots')}
+            </p>
+          </div>
+        )}
+
+        {topupScreenshotsError && (
+          <div className="p-4 rounded-lg bg-error/10 border border-error/30">
+            <p className="text-error text-sm">{topupScreenshotsError}</p>
+          </div>
+        )}
+
+        {canStart && (
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label className="text-muted-foreground font-normal">
+                {t('admin.fullImport.batchSize', 'Batch size')}
+              </Label>
+              <Input
+                type="number"
+                value={batchSize}
+                onChange={(e) => setBatchSize(parseInt(e.target.value) || 50)}
+                min={10}
+                max={500}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-muted-foreground font-normal">
+                {t('admin.topupScreenshots.targetPerGame', 'Target captures per game')}
+              </Label>
+              <Input
+                type="number"
+                value={targetScreenshotsPerGame}
+                onChange={(e) =>
+                  setTargetScreenshotsPerGame(parseInt(e.target.value) || 5)
+                }
+                min={1}
+                max={10}
+              />
+            </div>
+          </div>
+        )}
+      </CardContent>
+
+      <CardFooter className="flex gap-2">
+        {canStart && (
+          <Button
+            variant="gaming"
+            onClick={handleStart}
+            disabled={topupScreenshotsLoading}
+            className="flex-1"
+          >
+            {topupScreenshotsLoading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                {t('common.loading', 'Loading')}
+              </>
+            ) : (
+              <>
+                <Play className="h-4 w-4 mr-2" />
+                {t('admin.topupScreenshots.start', 'Start top-up')}
+              </>
+            )}
+          </Button>
+        )}
+
+        {canPause && (
+          <Button
+            variant="secondary"
+            onClick={handlePause}
+            disabled={topupScreenshotsLoading}
+            className="flex-1"
+          >
+            {topupScreenshotsLoading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                {t('common.loading', 'Loading')}
+              </>
+            ) : (
+              <>
+                <Pause className="h-4 w-4 mr-2" />
+                {t('admin.fullImport.pause', 'Pause')}
+              </>
+            )}
+          </Button>
+        )}
+
+        {canResume && (
+          <Button
+            variant="gaming"
+            onClick={handleResume}
+            disabled={topupScreenshotsLoading}
+            className="flex-1"
+          >
+            {topupScreenshotsLoading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                {t('common.loading', 'Loading')}
+              </>
+            ) : (
+              <>
+                <RefreshCw className="h-4 w-4 mr-2" />
+                {t('admin.fullImport.resume', 'Resume')}
+              </>
+            )}
+          </Button>
+        )}
+
+        {canCancel && (
+          <Button
+            variant="destructive"
+            onClick={handleCancel}
+            disabled={topupScreenshotsLoading}
+          >
+            <X className="h-4 w-4 mr-2" />
+            {t('common.cancel', 'Cancel')}
+          </Button>
+        )}
+
+        {(currentTopupScreenshots?.status === 'in_progress' ||
+          currentTopupScreenshots?.status === 'paused') && (
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={fetchCurrentTopupScreenshots}
+            disabled={topupScreenshotsLoading}
+          >
+            <RefreshCw className={`h-4 w-4 ${topupScreenshotsLoading ? 'animate-spin' : ''}`} />
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
+  )
+}

--- a/packages/frontend/src/lib/api/admin.ts
+++ b/packages/frontend/src/lib/api/admin.ts
@@ -565,6 +565,61 @@ export const adminApi = {
   },
 
   // ============================================
+  // Top-Up Screenshots (Backfill)
+  // ============================================
+
+  async startTopupScreenshots(config?: {
+    batchSize?: number
+    targetScreenshotsPerGame?: number
+  }): Promise<{ topupState: ImportState; job: { id: string; name: string } }> {
+    const response = await fetch('/api/admin/jobs/topup-screenshots/start', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config || {}),
+    })
+    return handleResponse<{ topupState: ImportState; job: { id: string; name: string } }>(response)
+  },
+
+  async getCurrentTopupScreenshots(): Promise<{ topupState: ImportState | null }> {
+    const response = await fetch('/api/admin/jobs/topup-screenshots/current', {
+      credentials: 'include',
+    })
+    return handleResponse<{ topupState: ImportState | null }>(response)
+  },
+
+  async getTopupScreenshotsState(id: number): Promise<{ topupState: ImportState }> {
+    const response = await fetch(`/api/admin/jobs/topup-screenshots/${id}`, {
+      credentials: 'include',
+    })
+    return handleResponse<{ topupState: ImportState }>(response)
+  },
+
+  async pauseTopupScreenshots(id: number): Promise<{ topupState: ImportState }> {
+    const response = await fetch(`/api/admin/jobs/topup-screenshots/${id}/pause`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+    return handleResponse<{ topupState: ImportState }>(response)
+  },
+
+  async resumeTopupScreenshots(id: number): Promise<{ topupState: ImportState; job: { id: string; name: string } }> {
+    const response = await fetch(`/api/admin/jobs/topup-screenshots/${id}/resume`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+    return handleResponse<{ topupState: ImportState; job: { id: string; name: string } }>(response)
+  },
+
+  async cancelTopupScreenshots(id: number): Promise<{ topupState: ImportState }> {
+    const response = await fetch(`/api/admin/jobs/topup-screenshots/${id}/cancel`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+    return handleResponse<{ topupState: ImportState }>(response)
+  },
+
+  // ============================================
   // User Management
   // ============================================
 

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { useSession } from '@/lib/auth-client'
 import { useAdminStore } from '@/stores/adminStore'
 import { JobList } from '@/components/admin/JobList'
+import { TopupScreenshotsCard } from '@/components/admin/TopupScreenshotsCard'
 import { GameList } from '@/components/admin/GameList'
 import { UserList } from '@/components/admin/UserList'
 import { EmailSettings } from '@/components/admin/EmailSettings'
@@ -138,7 +139,12 @@ export default function AdminPage() {
               animate="animate"
               exit="exit"
             >
-              {activeTab === 'jobs' && <JobList />}
+              {activeTab === 'jobs' && (
+                <div className="space-y-6">
+                  <TopupScreenshotsCard />
+                  <JobList />
+                </div>
+              )}
               {activeTab === 'games' && <GameList />}
               {activeTab === 'users' && <UserList />}
               {activeTab === 'email' && <EmailSettings />}

--- a/packages/frontend/src/stores/adminStore.ts
+++ b/packages/frontend/src/stores/adminStore.ts
@@ -162,6 +162,19 @@ interface AdminState {
   resumeRecalculateScores: () => Promise<void>
   updateRecalculateScoresProgress: (event: RecalculateScoresProgressEvent) => void
 
+  // Top-Up Screenshots (Backfill)
+  currentTopupScreenshots: ImportState | null
+  topupScreenshotsLoading: boolean
+  topupScreenshotsError: string | null
+  fetchCurrentTopupScreenshots: () => Promise<void>
+  startTopupScreenshots: (config?: {
+    batchSize?: number
+    targetScreenshotsPerGame?: number
+  }) => Promise<ImportState>
+  pauseTopupScreenshots: () => Promise<void>
+  resumeTopupScreenshots: () => Promise<void>
+  cancelTopupScreenshots: () => Promise<void>
+
   // Users data
   users: User[]
   usersLoading: boolean
@@ -211,6 +224,11 @@ export const useAdminStore = create<AdminState>()(
       currentRecalculateScores: null,
       recalculateScoresLoading: false,
       recalculateScoresError: null,
+
+      // Top-Up Screenshots initial state
+      currentTopupScreenshots: null,
+      topupScreenshotsLoading: false,
+      topupScreenshotsError: null,
 
       // Users initial state
       users: [],
@@ -658,6 +676,73 @@ export const useAdminStore = create<AdminState>()(
           throw err
         }
       },
+
+      // Top-Up Screenshots Actions
+      fetchCurrentTopupScreenshots: async () => {
+        try {
+          const { topupState } = await adminApi.getCurrentTopupScreenshots()
+          set({ currentTopupScreenshots: topupState })
+        } catch (err) {
+          console.error('Failed to fetch current topup state:', err)
+        }
+      },
+
+      startTopupScreenshots: async (config) => {
+        set({ topupScreenshotsLoading: true, topupScreenshotsError: null })
+        try {
+          const { topupState } = await adminApi.startTopupScreenshots(config)
+          set({ currentTopupScreenshots: topupState, topupScreenshotsLoading: false })
+          get().fetchJobs()
+          return topupState
+        } catch (err) {
+          set({ topupScreenshotsError: (err as Error).message, topupScreenshotsLoading: false })
+          throw err
+        }
+      },
+
+      pauseTopupScreenshots: async () => {
+        const { currentTopupScreenshots } = get()
+        if (!currentTopupScreenshots) return
+
+        set({ topupScreenshotsLoading: true, topupScreenshotsError: null })
+        try {
+          const { topupState } = await adminApi.pauseTopupScreenshots(currentTopupScreenshots.id)
+          set({ currentTopupScreenshots: topupState, topupScreenshotsLoading: false })
+        } catch (err) {
+          set({ topupScreenshotsError: (err as Error).message, topupScreenshotsLoading: false })
+          throw err
+        }
+      },
+
+      resumeTopupScreenshots: async () => {
+        const { currentTopupScreenshots } = get()
+        if (!currentTopupScreenshots) return
+
+        set({ topupScreenshotsLoading: true, topupScreenshotsError: null })
+        try {
+          const { topupState } = await adminApi.resumeTopupScreenshots(currentTopupScreenshots.id)
+          set({ currentTopupScreenshots: topupState, topupScreenshotsLoading: false })
+          get().fetchJobs()
+        } catch (err) {
+          set({ topupScreenshotsError: (err as Error).message, topupScreenshotsLoading: false })
+          throw err
+        }
+      },
+
+      cancelTopupScreenshots: async () => {
+        const { currentTopupScreenshots } = get()
+        if (!currentTopupScreenshots) return
+
+        set({ topupScreenshotsLoading: true, topupScreenshotsError: null })
+        try {
+          const { topupState } = await adminApi.cancelTopupScreenshots(currentTopupScreenshots.id)
+          set({ currentTopupScreenshots: topupState, topupScreenshotsLoading: false })
+        } catch (err) {
+          set({ topupScreenshotsError: (err as Error).message, topupScreenshotsLoading: false })
+          throw err
+        }
+      },
+
       // Users Actions
       fetchUsers: async (params) => {
         const { usersPagination, usersSearch, usersSort } = get()

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -478,7 +478,7 @@ export interface GameSessionDetailsResponse {
 // Job Management (Admin)
 // ============================================
 
-export type JobType = 'import-games' | 'import-screenshots' | 'sync-new-games' | 'batch-import-games' | 'create-daily-challenge' | 'sync-all-games' | 'cleanup-anonymous-users' | 'recalculate-scores' | 'clear-daily-data'
+export type JobType = 'import-games' | 'import-screenshots' | 'sync-new-games' | 'batch-import-games' | 'create-daily-challenge' | 'sync-all-games' | 'cleanup-anonymous-users' | 'recalculate-scores' | 'clear-daily-data' | 'topup-screenshots'
 export type JobStatus = 'waiting' | 'active' | 'completed' | 'failed' | 'delayed'
 
 // Import State for batch processing
@@ -552,6 +552,9 @@ export interface JobData {
   dryRun?: boolean
   startDate?: string
   endDate?: string
+  // For topup-screenshots
+  topupStateId?: number
+  targetScreenshotsPerGame?: number
 }
 
 export interface JobResult {
@@ -587,6 +590,9 @@ export interface JobResult {
   sessionsDeleted?: number
   challengeId?: number
   challengeDate?: string
+  // For topup-screenshots
+  topupStateId?: number
+  gamesToppedUp?: number
 }
 
 // Job API Types


### PR DESCRIPTION
Raises the default capture count for new game imports from 3 to 5 across
the screenshot-fetcher CLI, batch-import / sync-all workers, admin routes,
import_states column default, and the admin UI.

Adds a new topup-screenshots job that walks the existing games table,
fetches the next slice of RAWG screenshots for any game whose active
capture count is below the target, downloads them to the conventional
screenshot_N.jpg path, and inserts new screenshot rows. Pause / resume /
cancel are wired through the shared import_states machinery and exposed
via /api/admin/jobs/topup-screenshots/* plus a TopupScreenshotsCard on
the admin Jobs tab so admins can backfill the existing 1500+ games to 5
captures each.