### PR TITLE
Add email notification jobs and job categories UI

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -623,6 +623,12 @@
       "clearDailyDataRunning": "Clearing daily data...",
       "recalculateScores": "Recalculate Scores",
       "recalculateScoresRunning": "Recalculating scores...",
+      "streakRiskEmail": "Streak Risk Email",
+      "streakRiskEmailRunning": "Sending streak risk emails...",
+      "relanceEmail": "Re-engagement Email",
+      "relanceEmailRunning": "Sending re-engagement emails...",
+      "inactiveUserReminder": "Inactive User Reminder",
+      "inactiveUserReminderRunning": "Sending inactive user reminders...",
       "jobList": "List of Tasks",
       "manual": "Manual",
       "batchImportGames": "Batch Import Games",
@@ -639,7 +645,17 @@
         "cleanupAnonymousUsers": "Removes inactive anonymous user accounts to optimize the database and free up space.",
         "clearDailyData": "Clears all game session data for the current day's daily challenge. This allows users to replay the challenge.",
         "recalculateScores": "Recalculates scores for all completed game sessions using the current scoring algorithm. Ensures historical data reflects the latest scoring rules.",
+        "streakRiskEmail": "Sends an alert email to players whose daily streak is about to expire, encouraging them to come back and play.",
+        "relanceEmail": "Sends a re-engagement email to registered users who haven't played yet, encouraging them to try their first challenge.",
+        "inactiveUserReminder": "Sends a win-back email to long-inactive users to invite them back to the platform.",
         "default": "Automatic system scheduled task."
+      },
+      "categories": {
+        "Challenge": "Challenge",
+        "Maintenance": "Maintenance",
+        "Tournament": "Tournament",
+        "Notification": "Notification",
+        "Other": "Other"
       },
       "status": {
         "waiting": "Waiting",
@@ -687,6 +703,17 @@
         "completed": "Completed",
         "failed": "Failed"
       }
+    },
+    "topupScreenshots": {
+      "title": "Top-Up Screenshots",
+      "description": "Backfill existing games up to the target number of captures by pulling missing screenshots from RAWG.",
+      "targetPerGame": "Target captures per game",
+      "start": "Start top-up",
+      "completed": "Top-up complete",
+      "gamesToppedUp": "games topped up",
+      "newScreenshots": "new screenshots",
+      "candidates": "Candidates",
+      "toppedUp": "Topped up"
     },
     "games": {
       "title": "Games",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -623,6 +623,12 @@
       "clearDailyDataRunning": "Effacement des données en cours...",
       "recalculateScores": "Recalculer les Scores",
       "recalculateScoresRunning": "Recalcul des scores en cours...",
+      "streakRiskEmail": "Email d'Alerte de Série",
+      "streakRiskEmailRunning": "Envoi des alertes de série...",
+      "relanceEmail": "Email de Relance",
+      "relanceEmailRunning": "Envoi des emails de relance...",
+      "inactiveUserReminder": "Rappel Utilisateurs Inactifs",
+      "inactiveUserReminderRunning": "Envoi des rappels aux utilisateurs inactifs...",
       "jobList": "Liste des Tâches",
       "manual": "Manuel",
       "batchImportGames": "Importer les Jeux en Lot",
@@ -639,7 +645,17 @@
         "cleanupAnonymousUsers": "Supprime les comptes utilisateurs anonymes inactifs pour optimiser la base de données et libérer de l'espace.",
         "clearDailyData": "Efface toutes les données de session de jeu pour le défi quotidien du jour. Permet aux utilisateurs de rejouer le défi.",
         "recalculateScores": "Recalcule les scores de toutes les sessions de jeu terminées en utilisant l'algorithme de notation actuel. Garantit que les données historiques reflètent les dernières règles de notation.",
+        "streakRiskEmail": "Envoie un email d'alerte aux joueurs dont la série quotidienne est sur le point d'expirer afin de les inciter à revenir jouer.",
+        "relanceEmail": "Envoie un email de relance aux utilisateurs inscrits qui n'ont pas encore joué pour les encourager à essayer leur premier défi.",
+        "inactiveUserReminder": "Envoie un email de réactivation aux utilisateurs inactifs depuis longtemps pour les inviter à revenir sur la plateforme.",
         "default": "Tâche planifiée automatique du système."
+      },
+      "categories": {
+        "Challenge": "Défi",
+        "Maintenance": "Maintenance",
+        "Tournament": "Tournoi",
+        "Notification": "Notification",
+        "Other": "Autre"
       },
       "status": {
         "waiting": "En attente",
@@ -781,6 +797,17 @@
         "completed": "Termine",
         "failed": "Echoue"
       }
