### PR TITLE
fix(geo): refuse placeholder image URLs and add map/screenshot fallback UI

### DIFF
--- a/packages/backend/src/domain/services/geo-game.service.ts
+++ b/packages/backend/src/domain/services/geo-game.service.ts
@@ -94,6 +94,22 @@ function validPoint(p: GeoPoint): boolean {
   )
 }
 
+// Hosts/paths used by the dev seed (`seeds/010_geo_elden_ring.ts`) that must
+// never be served as a real daily challenge. The seed is guarded by
+// NODE_ENV !== 'production', but if a row slips into a non-prod-flagged
+// deployment we'd otherwise show players a visibly fake placeholder image.
+// Treat any of these as "challenge not configured" instead.
+const PLACEHOLDER_URL_PATTERNS = [
+  /(^|\/\/)placehold\.co\//i,
+  /(^|\/\/)via\.placeholder\.com\//i,
+  /\/map-placeholder\.(jpg|jpeg|png|webp)(\?|$)/i,
+]
+
+function isPlaceholderImageUrl(url: string | null | undefined): boolean {
+  if (!url) return true
+  return PLACEHOLDER_URL_PATTERNS.some((p) => p.test(url))
+}
+
 function monthPeriodOf(dateStr: string): string {
   return dateStr.slice(0, 7)
 }
@@ -131,6 +147,18 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
       const map = await geoMapRepository.findById(meta.geoMapId)
       if (!map) {
         log.error({ metaId: meta.id }, 'meta references missing map')
+        return null
+      }
+
+      if (isPlaceholderImageUrl(candidate.imageUrl) || isPlaceholderImageUrl(map.imageUrl)) {
+        log.error(
+          {
+            challengeId: challenge.id,
+            candidateImageUrl: candidate.imageUrl,
+            mapImageUrl: map.imageUrl,
+          },
+          'refusing to serve daily challenge backed by placeholder image URL',
+        )
         return null
       }
 

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1275,6 +1275,7 @@
       "distance": "Distance",
       "formula": "Formula",
       "screenshotUnavailable": "Screenshot preview unavailable.",
+      "mapUnavailable": "Map unavailable.",
       "errors": {
         "noChallenge": "No geo challenge is available for today yet. Please check back later."
       }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1275,6 +1275,7 @@
       "distance": "Distance",
       "formula": "Formule",
       "screenshotUnavailable": "Aperçu de la capture indisponible.",
+      "mapUnavailable": "Carte indisponible.",
       "errors": {
         "noChallenge": "Aucun défi géo n'est encore disponible pour aujourd'hui. Revenez plus tard."
       }

--- a/packages/frontend/src/components/geo/MapCanvas.tsx
+++ b/packages/frontend/src/components/geo/MapCanvas.tsx
@@ -1,6 +1,9 @@
-import { useRef, useState, type MouseEvent } from 'react'
+import { useEffect, useRef, useState, type MouseEvent } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { GeoPoint } from '@the-box/types'
 import { cn } from '@/lib/utils'
