### PR TITLE
fix(admin/geo): rewrite Pins-tab intro to match actual workflow

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -572,12 +572,12 @@
       },
       "intro": {
         "title": "How this page works",
-        "step1Title": "1. Import sources",
-        "step1Body": "Pull a game's annotated map from a Fandom wiki, then bring in screenshots from Steam. Both run as background jobs — watch progress in the Jobs tab.",
-        "step2Title": "2. Schedule a daily challenge",
-        "step2Body": "Pick the screenshot that the daily Geo round should use. Leave the date blank to schedule for tomorrow (UTC).",
+        "step1Title": "1. Curate games",
+        "step1Body": "Pick the games that should feed the Geo challenge in the Games tab. The ingestion pipeline then pulls their maps (Registry → Fandom → Wikidata → Manual) and Steam screenshots in the background.",
+        "step2Title": "2. Track ingestion",
+        "step2Body": "Watch maps land tier by tier in the Maps tab. Re-run the pipeline or upload a map manually for any game still missing one.",
         "step3Title": "3. Review crowdsourced pins",
-        "step3Body": "Players drop pins guessing where each screenshot was taken. When pins converge, promote a canonical location so the screenshot can ship in a daily challenge."
+        "step3Body": "Players drop pins guessing where each screenshot was taken. When pins converge, promote a canonical location — the Schedule button at the top will then queue the next validated screenshot for the daily challenge."
       },
       "candidates": "Candidates",
       "empty": "No candidates match this filter.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -572,12 +572,12 @@
       },
       "intro": {
         "title": "Comment cette page fonctionne",
-        "step1Title": "1. Importer les sources",
-        "step1Body": "Récupérez la carte annotée d'un jeu depuis un wiki Fandom, puis importez les captures depuis Steam. Les deux opérations s'exécutent en arrière-plan — surveillez l'avancement dans l'onglet Tâches.",
-        "step2Title": "2. Planifier un défi quotidien",
-        "step2Body": "Choisissez la capture qui sera utilisée pour le défi Géo du jour. Laissez la date vide pour planifier pour demain (UTC).",
+        "step1Title": "1. Curater les jeux",
+        "step1Body": "Choisissez dans l'onglet Jeux ceux qui doivent alimenter le défi Géo. Le pipeline d'ingestion récupère ensuite leurs cartes (Registre → Fandom → Wikidata → Manuel) et les captures Steam en arrière-plan.",
+        "step2Title": "2. Suivre l'ingestion",
+        "step2Body": "Visualisez l'avancement niveau par niveau dans l'onglet Cartes. Relancez le pipeline ou téléversez une carte manuellement si un jeu reste sans carte.",
         "step3Title": "3. Valider les épingles",
-        "step3Body": "Les joueurs déposent des épingles pour deviner où chaque capture a été prise. Lorsqu'elles convergent, promouvez un emplacement canonique pour que la capture puisse être utilisée dans un défi quotidien."
+        "step3Body": "Les joueurs déposent des épingles pour deviner où chaque capture a été prise. Lorsqu'elles convergent, promouvez un emplacement canonique : le bouton Planifier en haut programmera la prochaine capture validée pour le défi quotidien."
       },
       "candidates": "Candidats",
       "empty": "Aucun candidat ne correspond à ce filtre.",


### PR DESCRIPTION
The 3-step explainer referenced a non-existent "Tâches/Jobs" tab and a
"pick a screenshot + leave date blank" scheduler UI that no longer
exists. Rewrite the steps to match the real flow: curate games →
track tier-based map ingestion in the Maps tab → validate
crowdsourced pins (the Schedule button in the header strip queues the
next validated screenshot).