+    },
+    "topupScreenshots": {
+      "title": "Compléter les Captures",
+      "description": "Compléter les jeux existants jusqu'au nombre cible de captures en récupérant les captures manquantes depuis RAWG.",
+      "targetPerGame": "Captures cibles par jeu",
+      "start": "Démarrer la complétion",
+      "completed": "Complétion terminée",
+      "gamesToppedUp": "jeux complétés",
+      "newScreenshots": "nouvelles captures",
+      "candidates": "Candidats",
+      "toppedUp": "Complétés"
     },
     "email": {
       "title": "Paramètres Email",

--- a/packages/frontend/src/components/admin/JobList.tsx
+++ b/packages/frontend/src/components/admin/JobList.tsx
@@ -80,6 +80,9 @@ function getJobTranslationKey(jobName: string): string {
     'send-tournament-reminders': 'admin.jobs.sendTournamentReminders',
     'recalculate-scores': 'admin.jobs.recalculateScores',
     'clear-daily-data': 'admin.jobs.clearDailyData',
+    'streak-risk-email': 'admin.jobs.streakRiskEmail',
+    'relance-email': 'admin.jobs.relanceEmail',
+    'inactive-user-reminder': 'admin.jobs.inactiveUserReminder',
   }
   return keyMap[jobName] || jobName
 }
@@ -96,6 +99,9 @@ function getJobRunningTranslationKey(jobName: string): string {
     'send-tournament-reminders': 'admin.jobs.sendTournamentRemindersRunning',
     'recalculate-scores': 'admin.jobs.recalculateScoresRunning',
     'clear-daily-data': 'admin.jobs.clearDailyDataRunning',
+    'streak-risk-email': 'admin.jobs.streakRiskEmailRunning',
+    'relance-email': 'admin.jobs.relanceEmailRunning',
+    'inactive-user-reminder': 'admin.jobs.inactiveUserReminderRunning',
   }
   return keyMap[jobName] || jobName
 }
@@ -154,6 +160,21 @@ function getJobMetadata(jobName: string, t: (key: string) => string) {
       description: t('admin.jobs.descriptions.clearDailyData'),
       icon: <Trash2 className="h-4 w-4" />,
       category: 'Maintenance',
+    },
+    'streak-risk-email': {
+      description: t('admin.jobs.descriptions.streakRiskEmail'),
+      icon: <Mail className="h-4 w-4" />,
+      category: 'Notification',
+    },
+    'relance-email': {
+      description: t('admin.jobs.descriptions.relanceEmail'),
+      icon: <Mail className="h-4 w-4" />,
+      category: 'Notification',
+    },
+    'inactive-user-reminder': {
+      description: t('admin.jobs.descriptions.inactiveUserReminder'),
+      icon: <Mail className="h-4 w-4" />,
+      category: 'Notification',
     },
   }
 
@@ -352,7 +373,7 @@ export function JobList() {
                                       {t(getJobTranslationKey(job.name))}
                                     </span>
                                     <span className="text-[10px] sm:text-xs text-muted-foreground">
-                                      {metadata.category}
+                                      {t(`admin.jobs.categories.${metadata.category}`)}
                                     </span>
                                   </div>
                                 </div>


### PR DESCRIPTION
## Summary
This PR adds support for three new email notification jobs and introduces a job categorization system to the admin job management interface.

## Key Changes
- **New Email Jobs**: Added three new scheduled jobs for user engagement:
  - `streak-risk-email`: Alerts players when their daily streak is about to expire
  - `relance-email`: Re-engagement emails for registered users who haven't played yet
  - `inactive-user-reminder`: Win-back emails for long-inactive users

- **Job Categorization**: Implemented a job category system with five categories:
  - Challenge
  - Maintenance
  - Tournament
  - Notification
  - Other

- **UI Updates**: 
  - Updated `JobList.tsx` to map new jobs to their translation keys and metadata
  - Added job metadata (descriptions, Mail icons, categories) for the three new email jobs
  - Modified category display to use translated category names instead of raw strings

- **Localization**: Added English and French translations for:
  - Job names and running states
  - Job descriptions
  - Category labels

## Implementation Details
- New email jobs are categorized as "Notification" type with Mail icons
- Job categories are now translatable, allowing for multi-language support
- The translation key mapping follows the existing pattern for consistency
- All three new jobs include both idle and running state translations

https://claude.ai/code/session_01JccQp2vqnSTM78nMUtfjLs