### PR TITLE
fix(i18n): move manualMap keys to admin.geo.manualMap

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -669,25 +669,6 @@
           "candidates_one": "{{count}} screenshot",
           "candidates_other": "{{count}} screenshots"
         },
-        "manualMap": {
-          "title": "Manual map for \"{{name}}\"",
-          "description": "Last-resort upload when the registry, Fandom, and Wikidata sources didn't produce a usable map. The image must be hosted on a stable URL — no upload happens here.",
-          "descriptionReplace": "Replace the active map for this game. The previous map is deactivated; existing screenshot pins remain valid because coordinates are normalized.",
-          "fields": {
-            "imageUrl": "Image URL",
-            "widthPx": "Width (px)",
-            "heightPx": "Height (px)",
-            "license": "License",
-            "attribution": "Attribution",
-            "sourceUrl": "Source page URL"
-          },
-          "submit": "Save map",
-          "submitReplace": "Replace map",
-          "errors": {
-            "required": "Image URL, width, height, and license are required."
-          },
-          "success": "Manual map saved for \"{{name}}\"."
-        },
         "suggestions": {
           "title": "Suggestions",
           "subtitle": "Popular games not yet curated (sorted by Metacritic).",
@@ -703,6 +684,25 @@
           "reimportQueued": "Re-ingestion queued for \"{{name}}\"",
           "scheduled": "Scheduling triggered (job {{id}})"
         }
+      },
+      "manualMap": {
+        "title": "Manual map for \"{{name}}\"",
+        "description": "Last-resort upload when the registry, Fandom, and Wikidata sources didn't produce a usable map. The image must be hosted on a stable URL — no upload happens here.",
+        "descriptionReplace": "Replace the active map for this game. The previous map is deactivated; existing screenshot pins remain valid because coordinates are normalized.",
+        "fields": {
+          "imageUrl": "Image URL",
+          "widthPx": "Width (px)",
+          "heightPx": "Height (px)",
+          "license": "License",
+          "attribution": "Attribution",
+          "sourceUrl": "Source page URL"
+        },
+        "submit": "Save map",
+        "submitReplace": "Replace map",
+        "errors": {
+          "required": "Image URL, width, height, and license are required."
+        },
+        "success": "Manual map saved for \"{{name}}\"."
       }
     },
     "growth": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -669,25 +669,6 @@
           "candidates_one": "{{count}} capture",
           "candidates_other": "{{count}} captures"
         },
-        "manualMap": {
-          "title": "Carte manuelle pour « {{name}} »",
-          "description": "Solution de dernier recours quand les sources registry, Fandom et Wikidata n'ont rien donné. L'image doit déjà être hébergée à une URL stable — aucun fichier n'est téléversé ici.",
-          "descriptionReplace": "Remplacer la carte active de ce jeu. L'ancienne carte est désactivée ; les pins existants restent valides puisque les coordonnées sont normalisées.",
-          "fields": {
-            "imageUrl": "URL de l'image",
-            "widthPx": "Largeur (px)",
-            "heightPx": "Hauteur (px)",
-            "license": "Licence",
-            "attribution": "Attribution",
-            "sourceUrl": "URL de la page source"
-          },
-          "submit": "Enregistrer la carte",
-          "submitReplace": "Remplacer la carte",
-          "errors": {
-            "required": "L'URL de l'image, la largeur, la hauteur et la licence sont obligatoires."
-          },
-          "success": "Carte manuelle enregistrée pour « {{name}} »."
-        },
         "suggestions": {
           "title": "Suggestions",
           "subtitle": "Jeux populaires non encore curatés (triés par Metacritic).",
@@ -703,6 +684,25 @@
           "reimportQueued": "Ré-ingestion lancée pour « {{name}} »",
           "scheduled": "Planification lancée (tâche {{id}})"
         }
+      },
+      "manualMap": {
+        "title": "Carte manuelle pour « {{name}} »",
+        "description": "Solution de dernier recours quand les sources registry, Fandom et Wikidata n'ont rien donné. L'image doit déjà être hébergée à une URL stable — aucun fichier n'est téléversé ici.",
+        "descriptionReplace": "Remplacer la carte active de ce jeu. L'ancienne carte est désactivée ; les pins existants restent valides puisque les coordonnées sont normalisées.",
+        "fields": {
+          "imageUrl": "URL de l'image",
+          "widthPx": "Largeur (px)",
+          "heightPx": "Hauteur (px)",
+          "license": "Licence",
+          "attribution": "Attribution",
+          "sourceUrl": "URL de la page source"
+        },
+        "submit": "Enregistrer la carte",
+        "submitReplace": "Remplacer la carte",
+        "errors": {
+          "required": "L'URL de l'image, la largeur, la hauteur et la licence sont obligatoires."
+        },
+        "success": "Carte manuelle enregistrée pour « {{name}} »."
       }
     },
     "growth": {


### PR DESCRIPTION
The GeoManualMapDialog component looks up translations under
admin.geo.manualMap.*, but the keys were nested one level too deep at
admin.geo.health.manualMap.*, causing raw keys (admin.geo.manualMap.title,
.fields.imageUrl, .submitReplace, etc.) to render in the dialog.

Move the manualMap block out of admin.geo.health to be a direct child of
admin.geo in both fr and en translation files.