+import { isPlaceholderImageUrl } from '@/lib/geo-image'
+import { ImageOff } from 'lucide-react'
 
 export interface MapCanvasProps {
     imageUrl: string
@@ -36,11 +39,19 @@ export function MapCanvas({
     className,
     showGuessLine,
 }: MapCanvasProps) {
+    const { t } = useTranslation()
     const containerRef = useRef<HTMLDivElement>(null)
     const [hover, setHover] = useState<GeoPoint | null>(null)
+    // Treat known placeholder URLs as failed up-front: they "load" successfully
+    // (placehold.co returns a real image) so onError would never fire.
+    const [errored, setErrored] = useState(() => isPlaceholderImageUrl(imageUrl))
+
+    useEffect(() => {
+        setErrored(isPlaceholderImageUrl(imageUrl))
+    }, [imageUrl])
 
     const handleClick = (e: MouseEvent<HTMLDivElement>) => {
-        if (disabled || !onPin) return
+        if (disabled || errored || !onPin) return
         const rect = containerRef.current?.getBoundingClientRect()
         if (!rect) return
         const x = (e.clientX - rect.left) / rect.width
@@ -52,7 +63,7 @@ export function MapCanvas({
     }
 
     const handleMove = (e: MouseEvent<HTMLDivElement>) => {
-        if (disabled) return
+        if (disabled || errored) return
         const rect = containerRef.current?.getBoundingClientRect()
         if (!rect) return
         setHover({
@@ -62,6 +73,23 @@ export function MapCanvas({
     }
 
     const aspectRatio = widthPx > 0 && heightPx > 0 ? `${widthPx} / ${heightPx}` : '16 / 9'
+
+    if (errored) {
+        return (
+            <div
+                style={{ aspectRatio }}
+                className={cn(
+                    'relative w-full rounded-lg border border-dashed bg-muted/30 flex flex-col items-center justify-center gap-2 px-4 text-center text-xs text-muted-foreground',
+                    className,
+                )}
+                role="img"
+                aria-label={t('geo.daily.mapUnavailable', 'Map unavailable')}
+            >
+                <ImageOff className="h-6 w-6 opacity-60" aria-hidden />
+                <span>{t('geo.daily.mapUnavailable', 'Map unavailable')}</span>
+            </div>
+        )
+    }
 
     return (
         <div
@@ -78,6 +106,16 @@ export function MapCanvas({
             role={disabled ? 'img' : 'button'}
             aria-label="Pin location on the map"
         >
+            {/* Hidden probe so we can detect a 404 on the background image,
+                which CSS background-image cannot signal. */}
+            <img
+                src={imageUrl}
+                alt=""
+                className="hidden"
+                onError={() => setErrored(true)}
+                aria-hidden
+            />
+
             {/* Crosshair at hover position */}
             {!disabled && hover && (
                 <Crosshair x={hover.x} y={hover.y} faint />

--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
     ImageOverlay,
     MapContainer,
@@ -8,8 +9,10 @@ import {
 } from 'react-leaflet'
 import L, { CRS, type LatLngBoundsExpression, type LatLngExpression } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
+import { ImageOff } from 'lucide-react'
 import type { GeoPoint } from '@the-box/types'
 import { cn } from '@/lib/utils'
+import { isPlaceholderImageUrl } from '@/lib/geo-image'
 import type { MapCanvasProps } from './MapCanvas'
 
 // Leaflet-based map canvas. Same public API as MapCanvas so the pages are
@@ -45,6 +48,7 @@ export function MapCanvasLeaflet({
     className,
     showGuessLine,
 }: MapCanvasProps) {
+    const { t } = useTranslation()
     // CRS.Simple: y=0 at top, +y downward in our normalized space; Leaflet's
     // default Simple CRS has +y upward. Flip y at the conversion boundary.
     const bounds: LatLngBoundsExpression = useMemo(
@@ -55,14 +59,47 @@ export function MapCanvasLeaflet({
         [widthPx, heightPx],
     )
 
+    // See MapCanvas.tsx for the rationale: placeholder URLs may load OK, real
+    // 404s won't surface through Leaflet's ImageOverlay, so probe with a hidden
+    // <img> in addition to the proactive placeholder check.
+    const [errored, setErrored] = useState(() => isPlaceholderImageUrl(imageUrl))
+
+    useEffect(() => {
+        setErrored(isPlaceholderImageUrl(imageUrl))
+    }, [imageUrl])
+
     const pinLatLng = pointToLatLng(pin, widthPx, heightPx)
     const canonicalLatLng = pointToLatLng(canonical, widthPx, heightPx)
+
+    if (errored) {
+        return (
+            <div
+                className={cn(
+                    'relative w-full rounded-lg border border-dashed bg-muted/30 flex flex-col items-center justify-center gap-2 px-4 text-center text-xs text-muted-foreground',
+                    className,
+                )}
+                style={{ aspectRatio: `${widthPx} / ${heightPx}` }}
+                role="img"
+                aria-label={t('geo.daily.mapUnavailable', 'Map unavailable')}
+            >
+                <ImageOff className="h-6 w-6 opacity-60" aria-hidden />
+                <span>{t('geo.daily.mapUnavailable', 'Map unavailable')}</span>
+            </div>
+        )
+    }
 
     return (
         <div
             className={cn('w-full overflow-hidden rounded-lg', className)}
             style={{ aspectRatio: `${widthPx} / ${heightPx}` }}
         >
+            <img
+                src={imageUrl}
+                alt=""
+                className="hidden"
+                onError={() => setErrored(true)}
+                aria-hidden
+            />
             <MapContainer
                 crs={CRS.Simple}
                 bounds={bounds}

--- a/packages/frontend/src/lib/geo-image.ts
+++ b/packages/frontend/src/lib/geo-image.ts
@@ -1,0 +1,15 @@
+// Mirror of the backend's PLACEHOLDER_URL_PATTERNS in
+// packages/backend/src/domain/services/geo-game.service.ts. Keep both lists in
+// sync — the backend refuses to *serve* these URLs, the frontend refuses to
+// *render* them in case a stale row sneaks through (cached responses, mocked
+// API mode, etc.).
+const PLACEHOLDER_URL_PATTERNS: RegExp[] = [
+    /(^|\/\/)placehold\.co\//i,
+    /(^|\/\/)via\.placeholder\.com\//i,
+    /\/map-placeholder\.(jpg|jpeg|png|webp)(\?|$)/i,
+]
+
+export function isPlaceholderImageUrl(url: string | null | undefined): boolean {
+    if (!url) return true
+    return PLACEHOLDER_URL_PATTERNS.some((p) => p.test(url))
+}

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -8,7 +8,8 @@ import { ReportCaptureDialog } from '@/components/ReportCaptureDialog'
 import { CubeBackground } from '@/components/backgrounds/CubeBackground'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Loader2, MapPin, Trophy } from 'lucide-react'
+import { ImageOff, Loader2, MapPin, Trophy } from 'lucide-react'
+import { isPlaceholderImageUrl } from '@/lib/geo-image'
 
 function todayIso(): string {
     return new Date().toISOString().slice(0, 10)
@@ -179,11 +180,20 @@ function ResultBlock({
 
 function ScreenshotFrame({ imageUrl }: { imageUrl: string }) {
     const { t } = useTranslation()
-    const [errored, setErrored] = useState(false)
+    // Proactively flag known placeholder hosts (placehold.co etc.) — they
+    // *successfully* load a real image and would otherwise sneak past the
+    // onError fallback as a fake-looking screenshot.
+    const [errored, setErrored] = useState(() => isPlaceholderImageUrl(imageUrl))
+
+    useEffect(() => {
+        setErrored(isPlaceholderImageUrl(imageUrl))
+    }, [imageUrl])
+
     if (errored) {
         return (
-            <div className="aspect-video w-full rounded-lg border bg-muted/30 flex items-center justify-center text-xs text-muted-foreground">
-                {t('geo.daily.screenshotUnavailable', 'Screenshot preview unavailable.')}
+            <div className="aspect-video w-full rounded-lg border border-dashed bg-muted/30 flex flex-col items-center justify-center gap-2 text-xs text-muted-foreground">
+                <ImageOff className="h-6 w-6 opacity-60" aria-hidden />
+                <span>{t('geo.daily.screenshotUnavailable', 'Screenshot preview unavailable.')}</span>
             </div>
         )
     }


### PR DESCRIPTION
The dev seed (`seeds/010_geo_elden_ring.ts`) inserts placehold.co
screenshots and a non-existent Fandom map-placeholder URL. When that
data leaks into a deployment that isn't flagged NODE_ENV=production,
the daily challenge silently rendered a placeholder image as the
"screenshot" and a broken-image icon for the map.

- Refuse to serve a daily challenge whose candidate or map image points
  at a known placeholder host (placehold.co, via.placeholder.com,
  *map-placeholder.{jpg,png,...}). The route already returns 404 +
  NO_CHALLENGE on null, which the frontend renders as the existing
  "no challenge available" message.
- Mirror the same patterns in the frontend (lib/geo-image.ts) and have
  ScreenshotFrame, MapCanvas, and MapCanvasLeaflet show a clear
  "unavailable" fallback when imageUrl matches a placeholder or a real
  load error fires. The CSS background-image map needs a hidden <img>
  probe to detect 404s, since background-image has no onError event.