### PR TITLE
Switch Fandom map importer to Interactive Maps namespace

### DIFF
--- a/packages/backend/migrations/20260425_geo_fandom_interactive_maps.ts
+++ b/packages/backend/migrations/20260425_geo_fandom_interactive_maps.ts
@@ -1,0 +1,46 @@
+import type { Knex } from 'knex'
+
+// Switches the Fandom map importer from scraping arbitrary `prop=images`
+// attachments off random wiki pages to the structured Fandom Interactive
+// Maps feature (namespace 2900, `Map:`). Two new columns track the source
+// map identity for re-resolution and change detection.
+//
+// Also resets curated games whose `wiki_page_title` was filled in by the
+// previous heuristic resolver (Interactive_Map / World_Map / Map / Maps /
+// Atlas) — those values are not real `Map:` page names, so the new
+// resolver must run again to discover the actual interactive map.
+
+const LEGACY_PAGE_TITLES = ['Interactive_Map', 'World_Map', 'Map', 'Maps', 'Atlas']
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('geo_map', (table) => {
+    table
+      .string('wiki_map_name', 200)
+      .nullable()
+      .comment('Fandom Map: page title without the namespace prefix')
+    table
+      .bigInteger('wiki_revision_id')
+      .nullable()
+      .comment('Fandom map JSON revisionId at import time, for change detection')
+  })
+
+  await knex('games')
+    .whereIn('wiki_page_title', LEGACY_PAGE_TITLES)
+    .update({
+      wiki_page_title: null,
+      geo_metadata_status: 'pending',
+      geo_metadata_resolved_at: null,
+    })
+
+  // Drop tombstones from the previous metadata strategy so the resolver
+  // gets a clean run with the Map: namespace lookup.
+  await knex('geo_ingest_failure').where({ source: 'metadata' }).delete()
+  await knex('geo_ingest_failure').where({ source: 'fandom' }).delete()
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('geo_map', (table) => {
+    table.dropColumn('wiki_revision_id')
+    table.dropColumn('wiki_map_name')
+  })
+}

--- a/packages/backend/src/domain/services/geo-metadata.service.ts
+++ b/packages/backend/src/domain/services/geo-metadata.service.ts
@@ -2,13 +2,10 @@
 // behaviour testable without a network. The resolver worker layers
 // HTTP probes on top of these.
 
