### PR TITLE
feat(admin/geo): add per-game tier diagnosis Maps tab

### DIFF
--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -46,6 +46,7 @@ import {
 } from '../../infrastructure/repositories/index.js'
 import { GEO_CONSENSUS_VERSION } from '../../domain/services/index.js'
 import { geoQueue } from '../../infrastructure/queue/queues.js'
+import { findRegistryEntryBySlug } from '../../infrastructure/queue/workers/geo-registry-import-logic.js'
 
 // Cap even admin-triggered sends so a mistake or compromised admin
 // account can't spray mail on Resend's dime. Keyed by user id so two
@@ -1800,6 +1801,193 @@ router.get('/geo/games', async (req, res, next) => {
           developer: r.developer,
           metacritic: r.metacritic,
         })),
+      },
+    })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// ---------- Per-game tier diagnosis ----------
+
+// Returns the four-tier ingestion state for a single game so the admin can see
+// at a glance which tiers were tried, which tombstoned, and which would run
+// next. Drives the Maps tab's side panel.
+router.get('/geo/games/:id/sources', async (req, res, next) => {
+  try {
+    const id = Number(req.params.id)
+    if (!Number.isFinite(id) || id <= 0) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+
+    const game = await db('games')
+      .where({ id })
+      .first<{
+        id: number
+        name: string
+        slug: string
+        wiki_subdomain: string | null
+        wiki_page_title: string | null
+        wikidata_qid: string | null
+      }>('id', 'name', 'slug', 'wiki_subdomain', 'wiki_page_title', 'wikidata_qid')
+    if (!game) {
+      res.status(404).json({ success: false, error: { code: 'GAME_NOT_FOUND' } })
+      return
+    }
+
+    const [activeMap, registryEntry, failures] = await Promise.all([
+      geoMapRepository.findActiveByGameId(id),
+      findRegistryEntryBySlug(game.slug),
+      db('geo_ingest_failure')
+        .where({ game_id: id })
+        .select<
+          Array<{
+            source: string
+            reason: string
+            attempt_count: number
+            last_attempt_at: Date
+            retry_after: Date
+          }>
+        >('source', 'reason', 'attempt_count', 'last_attempt_at', 'retry_after'),
+    ])
+
+    const failureBySource = new Map(failures.map((f) => [f.source, f]))
+    const now = Date.now()
+
+    const tier = (
+      key: 'registry' | 'fandom' | 'wikidata' | 'manual',
+      state:
+        | { status: 'matched'; via: string; license?: string; sourceUrl?: string }
+        | { status: 'tombstoned'; reason: string; attempts: number; retryAfter: Date }
+        | { status: 'untried'; reason?: string }
+        | { status: 'eligible' },
+    ) => ({ tier: key, ...state })
+
+    const sources: Array<ReturnType<typeof tier>> = []
+
+    // Tier 1 — Registry
+    if (activeMap?.source === 'registry') {
+      sources.push(
+        tier('registry', {
+          status: 'matched',
+          via: 'curated registry',
+          license: activeMap.license,
+          sourceUrl: activeMap.sourceUrl,
+        }),
+      )
+    } else if (registryEntry) {
+      const tomb = failureBySource.get('registry')
+      if (tomb && tomb.retry_after.getTime() > now) {
+        sources.push(
+          tier('registry', {
+            status: 'tombstoned',
+            reason: tomb.reason,
+            attempts: tomb.attempt_count,
+            retryAfter: tomb.retry_after,
+          }),
+        )
+      } else {
+        sources.push(tier('registry', { status: 'eligible' }))
+      }
+    } else {
+      sources.push(
+        tier('registry', { status: 'untried', reason: 'no registry entry for slug' }),
+      )
+    }
+
+    // Tier 2 — Fandom
+    if (activeMap?.source === 'fandom') {
+      sources.push(
+        tier('fandom', {
+          status: 'matched',
+          via: `${game.wiki_subdomain ?? '?'}.fandom.com`,
+          license: activeMap.license,
+          sourceUrl: activeMap.sourceUrl,
+        }),
+      )
+    } else if (game.wiki_subdomain && game.wiki_page_title) {
+      const tomb = failureBySource.get('fandom')
+      if (tomb && tomb.retry_after.getTime() > now) {
+        sources.push(
+          tier('fandom', {
+            status: 'tombstoned',
+            reason: tomb.reason,
+            attempts: tomb.attempt_count,
+            retryAfter: tomb.retry_after,
+          }),
+        )
+      } else {
+        sources.push(tier('fandom', { status: 'eligible' }))
+      }
+    } else {
+      sources.push(
+        tier('fandom', { status: 'untried', reason: 'no wiki_subdomain / Map: page resolved' }),
+      )
+    }
+
+    // Tier 3 — Wikidata
+    if (activeMap?.source === 'wikidata') {
+      sources.push(
+        tier('wikidata', {
+          status: 'matched',
+          via: game.wikidata_qid ?? 'P242',
+          license: activeMap.license,
+          sourceUrl: activeMap.sourceUrl,
+        }),
+      )
+    } else if (game.wikidata_qid) {
+      const tomb = failureBySource.get('wikidata')
+      if (tomb && tomb.retry_after.getTime() > now) {
+        sources.push(
+          tier('wikidata', {
+            status: 'tombstoned',
+            reason: tomb.reason,
+            attempts: tomb.attempt_count,
+            retryAfter: tomb.retry_after,
+          }),
+        )
+      } else {
+        sources.push(tier('wikidata', { status: 'eligible' }))
+      }
+    } else {
+      sources.push(
+        tier('wikidata', { status: 'untried', reason: 'wikidata_qid unresolved' }),
+      )
+    }
+
+    // Tier 4 — Manual
+    if (activeMap?.source === 'manual') {
+      sources.push(
+        tier('manual', {
+          status: 'matched',
+          via: 'admin upload',
+          license: activeMap.license,
+          sourceUrl: activeMap.sourceUrl,
+        }),
+      )
+    } else {
+      sources.push(tier('manual', { status: 'untried' }))
+    }
+
+    res.json({
+      success: true,
+      data: {
+        gameId: game.id,
+        gameName: game.name,
+        slug: game.slug,
+        activeMap: activeMap
+          ? {
+              id: activeMap.id,
+              source: activeMap.source,
+              imageUrl: activeMap.imageUrl,
+              license: activeMap.license,
+              attribution: activeMap.attribution,
+              widthPx: activeMap.widthPx,
+              heightPx: activeMap.heightPx,
+            }
+          : null,
+        sources,
       },
     })
   } catch (err) {

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -480,6 +480,49 @@
     "geo": {
       "title": "Geo Moderation",
       "subtitle": "Curate the Geo daily challenge: import sources, schedule challenges, and validate crowdsourced pins.",
+      "tabs": {
+        "pins": "Pins",
+        "maps": "Maps"
+      },
+      "maps": {
+        "title": "Maps per game",
+        "subtitle": "Click a game to see which ingestion tiers ran or would run next.",
+        "refresh": "Refresh",
+        "empty": "No curated games yet. Add some from the curated list in the Pins tab.",
+        "reimportQueued": "Re-run pipeline queued for \"{{name}}\".",
+        "row": {
+          "hasMap": "Map",
+          "noMap": "No map",
+          "failed": "Failed"
+        },
+        "tiers": {
+          "registry": "Tier 1 — Registry",
+          "fandom": "Tier 2 — Fandom",
+          "wikidata": "Tier 3 — Wikidata",
+          "steam": "Steam",
+          "manual": "Tier 4 — Manual"
+        },
+        "tierStatus": {
+          "matched": "Matched",
+          "tombstoned_one": "Tombstoned ({{count}} attempt)",
+          "tombstoned_other": "Tombstoned ({{count}} attempts)",
+          "eligible": "Eligible",
+          "untried": "Skipped",
+          "eligibleHint": "Will run on the next ingest tick if no earlier tier wins.",
+          "retryAfter": "Retry after {{time}}"
+        },
+        "viewSource": "View source",
+        "actions": {
+          "rerun": "Re-run pipeline",
+          "uploadManual": "Upload manually"
+        },
+        "sidePanel": {
+          "empty": "Select a game",
+          "hint": "Pick a game on the left to see its tier-by-tier ingestion state.",
+          "noActive": "No active map yet — see tier states below.",
+          "activeViaTier": "Active via {{tier}} · {{license}}"
+        }
+      },
       "intro": {
         "title": "How this page works",
         "step1Title": "1. Import sources",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -480,6 +480,49 @@
     "geo": {
       "title": "Modération Géo",
       "subtitle": "Curatez le défi Géo quotidien : importez les sources, planifiez les défis et validez les épingles communautaires.",
+      "tabs": {
+        "pins": "Épingles",
+        "maps": "Cartes"
+      },
+      "maps": {
+        "title": "Cartes par jeu",
+        "subtitle": "Cliquez sur un jeu pour voir quels niveaux d'ingestion ont été essayés ou seraient lancés ensuite.",
+        "refresh": "Rafraîchir",
+        "empty": "Aucun jeu curaté pour le moment. Ajoutez-en depuis la liste curatée de l'onglet Épingles.",
+        "reimportQueued": "Pipeline relancé pour « {{name}} ».",
+        "row": {
+          "hasMap": "Carte",
+          "noMap": "Sans carte",
+          "failed": "Échec"
+        },
+        "tiers": {
+          "registry": "Niveau 1 — Registre",
+          "fandom": "Niveau 2 — Fandom",
+          "wikidata": "Niveau 3 — Wikidata",
+          "steam": "Steam",
+          "manual": "Niveau 4 — Manuel"
+        },
+        "tierStatus": {
+          "matched": "Trouvé",
+          "tombstoned_one": "Tombé ({{count}} tentative)",
+          "tombstoned_other": "Tombé ({{count}} tentatives)",
+          "eligible": "Éligible",
+          "untried": "Ignoré",
+          "eligibleHint": "Sera tenté à la prochaine passe si aucun niveau précédent ne réussit.",
+          "retryAfter": "Nouvel essai après {{time}}"
+        },
+        "viewSource": "Voir la source",
+        "actions": {
+          "rerun": "Relancer le pipeline",
+          "uploadManual": "Téléverser manuellement"
+        },
+        "sidePanel": {
+          "empty": "Sélectionnez un jeu",
+          "hint": "Choisissez un jeu à gauche pour voir l'état d'ingestion niveau par niveau.",
+          "noActive": "Aucune carte active — voir l'état des niveaux ci-dessous.",
+          "activeViaTier": "Actif via {{tier}} · {{license}}"
+        }
+      },
       "intro": {
         "title": "Comment cette page fonctionne",
         "step1Title": "1. Importer les sources",

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -1,0 +1,465 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+    Loader2,
+    RefreshCw,
+    Upload,
+    RotateCw,
+    CheckCircle2,
+    XCircle,
+    AlertTriangle,
+    Clock,
+    MinusCircle,
+    Sparkles,
+} from 'lucide-react'
+import { GeoManualMapDialog } from './GeoManualMapDialog'
+
+// Per-game ingestion-state surface. Replaces the global metric-tile grid +
+// failures table from GeoAdminActions with a focused, drill-down table where
+// each row's side panel shows which of the four geo_map ingestion tiers
+// (registry / fandom / wikidata / manual) ran or would run next, and why
+// any failed. Triage flow: scan rows for ⚠/✗, click row, side panel
+// explains the cascade state, fix via "Re-run" or "Upload manually".
+
+interface CuratedGame {
+    id: number
+    name: string
+    slug: string
+    metadataStatus: 'pending' | 'resolved' | 'unresolved'
+    hasMap: boolean
+    candidateCount: number
+}
+
+interface ActiveMapInfo {
+    id: number
+    source: 'registry' | 'fandom' | 'wikidata' | 'steam' | 'manual'
+    imageUrl: string
+    license: string
+    attribution: string | null
+    widthPx: number
+    heightPx: number
+}
+
+type TierKey = 'registry' | 'fandom' | 'wikidata' | 'manual'
+
+type TierStateBase = { tier: TierKey }
+type TierState =
+    | (TierStateBase & {
+          status: 'matched'
+          via: string
+          license?: string
+          sourceUrl?: string
+      })
+    | (TierStateBase & {
+          status: 'tombstoned'
+          reason: string
+          attempts: number
+          retryAfter: string
+      })
+    | (TierStateBase & { status: 'eligible' })
+    | (TierStateBase & { status: 'untried'; reason?: string })
+
+interface SourcesResponse {
+    gameId: number
+    gameName: string
+    slug: string
+    activeMap: ActiveMapInfo | null
+    sources: TierState[]
+}
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(path, {
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        ...init,
+    })
+    const json = await res.json().catch(() => ({}))
+    if (!res.ok || !json?.success) {
+        throw new Error(json?.error?.code ?? `request failed: ${res.status}`)
+    }
+    return json.data as T
+}
+
+export function GeoMapsTab() {
+    const { t } = useTranslation()
+    const [games, setGames] = useState<CuratedGame[] | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+    const [selectedId, setSelectedId] = useState<number | null>(null)
+    const [sources, setSources] = useState<SourcesResponse | null>(null)
+    const [sourcesLoading, setSourcesLoading] = useState(false)
+    const [busyAction, setBusyAction] = useState<'reimport' | null>(null)
+    const [message, setMessage] = useState<string | null>(null)
+    const [manualUploadFor, setManualUploadFor] = useState<CuratedGame | null>(null)
+
+    const reload = useCallback(async () => {
+        setLoading(true)
+        try {
+            const data = await fetchJson<{ games: CuratedGame[] }>(
+                '/api/admin/geo/games?curated=true&limit=100',
+            )
+            setGames(data.games)
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setLoading(false)
+        }
+    }, [])
+
+    const reloadSources = useCallback(async (gameId: number) => {
+        setSourcesLoading(true)
+        try {
+            const data = await fetchJson<SourcesResponse>(
+                `/api/admin/geo/games/${gameId}/sources`,
+            )
+            setSources(data)
+        } catch (e) {
+            setError(String(e))
+            setSources(null)
+        } finally {
+            setSourcesLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        void reload()
+    }, [reload])
+
+    useEffect(() => {
+        if (selectedId !== null) void reloadSources(selectedId)
+        else setSources(null)
+    }, [selectedId, reloadSources])
+
+    const reimport = async (game: CuratedGame) => {
+        setBusyAction('reimport')
+        setMessage(null)
+        setError(null)
+        try {
+            await fetchJson('/api/admin/geo/reimport', {
+                method: 'POST',
+                body: JSON.stringify({ gameId: game.id }),
+            })
+            setMessage(t('admin.geo.maps.reimportQueued', { name: game.name }))
+            await Promise.all([reload(), reloadSources(game.id)])
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setBusyAction(null)
+        }
+    }
+
+    const onManualSuccess = () => {
+        setMessage(
+            t('admin.geo.manualMap.success', {
+                name: manualUploadFor?.name ?? '',
+            }),
+        )
+        const id = manualUploadFor?.id
+        void Promise.all([reload(), id !== undefined ? reloadSources(id) : Promise.resolve()])
+    }
+
+    const selectedGame = games?.find((g) => g.id === selectedId) ?? null
+
+    return (
+        <div className="grid gap-4 lg:grid-cols-5">
+            {/* Left: per-game table */}
+            <Card className="lg:col-span-3">
+                <CardHeader className="pb-3">
+                    <div className="flex items-start justify-between gap-2">
+                        <div>
+                            <CardTitle className="text-sm">
+                                {t('admin.geo.maps.title')}
+                            </CardTitle>
+                            <CardDescription className="text-xs">
+                                {t('admin.geo.maps.subtitle')}
+                            </CardDescription>
+                        </div>
+                        <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => void reload()}
+                            disabled={loading}
+                            aria-label={t('admin.geo.maps.refresh')}
+                            className="h-7 w-7 p-0"
+                        >
+                            <RefreshCw
+                                className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`}
+                            />
+                        </Button>
+                    </div>
+                </CardHeader>
+                <CardContent className="p-0">
+                    {message && (
+                        <div className="mx-4 mb-3 rounded border border-success/40 bg-success/10 p-2 text-xs text-success">
+                            {message}
+                        </div>
+                    )}
+                    {error && (
+                        <div className="mx-4 mb-3 rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
+                            {error}
+                        </div>
+                    )}
+                    {loading && games === null ? (
+                        <div className="flex justify-center py-12">
+                            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                        </div>
+                    ) : games && games.length > 0 ? (
+                        <ul className="divide-y divide-border/40">
+                            {games.map((g) => (
+                                <li
+                                    key={g.id}
+                                    className={`px-4 py-2.5 text-xs cursor-pointer transition-colors ${
+                                        selectedId === g.id
+                                            ? 'bg-muted/40'
+                                            : 'hover:bg-muted/20'
+                                    }`}
+                                    onClick={() => setSelectedId(g.id)}
+                                >
+                                    <div className="flex items-center justify-between gap-2">
+                                        <span className="font-medium truncate">
+                                            {g.name}
+                                        </span>
+                                        <MapStatusBadge game={g} t={t} />
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="px-4 py-6 text-xs text-muted-foreground">
+                            {t('admin.geo.maps.empty')}
+                        </p>
+                    )}
+                </CardContent>
+            </Card>
+
+            {/* Right: tier-cascade side panel */}
+            <Card className="lg:col-span-2">
+                <CardHeader className="pb-3">
+                    <CardTitle className="text-sm">
+                        {selectedGame
+                            ? selectedGame.name
+                            : t('admin.geo.maps.sidePanel.empty')}
+                    </CardTitle>
+                    {selectedGame && sources?.activeMap && (
+                        <CardDescription className="text-xs">
+                            {t('admin.geo.maps.sidePanel.activeViaTier', {
+                                tier: t(`admin.geo.maps.tiers.${sources.activeMap.source}`),
+                                license: sources.activeMap.license,
+                            })}
+                        </CardDescription>
+                    )}
+                    {selectedGame && sources && !sources.activeMap && (
+                        <CardDescription className="text-xs text-warning">
+                            {t('admin.geo.maps.sidePanel.noActive')}
+                        </CardDescription>
+                    )}
+                </CardHeader>
+                <CardContent className="space-y-3">
+                    {!selectedGame ? (
+                        <p className="text-xs text-muted-foreground">
+                            {t('admin.geo.maps.sidePanel.hint')}
+                        </p>
+                    ) : sourcesLoading && !sources ? (
+                        <div className="flex justify-center py-6">
+                            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                        </div>
+                    ) : sources ? (
+                        <>
+                            <ol className="space-y-2">
+                                {sources.sources.map((s) => (
+                                    <TierRow key={s.tier} state={s} t={t} />
+                                ))}
+                            </ol>
+                            <div className="flex flex-col gap-2 border-t border-border/40 pt-3 sm:flex-row">
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    className="flex-1"
+                                    disabled={busyAction !== null}
+                                    onClick={() => void reimport(selectedGame)}
+                                >
+                                    {busyAction === 'reimport' ? (
+                                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                                    ) : (
+                                        <RotateCw className="h-3.5 w-3.5 mr-1.5" />
+                                    )}
+                                    {t('admin.geo.maps.actions.rerun')}
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    className="flex-1"
+                                    onClick={() => setManualUploadFor(selectedGame)}
+                                >
+                                    <Upload className="h-3.5 w-3.5 mr-1.5" />
+                                    {t('admin.geo.maps.actions.uploadManual')}
+                                </Button>
+                            </div>
+                        </>
+                    ) : null}
+                </CardContent>
+            </Card>
+
+            <GeoManualMapDialog
+                isOpen={manualUploadFor !== null}
+                onClose={() => setManualUploadFor(null)}
+                game={
+                    manualUploadFor && {
+                        id: manualUploadFor.id,
+                        name: manualUploadFor.name,
+                        hasMap: manualUploadFor.hasMap,
+                    }
+                }
+                onSuccess={onManualSuccess}
+            />
+        </div>
+    )
+}
+
+function MapStatusBadge({
+    game,
+    t,
+}: {
+    game: CuratedGame
+    t: ReturnType<typeof useTranslation>['t']
+}) {
+    if (game.hasMap) {
+        return (
+            <Badge variant="success" className="gap-1 text-[10px] px-1.5 py-0">
+                <CheckCircle2 className="h-3 w-3" aria-hidden />
+                {t('admin.geo.maps.row.hasMap')}
+            </Badge>
+        )
+    }
+    if (game.metadataStatus === 'unresolved') {
+        return (
+            <Badge variant="destructive" className="gap-1 text-[10px] px-1.5 py-0">
+                <XCircle className="h-3 w-3" aria-hidden />
+                {t('admin.geo.maps.row.failed')}
+            </Badge>
+        )
+    }
+    return (
+        <Badge variant="warning" className="gap-1 text-[10px] px-1.5 py-0">
+            <AlertTriangle className="h-3 w-3" aria-hidden />
+            {t('admin.geo.maps.row.noMap')}
+        </Badge>
+    )
+}
+
+function TierRow({
+    state,
+    t,
+}: {
+    state: TierState
+    t: ReturnType<typeof useTranslation>['t']
+}) {
+    const tierLabel = t(`admin.geo.maps.tiers.${state.tier}`)
+
+    if (state.status === 'matched') {
+        return (
+            <li className="rounded border border-success/30 bg-success/5 p-2.5 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium flex items-center gap-1.5">
+                        <Sparkles className="h-3 w-3 text-success" aria-hidden />
+                        {tierLabel}
+                    </span>
+                    <span className="text-[10px] uppercase tracking-wide text-success">
+                        {t('admin.geo.maps.tierStatus.matched')}
+                    </span>
+                </div>
+                <p className="pt-1 text-[11px] text-muted-foreground leading-snug">
+                    {state.via}
+                    {state.license && ` · ${state.license}`}
+                </p>
+                {state.sourceUrl && (
+                    <a
+                        href={state.sourceUrl}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="text-[11px] text-primary hover:underline"
+                    >
+                        {t('admin.geo.maps.viewSource')}
+                    </a>
+                )}
+            </li>
+        )
+    }
+
+    if (state.status === 'tombstoned') {
+        const retry = new Date(state.retryAfter)
+        return (
+            <li className="rounded border border-destructive/30 bg-destructive/5 p-2.5 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium flex items-center gap-1.5">
+                        <XCircle className="h-3 w-3 text-destructive" aria-hidden />
+                        {tierLabel}
+                    </span>
+                    <span className="text-[10px] uppercase tracking-wide text-destructive">
+                        {t('admin.geo.maps.tierStatus.tombstoned', { count: state.attempts })}
+                    </span>
+                </div>
+                <p
+                    className="pt-1 text-[11px] text-muted-foreground leading-snug break-words"
+                    title={state.reason}
+                >
+                    {state.reason}
+                </p>
+                <p className="pt-0.5 text-[10px] text-muted-foreground inline-flex items-center gap-1">
+                    <Clock className="h-2.5 w-2.5" aria-hidden />
+                    {t('admin.geo.maps.tierStatus.retryAfter', {
+                        time: retry.toLocaleString(),
+                    })}
+                </p>
+            </li>
+        )
+    }
+
+    if (state.status === 'eligible') {
+        return (
+            <li className="rounded border border-warning/30 bg-warning/5 p-2.5 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium flex items-center gap-1.5">
+                        <Clock className="h-3 w-3 text-warning" aria-hidden />
+                        {tierLabel}
+                    </span>
+                    <span className="text-[10px] uppercase tracking-wide text-warning">
+                        {t('admin.geo.maps.tierStatus.eligible')}
+                    </span>
+                </div>
+                <p className="pt-1 text-[11px] text-muted-foreground leading-snug">
+                    {t('admin.geo.maps.tierStatus.eligibleHint')}
+                </p>
+            </li>
+        )
+    }
+
+    // untried
+    return (
+        <li className="rounded border border-border/40 bg-muted/10 p-2.5 text-xs">
+            <div className="flex items-center justify-between gap-2">
+                <span className="font-medium flex items-center gap-1.5 text-muted-foreground">
+                    <MinusCircle className="h-3 w-3" aria-hidden />
+                    {tierLabel}
+                </span>
+                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    {t('admin.geo.maps.tierStatus.untried')}
+                </span>
+            </div>
+            {state.reason && (
+                <p className="pt-1 text-[11px] text-muted-foreground leading-snug">
+                    {state.reason}
+                </p>
+            )}
+        </li>
+    )
+}

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -16,9 +16,11 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog'
-import { Loader2, Trash2, Info, MapPin, ChevronDown } from 'lucide-react'
+import { Loader2, Trash2, Info, MapPin, ChevronDown, Map, ListChecks } from 'lucide-react'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { GeoAdminActions } from './GeoAdminActions'
+import { GeoMapsTab } from './GeoMapsTab'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type {
     GeoMap,
     GeoPinSubmission,
@@ -165,6 +167,23 @@ export function GeoReviewPanel() {
                 <p className="text-sm text-muted-foreground">{t('admin.geo.subtitle')}</p>
             </header>
 
+            <Tabs defaultValue="pins" className="space-y-4">
+                <TabsList>
+                    <TabsTrigger value="pins" className="gap-1.5">
+                        <ListChecks className="h-3.5 w-3.5" />
+                        {t('admin.geo.tabs.pins')}
+                    </TabsTrigger>
+                    <TabsTrigger value="maps" className="gap-1.5">
+                        <Map className="h-3.5 w-3.5" />
+                        {t('admin.geo.tabs.maps')}
+                    </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="maps" className="space-y-4">
+                    <GeoMapsTab />
+                </TabsContent>
+
+                <TabsContent value="pins" className="space-y-4">
             {/* Workflow explainer */}
             <Collapsible open={introOpen} onOpenChange={setIntroOpen}>
                 <Card className="border-neon-pink/30 bg-linear-to-r from-neon-pink/5 via-neon-purple/5 to-transparent">
@@ -374,6 +393,8 @@ export function GeoReviewPanel() {
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
+                </TabsContent>
+            </Tabs>
         </div>
     )
 }


### PR DESCRIPTION
## Summary

First slice of the geo admin simplification (per the feature review): split into two tabs (**Pins** | **Maps**) and add a Maps tab that shows the four-tier ingestion cascade per game. The existing global failures list and metric grid don't tell an operator *why* a particular game has no map — this fixes that with a focused per-game drill-down.

## What's new

**Backend**
- `GET /api/admin/geo/games/:id/sources` returns a structured tier state per game: `matched | tombstoned | eligible | untried`, with reason, attempt count, retry-after, and license per source. Reads `geo_ingest_failure` for live tombstones and the registry helper for Tier 1 eligibility.

**Frontend**
- `GeoMapsTab.tsx` — left column lists curated games with status badges (Map / No map / Failed); right column shows the tier cascade for the selected game. Each tier row is color-coded by state and shows the failure reason for tombstoned tiers.
- Side panel exposes the two triage actions inline: **Re-run pipeline** (existing `POST /reimport`) and **Upload manually** (reuses `GeoManualMapDialog`). No more hunting for these in the curated-row icon trio.
- `GeoReviewPanel` now wraps its existing review UI in a Pins tab and hosts the new Maps tab alongside.

**i18n**
- Full FR + EN.

## Why

From the feature review:
> "Tombstone failures are global, not contextual — Skyrim has no map doesn't tell you which tier failed. The new 4-tier cascade made this worse: there are now four ways for a game to be mapless."

Now an operator scanning for problems can: see ⚠/✗ in the table → click the row → read which tier matched, which is tombstoned and why, what's eligible to run next.

## Out of scope (subsequent PRs)

- Persistent header strip (`38/42 maps · 12 pins · 0 errors`)
- Unified Games tab with bulk curate (`POST /curated/bulk`)
- Tab 1 polish: cmd-K candidate navigation, intro-to-modal, kebab schedule

## Test plan

- [x] `npm run build` passes (backend + frontend)
- [x] `npm run lint` — no new warnings (5 pre-existing, untouched files)
- [ ] Manual: open admin → Geo tab → Maps subtab → click a curated game → side panel shows 4 tier rows
- [ ] Manual: click "Re-run pipeline" → side panel refreshes with updated tier states
- [ ] Manual: click "Upload manually" → existing dialog opens; on success the Map status badge flips to "Map"

https://claude.ai/code/session_01RFcqphCNu6CScS1HjqUeZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFcqphCNu6CScS1HjqUeZY)_