### PR TITLE
fix(admin/geo): raise games list limit cap to fit moderation tabs

### DIFF
--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1683,11 +1683,12 @@ router.get('/geo/health', async (_req, res, next) => {
 // active map present, candidate count). With `curated=false` it proposes
 // non-curated games ranked by Metacritic (descending) — that signal correlates
 // well with "famous game with a Fandom wiki and Steam listing", which is the
-// shape the auto-ingester can actually handle. Limit is small by design; the
-// admin scrolls a curated shortlist, not the whole catalogue.
+// shape the auto-ingester can actually handle. Cap matches the bulk-curate
+// endpoint (500) so the Jeux/Cartes tabs can load the whole moderation list
+// in one shot.
 const gamesQuerySchema = z.object({
   curated: z.enum(['true', 'false']).default('true'),
-  limit: z.coerce.number().int().positive().max(50).default(20),
+  limit: z.coerce.number().int().positive().max(500).default(20),
 })
 
 router.get('/geo/games', async (req, res, next) => {


### PR DESCRIPTION
The Jeux and Cartes tabs request limit=200 / limit=100 to load the full
curated set and candidate pool for bulk moderation, but the schema still
enforced max(50) from the pre-tabs design — every load surfaced as
"Error: VALIDATION_ERROR" in both panels. Bump the cap to 500 so it
matches the neighbouring bulk-curate ceiling.