-const DEFAULT_WIKI_PAGE_TITLES = [
-  'Interactive_Map',
-  'World_Map',
-  'Map',
-  'Maps',
-  'Atlas',
-] as const
+// Fandom Interactive Maps live in namespace 2900 (`Map:`) on every wiki
+// that has the feature enabled. The resolver discovers maps by listing
+// pages in this namespace via `?action=query&list=allpages&apnamespace=2900`.
+export const FANDOM_MAP_NAMESPACE = 2900
 
 /**
  * Derive Fandom subdomain candidates from a game slug. Most Fandom wikis
@@ -34,8 +31,38 @@ export function wikiSubdomainCandidates(slug: string): string[] {
   return out
 }
 
-export function defaultWikiPageTitles(): readonly string[] {
-  return DEFAULT_WIKI_PAGE_TITLES
+/**
+ * Score a `Map:` page title against the curated game's name + slug to pick
+ * the most likely "main" map when a wiki publishes several. Higher is
+ * better. The scoring rewards titles that:
+ *   - mention the game name or its slug tokens (game-specific maps),
+ *   - mention "world" / "overworld" / "atlas" (top-level maps),
+ *   - mention "map" generically.
+ *
+ * Pure function so the resolver can be exercised without network access.
+ */
+export function scoreMapTitle(
+  mapTitle: string,
+  gameName: string,
+  slug: string,
+): number {
+  const t = mapTitle.toLowerCase().replace(/_/g, ' ')
+  const name = normalizeGameTitle(gameName)
+  const slugTokens = slug
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((tok) => tok.length >= 3)
+
+  let score = 0
+  if (name && t.includes(name)) score += 50
+  for (const tok of slugTokens) {
+    if (t.includes(tok)) score += 8
+  }
+  if (/\b(world|overworld|atlas)\b/.test(t)) score += 20
+  if (/\bmap\b/.test(t)) score += 5
+  // Penalise obvious sub-region or DLC maps when a top-level alternative exists.
+  if (/\b(zone|region|area|level|dlc|dungeon|interior|building)\b/.test(t)) score -= 6
+  return score
 }
 
 /**

--- a/packages/backend/src/domain/services/index.ts
+++ b/packages/backend/src/domain/services/index.ts
@@ -59,10 +59,11 @@ export {
 } from './geo-game.service.js'
 export {
   wikiSubdomainCandidates,
-  defaultWikiPageTitles,
+  scoreMapTitle,
   parseSteamAppIdFromUrl,
   normalizeGameTitle,
   tombstoneRetryAfter,
+  FANDOM_MAP_NAMESPACE,
 } from './geo-metadata.service.js'
 
 // ---------------------------------------------------------------------------

--- a/packages/backend/src/infrastructure/queue/workers/geo-fandom-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-fandom-import-logic.ts
@@ -7,19 +7,24 @@ import { tombstoneRetryAfter } from '../../../domain/services/geo-metadata.servi
 
 const log = queueLogger.child({ worker: 'geo-fandom-import' })
 
-// Fandom exposes a standard MediaWiki API per wiki subdomain:
-//   https://<subdomain>.fandom.com/api.php?action=query&prop=imageinfo&...
-// We fetch a single page's primary image and record attribution under the
-// default CC-BY-SA-3.0 license that Fandom wikis publish under.
+// Fandom Interactive Maps are structured JSON exposed via the MediaWiki
+// `getmap` action on each wiki:
+//   https://<subdomain>.fandom.com/api.php?action=getmap&name=<MapPageName>
+// The response includes a `backgroundImage` (URL + width + height), the
+// map's `revisionId` (used for change detection on re-imports), and the
+// coordinate system metadata (`origin`, `coordinateOrder`).
 //
-// Rate-limit: a single request per call site; callers should not loop.
+// Fandom user-generated content is published under CC-BY-SA-3.0 by default.
 
-const DEFAULT_USER_AGENT = 'the-box-geo-importer/1.0 (+https://github.com/Wifsimster/the-box)'
+const DEFAULT_USER_AGENT =
+  'the-box-geo-importer/1.0 (+https://github.com/Wifsimster/the-box)'
 const FANDOM_DEFAULT_LICENSE = 'CC-BY-SA-3.0'
 
 export interface ImportFandomMapInput {
   gameId: number
   wikiSubdomain: string
+  // The Fandom Map: page name without the namespace prefix
+  // (e.g. `Avatar_world_map`, not `Map:Avatar_world_map`).
   pageTitle: string
   userAgent?: string
 }
@@ -30,31 +35,18 @@ export interface ImportFandomMapResult {
   reason?: string
 }
 
-interface MediaWikiImageInfo {
-  url?: string
-  width?: number
-  height?: number
-  descriptionshorturl?: string
-}
-
-interface MediaWikiPage {
-  pageid?: number
-  title?: string
-  imageinfo?: MediaWikiImageInfo[]
-  images?: Array<{ title: string }>
-}
-
-interface MediaWikiQueryResponse {
-  query?: {
-    pages?: Record<string, MediaWikiPage>
+interface GetMapResponse {
+  backgroundImage?: {
+    url?: string
+    width?: number
+    height?: number
   }
+  mapImage?: string
+  revisionId?: number
+  origin?: string
+  coordinateOrder?: string
 }
 
-/**
- * Resolve the primary image attached to a wiki page. We hit the page with
- * `prop=images` first to find image titles, then fetch `prop=imageinfo` on
- * the top candidate to get its URL + dimensions.
- */
 export async function importFandomMap(
   input: ImportFandomMapInput,
 ): Promise<ImportFandomMapResult> {
@@ -67,41 +59,41 @@ export async function importFandomMap(
     return { imported: false, geoMapId: existing.id, reason: 'map already exists' }
   }
 
-  const base = `https://${wikiSubdomain}.fandom.com/api.php`
-  const pageImagesUrl = `${base}?action=query&format=json&prop=images&titles=${encodeURIComponent(pageTitle)}&imlimit=20`
+  const url =
+    `https://${wikiSubdomain}.fandom.com/api.php` +
+    `?action=getmap&format=json&name=${encodeURIComponent(pageTitle)}`
 
-  log.info({ gameId, wikiSubdomain, pageTitle }, 'fetching page images')
-  const pagesRes = await fetchJson<MediaWikiQueryResponse>(pageImagesUrl, ua)
-  const page = firstPage(pagesRes)
-  const imageTitle = page?.images?.find((i) => looksLikeMap(i.title))?.title ?? page?.images?.[0]?.title
+  log.info({ gameId, wikiSubdomain, pageTitle }, 'fetching interactive map')
 
-  if (!imageTitle) {
-    await recordFandomTombstone(gameId, 'no images on page')
-    return { imported: false, reason: 'no images on page' }
+  let data: GetMapResponse
+  try {
+    data = await fetchJson<GetMapResponse>(url, ua)
+  } catch (err) {
+    await recordFandomTombstone(gameId, `getmap fetch failed: ${String(err)}`)
+    return { imported: false, reason: 'getmap fetch failed' }
   }
 
-  const infoUrl = `${base}?action=query&format=json&prop=imageinfo&iiprop=url|size|url&titles=${encodeURIComponent(imageTitle)}`
-  const infoRes = await fetchJson<MediaWikiQueryResponse>(infoUrl, ua)
-  const infoPage = firstPage(infoRes)
-  const info = infoPage?.imageinfo?.[0]
-  if (!info?.url || !info.width || !info.height) {
-    await recordFandomTombstone(gameId, 'image info missing url or dimensions')
-    return { imported: false, reason: 'image info missing url or dimensions' }
+  const bg = data.backgroundImage
+  if (!bg?.url || !bg.width || !bg.height) {
+    await recordFandomTombstone(gameId, 'getmap returned no backgroundImage')
+    return { imported: false, reason: 'getmap returned no backgroundImage' }
   }
 
   const map = await geoMapRepository.create({
     gameId,
     source: 'fandom',
-    sourceUrl: info.descriptionshorturl ?? `https://${wikiSubdomain}.fandom.com/wiki/${encodeURIComponent(pageTitle)}`,
-    imageUrl: info.url,
-    widthPx: info.width,
-    heightPx: info.height,
+    sourceUrl: `https://${wikiSubdomain}.fandom.com/wiki/Map:${encodeURIComponent(pageTitle)}`,
+    imageUrl: bg.url,
+    widthPx: bg.width,
+    heightPx: bg.height,
     license: FANDOM_DEFAULT_LICENSE,
-    attribution: `${wikiSubdomain}.fandom.com — ${imageTitle}`,
+    attribution: `${wikiSubdomain}.fandom.com — Map:${pageTitle}`,
+    wikiMapName: pageTitle,
+    wikiRevisionId: data.revisionId ?? null,
   })
 
   await geoIngestFailureRepository.clear(gameId, 'fandom')
-  log.info({ gameId, mapId: map.id }, 'imported fandom map')
+  log.info({ gameId, mapId: map.id, revisionId: data.revisionId }, 'imported fandom map')
   return { imported: true, geoMapId: map.id }
 }
 
@@ -115,20 +107,10 @@ async function recordFandomTombstone(gameId: number, reason: string): Promise<vo
   })
 }
 
