### PR TITLE
fix(docker): ship packages/backend/data/ to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,10 @@ COPY packages/backend/migrations ./packages/backend/migrations
 COPY packages/backend/seeds ./packages/backend/seeds
 COPY packages/backend/knexfile.ts ./packages/backend/knexfile.ts
 
+# Copy runtime data files (e.g. geo-map-registry.json read by the
+# Tier 1 geo ingestion path at packages/backend/data/...)
+COPY packages/backend/data ./packages/backend/data
+
 # Copy built frontend to be served by Node.js
 COPY --from=builder /app/packages/frontend/dist ./packages/frontend/dist
 


### PR DESCRIPTION
The admin "Cartes par jeu" tab calls /api/admin/geo/games/:id/sources,
which loads packages/backend/data/geo-map-registry.json on every
request via findRegistryEntryBySlug to compute Tier 1 eligibility.
The runner stage was only copying dist/, migrations/, seeds/ and
knexfile.ts, so readFile threw ENOENT and the whole endpoint
returned 500 INTERNAL_ERROR for every game (regardless of whether
the game actually had a registry entry). The same path also ran
inside the recurring registry-import worker, silently breaking
Tier 1 auto-ingestion in production.

https://claude.ai/code/session_01NH6gcbzzMGHHpRo8DtowWX