### PR TITLE
fix(admin): mobile-first layout for admin page and all tabs

### DIFF
--- a/packages/frontend/src/components/admin/ChallengeManager.tsx
+++ b/packages/frontend/src/components/admin/ChallengeManager.tsx
@@ -38,21 +38,29 @@ export function ChallengeManager() {
 
   return (
     <Card className="relative bg-card/50 backdrop-blur-sm border-neon-purple/30">
-      {/* Date Badge - Top Right */}
-      <div className="absolute top-4 right-4 sm:top-6 sm:right-6">
+      {/* Date Badge - Top Right (desktop) / inline (mobile) */}
+      <div className="hidden sm:block absolute top-6 right-6">
         <div className="flex flex-col items-end gap-1">
           <span className="text-xs text-muted-foreground uppercase tracking-wide">{t('admin.challenges.date')}</span>
           <div className="bg-neon-purple/20 border border-neon-purple/40 rounded-lg px-3 py-1.5 backdrop-blur-sm">
-            <span className="font-mono text-lg sm:text-xl font-bold text-neon-purple">{today}</span>
+            <span className="font-mono text-xl font-bold text-neon-purple">{today}</span>
           </div>
         </div>
       </div>
 
-      <CardHeader className="p-4 sm:p-6 pr-24 sm:pr-32">
+      <CardHeader className="p-4 sm:p-6 sm:pr-32">
         <div className="flex items-start gap-3">
-          <Calendar className="h-6 w-6 text-neon-purple shrink-0 mt-0.5" />
+          <Calendar className="h-5 w-5 sm:h-6 sm:w-6 text-neon-purple shrink-0 mt-0.5" />
           <div className="min-w-0 flex-1 space-y-1">
-            <CardTitle className="text-lg sm:text-xl">{t('admin.challenges.todaysChallenge')}</CardTitle>
+            <div className="flex items-start justify-between gap-2">
+              <CardTitle className="text-base sm:text-xl">{t('admin.challenges.todaysChallenge')}</CardTitle>
+              <div className="flex sm:hidden flex-col items-end gap-0.5 shrink-0">
+                <span className="text-[10px] text-muted-foreground uppercase tracking-wide">{t('admin.challenges.date')}</span>
+                <div className="bg-neon-purple/20 border border-neon-purple/40 rounded-md px-2 py-0.5 backdrop-blur-sm">
+                  <span className="font-mono text-xs font-bold text-neon-purple">{today}</span>
+                </div>
+              </div>
+            </div>
             <CardDescription className="text-xs sm:text-sm">{t('admin.challenges.rerollDesc')}</CardDescription>
           </div>
         </div>

--- a/packages/frontend/src/components/admin/DeleteConfirmDialog.tsx
+++ b/packages/frontend/src/components/admin/DeleteConfirmDialog.tsx
@@ -31,16 +31,16 @@ export function DeleteConfirmDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent>
+      <DialogContent className="max-w-sm sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={isLoading}>
+        <DialogFooter className="flex flex-col-reverse sm:flex-row gap-2">
+          <Button variant="outline" onClick={onClose} disabled={isLoading} className="w-full sm:w-auto">
             {t('common.cancel')}
           </Button>
-          <Button variant="destructive" onClick={onConfirm} disabled={isLoading}>
+          <Button variant="destructive" onClick={onConfirm} disabled={isLoading} className="w-full sm:w-auto">
             {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
             {t('common.delete')}
           </Button>

--- a/packages/frontend/src/components/admin/EmailLogPanel.tsx
+++ b/packages/frontend/src/components/admin/EmailLogPanel.tsx
@@ -77,7 +77,7 @@ export function EmailLogPanel() {
 
   return (
     <Card>
-      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 space-y-0">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 space-y-0 p-4 sm:p-6">
         <CardTitle className="flex items-center gap-2 text-base min-w-0">
           <Mail className="h-4 w-4 text-neon-purple shrink-0" />
           <span className="truncate">{t('admin.emailLog.title')}</span>
@@ -95,7 +95,7 @@ export function EmailLogPanel() {
           <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
         </Button>
       </CardHeader>
-      <CardContent>
+      <CardContent className="p-4 sm:p-6 pt-0 sm:pt-0">
         <div className="flex flex-col sm:flex-row gap-2 mb-4">
           <Input
             placeholder={t('admin.emailLog.searchPlaceholder')}
@@ -106,7 +106,7 @@ export function EmailLogPanel() {
           <select
             value={type}
             onChange={(e) => setType(e.target.value as EmailLogType | '')}
-            className="bg-background border border-border rounded-md px-3 py-2 text-sm"
+            className="bg-background border border-border rounded-md px-3 py-2 text-sm w-full sm:w-auto"
           >
             <option value="">{t('admin.emailLog.filterType')}</option>
             {TYPE_OPTIONS.map((o) => (
@@ -118,7 +118,7 @@ export function EmailLogPanel() {
           <select
             value={status}
             onChange={(e) => setStatus(e.target.value as EmailLogStatus | '')}
-            className="bg-background border border-border rounded-md px-3 py-2 text-sm"
+            className="bg-background border border-border rounded-md px-3 py-2 text-sm w-full sm:w-auto"
           >
             <option value="">{t('admin.emailLog.filterStatus')}</option>
             {STATUS_OPTIONS.map((o) => (
@@ -135,7 +135,39 @@ export function EmailLogPanel() {
           </div>
         ) : entries && entries.length > 0 ? (
           <>
-            <div className="overflow-x-auto">
+            {/* Mobile cards */}
+            <div className="space-y-2 md:hidden">
+              {entries.map((row) => (
+                <div
+                  key={row.id}
+                  className="rounded-lg border border-border bg-background/40 p-3 space-y-2"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <Badge variant="outline" className="text-[10px] font-normal">
+                      {t(`admin.emailLog.types.${row.type}`)}
+                    </Badge>
+                    <StatusBadge status={row.status} />
+                  </div>
+                  <div className="font-mono text-xs break-all text-muted-foreground">
+                    {row.recipient}
+                  </div>
+                  <div className="text-sm break-words" title={row.subject}>
+                    {row.subject}
+                  </div>
+                  {row.errorMessage && (
+                    <div className="text-[11px] text-destructive break-words" title={row.errorMessage}>
+                      {row.errorMessage}
+                    </div>
+                  )}
+                  <div className="text-[11px] text-muted-foreground">
+                    {formatWhen(row.sentAt, i18n.language)}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Desktop table */}
+            <div className="hidden md:block overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-border text-left text-xs uppercase text-muted-foreground">

--- a/packages/frontend/src/components/admin/EmailSettings.tsx
+++ b/packages/frontend/src/components/admin/EmailSettings.tsx
@@ -82,19 +82,19 @@ export function EmailSettings() {
 
   return (
     <Card className="bg-card/50 backdrop-blur-sm border-neon-purple/30">
-      <CardHeader>
+      <CardHeader className="p-4 sm:p-6">
         <div className="flex items-center gap-3">
-          <Mail className="h-6 w-6 text-neon-purple" />
-          <div>
-            <CardTitle>{t('admin.email.title')}</CardTitle>
-            <CardDescription>{t('admin.email.description')}</CardDescription>
+          <Mail className="h-5 w-5 sm:h-6 sm:w-6 text-neon-purple shrink-0" />
+          <div className="min-w-0">
+            <CardTitle className="text-base sm:text-lg">{t('admin.email.title')}</CardTitle>
+            <CardDescription className="text-xs sm:text-sm">{t('admin.email.description')}</CardDescription>
           </div>
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4">
+      <CardContent className="space-y-4 p-4 sm:p-6 pt-0 sm:pt-0">
         <div className="space-y-3">
-          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-muted/50">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 p-3 rounded-lg bg-muted/50">
             <span className="text-sm font-medium shrink-0">{t('admin.email.status')}</span>
             <div className="flex items-center gap-2 min-w-0">
               {config?.configured ? (
@@ -111,16 +111,16 @@ export function EmailSettings() {
             </div>
           </div>
 
-          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-muted/50">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 p-3 rounded-lg bg-muted/50">
             <span className="text-sm font-medium shrink-0">{t('admin.email.apiKey')}</span>
             <span className="text-sm text-muted-foreground truncate">
               {config?.hasApiKey ? t('admin.email.apiKeySet') : t('admin.email.apiKeyNotSet')}
             </span>
           </div>
 
-          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-muted/50">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 p-3 rounded-lg bg-muted/50">
             <span className="text-sm font-medium shrink-0">{t('admin.email.fromAddress')}</span>
-            <span className="text-sm font-mono text-foreground truncate text-right">
+            <span className="text-sm font-mono text-foreground truncate sm:text-right break-all">
               {config?.emailFrom || '-'}
             </span>
           </div>
@@ -139,7 +139,7 @@ export function EmailSettings() {
         </div>
       </CardContent>
 
-      <CardFooter>
+      <CardFooter className="p-4 sm:p-6 pt-0 sm:pt-0">
         <Button
           variant="gaming"
           onClick={handleTestEmail}

--- a/packages/frontend/src/components/admin/FullImportCard.tsx
+++ b/packages/frontend/src/components/admin/FullImportCard.tsx
@@ -112,23 +112,23 @@ export function FullImportCard() {
 
   return (
     <Card className="bg-card/50 backdrop-blur-sm border-neon-purple/30">
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Database className="h-6 w-6 text-neon-purple" />
-            <div>
-              <CardTitle>{t('admin.fullImport.title')}</CardTitle>
-              <CardDescription>{t('admin.fullImport.description')}</CardDescription>
+      <CardHeader className="p-4 sm:p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <Database className="h-5 w-5 sm:h-6 sm:w-6 text-neon-purple shrink-0" />
+            <div className="min-w-0">
+              <CardTitle className="text-base sm:text-lg">{t('admin.fullImport.title')}</CardTitle>
+              <CardDescription className="text-xs sm:text-sm">{t('admin.fullImport.description')}</CardDescription>
             </div>
           </div>
-          {getStatusBadge()}
+          <div className="self-start sm:self-auto">{getStatusBadge()}</div>
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4">
+      <CardContent className="space-y-4 p-4 sm:p-6 pt-0 sm:pt-0">
         {/* Progress section - shown when import exists and is active/paused */}
         {currentImport && (currentImport.status === 'in_progress' || currentImport.status === 'paused') && (
-          <div className="space-y-3 p-4 rounded-lg bg-background/50">
+          <div className="space-y-3 p-3 sm:p-4 rounded-lg bg-background/50">
             {/* Progress bar */}
             <div className="space-y-1">
               <div className="flex justify-between text-sm">
@@ -139,7 +139,7 @@ export function FullImportCard() {
             </div>
 
             {/* Stats grid */}
-            <div className="grid grid-cols-2 gap-3 text-sm">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-3 text-sm">
               <div className="flex justify-between">
                 <span className="text-muted-foreground">{t('admin.fullImport.totalAvailable')}:</span>
                 <span>{currentImport.totalGamesAvailable?.toLocaleString(i18n.language) || '...'}</span>
@@ -195,7 +195,7 @@ export function FullImportCard() {
         {/* Configuration form - only when no active import */}
         {canStart && (
           <div className="space-y-4">
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
               <div className="space-y-2">
                 <Label className="text-muted-foreground font-normal">
                   {t('admin.fullImport.batchSize')}
@@ -237,7 +237,7 @@ export function FullImportCard() {
         )}
       </CardContent>
 
-      <CardFooter className="flex gap-2">
+      <CardFooter className="flex flex-col sm:flex-row gap-2 p-4 sm:p-6 pt-0 sm:pt-0">
         {/* Start button */}
         {canStart && (
           <Button
@@ -311,6 +311,7 @@ export function FullImportCard() {
             size="icon"
             onClick={fetchCurrentImport}
             disabled={fullImportLoading}
+            className="w-full sm:w-10"
           >
             <RefreshCw className={`h-4 w-4 ${fullImportLoading ? 'animate-spin' : ''}`} />
           </Button>

--- a/packages/frontend/src/components/admin/GameForm.tsx
+++ b/packages/frontend/src/components/admin/GameForm.tsx
@@ -137,8 +137,8 @@ export function GameForm({
   return (
     <Card className="border-0 shadow-none">
       <CardHeader className="px-0 pt-0 pr-8">
-        <div className="flex items-center justify-between">
-          <CardTitle>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+          <CardTitle className="text-base sm:text-lg">
             {isEditing ? t('admin.games.editGame') : t('admin.games.addGame')}
           </CardTitle>
           {isEditing && onSyncRawg && (
@@ -148,6 +148,7 @@ export function GameForm({
               size="sm"
               onClick={onSyncRawg}
               disabled={isSyncing || isLoading}
+              className="w-full sm:w-auto"
             >
               {isSyncing ? (
                 <Loader2 className="h-4 w-4 animate-spin mr-2" />
@@ -322,9 +323,9 @@ export function GameForm({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>{t('admin.games.form.coverImageUrl')}</FormLabel>
-                  <div className="flex gap-4">
+                  <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
                     {/* Image Preview */}
-                    <div className="relative w-24 h-32 shrink-0 rounded-lg overflow-hidden bg-muted border border-border">
+                    <div className="relative w-24 h-32 shrink-0 rounded-lg overflow-hidden bg-muted border border-border self-start">
                       {field.value && !imageError ? (
                         <img
                           src={field.value}
@@ -358,11 +359,11 @@ export function GameForm({
               )}
             />
 
-            <div className="flex justify-end gap-2 pt-4">
-              <Button type="button" variant="outline" onClick={onCancel} disabled={isLoading}>
+            <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pt-4">
+              <Button type="button" variant="outline" onClick={onCancel} disabled={isLoading} className="w-full sm:w-auto">
                 {t('common.cancel')}
               </Button>
-              <Button type="submit" variant="gaming" disabled={isLoading}>
+              <Button type="submit" variant="gaming" disabled={isLoading} className="w-full sm:w-auto">
                 {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
                 {isEditing ? t('common.save') : t('common.create')}
               </Button>

--- a/packages/frontend/src/components/admin/GameList.tsx
+++ b/packages/frontend/src/components/admin/GameList.tsx
@@ -153,8 +153,8 @@ export function GameList() {
 
   return (
     <Card className="bg-card/50 backdrop-blur-sm">
-      <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 space-y-0">
-        <CardTitle className="flex items-center gap-2 min-w-0">
+      <CardHeader className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-2 sm:gap-3 space-y-0 p-4 sm:p-6">
+        <CardTitle className="flex items-center gap-2 min-w-0 text-base sm:text-lg">
           <span className="truncate">{t('admin.games.title')}</span>
           {gamesPagination.total > 0 && (
             <span className="text-sm font-normal text-muted-foreground shrink-0">
@@ -162,13 +162,13 @@ export function GameList() {
             </span>
           )}
         </CardTitle>
-        <Button variant="gaming" onClick={() => setIsFormOpen(true)} className="shrink-0">
+        <Button variant="gaming" onClick={() => setIsFormOpen(true)} className="w-full sm:w-auto shrink-0">
           <Plus className="h-4 w-4" />
           {t('admin.games.addGame')}
         </Button>
       </CardHeader>
 
-      <CardContent>
+      <CardContent className="p-4 sm:p-6 pt-0 sm:pt-0">
         {/* Search */}
         <div className="mb-4">
           <div className="relative">
@@ -243,7 +243,7 @@ export function GameList() {
 
       {/* Create/Edit Dialog */}
       <Dialog open={isFormOpen || !!editingGame} onOpenChange={handleCloseForm}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogTitle className="sr-only">
             {editingGame ? t('admin.games.editGame') : t('admin.games.addGame')}
           </DialogTitle>

--- a/packages/frontend/src/components/admin/GeoGamesTab.tsx
+++ b/packages/frontend/src/components/admin/GeoGamesTab.tsx
@@ -197,11 +197,11 @@ export function GeoGamesTab() {
 
                 {/* Bulk action bar (only when something is selected) */}
                 {selected.size > 0 && (
-                    <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-primary/30 bg-primary/5 p-2 text-xs">
+                    <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-2 rounded-md border border-primary/30 bg-primary/5 p-2 text-xs">
                         <span className="font-medium">
                             {t('admin.geo.games.bulk.selected', { count: selected.size })}
                         </span>
-                        <div className="flex gap-1.5">
+                        <div className="flex flex-wrap gap-1.5">
                             <Button
                                 size="sm"
                                 variant="outline"
@@ -267,7 +267,7 @@ export function GeoGamesTab() {
                                 {t('admin.geo.games.col.status')}
                             </span>
                         </div>
-                        <ul className="divide-y divide-border/40 max-h-[520px] overflow-auto">
+                        <ul className="divide-y divide-border/40 max-h-[300px] sm:max-h-[520px] overflow-auto">
                             {rows.map((row) => (
                                 <GameRowItem
                                     key={row.id}

--- a/packages/frontend/src/components/admin/GeoHeaderStrip.tsx
+++ b/packages/frontend/src/components/admin/GeoHeaderStrip.tsx
@@ -116,7 +116,7 @@ export function GeoHeaderStrip({ onScheduleClick, scheduling }: GeoHeaderStripPr
                 <Button
                     size="sm"
                     variant="ghost"
-                    className="ml-auto h-7 text-xs"
+                    className="w-full sm:w-auto sm:ml-auto h-7 text-xs"
                     onClick={onScheduleClick}
                     disabled={scheduling}
                 >

--- a/packages/frontend/src/components/admin/GeoManualMapDialog.tsx
+++ b/packages/frontend/src/components/admin/GeoManualMapDialog.tsx
@@ -125,7 +125,7 @@ export function GeoManualMapDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && !submitting && onClose()}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-sm sm:max-w-md max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {t('admin.geo.manualMap.title', { name: game.name })}
@@ -238,7 +238,7 @@ export function GeoManualMapDialog({
           )}
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="flex flex-col-reverse sm:flex-row gap-2">
           <Button variant="outline" onClick={onClose} disabled={submitting}>
             {t('common.cancel')}
           </Button>

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -170,7 +170,7 @@ export function GeoMapsTab() {
     const selectedGame = games?.find((g) => g.id === selectedId) ?? null
 
     return (
-        <div className="grid gap-4 lg:grid-cols-5">
+        <div className="grid gap-3 sm:gap-4 grid-cols-1 lg:grid-cols-5">
             {/* Left: per-game table */}
             <Card className="lg:col-span-3">
                 <CardHeader className="pb-3">

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -205,16 +205,16 @@ export function GeoReviewPanel() {
             />
 
             <Tabs defaultValue="pins" className="space-y-4">
-                <TabsList>
-                    <TabsTrigger value="pins" className="gap-1.5">
+                <TabsList className="w-full overflow-x-auto justify-start sm:justify-center scrollbar-hide">
+                    <TabsTrigger value="pins" className="gap-1.5 shrink-0">
                         <ListChecks className="h-3.5 w-3.5" />
                         {t('admin.geo.tabs.pins')}
                     </TabsTrigger>
-                    <TabsTrigger value="maps" className="gap-1.5">
+                    <TabsTrigger value="maps" className="gap-1.5 shrink-0">
                         <Map className="h-3.5 w-3.5" />
                         {t('admin.geo.tabs.maps')}
                     </TabsTrigger>
-                    <TabsTrigger value="games" className="gap-1.5">
+                    <TabsTrigger value="games" className="gap-1.5 shrink-0">
                         <Library className="h-3.5 w-3.5" />
                         {t('admin.geo.tabs.games')}
                     </TabsTrigger>
@@ -296,14 +296,14 @@ export function GeoReviewPanel() {
                     <Loader2 className="h-6 w-6 animate-spin text-neon-pink" />
                 </div>
             ) : (
-                <div className="grid gap-4 lg:grid-cols-3">
+                <div className="grid gap-3 sm:gap-4 grid-cols-1 lg:grid-cols-3">
                     <Card className="lg:col-span-1">
-                        <CardHeader className="pb-2">
+                        <CardHeader className="pb-2 p-4 sm:p-6">
                             <CardTitle className="text-sm">
                                 {t('admin.geo.candidates')} ({candidates.length})
                             </CardTitle>
                         </CardHeader>
-                        <CardContent className="space-y-2 max-h-[520px] overflow-auto">
+                        <CardContent className="space-y-2 max-h-[300px] sm:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
                             {candidates.map((c) => (
                                 <button
                                     key={c.id}
@@ -332,14 +332,14 @@ export function GeoReviewPanel() {
                     </Card>
 
                     <Card className="lg:col-span-2">
-                        <CardHeader className="pb-2">
+                        <CardHeader className="pb-2 p-4 sm:p-6">
                             <CardTitle className="text-sm">
                                 {detail
                                     ? `#${detail.candidate.id} · ${t('admin.geo.candidateRow.pinCount', { count: detail.pins.length })}`
                                     : t('admin.geo.pickOne')}
                             </CardTitle>
                         </CardHeader>
-                        <CardContent className="space-y-3">
+                        <CardContent className="space-y-3 p-4 sm:p-6 pt-0 sm:pt-0">
                             {detail && detail.map ? (
                                 <>
                                     <img
@@ -364,7 +364,7 @@ export function GeoReviewPanel() {
                                         disabled={!!detail.meta}
                                     />
                                     {detail.meta ? (
-                                        <div className="flex items-center justify-between gap-3">
+                                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
                                             <p className="text-xs text-warning">
                                                 {t('admin.geo.alreadyPromoted')}
                                             </p>
@@ -373,13 +373,14 @@ export function GeoReviewPanel() {
                                                 variant="destructive"
                                                 onClick={() => setDemoteOpen(true)}
                                                 disabled={saving}
+                                                className="w-full sm:w-auto"
                                             >
                                                 <Trash2 className="h-3.5 w-3.5 mr-2" />
                                                 {t('admin.geo.demote')}
                                             </Button>
                                         </div>
                                     ) : (
-                                        <div className="flex items-center justify-between">
+                                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                                             <span className="text-xs text-muted-foreground">
                                                 {pin
                                                     ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
@@ -389,7 +390,7 @@ export function GeoReviewPanel() {
                                                 size="sm"
                                                 onClick={applyOverride}
                                                 disabled={!pin || saving}
-                                                className="gradient-gaming hover:opacity-90"
+                                                className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
                                             >
                                                 {saving && (
                                                     <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
@@ -410,14 +411,14 @@ export function GeoReviewPanel() {
             )}
 
             <Dialog open={demoteOpen} onOpenChange={(open) => !saving && setDemoteOpen(open)}>
-                <DialogContent>
+                <DialogContent className="max-w-sm sm:max-w-md">
                     <DialogHeader>
                         <DialogTitle>{t('admin.geo.demoteDialog.title')}</DialogTitle>
                         <DialogDescription>
                             {t('admin.geo.demoteDialog.description')}
                         </DialogDescription>
                     </DialogHeader>
-                    <DialogFooter>
+                    <DialogFooter className="flex flex-col-reverse sm:flex-row gap-2">
                         <Button
                             variant="outline"
                             onClick={() => setDemoteOpen(false)}

--- a/packages/frontend/src/components/admin/GrowthStats.tsx
+++ b/packages/frontend/src/components/admin/GrowthStats.tsx
@@ -58,14 +58,14 @@ export function GrowthStats() {
     <div className="space-y-4 sm:space-y-6">
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
         <Card>
-          <CardHeader className="pb-2">
+          <CardHeader className="pb-2 p-4 sm:p-6">
             <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
               <UserPlus className="h-4 w-4" />
               {t('admin.growth.referralsClaimed')}
             </CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold gradient-gaming bg-clip-text text-transparent">
+          <CardContent className="p-4 sm:p-6 pt-0 sm:pt-0">
+            <div className="text-2xl sm:text-3xl font-bold gradient-gaming bg-clip-text text-transparent">
               {stats.referrals.claimedTotal}
             </div>
             <p className="text-xs text-muted-foreground mt-1">
@@ -75,14 +75,14 @@ export function GrowthStats() {
         </Card>
 
         <Card>
-          <CardHeader className="pb-2">
+          <CardHeader className="pb-2 p-4 sm:p-6">
             <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
               <TrendingUp className="h-4 w-4" />
               {t('admin.growth.consentRate')}
             </CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold text-neon-cyan">
+          <CardContent className="p-4 sm:p-6 pt-0 sm:pt-0">
+            <div className="text-2xl sm:text-3xl font-bold text-neon-cyan">
               {stats.consent.ratePercent}%
             </div>
             <p className="text-xs text-muted-foreground mt-1">
@@ -95,14 +95,14 @@ export function GrowthStats() {
         </Card>
 
         <Card>
-          <CardHeader className="pb-2">
+          <CardHeader className="pb-2 p-4 sm:p-6">
             <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
               <Mail className="h-4 w-4" />
               {t('admin.growth.streakEmails')}
             </CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold text-neon-pink">
+          <CardContent className="p-4 sm:p-6 pt-0 sm:pt-0">
+            <div className="text-2xl sm:text-3xl font-bold text-neon-pink">
               {stats.streakRiskEmail.sentLast24h}
             </div>
             <p className="text-xs text-muted-foreground mt-1">
@@ -116,11 +116,11 @@ export function GrowthStats() {
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle>{t('admin.growth.topReferrers')}</CardTitle>
-          <CardDescription>{t('admin.growth.topReferrersHint')}</CardDescription>
+        <CardHeader className="p-4 sm:p-6">
+          <CardTitle className="text-base sm:text-lg">{t('admin.growth.topReferrers')}</CardTitle>
+          <CardDescription className="text-xs sm:text-sm">{t('admin.growth.topReferrersHint')}</CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="p-4 sm:p-6 pt-0 sm:pt-0">
           {stats.referrals.topReferrers.length === 0 ? (
             <p className="text-sm text-muted-foreground py-4 text-center">
               {t('admin.growth.noReferrers')}

--- a/packages/frontend/src/components/admin/JobList.tsx
+++ b/packages/frontend/src/components/admin/JobList.tsx
@@ -514,7 +514,7 @@ export function JobList() {
 
       {/* Cancel Stuck Sync Dialog */}
       <Dialog open={showCancelSyncDialog} onOpenChange={setShowCancelSyncDialog}>
-        <DialogContent>
+        <DialogContent className="max-w-sm sm:max-w-md">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-warning" />
@@ -524,7 +524,7 @@ export function JobList() {
               {t('admin.jobs.syncConflict.description', 'A sync-all job is already in progress or paused. Would you like to cancel it and start a new one?')}
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter className="flex gap-2 sm:gap-0">
+          <DialogFooter className="flex flex-col-reverse sm:flex-row gap-2">
             <Button
               variant="outline"
               onClick={() => setShowCancelSyncDialog(false)}

--- a/packages/frontend/src/components/admin/JobQueuePanel.tsx
+++ b/packages/frontend/src/components/admin/JobQueuePanel.tsx
@@ -211,26 +211,26 @@ export function JobQueuePanel({ onMinimizedChange }: JobQueuePanelProps = {}) {
 
                         {/* Filter Tabs */}
                         <Tabs value={filterTab} onValueChange={(value) => setFilterTab(value as 'all' | 'active' | 'completed' | 'failed' | 'delayed')} className="w-full">
-                            <TabsList className="w-full h-8 p-0.5">
-                                <TabsTrigger value="all" className="flex-1 text-[10px] h-7 px-2">
+                            <TabsList className="w-full h-auto p-0.5 grid grid-cols-2 sm:flex sm:h-8 gap-0.5">
+                                <TabsTrigger value="all" className="flex-1 text-[10px] h-7 px-1.5 sm:px-2">
                                     {t('admin.jobs.filter.all', 'All')}
                                     <Badge variant="secondary" className="ml-1 h-4 min-w-4 px-1 text-[9px]">
                                         {jobs.length}
                                     </Badge>
                                 </TabsTrigger>
-                                <TabsTrigger value="active" className="flex-1 text-[10px] h-7 px-2">
+                                <TabsTrigger value="active" className="flex-1 text-[10px] h-7 px-1.5 sm:px-2">
                                     {t('admin.jobs.filter.active', 'Active')}
                                     <Badge variant="info" className="ml-1 h-4 min-w-4 px-1 text-[9px]">
                                         {activeJobs.length}
                                     </Badge>
                                 </TabsTrigger>
-                                <TabsTrigger value="completed" className="flex-1 text-[10px] h-7 px-2">
+                                <TabsTrigger value="completed" className="flex-1 text-[10px] h-7 px-1.5 sm:px-2">
                                     {t('admin.jobs.filter.completed', 'Done')}
                                     <Badge variant="success" className="ml-1 h-4 min-w-4 px-1 text-[9px]">
                                         {completedJobs.length}
                                     </Badge>
                                 </TabsTrigger>
-                                <TabsTrigger value="failed" className="flex-1 text-[10px] h-7 px-2">
+                                <TabsTrigger value="failed" className="flex-1 text-[10px] h-7 px-1.5 sm:px-2">
                                     {t('admin.jobs.filter.failed', 'Failed')}
                                     <Badge variant="destructive" className="ml-1 h-4 min-w-4 px-1 text-[9px]">
                                         {failedJobs.length}

--- a/packages/frontend/src/components/admin/JobTriggerCard.tsx
+++ b/packages/frontend/src/components/admin/JobTriggerCard.tsx
@@ -40,18 +40,18 @@ export function JobTriggerCard({ type }: JobTriggerCardProps) {
 
   return (
     <Card className="bg-card/50 backdrop-blur-sm">
-      <CardHeader>
+      <CardHeader className="p-4 sm:p-6">
         <div className="flex items-center gap-3">
           {isGamesImport ? (
-            <Gamepad2 className="h-6 w-6 text-neon-purple" />
+            <Gamepad2 className="h-5 w-5 sm:h-6 sm:w-6 text-neon-purple shrink-0" />
           ) : (
-            <Download className="h-6 w-6 text-neon-pink" />
+            <Download className="h-5 w-5 sm:h-6 sm:w-6 text-neon-pink shrink-0" />
           )}
-          <div>
-            <CardTitle>
+          <div className="min-w-0">
+            <CardTitle className="text-base sm:text-lg">
               {isGamesImport ? t('admin.jobs.importGames') : t('admin.jobs.importScreenshots')}
             </CardTitle>
-            <CardDescription>
+            <CardDescription className="text-xs sm:text-sm">
               {isGamesImport
                 ? t('admin.jobs.importGamesDesc')
                 : t('admin.jobs.importScreenshotsDesc')}
@@ -61,8 +61,8 @@ export function JobTriggerCard({ type }: JobTriggerCardProps) {
       </CardHeader>
 
       {isGamesImport && (
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+        <CardContent className="space-y-4 p-4 sm:p-6 pt-0 sm:pt-0">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
             <div className="space-y-2">
               <Label className="text-muted-foreground font-normal">
                 {t('admin.jobs.targetGames')}
@@ -103,7 +103,7 @@ export function JobTriggerCard({ type }: JobTriggerCardProps) {
         </CardContent>
       )}
 
-      <CardFooter>
+      <CardFooter className="p-4 sm:p-6 pt-0 sm:pt-0">
         <Button
           variant="gaming"
           onClick={handleStart}

--- a/packages/frontend/src/components/admin/ReportsModerationPanel.tsx
+++ b/packages/frontend/src/components/admin/ReportsModerationPanel.tsx
@@ -93,12 +93,12 @@ export function ReportsModerationPanel() {
 
     return (
         <Card>
-            <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 space-y-0">
+            <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 space-y-0 p-4 sm:p-6">
                 <CardTitle className="flex items-center gap-2 text-base min-w-0">
                     <Flag className="h-4 w-4 text-neon-pink shrink-0" />
                     <span className="truncate">{t('admin.reports.title')}</span>
                 </CardTitle>
-                <div className="flex items-center justify-between sm:justify-end gap-3 shrink-0">
+                <div className="flex items-center justify-between sm:justify-end gap-3 sm:shrink-0">
                     <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer select-none">
                         <Checkbox
                             checked={onlyDeactivated}
@@ -119,7 +119,7 @@ export function ReportsModerationPanel() {
                     </Button>
                 </div>
             </CardHeader>
-            <CardContent>
+            <CardContent className="p-4 sm:p-6 pt-0 sm:pt-0">
                 {loading && reports === null ? (
                     <div className="flex justify-center py-12">
                         <Loader2 className="h-6 w-6 animate-spin text-neon-pink" />
@@ -197,6 +197,7 @@ export function ReportsModerationPanel() {
                                         size="sm"
                                         onClick={() => void handleReactivate(row)}
                                         disabled={pendingKey === rowKey(row)}
+                                        className="w-full sm:w-auto sm:shrink-0"
                                     >
                                         {pendingKey === rowKey(row) ? (
                                             <Loader2 className="h-4 w-4 animate-spin mr-2" />

--- a/packages/frontend/src/components/admin/ScreenshotsDialog.tsx
+++ b/packages/frontend/src/components/admin/ScreenshotsDialog.tsx
@@ -79,7 +79,7 @@ export function ScreenshotsDialog({ game, open, onOpenChange }: ScreenshotsDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl">
+      <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-2xl lg:max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {t('admin.games.screenshotsDialog.title', { name: game?.name })}
@@ -110,27 +110,27 @@ export function ScreenshotsDialog({ game, open, onOpenChange }: ScreenshotsDialo
                   <Button
                     variant="overlay"
                     size="icon"
-                    className="absolute left-2 top-1/2 -translate-y-1/2 h-10 w-10"
+                    className="absolute left-1 sm:left-2 top-1/2 -translate-y-1/2 h-9 w-9 sm:h-10 sm:w-10"
                     onClick={goToPrevious}
                     aria-label={t('admin.games.screenshotsDialog.previous')}
                   >
-                    <ChevronLeft className="h-6 w-6" />
+                    <ChevronLeft className="h-5 w-5 sm:h-6 sm:w-6" />
                   </Button>
                   <Button
                     variant="overlay"
                     size="icon"
-                    className="absolute right-2 top-1/2 -translate-y-1/2 h-10 w-10"
+                    className="absolute right-1 sm:right-2 top-1/2 -translate-y-1/2 h-9 w-9 sm:h-10 sm:w-10"
                     onClick={goToNext}
                     aria-label={t('admin.games.screenshotsDialog.next')}
                   >
-                    <ChevronRight className="h-6 w-6" />
+                    <ChevronRight className="h-5 w-5 sm:h-6 sm:w-6" />
                   </Button>
                 </>
               )}
 
               {/* Info overlay */}
-              <div className="absolute bottom-0 left-0 right-0 bg-linear-to-t from-black/80 to-transparent p-4">
-                <div className="flex items-center justify-between">
+              <div className="absolute bottom-0 left-0 right-0 bg-linear-to-t from-black/80 to-transparent p-3 sm:p-4">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-2">
                   {currentScreenshot && (
                     <Badge variant={getDifficultyLabel(currentScreenshot.difficulty).variant}>
                       {t('admin.games.screenshotsDialog.difficulty')}: {getDifficultyLabel(currentScreenshot.difficulty).label}

--- a/packages/frontend/src/components/admin/TopupScreenshotsCard.tsx
+++ b/packages/frontend/src/components/admin/TopupScreenshotsCard.tsx
@@ -94,15 +94,15 @@ export function TopupScreenshotsCard() {
 
   return (
     <Card className="bg-card/50 backdrop-blur-sm border-neon-purple/30">
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Images className="h-6 w-6 text-neon-purple" />
-            <div>
-              <CardTitle>
+      <CardHeader className="p-4 sm:p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <Images className="h-5 w-5 sm:h-6 sm:w-6 text-neon-purple shrink-0" />
+            <div className="min-w-0">
+              <CardTitle className="text-base sm:text-lg">
                 {t('admin.topupScreenshots.title', 'Top-Up Screenshots')}
               </CardTitle>
-              <CardDescription>
+              <CardDescription className="text-xs sm:text-sm">
                 {t(
                   'admin.topupScreenshots.description',
                   'Backfill existing games up to the target number of captures by pulling missing screenshots from RAWG.'
@@ -110,14 +110,14 @@ export function TopupScreenshotsCard() {
               </CardDescription>
             </div>
           </div>
-          {getStatusBadge()}
+          <div className="self-start sm:self-auto">{getStatusBadge()}</div>
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4">
+      <CardContent className="space-y-4 p-4 sm:p-6 pt-0 sm:pt-0">
         {currentTopupScreenshots &&
           (currentTopupScreenshots.status === 'in_progress' || currentTopupScreenshots.status === 'paused') && (
-            <div className="space-y-3 p-4 rounded-lg bg-background/50">
+            <div className="space-y-3 p-3 sm:p-4 rounded-lg bg-background/50">
               <div className="space-y-1">
                 <div className="flex justify-between text-sm">
                   <span>{t('admin.fullImport.progress', 'Progress')}</span>
@@ -126,7 +126,7 @@ export function TopupScreenshotsCard() {
                 <Progress value={progress} className="h-2" />
               </div>
 
-              <div className="grid grid-cols-2 gap-3 text-sm">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-3 text-sm">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">
                     {t('admin.topupScreenshots.candidates', 'Candidates')}:
@@ -198,7 +198,7 @@ export function TopupScreenshotsCard() {
         )}
 
         {canStart && (
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
             <div className="space-y-2">
               <Label className="text-muted-foreground font-normal">
                 {t('admin.fullImport.batchSize', 'Batch size')}
@@ -229,7 +229,7 @@ export function TopupScreenshotsCard() {
         )}
       </CardContent>
 
-      <CardFooter className="flex gap-2">
+      <CardFooter className="flex flex-col sm:flex-row gap-2 p-4 sm:p-6 pt-0 sm:pt-0">
         {canStart && (
           <Button
             variant="gaming"
@@ -298,6 +298,7 @@ export function TopupScreenshotsCard() {
             variant="destructive"
             onClick={handleCancel}
             disabled={topupScreenshotsLoading}
+            className="w-full sm:w-auto"
           >
             <X className="h-4 w-4 mr-2" />
             {t('common.cancel', 'Cancel')}
@@ -311,6 +312,7 @@ export function TopupScreenshotsCard() {
             size="icon"
             onClick={fetchCurrentTopupScreenshots}
             disabled={topupScreenshotsLoading}
+            className="w-full sm:w-10"
           >
             <RefreshCw className={`h-4 w-4 ${topupScreenshotsLoading ? 'animate-spin' : ''}`} />
           </Button>

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -118,7 +118,7 @@ export default function AdminPage() {
       className="flex min-h-screen"
     >
       {/* Main Content Area */}
-      <div className="flex-1 transition-all duration-300" style={{ paddingRight: sidebarOffset }}>
+      <div className="flex-1 min-w-0 transition-all duration-300" style={{ paddingRight: sidebarOffset }}>
         <div className="container mx-auto px-3 sm:px-4 py-4 sm:py-8">
           <motion.div
             variants={fadeInLeft}


### PR DESCRIPTION
Address mobile responsiveness across the admin surface:

- AdminPage: ensure flex content has min-w-0 so panels don't push width
- FullImportCard / TopupScreenshotsCard / JobTriggerCard: stack header,
  collapse multi-column grids to 1 column on mobile, stack footer buttons
- EmailLogPanel: stack filter row, give selects full width on mobile,
  add a card-based mobile fallback for the table
- EmailSettings: stack info rows on mobile, scale title/icon
- GeoReviewPanel: explicit single-column grid below lg, scrollable tabs
  that don't overflow, smaller candidate list on mobile, stack the pin
  action row, constrain demote dialog
- GeoMapsTab / GeoGamesTab: explicit grid-cols-1 on mobile, stack bulk
  action bar, reduce mobile list height
- GeoHeaderStrip: schedule button goes full-width on mobile
- GeoManualMapDialog / ScreenshotsDialog / DeleteConfirmDialog /
  GameList dialog: viewport-aware max-width and max-h with overflow,
  stacked footer buttons
- ScreenshotsDialog: smaller nav buttons on mobile, stacked badge row
- GameForm: stack header and submit row, image preview moves above
  input on mobile
- JobQueuePanel: filter tabs use a 2x2 grid on mobile to avoid the four
  tabs being squeezed into a single line
- ChallengeManager: move date badge from absolute overlap to inline on
  mobile so it doesn't collide with the title
- GrowthStats / ReportsModerationPanel: tighter mobile padding,
  reactivate button goes full-width on mobile