### PR TITLE
Move report button to bottom-right to avoid score panel overlap

### DIFF
--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -657,10 +657,10 @@ export default function GamePage() {
                 <Loader2 className="w-8 h-8 animate-spin text-primary" />
               )}
               {/* Report button — overlay on the viewer; only shown while we
-                  have a real screenshot in play. Sits above the gradient
-                  overlays (z-30) so it stays clickable. */}
+                  have a real screenshot in play. Pinned to the bottom-right
+                  to avoid overlapping the score panel (z-40) at the top. */}
               {currentScreenshotData?.screenshotId && (
-                <div className="absolute top-2 right-2 z-30">
+                <div className="absolute bottom-2 right-2 z-30">
                   <ReportCaptureDialog
                     target={{ screenshotId: currentScreenshotData.screenshotId }}
                     isAuthenticated={!!session?.user?.id}


### PR DESCRIPTION
## Summary
Repositioned the report capture button from the top-right to the bottom-right of the game screenshot viewer to prevent it from overlapping with the score panel.

## Changes
- Changed button positioning from `top-2 right-2` to `bottom-2 right-2`
- Updated comment to reflect the new positioning rationale and clarify that the button is pinned to avoid overlapping the score panel at the top
- Maintained z-index at `z-30` for proper layering

## Details
The report button is now anchored to the bottom-right corner of the screenshot viewer, ensuring it remains visible and clickable without interfering with the score panel UI element positioned at the top of the interface.

https://claude.ai/code/session_01AVpSd51rdoMkqUddjfvSR3