### PR TITLE
Improve accessibility: i18n, focus indicators, contrast, and ARIA

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="fr" class="dark">
 
 <head>
   <meta charset="UTF-8" />

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -65,6 +65,7 @@
     },
     "status": {
       "earned": "Earned",
+      "locked": "Locked",
       "hidden": "Hidden achievement",
       "hiddenDescription": "Hidden achievement - complete it to reveal!",
       "noAchievements": "No achievements available yet",
@@ -94,6 +95,11 @@
     "dailyChallenge": "Daily Challenge",
     "startChallenge": "Start Challenge",
     "challengeComplete": "Challenge Complete!",
+    "screenshotAlt": {
+      "current": "Screenshot {{position}} of {{total}}",
+      "previous": "Previous screenshot",
+      "next": "Next screenshot"
+    },
     "screenshots": "screenshots",
     "round": "Round",
     "score": "Score",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -65,6 +65,7 @@
     },
     "status": {
       "earned": "Obtenu",
+      "locked": "Verrouillé",
       "hidden": "Succès caché",
       "hiddenDescription": "Succès caché - complétez-le pour le révéler !",
       "noAchievements": "Aucun succès disponible pour le moment",
@@ -94,6 +95,11 @@
     "dailyChallenge": "Défi Quotidien",
     "startChallenge": "Commencer le Défi",
     "challengeComplete": "Défi Terminé !",
+    "screenshotAlt": {
+      "current": "Capture {{position}} sur {{total}}",
+      "previous": "Capture précédente",
+      "next": "Capture suivante"
+    },
     "screenshots": "captures",
     "round": "Round",
     "score": "Score",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -58,10 +58,16 @@ function LanguageLayout() {
   const { data: session } = useSession()
   const { fetchStatus, reset } = useDailyLoginStore()
 
-  // Sync i18n language with URL (must be before any early returns)
+  // Sync i18n language with URL (must be before any early returns).
+  // Also sync `<html lang>` so screen readers pick the right pronunciation.
   useEffect(() => {
-    if (lang && SUPPORTED_LANGUAGES.includes(lang as SupportedLanguage) && i18n.language !== lang) {
-      i18n.changeLanguage(lang)
+    if (lang && SUPPORTED_LANGUAGES.includes(lang as SupportedLanguage)) {
+      if (i18n.language !== lang) {
+        i18n.changeLanguage(lang)
+      }
+      if (typeof document !== 'undefined' && document.documentElement.lang !== lang) {
+        document.documentElement.lang = lang
+      }
     }
   }, [lang, i18n])
 

--- a/packages/frontend/src/components/achievement/AchievementCard.tsx
+++ b/packages/frontend/src/components/achievement/AchievementCard.tsx
@@ -44,18 +44,26 @@ export function AchievementCard({ achievement, size = 'medium', className }: Ach
         return t(`achievements.categories.${category}`)
     }
 
+    const lockedLabel = t('achievements.status.locked')
+    const earnedLabel = t('achievements.status.earned')
+    // A non-color status hint that screen readers can use ("locked" /
+    // "earned"). We render the same cue visually as a Lock icon so users
+    // who can't perceive the purple-vs-grey delta still get the signal.
+    const statusAriaLabel = isComplete ? earnedLabel : lockedLabel
+
     if (size === 'small') {
         return (
             <div
+                aria-label={statusAriaLabel}
                 className={cn(
                     'relative flex items-center gap-3 rounded-lg border p-3 transition-all',
                     isComplete
                         ? 'border-primary/40 bg-primary/10 shadow-sm'
-                        : 'border-muted/30 bg-muted/5 opacity-60',
+                        : 'border-muted/30 bg-muted/5 opacity-80',
                     className
                 )}
             >
-                <div className="text-3xl">{isLocked ? <Lock className="w-8 h-8" /> : achievement.iconUrl}</div>
+                <div className="text-3xl">{isLocked ? <Lock className="w-8 h-8" aria-hidden="true" /> : achievement.iconUrl}</div>
                 <div className="flex-1 min-w-0">
                     <div className="font-semibold text-sm truncate">
                         {isLocked ? '???' : achievement.name}
@@ -76,6 +84,9 @@ export function AchievementCard({ achievement, size = 'medium', className }: Ach
                             ✓
                         </Badge>
                     )}
+                    {!isComplete && !isLocked && (
+                        <Lock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+                    )}
                 </div>
             </div>
         )
@@ -83,18 +94,29 @@ export function AchievementCard({ achievement, size = 'medium', className }: Ach
 
     return (
         <Card
+            aria-label={statusAriaLabel}
             className={cn(
                 'relative overflow-hidden transition-all',
                 isComplete
                     ? 'border-primary/40 bg-primary/10 hover:border-primary/60 shadow-sm'
-                    : 'border-muted/30 bg-muted/5 opacity-70 hover:opacity-85',
+                    : 'border-muted/30 bg-muted/5 opacity-85 hover:opacity-100',
                 className
             )}
         >
-            {isComplete && (
+            {isComplete ? (
                 <div className="absolute top-2 right-2">
                     <Badge variant="success" className="text-xs flex items-center gap-1">
-                        ✓ {t('achievements.status.earned')}
+                        ✓ {earnedLabel}
+                    </Badge>
+                </div>
+            ) : (
+                <div className="absolute top-2 right-2">
+                    <Badge
+                        variant="outline"
+                        className="text-xs flex items-center gap-1 border-muted-foreground/40 text-muted-foreground"
+                    >
+                        <Lock className="h-3 w-3" aria-hidden="true" />
+                        {lockedLabel}
                     </Badge>
                 </div>
             )}
@@ -105,7 +127,7 @@ export function AchievementCard({ achievement, size = 'medium', className }: Ach
                         'text-4xl p-2 rounded-lg',
                         isComplete ? 'bg-primary/20 ring-2 ring-primary/30' : 'bg-muted/20'
                     )}>
-                        {isLocked ? <Lock className="w-10 h-10" /> : achievement.iconUrl}
+                        {isLocked ? <Lock className="w-10 h-10" aria-hidden="true" /> : achievement.iconUrl}
                     </div>
                     <div className="flex-1 min-w-0">
                         <CardTitle className="text-lg">

--- a/packages/frontend/src/components/game/ScreenshotViewer.tsx
+++ b/packages/frontend/src/components/game/ScreenshotViewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
+import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { useGameStore } from '@/stores/gameStore'
 import { gameApi } from '@/lib/api/game'
@@ -16,6 +17,7 @@ export function ScreenshotViewer({
   className,
   onLoad,
 }: ScreenshotViewerProps) {
+  const { t } = useTranslation()
   const [images, setImages] = useState<{ url: string | null; alt?: string }[]>([])
   const [currentCarouselIndex, setCurrentCarouselIndex] = useState(1)
 
@@ -64,9 +66,16 @@ export function ScreenshotViewer({
   // Build images array: [prev, current, next]
   useEffect(() => {
     const newImages = [
-      { url: null, alt: 'Previous screenshot' },
-      { url: imageUrl, alt: `Screenshot ${currentPosition}` },
-      { url: null, alt: 'Next screenshot' },
+      { url: null, alt: t('game.screenshotAlt.previous', { defaultValue: 'Previous screenshot' }) },
+      {
+        url: imageUrl,
+        alt: t('game.screenshotAlt.current', {
+          defaultValue: 'Screenshot {{position}} of {{total}}',
+          position: currentPosition,
+          total: totalScreenshots,
+        }),
+      },
+      { url: null, alt: t('game.screenshotAlt.next', { defaultValue: 'Next screenshot' }) },
     ]
 
     // Load adjacent screenshots
@@ -76,7 +85,14 @@ export function ScreenshotViewer({
           .then((data) => {
             setImages((prev) => {
               const updated = [...prev]
-              updated[0] = { url: data.imageUrl, alt: `Screenshot ${findPreviousPosition}` }
+              updated[0] = {
+                url: data.imageUrl,
+                alt: t('game.screenshotAlt.current', {
+                  defaultValue: 'Screenshot {{position}} of {{total}}',
+                  position: findPreviousPosition,
+                  total: totalScreenshots,
+                }),
+              }
               return updated
             })
           })
@@ -88,7 +104,14 @@ export function ScreenshotViewer({
           .then((data) => {
             setImages((prev) => {
               const updated = [...prev]
-              updated[2] = { url: data.imageUrl, alt: `Screenshot ${findNextPosition}` }
+              updated[2] = {
+                url: data.imageUrl,
+                alt: t('game.screenshotAlt.current', {
+                  defaultValue: 'Screenshot {{position}} of {{total}}',
+                  position: findNextPosition,
+                  total: totalScreenshots,
+                }),
+              }
               return updated
             })
           })
@@ -100,7 +123,7 @@ export function ScreenshotViewer({
     setImages(newImages)
 
     setCurrentCarouselIndex(1) // Reset to center
-  }, [imageUrl, currentPosition, sessionId, gamePhase, findPreviousPosition, findNextPosition])
+  }, [imageUrl, currentPosition, totalScreenshots, sessionId, gamePhase, findPreviousPosition, findNextPosition, t])
 
   // Handle carousel slide change (disabled - swipe removed)
   const handleSlideChange = (_index: number) => {

--- a/packages/frontend/src/components/home/HomeAchievementTeaser.tsx
+++ b/packages/frontend/src/components/home/HomeAchievementTeaser.tsx
@@ -47,7 +47,10 @@ interface TeaserCardProps {
 
 function TeaserCard({ achievement, lockedLabel }: TeaserCardProps) {
   return (
-    <div className="group relative h-full overflow-hidden rounded-xl border border-neon-purple/30 bg-card/60 backdrop-blur-sm transition-colors hover:border-neon-pink/60">
+    <div
+      className="group relative h-full overflow-hidden rounded-xl border border-neon-purple/30 bg-card/60 backdrop-blur-sm transition-colors hover:border-neon-pink/60"
+      aria-label={`${achievement.name} — ${lockedLabel}`}
+    >
       <div
         aria-hidden="true"
         className="pointer-events-none absolute -top-12 -right-12 h-32 w-32 rounded-full bg-neon-pink/20 blur-3xl opacity-50 group-hover:opacity-70 transition-opacity"
@@ -60,10 +63,14 @@ function TeaserCard({ achievement, lockedLabel }: TeaserCardProps) {
                 {achievement.iconUrl ?? '🏆'}
               </span>
             }
-            className="opacity-80 grayscale-[0.4] group-hover:grayscale-0 group-hover:opacity-100 transition"
+            className="opacity-90 grayscale-[0.3] group-hover:grayscale-0 group-hover:opacity-100 transition"
           />
-          <span className="absolute -bottom-1.5 -right-1.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-background/90 border border-neon-purple/40 text-muted-foreground">
-            <Lock className="h-3 w-3" aria-label={lockedLabel} />
+          <span
+            className="absolute -bottom-1.5 -right-1.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-background/90 border border-neon-purple/40 text-foreground"
+            role="img"
+            aria-label={lockedLabel}
+          >
+            <Lock className="h-3 w-3" aria-hidden="true" />
           </span>
         </div>
         <h3 className="text-sm sm:text-base font-semibold leading-tight text-foreground">
@@ -219,10 +226,10 @@ export function HomeAchievementTeaser() {
         </div>
         <Link
           to={localizedPath('/profile')}
-          className="hidden sm:inline-flex items-center gap-1.5 text-sm font-semibold text-foreground hover:text-neon-pink transition-colors shrink-0"
+          className="hidden sm:inline-flex items-center gap-1.5 min-h-[44px] px-3 py-2 -mx-3 rounded-md text-sm font-semibold text-foreground hover:text-neon-pink transition-colors shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           {t('home.achievements.cta')}
-          <ArrowRight className="h-4 w-4" />
+          <ArrowRight className="h-4 w-4" aria-hidden="true" />
         </Link>
       </div>
 
@@ -259,10 +266,10 @@ export function HomeAchievementTeaser() {
       <div className="mt-4 sm:hidden text-center">
         <Link
           to={localizedPath('/profile')}
-          className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground hover:text-neon-pink transition-colors"
+          className="inline-flex items-center gap-1.5 min-h-[44px] px-4 py-2 rounded-md text-sm font-semibold text-foreground hover:text-neon-pink transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           {t('home.achievements.cta')}
-          <ArrowRight className="h-4 w-4" />
+          <ArrowRight className="h-4 w-4" aria-hidden="true" />
         </Link>
       </div>
     </motion.section>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -17,23 +17,28 @@
   --secondary: oklch(0.279 0.041 283.713);
   --secondary-foreground: oklch(0.984 0.003 247.858);
   --muted: oklch(0.279 0.041 283.713);
-  --muted-foreground: oklch(0.704 0.04 283.713);
+  /* Bumped from 0.704 → 0.78 so secondary text on tinted card surfaces
+     (e.g. bg-muted/5, bg-card/60) clears the WCAG AA 4.5:1 ratio. */
+  --muted-foreground: oklch(0.78 0.035 283.713);
   --accent: oklch(0.279 0.041 283.713);
   --accent-foreground: oklch(0.984 0.003 247.858);
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.984 0.003 247.858);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.551 0.027 283.713);
+  /* Brighter focus ring so keyboard users see it against the dark theme. */
+  --ring: oklch(0.78 0.18 320);
   --chart-1: oklch(0.702 0.183 293.541);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
 
-  /* Gaming neon colors (preserved) */
+  /* Gaming neon colors (preserved). `--neon-pink` lifted from #ec4899 →
+     #f472b6 so pink-on-dark text (countdown clock, hover links) clears the
+     4.5:1 contrast ratio. Decorative glows still read as the same pink. */
   --neon-purple: #a855f7;
-  --neon-pink: #ec4899;
+  --neon-pink: #f472b6;
   --neon-blue: #3b82f6;
   --neon-cyan: #06b6d4;
 
@@ -147,6 +152,16 @@ body {
   min-height: 100vh;
 }
 
+/* Default keyboard focus ring. Components that need a custom ring can
+   override locally with `focus-visible:` utilities; this just guarantees
+   that every interactive element shows *something* when tabbed to so we
+   don't ship a UI with no visible focus indicator. */
+:focus-visible {
+  outline: 2px solid var(--color-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
 /* Custom scrollbar for dark theme */
 ::-webkit-scrollbar {
   width: 8px;
@@ -252,6 +267,12 @@ body {
 .card-interactive:hover {
   border-color: oklch(0.7 0.25 300 / 0.5);
   box-shadow: var(--glow-md);
+}
+
+.card-interactive:focus-visible {
+  outline: none;
+  border-color: var(--color-ring);
+  box-shadow: 0 0 0 3px oklch(0.78 0.18 320 / 0.6), var(--glow-md);
 }
 
 /* Neon grid backdrop (TierIntro, hero backdrops) */

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -178,9 +178,18 @@ export default function HomePage() {
                   </div>
                 </div>
 
-                {/* Countdown timer */}
-                <div className="flex items-center justify-center gap-2 pt-3 border-t border-neon-purple/20">
-                  <Clock className="h-4 w-4 text-neon-pink" />
+                {/* Countdown timer.
+                    `role="timer"` + `aria-live="polite"` lets assistive tech
+                    announce the countdown without interrupting; `aria-atomic`
+                    re-reads the whole label rather than a stray digit. */}
+                <div
+                  role="timer"
+                  aria-live="polite"
+                  aria-atomic="true"
+                  aria-label={`${t('home.nextDailyIn')} ${String(timeRemaining.hours).padStart(2, '0')}:${String(timeRemaining.minutes).padStart(2, '0')}:${String(timeRemaining.seconds).padStart(2, '0')}`}
+                  className="flex items-center justify-center gap-2 pt-3 border-t border-neon-purple/20"
+                >
+                  <Clock className="h-4 w-4 text-neon-pink" aria-hidden="true" />
                   <span className="text-xs sm:text-sm text-muted-foreground">
                     {t('home.nextDailyIn')}
                   </span>


### PR DESCRIPTION
## Summary
This PR enhances accessibility across the application by adding internationalization support for alt text, improving keyboard navigation with visible focus indicators, increasing color contrast for WCAG AA compliance, and adding proper ARIA labels and roles for screen readers.

## Key Changes

### Internationalization & Alt Text
- Added i18n support to `ScreenshotViewer` component with localized alt text for screenshot carousel images (previous, current, next)
- Added translation keys for achievement status labels ("locked" and "earned") in English and French locales
- Updated `App.tsx` to sync `<html lang>` attribute with i18n language for proper screen reader pronunciation

### Keyboard Navigation & Focus Indicators
- Added global `:focus-visible` styles with 2px outline using the new ring color for all interactive elements
- Created `.card-interactive:focus-visible` utility for custom focus styling on card components
- Enhanced CTA links in `HomeAchievementTeaser` with proper focus ring styling and minimum touch target size (44px)
- Added `aria-hidden="true"` to decorative icons (Lock, ArrowRight, Clock) to prevent screen reader redundancy

### Color Contrast Improvements
- Bumped `--muted-foreground` from `0.704` to `0.78` oklch lightness to meet WCAG AA 4.5:1 contrast ratio on tinted surfaces
- Updated `--ring` color to brighter `oklch(0.78 0.18 320)` for better visibility against dark theme
- Lifted `--neon-pink` from `#ec4899` to `#f472b6` for improved text contrast while maintaining visual identity
- Increased opacity of locked achievement cards from `0.70` to `0.85` for better visibility

### ARIA & Semantic HTML
- Added `aria-label` to achievement cards with status information (locked/earned)
- Added `role="timer"`, `aria-live="polite"`, and `aria-atomic="true"` to countdown timer in `HomePage` for dynamic content announcements
- Enhanced `TeaserCard` with proper `aria-label` and `role="img"` on lock icon container
- Improved `AchievementCard` with status aria labels and visual lock indicators for locked achievements

### Visual Polish
- Adjusted grayscale filter on achievement teaser icons from `0.4` to `0.3` for better visibility
- Changed lock icon color in teaser from `text-muted-foreground` to `text-foreground` for better contrast
- Updated opacity values on achievement cards for improved visual hierarchy

## Notable Implementation Details
- The focus ring styling uses CSS custom properties for consistency and theme-aware colors
- Screenshot alt text now includes position and total count (e.g., "Screenshot 2 of 5") for better context
- All decorative icons are properly hidden from assistive technology while semantic icons retain labels
- The countdown timer uses `aria-atomic` to ensure the entire time string is announced together, not individual digits

https://claude.ai/code/session_01HLpskG4VLWUakxM3kZLZmY