### PR TITLE
Fix Docker build on Alpine ARM64 by skipping better-sqlite3 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,15 @@ COPY package.json package-lock.json ./
 COPY packages/types/package.json ./packages/types/
 COPY packages/backend/package.json ./packages/backend/
 
-# Install production dependencies only + tsx for migrations + better-auth CLI
-# --ignore-scripts skips lifecycle scripts like prepare (which runs husky)
-RUN npm ci --omit=dev --ignore-scripts && npm install -w @the-box/backend tsx @better-auth/cli
+# Install production dependencies only + tsx for migrations + better-auth CLI.
+# --ignore-scripts on both installs skips lifecycle scripts: prepare (husky)
+# on the workspace install, and native build scripts on @better-auth/cli's
+# transitive better-sqlite3 dependency. We use Postgres, so the sqlite native
+# binding is never loaded — building it would otherwise fail on alpine-arm64
+# where prebuilds aren't always available and python/g++ aren't installed.
+# @better-auth/cli is pinned to keep Docker builds reproducible.
+RUN npm ci --omit=dev --ignore-scripts && \
+    npm install --ignore-scripts -w @the-box/backend tsx @better-auth/cli@1.4.10
 
 # Copy built backend artifacts
 COPY --from=builder /app/packages/types/dist ./packages/types/dist


### PR DESCRIPTION
## Summary
Updated the Dockerfile to prevent native dependency build failures on Alpine ARM64 by adding `--ignore-scripts` flag to the `@better-auth/cli` installation and pinning its version for reproducibility.

## Key Changes
- Added `--ignore-scripts` flag to the `npm install` command for `@better-auth/cli` to skip native build scripts for transitive dependencies like `better-sqlite3`
- Pinned `@better-auth/cli` to version `1.4.10` to ensure reproducible Docker builds
- Expanded comments to explain why `--ignore-scripts` is necessary: the project uses Postgres (not SQLite), so the native SQLite binding is never loaded and doesn't need to be built

## Implementation Details
The change prevents build failures on Alpine ARM64 where:
- Prebuilt binaries for `better-sqlite3` may not be available
- Python and g++ are not installed in the base image
- Building native modules would fail unnecessarily

By skipping the build scripts, we avoid attempting to compile `better-sqlite3` while still allowing `@better-auth/cli` to function correctly with the Postgres database backend.

https://claude.ai/code/session_01JzBkeS1BpDKPL1HxW6KPZS