### PR TITLE
feat(admin): add manual map upload dialog for geo Tier 4

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -568,6 +568,7 @@
           "loading": "Loading curated list…",
           "remove": "Remove",
           "reimport": "Re-import",
+          "manualUpload": "Upload map manually",
           "status": {
             "pending": "Metadata pending",
             "resolved": "Metadata ready",
@@ -577,6 +578,25 @@
           "noMap": "No map yet",
           "candidates_one": "{{count}} screenshot",
           "candidates_other": "{{count}} screenshots"
+        },
+        "manualMap": {
+          "title": "Manual map for \"{{name}}\"",
+          "description": "Last-resort upload when the registry, Fandom, and Wikidata sources didn't produce a usable map. The image must be hosted on a stable URL — no upload happens here.",
+          "descriptionReplace": "Replace the active map for this game. The previous map is deactivated; existing screenshot pins remain valid because coordinates are normalized.",
+          "fields": {
+            "imageUrl": "Image URL",
+            "widthPx": "Width (px)",
+            "heightPx": "Height (px)",
+            "license": "License",
+            "attribution": "Attribution",
+            "sourceUrl": "Source page URL"
+          },
+          "submit": "Save map",
+          "submitReplace": "Replace map",
+          "errors": {
+            "required": "Image URL, width, height, and license are required."
+          },
+          "success": "Manual map saved for \"{{name}}\"."
         },
         "suggestions": {
           "title": "Suggestions",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -568,6 +568,7 @@
           "loading": "Chargement de la liste curatée…",
           "remove": "Retirer",
           "reimport": "Réimporter",
+          "manualUpload": "Téléverser une carte manuellement",
           "status": {
             "pending": "Métadonnées en attente",
             "resolved": "Métadonnées prêtes",
@@ -577,6 +578,25 @@
           "noMap": "Sans carte",
           "candidates_one": "{{count}} capture",
           "candidates_other": "{{count}} captures"
+        },
+        "manualMap": {
+          "title": "Carte manuelle pour « {{name}} »",
+          "description": "Solution de dernier recours quand les sources registry, Fandom et Wikidata n'ont rien donné. L'image doit déjà être hébergée à une URL stable — aucun fichier n'est téléversé ici.",
+          "descriptionReplace": "Remplacer la carte active de ce jeu. L'ancienne carte est désactivée ; les pins existants restent valides puisque les coordonnées sont normalisées.",
+          "fields": {
+            "imageUrl": "URL de l'image",
+            "widthPx": "Largeur (px)",
+            "heightPx": "Hauteur (px)",
+            "license": "Licence",
+            "attribution": "Attribution",
+            "sourceUrl": "URL de la page source"
+          },
+          "submit": "Enregistrer la carte",
+          "submitReplace": "Remplacer la carte",
+          "errors": {
+            "required": "L'URL de l'image, la largeur, la hauteur et la licence sont obligatoires."
+          },
+          "success": "Carte manuelle enregistrée pour « {{name}} »."
         },
         "suggestions": {
           "title": "Suggestions",

--- a/packages/frontend/src/components/admin/GeoAdminActions.tsx
+++ b/packages/frontend/src/components/admin/GeoAdminActions.tsx
@@ -21,7 +21,9 @@ import {
     CheckCircle2,
     XCircle,
     Star,
+    Upload,
 } from 'lucide-react'
+import { GeoManualMapDialog } from './GeoManualMapDialog'
 
 interface HealthData {
     coverage: { curated: number; resolved: number; withMap: number; total: number }
@@ -124,6 +126,7 @@ export function GeoAdminActions() {
     const [busyAction, setBusyAction] = useState<
         'curate' | 'remove' | 'reimport' | 'schedule' | null
     >(null)
+    const [manualUploadFor, setManualUploadFor] = useState<CuratedGame | null>(null)
 
     const reloadHealth = useCallback(async () => {
         setLoadingHealth(true)
@@ -431,6 +434,7 @@ export function GeoAdminActions() {
                                     busy={busyId === g.id ? busyAction : null}
                                     onRemove={() => void setCuration(g, false)}
                                     onReimport={() => void reimport(g)}
+                                    onManualUpload={() => setManualUploadFor(g)}
                                     t={t}
                                 />
                             ))}
@@ -500,6 +504,26 @@ export function GeoAdminActions() {
                     </div>
                 </section>
             </CardContent>
+
+            <GeoManualMapDialog
+                isOpen={manualUploadFor !== null}
+                onClose={() => setManualUploadFor(null)}
+                game={
+                    manualUploadFor && {
+                        id: manualUploadFor.id,
+                        name: manualUploadFor.name,
+                        hasMap: manualUploadFor.hasMap,
+                    }
+                }
+                onSuccess={() => {
+                    setMessage(
+                        t('admin.geo.manualMap.success', {
+                            name: manualUploadFor?.name ?? '',
+                        }),
+                    )
+                    void Promise.all([reloadCurated(), reloadHealth()])
+                }}
+            />
         </Card>
     )
 }
@@ -551,10 +575,18 @@ interface CuratedRowProps {
     busy: 'curate' | 'remove' | 'reimport' | 'schedule' | null
     onRemove: () => void
     onReimport: () => void
+    onManualUpload: () => void
     t: ReturnType<typeof useTranslation>['t']
 }
 
-function CuratedRow({ game, busy, onRemove, onReimport, t }: CuratedRowProps) {
+function CuratedRow({
+    game,
+    busy,
+    onRemove,
+    onReimport,
+    onManualUpload,
+    t,
+}: CuratedRowProps) {
     const statusKey = `admin.geo.health.curatedList.status.${game.metadataStatus}` as const
     return (
         <li className="flex items-start justify-between gap-2 rounded-md border border-border/50 bg-muted/10 p-2.5 text-xs">
@@ -598,6 +630,17 @@ function CuratedRow({ game, busy, onRemove, onReimport, t }: CuratedRowProps) {
                 </div>
             </div>
             <div className="flex shrink-0 items-center gap-0.5">
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={busy !== null}
+                    onClick={onManualUpload}
+                    aria-label={t('admin.geo.health.curatedList.manualUpload')}
+                    title={t('admin.geo.health.curatedList.manualUpload')}
+                    className="h-7 w-7 p-0"
+                >
+                    <Upload className="h-3.5 w-3.5" />
+                </Button>
                 <Button
                     size="sm"
                     variant="ghost"

--- a/packages/frontend/src/components/admin/GeoManualMapDialog.tsx
+++ b/packages/frontend/src/components/admin/GeoManualMapDialog.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Loader2 } from 'lucide-react'
+
+// Tier 4 in the geo_map ingestion cascade: when no curated registry entry,
+// Fandom Interactive Map, or Wikidata P242 image is available for a game,
+// an admin can paste in a stable image URL with declared license and
+// attribution. The backend route (`POST /api/admin/geo/maps/manual`) does
+// no image processing — the admin is responsible for hosting the asset.
+
+interface GeoManualMapDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  game: { id: number; name: string; hasMap: boolean } | null
+  onSuccess: () => void
+}
+
+interface FormState {
+  imageUrl: string
+  widthPx: string
+  heightPx: string
+  license: string
+  attribution: string
+  sourceUrl: string
+}
+
+const EMPTY: FormState = {
+  imageUrl: '',
+  widthPx: '',
+  heightPx: '',
+  license: '',
+  attribution: '',
+  sourceUrl: '',
+}
+
+export function GeoManualMapDialog({
+  isOpen,
+  onClose,
+  game,
+  onSuccess,
+}: GeoManualMapDialogProps) {
+  const { t } = useTranslation()
+  const [form, setForm] = useState<FormState>(EMPTY)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset every time the dialog opens for a fresh game so previously-typed
+  // values don't leak across sessions.
+  useEffect(() => {
+    if (isOpen) {
+      setForm(EMPTY)
+      setError(null)
+    }
+  }, [isOpen, game?.id])
+
+  if (!game) return null
+
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }))
+
+  const submit = async () => {
+    if (submitting) return
+    setError(null)
+    const widthPx = Number(form.widthPx)
+    const heightPx = Number(form.heightPx)
+    if (
+      !form.imageUrl ||
+      !form.license ||
+      !Number.isFinite(widthPx) ||
+      widthPx <= 0 ||
+      !Number.isFinite(heightPx) ||
+      heightPx <= 0
+    ) {
+      setError(t('admin.geo.manualMap.errors.required'))
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/admin/geo/maps/manual', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          gameId: game.id,
+          imageUrl: form.imageUrl,
+          widthPx,
+          heightPx,
+          license: form.license,
+          attribution: form.attribution || undefined,
+          sourceUrl: form.sourceUrl || undefined,
+          // If a map already exists, the operator is explicitly overwriting
+          // it; otherwise the backend would 409 on duplicate.
+          replaceActive: game.hasMap,
+        }),
+      })
+      const json = (await res.json().catch(() => ({}))) as {
+        success?: boolean
+        error?: { code?: string; message?: string }
+      }
+      if (!res.ok || !json.success) {
+        throw new Error(
+          json.error?.message ?? json.error?.code ?? `request failed: ${res.status}`,
+        )
+      }
+      onSuccess()
+      onClose()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && !submitting && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t('admin.geo.manualMap.title', { name: game.name })}
+          </DialogTitle>
+          <DialogDescription>
+            {game.hasMap
+              ? t('admin.geo.manualMap.descriptionReplace')
+              : t('admin.geo.manualMap.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Field
+            id="manual-map-image-url"
+            label={t('admin.geo.manualMap.fields.imageUrl')}
+            required
+          >
+            <Input
+              id="manual-map-image-url"
+              type="url"
+              placeholder="https://..."
+              value={form.imageUrl}
+              onChange={(e) => set('imageUrl', e.target.value)}
+              disabled={submitting}
+            />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field
+              id="manual-map-width"
+              label={t('admin.geo.manualMap.fields.widthPx')}
+              required
+            >
+              <Input
+                id="manual-map-width"
+                type="number"
+                inputMode="numeric"
+                min={1}
+                max={32768}
+                value={form.widthPx}
+                onChange={(e) => set('widthPx', e.target.value)}
+                disabled={submitting}
+              />
+            </Field>
+            <Field
+              id="manual-map-height"
+              label={t('admin.geo.manualMap.fields.heightPx')}
+              required
+            >
+              <Input
+                id="manual-map-height"
+                type="number"
+                inputMode="numeric"
+                min={1}
+                max={32768}
+                value={form.heightPx}
+                onChange={(e) => set('heightPx', e.target.value)}
+                disabled={submitting}
+              />
+            </Field>
+          </div>
+
+          <Field
+            id="manual-map-license"
+            label={t('admin.geo.manualMap.fields.license')}
+            required
+          >
+            <Input
+              id="manual-map-license"
+              placeholder="CC-BY-SA-3.0, MIT, Publisher press kit, ..."
+              value={form.license}
+              onChange={(e) => set('license', e.target.value)}
+              disabled={submitting}
+            />
+          </Field>
+
+          <Field
+            id="manual-map-attribution"
+            label={t('admin.geo.manualMap.fields.attribution')}
+          >
+            <Input
+              id="manual-map-attribution"
+              value={form.attribution}
+              onChange={(e) => set('attribution', e.target.value)}
+              disabled={submitting}
+            />
+          </Field>
+
+          <Field
+            id="manual-map-source-url"
+            label={t('admin.geo.manualMap.fields.sourceUrl')}
+          >
+            <Input
+              id="manual-map-source-url"
+              type="url"
+              placeholder="https://..."
+              value={form.sourceUrl}
+              onChange={(e) => set('sourceUrl', e.target.value)}
+              disabled={submitting}
+            />
+          </Field>
+
+          {error && (
+            <p
+              role="alert"
+              className="rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={submitting}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={() => void submit()} disabled={submitting}>
+            {submitting && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+            {game.hasMap
+              ? t('admin.geo.manualMap.submitReplace')
+              : t('admin.geo.manualMap.submit')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Field({
+  id,
+  label,
+  required,
+  children,
+}: {
+  id: string
+  label: string
+  required?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className="text-xs">
+        {label}
+        {required && <span className="text-destructive ml-0.5">*</span>}
+      </Label>
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

The backend route `POST /api/admin/geo/maps/manual` landed in #65 but had no UI surface — operators had to curl the endpoint to populate a map for a game whose registry/Fandom/Wikidata sources all whiffed. This adds a small dialog wired into the curated-game row so Tier 4 is usable from the admin panel.

## Changes

- New `GeoManualMapDialog` component (shadcn primitives) with client-side validation mirroring the backend route shape: `imageUrl`, `widthPx`, `heightPx`, `license` required; `attribution`, `sourceUrl` optional.
- Auto-sets `replaceActive: true` when the curated game already has an active map so the call doesn't 409 — surfaces this in the dialog copy ("Replace map" vs "Save map").
- Adds an Upload button to each curated row alongside the existing re-import / remove actions.
- Refreshes the curated list and health card on success so the new map shows immediately.
- Full FR + EN i18n.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` — no new warnings (5 pre-existing in untouched files)
- [ ] Manual: open admin panel, click upload icon on a curated game without a map, fill the form with a real image URL → row flips to "Map imported"
- [ ] Manual: click upload on a game that already has a map → dialog says "Replace"; submit → previous map deactivated, new one active

https://claude.ai/code/session_01RFcqphCNu6CScS1HjqUeZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFcqphCNu6CScS1HjqUeZY)_