### PR TITLE
feat(admin): add last login datetime column to users table

### DIFF
--- a/packages/backend/migrations/20260425_user_last_login_at.ts
+++ b/packages/backend/migrations/20260425_user_last_login_at.ts
@@ -1,0 +1,33 @@
+import type { Knex } from 'knex'
+
+/**
+ * Adds `lastLoginAt` to the user table so the admin panel can display
+ * when each user last signed in. Uses camelCase to mirror Better Auth's
+ * other standard columns (`createdAt`, `updatedAt`) — better-auth returns
+ * column names verbatim, so this lets the frontend read `user.lastLoginAt`
+ * directly. Backfilled from the most recent session row so existing users
+ * don't appear as "never logged in".
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "lastLoginAt" TIMESTAMP WITH TIME ZONE
+  `)
+
+  await knex.raw(`
+    UPDATE "user" u
+    SET "lastLoginAt" = s.max_created
+    FROM (
+      SELECT "userId" AS user_id, MAX("createdAt") AS max_created
+      FROM session
+      GROUP BY "userId"
+    ) s
+    WHERE u.id = s.user_id
+  `)
+
+  await knex.raw('CREATE INDEX IF NOT EXISTS idx_user_last_login_at ON "user"("lastLoginAt")')
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP INDEX IF EXISTS idx_user_last_login_at')
+  await knex.raw('ALTER TABLE "user" DROP COLUMN IF EXISTS "lastLoginAt"')
+}

--- a/packages/backend/src/infrastructure/auth/auth.ts
+++ b/packages/backend/src/infrastructure/auth/auth.ts
@@ -168,6 +168,20 @@ function createAuth() {
     },
     trustedOrigins: [env.CORS_ORIGIN],
     databaseHooks: {
+      session: {
+        create: {
+          after: async (session) => {
+            try {
+              await pool.query(
+                'UPDATE "user" SET "lastLoginAt" = NOW() WHERE id = $1',
+                [session.userId]
+              );
+            } catch (error) {
+              authLogger.error({ err: error, userId: session.userId }, "failed to update last_login_at");
+            }
+          },
+        },
+      },
       user: {
         create: {
           before: async (user) => {

--- a/packages/backend/src/infrastructure/repositories/user.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/user.repository.ts
@@ -32,6 +32,7 @@ export interface UserRow {
   current_streak: number
   longest_streak: number
   last_played_at: Date | null
+  lastLoginAt: Date | null
   email_marketing_consent: boolean
   email_consent_updated_at: Date | null
 }
@@ -51,6 +52,7 @@ function mapRowToUser(row: UserRow): User {
     currentStreak: row.current_streak ?? 0,
     longestStreak: row.longest_streak ?? 0,
     lastPlayedAt: row.last_played_at?.toISOString(),
+    lastLoginAt: row.lastLoginAt?.toISOString(),
     createdAt: row.createdAt.toISOString(),
     emailMarketingConsent: row.email_marketing_consent ?? false,
     emailConsentUpdatedAt: row.email_consent_updated_at?.toISOString(),

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -821,6 +821,8 @@
       "totalScore": "Total Score",
       "currentStreak": "Current Streak",
       "createdAt": "Created At",
+      "lastLoginAt": "Last Login",
+      "neverLoggedIn": "Never",
       "actions": "Actions",
       "guest": "Guest",
       "searchPlaceholder": "Search users by email...",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -784,6 +784,8 @@
       "totalScore": "Score Total",
       "currentStreak": "Série Actuelle",
       "createdAt": "Créé Le",
+      "lastLoginAt": "Dernière Connexion",
+      "neverLoggedIn": "Jamais",
       "actions": "Actions",
       "guest": "Invité",
       "searchPlaceholder": "Rechercher un utilisateur par email...",

--- a/packages/frontend/src/components/admin/UserList.tsx
+++ b/packages/frontend/src/components/admin/UserList.tsx
@@ -202,6 +202,21 @@ export function UserList() {
     }
   }
 
+  const formatDateTime = (dateString?: string | null) => {
+    if (!dateString) return t('admin.users.neverLoggedIn')
+    try {
+      return new Date(dateString).toLocaleString(i18n.language, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    } catch {
+      return dateString
+    }
+  }
+
   return (
     <Card className="bg-card/50 backdrop-blur-sm">
       <CardHeader className="flex flex-row items-center justify-between space-y-0">
@@ -299,7 +314,7 @@ export function UserList() {
                         </Select>
                       </div>
 
-                      <dl className="grid grid-cols-3 gap-2 text-xs">
+                      <dl className="grid grid-cols-2 gap-2 text-xs">
                         <div className="space-y-0.5">
                           <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
                             {t('admin.users.totalScore')}
@@ -319,6 +334,12 @@ export function UserList() {
                             {t('admin.users.createdAt')}
                           </dt>
                           <dd className="text-muted-foreground">{formatDate(user.createdAt)}</dd>
+                        </div>
+                        <div className="space-y-0.5">
+                          <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                            {t('admin.users.lastLoginAt')}
+                          </dt>
+                          <dd className="text-muted-foreground">{formatDateTime(user.lastLoginAt)}</dd>
                         </div>
                       </dl>
 
@@ -367,6 +388,7 @@ export function UserList() {
                       <UserSortableHeader field="totalScore" sortField={usersSort.field} sortOrder={usersSort.order} onSort={handleSort}>{t('admin.users.totalScore')}</UserSortableHeader>
                       <UserSortableHeader field="currentStreak" sortField={usersSort.field} sortOrder={usersSort.order} onSort={handleSort}>{t('admin.users.currentStreak')}</UserSortableHeader>
                       <UserSortableHeader field="createdAt" sortField={usersSort.field} sortOrder={usersSort.order} onSort={handleSort}>{t('admin.users.createdAt')}</UserSortableHeader>
+                      <UserSortableHeader field="lastLoginAt" sortField={usersSort.field} sortOrder={usersSort.order} onSort={handleSort}>{t('admin.users.lastLoginAt')}</UserSortableHeader>
                       <TableHead className="text-right">{t('admin.users.actions')}</TableHead>
                     </TableRow>
                   </TableHeader>
@@ -418,6 +440,9 @@ export function UserList() {
                           <TableCell>{user.currentStreak ?? 0}</TableCell>
                           <TableCell className="text-muted-foreground">
                             {formatDate(user.createdAt)}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground whitespace-nowrap">
+                            {formatDateTime(user.lastLoginAt)}
                           </TableCell>
                           <TableCell className="text-right">
                             <div className="flex justify-end gap-1 opacity-70 group-hover:opacity-100 transition-opacity">

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,6 +15,7 @@ export interface User {
   currentStreak: number
   longestStreak?: number
   lastPlayedAt?: string
+  lastLoginAt?: string
   createdAt: string
   emailMarketingConsent: boolean
   emailConsentUpdatedAt?: string


### PR DESCRIPTION
Adds a "lastLoginAt" timestamp on the user table, populated via a
better-auth session-create hook on every sign-in. Existing rows are
backfilled from the most recent session record.

The admin users table (admin?tab=users) gains a sortable "Last Login"
column on desktop and a matching field on mobile cards, with EN/FR
translations and a "Never"/"Jamais" fallback for users who haven't
logged in since the column was introduced.