-function firstPage(resp: MediaWikiQueryResponse): MediaWikiPage | undefined {
-  const pages = resp.query?.pages
-  if (!pages) return undefined
-  return Object.values(pages)[0]
-}
-
-// Heuristic: prefer files that look like a world/region map over screenshots.
-function looksLikeMap(title: string): boolean {
-  const lower = title.toLowerCase()
-  return lower.includes('map') || lower.includes('world') || lower.includes('atlas')
-}
-
 async function fetchJson<T>(url: string, userAgent: string): Promise<T> {
-  const res = await fetch(url, { headers: { 'User-Agent': userAgent, Accept: 'application/json' } })
+  const res = await fetch(url, {
+    headers: { 'User-Agent': userAgent, Accept: 'application/json' },
+  })
   if (!res.ok) {
     throw new Error(`fandom fetch failed: ${res.status} ${res.statusText}`)
   }

--- a/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
@@ -2,8 +2,9 @@ import { db } from '../../database/connection.js'
 import { queueLogger } from '../../logger/logger.js'
 import { geoIngestFailureRepository } from '../../repositories/index.js'
 import {
-  defaultWikiPageTitles,
+  FANDOM_MAP_NAMESPACE,
   normalizeGameTitle,
+  scoreMapTitle,
   tombstoneRetryAfter,
   wikiSubdomainCandidates,
 } from '../../../domain/services/geo-metadata.service.js'
@@ -14,6 +15,7 @@ const DEFAULT_USER_AGENT =
   'the-box-geo-importer/1.0 (+https://github.com/Wifsimster/the-box)'
 const STEAM_STORESEARCH = 'https://store.steampowered.com/api/storesearch/'
 const FANDOM_BASE = (sub: string) => `https://${sub}.fandom.com`
+const MAP_TITLE_PREFIX = 'Map:'
 
 interface CuratedGameRow {
   id: number
@@ -32,20 +34,21 @@ export interface ResolveMetadataResult {
 }
 
 /**
- * Resolve missing Steam app id, wiki subdomain, and wiki page title for
- * curated games (`geo_curated = true`, `geo_metadata_status = 'pending'`).
+ * Resolve missing Steam app id, wiki subdomain, and Fandom Interactive Map
+ * page name for curated games (`geo_curated = true`,
+ * `geo_metadata_status = 'pending'`).
  *
  * Strategy:
- *   1. Steam app id: hit Steam's `storesearch` API by game name; pick the
- *      first hit whose normalized title matches.
- *   2. Wiki subdomain + page title: try each `<slug-variant>.fandom.com`
- *      with each likely page title (Interactive_Map, World_Map, Map, …);
- *      first HEAD that returns 200 wins.
+ *   1. Steam app id — hit Steam `storesearch`, pick the first hit whose
+ *      normalized title matches the game name.
+ *   2. Wiki subdomain + Map: page name — for each `<slug-variant>.fandom.com`,
+ *      list pages in the Fandom Interactive Maps namespace
+ *      (`?action=query&list=allpages&apnamespace=2900`). The first
+ *      subdomain that returns at least one map wins; we score the returned
+ *      titles and keep the highest-scoring one (without the `Map:` prefix).
  *
- * On full success → status='resolved'. On partial (e.g. wiki found but no
- * Steam) we still mark resolved and let the per-source importers handle
- * missing inputs. On total failure → status='unresolved' + tombstone with
- * exponential backoff so we don't loop.
+ * On any success → status='resolved'. On total failure → status='unresolved'
+ * + tombstone with exponential backoff so we don't loop.
  */
 export async function resolveGeoMetadataBatch(
   batchSize = 25,
@@ -71,9 +74,10 @@ export async function resolveGeoMetadataBatch(
   for (const row of rows) {
     try {
       const steamAppId = row.steam_app_id ?? (await resolveSteamAppId(row.name))
-      const wiki = row.wiki_subdomain
-        ? { subdomain: row.wiki_subdomain, pageTitle: row.wiki_page_title ?? 'Interactive_Map' }
-        : await resolveFandomPage(row.slug)
+      const wiki =
+        row.wiki_subdomain && row.wiki_page_title
+          ? { subdomain: row.wiki_subdomain, mapName: row.wiki_page_title }
+          : await resolveFandomInteractiveMap(row.name, row.slug)
 
       const haveAnything = Boolean(steamAppId) || Boolean(wiki)
       if (!haveAnything) {
@@ -82,7 +86,7 @@ export async function resolveGeoMetadataBatch(
         await geoIngestFailureRepository.record({
           gameId: row.id,
           source: 'metadata',
-          reason: 'no Steam appid and no Fandom wiki found',
+          reason: 'no Steam appid and no Fandom interactive map found',
           retryAfter: tombstoneRetryAfter(attempt),
         })
         await db('games')
@@ -97,16 +101,13 @@ export async function resolveGeoMetadataBatch(
         .update({
           steam_app_id: steamAppId,
           wiki_subdomain: wiki?.subdomain ?? row.wiki_subdomain,
-          wiki_page_title: wiki?.pageTitle ?? row.wiki_page_title,
+          wiki_page_title: wiki?.mapName ?? row.wiki_page_title,
           geo_metadata_status: 'resolved',
           geo_metadata_resolved_at: new Date(),
         })
       await geoIngestFailureRepository.clear(row.id, 'metadata')
       resolved++
-      log.info(
-        { gameId: row.id, steamAppId, wiki },
-        'resolved geo metadata',
-      )
+      log.info({ gameId: row.id, steamAppId, wiki }, 'resolved geo metadata')
     } catch (err) {
       log.warn({ gameId: row.id, err: String(err) }, 'metadata resolution error')
       skipped++
@@ -126,7 +127,8 @@ async function resolveSteamAppId(name: string): Promise<number | null> {
     const body = (await res.json()) as { items?: Array<{ id: number; name: string }> }
     if (!body.items?.length) return null
     const target = normalizeGameTitle(name)
-    const hit = body.items.find((it) => normalizeGameTitle(it.name) === target) ?? body.items[0]
+    const hit =
+      body.items.find((it) => normalizeGameTitle(it.name) === target) ?? body.items[0]
     return hit?.id ?? null
   } catch (err) {
     log.warn({ name, err: String(err) }, 'steam storesearch failed')
@@ -134,28 +136,58 @@ async function resolveSteamAppId(name: string): Promise<number | null> {
   }
 }
 
-async function resolveFandomPage(
-  slug: string,
-): Promise<{ subdomain: string; pageTitle: string } | null> {
-  const subs = wikiSubdomainCandidates(slug)
-  const titles = defaultWikiPageTitles()
+interface AllPagesResponse {
+  query?: { allpages?: Array<{ title: string }> }
+}
 
-  for (const sub of subs) {
-    for (const title of titles) {
-      const url = `${FANDOM_BASE(sub)}/wiki/${encodeURIComponent(title)}`
-      try {
-        const res = await fetch(url, {
-          method: 'HEAD',
-          headers: { 'User-Agent': DEFAULT_USER_AGENT },
-          redirect: 'follow',
-        })
-        if (res.ok) {
-          return { subdomain: sub, pageTitle: title }
-        }
-      } catch {
-        // network glitch on a probe is fine — keep trying.
-      }
+/**
+ * Walk subdomain candidates and ask each wiki for its `Map:` namespace
+ * via `action=query&list=allpages&apnamespace=2900`. The first subdomain
+ * that returns ≥1 map wins; we then score those titles to pick the most
+ * "main" map and strip the `Map:` prefix before storing.
+ */
+async function resolveFandomInteractiveMap(
+  gameName: string,
+  slug: string,
+): Promise<{ subdomain: string; mapName: string } | null> {
+  for (const sub of wikiSubdomainCandidates(slug)) {
+    const url =
+      `${FANDOM_BASE(sub)}/api.php?action=query&format=json` +
+      `&list=allpages&apnamespace=${FANDOM_MAP_NAMESPACE}&aplimit=100`
+    let body: AllPagesResponse
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': DEFAULT_USER_AGENT, Accept: 'application/json' },
+      })
+      if (!res.ok) continue
+      body = (await res.json()) as AllPagesResponse
+    } catch {
+      continue
+    }
+
+    const pages = body.query?.allpages ?? []
+    if (!pages.length) continue
+
+    const ranked = pages
+      .map((p) => stripMapPrefix(p.title))
+      .filter((t): t is string => Boolean(t))
+      .map((title) => ({ title, score: scoreMapTitle(title, gameName, slug) }))
+      .sort((a, b) => b.score - a.score)
+
+    const best = ranked[0]
+    if (best) {
+      log.info(
+        { sub, choice: best, candidates: ranked.length },
+        'fandom map discovered',
+      )
+      return { subdomain: sub, mapName: best.title }
     }
   }
   return null
+}
+
+function stripMapPrefix(title: string): string | null {
+  if (!title.startsWith(MAP_TITLE_PREFIX)) return null
+  const stripped = title.slice(MAP_TITLE_PREFIX.length).trim()
+  return stripped || null
 }

--- a/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
@@ -15,11 +15,20 @@ export interface GeoMapRow {
   consensus_radius: number
   license: string
   attribution: string | null
+  wiki_map_name: string | null
+  wiki_revision_id: string | number | null
   is_active: boolean
   created_at: Date
 }
 
 function mapRow(row: GeoMapRow): GeoMap {
+  // pg returns BIGINT as string; coerce to number when present.
+  const revision =
+    row.wiki_revision_id == null
+      ? undefined
+      : typeof row.wiki_revision_id === 'string'
+        ? Number(row.wiki_revision_id)
+        : row.wiki_revision_id
   return {
     id: row.id,
     gameId: row.game_id,
@@ -31,6 +40,8 @@ function mapRow(row: GeoMapRow): GeoMap {
     consensusRadius: row.consensus_radius,
     license: row.license,
     attribution: row.attribution ?? undefined,
+    wikiMapName: row.wiki_map_name ?? undefined,
+    wikiRevisionId: revision,
   }
 }
 
@@ -66,6 +77,8 @@ export const geoMapRepository = {
     consensusRadius?: number
     license: string
     attribution?: string
+    wikiMapName?: string | null
+    wikiRevisionId?: number | null
   }): Promise<GeoMap> {
     log.info({ gameId: data.gameId, source: data.source }, 'create')
     const [row] = await db('geo_map')
@@ -79,6 +92,8 @@ export const geoMapRepository = {
         consensus_radius: data.consensusRadius ?? 0.03,
         license: data.license,
         attribution: data.attribution ?? null,
+        wiki_map_name: data.wikiMapName ?? null,
+        wiki_revision_id: data.wikiRevisionId ?? null,
       })
       .returning<GeoMapRow[]>('*')
     return mapRow(row!)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -706,6 +706,11 @@ export interface GeoMap {
   consensusRadius: number
   license: string
   attribution?: string
+  // Fandom Interactive Maps source identity (only set for source='fandom').
+  // wikiMapName is the `Map:` page name without prefix; wikiRevisionId is
+  // the JSON revisionId at import time, used for change detection.
+  wikiMapName?: string
+  wikiRevisionId?: number
 }
 
 export interface GeoScreenshotCandidate {


### PR DESCRIPTION
## Summary

Refactors the Fandom wiki map discovery and import logic to use Fandom's structured Interactive Maps feature (namespace 2900, `Map:` prefix) instead of heuristically scraping arbitrary image attachments from wiki pages.

## Key Changes

- **Metadata Resolution**: Replace page title guessing (`Interactive_Map`, `World_Map`, etc.) with structured namespace queries
  - New `resolveFandomInteractiveMap()` queries `?action=query&list=allpages&apnamespace=2900` to discover actual `Map:` pages
  - Implements `scoreMapTitle()` scoring function to pick the most relevant map when multiple exist (rewards game name/slug mentions, "world"/"atlas" keywords, penalizes sub-region maps)
  - Removes `defaultWikiPageTitles()` and replaces with `FANDOM_MAP_NAMESPACE` constant

- **Map Import**: Switch from image scraping to structured map data
  - Replace two-step image discovery (`prop=images` → `prop=imageinfo`) with single `?action=getmap` call
  - Extract `backgroundImage` (URL + dimensions), `revisionId` (for change detection), and coordinate metadata directly from structured response
  - Simplifies error handling and removes heuristic image filtering

- **Database Schema**: Add two new columns to `geo_map` table
  - `wiki_map_name`: Stores the `Map:` page name without namespace prefix
  - `wiki_revision_id`: Tracks Fandom's revision ID for detecting map updates on re-imports

- **Data Migration**: Reset legacy metadata
  - Games with old heuristic page titles (`Interactive_Map`, `World_Map`, `Map`, `Maps`, `Atlas`) are reset to `pending` status so the new resolver discovers actual interactive maps
  - Clear existing metadata and Fandom tombstones for a clean resolver run

- **Type Updates**: Extend `GeoMap` interface with `wikiMapName` and `wikiRevisionId` fields

## Implementation Details

- The new resolver walks subdomain candidates and returns on first subdomain with ≥1 map (vs. trying all title variants)
- Scoring is a pure function for testability without network access
- Map prefix stripping (`Map:` → page name) happens during resolution, not import
- Maintains backward compatibility: partial success (e.g., Steam ID found but no map) still marks metadata as resolved

https://claude.ai/code/session_01PYcg21qNKGvtxhWhQ8RP77