### PR TITLE
fix(geo): refuse placeholder URLs + admin reset-scraping action

### DIFF
--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -35,6 +35,7 @@ import {
 import { resend } from '../../infrastructure/auth/auth.js'
 import { env } from '../../config/env.js'
 import { db } from '../../infrastructure/database/connection.js'
+import { routeLogger } from '../../infrastructure/logger/logger.js'
 import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
 import {
   geoScreenshotRepository,
@@ -2330,6 +2331,49 @@ router.post('/screenshot-reports/reactivate', async (req, res, next) => {
       screenshotId,
       geoScreenshotCandidateId,
     })
+    res.json({ success: true, data: result })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Wipes every piece of scraping progress + scraped data so the next run
+// starts from zero. Keeps operator curation choices (`games.geo_curated`)
+// and player-generated data (scores, leaderboards). User-visible impact:
+// the daily geo challenge will return NO_CHALLENGE until a new map is
+// imported and a challenge is scheduled.
+//
+// Cascade order matters here:
+//   - geo_challenge.geo_screenshot_meta_id is ON DELETE RESTRICT, so it must
+//     go first, otherwise the geo_map delete would fail when the cascade
+//     reaches geo_screenshot_meta.
+//   - geo_map cascades to geo_screenshot_candidate + geo_screenshot_meta,
+//     and those cascade to geo_pin / screenshot_reports.geo_* in turn.
+router.post('/scraping/reset', async (req, res, next) => {
+  try {
+    const result = await db.transaction(async (trx) => {
+      const importStates = await trx('import_states').delete()
+      const ingestFailures = await trx('geo_ingest_failure').delete()
+
+      await trx('games').update({
+        geo_metadata_status: 'pending',
+        geo_metadata_resolved_at: null,
+        wiki_subdomain: null,
+        wiki_page_title: null,
+        steam_app_id: null,
+        wikidata_qid: null,
+      })
+
+      const challenges = await trx('geo_challenge').delete()
+      const maps = await trx('geo_map').delete()
+
+      return { importStates, ingestFailures, challenges, maps }
+    })
+
+    routeLogger.warn(
+      { adminId: req.userId, ...result },
+      'admin reset scraping state from zero',
+    )
     res.json({ success: true, data: result })
   } catch (err) {
     next(err)

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -713,6 +713,25 @@
           "required": "Image URL, width, height, and license are required."
         },
         "success": "Manual map saved for \"{{name}}\"."
+      },
+      "reset": {
+        "title": "Danger zone — reset scraping",
+        "subtitle": "Wipes map and screenshot ingestion progress so the pipeline starts from zero. Curation flags (curated games) and player scores are kept.",
+        "cta": "Reset everything",
+        "success": "Scraping reset: {{importStates}} import states, {{ingestFailures}} failures, {{challenges}} geo challenges, {{maps}} maps deleted.",
+        "dialog": {
+          "title": "Confirm reset",
+          "body": "This action is irreversible. The daily geo challenge will return \"no challenge\" until a new map is imported and a challenge is scheduled.",
+          "bullets": {
+            "importStates": "Tracks every import state (RAWG: games, screenshots).",
+            "ingestFailures": "Clears ingestion failure tombstones (Fandom, Wikidata, Steam, registry).",
+            "maps": "Deletes every ingested map and its candidate screenshots.",
+            "challenges": "Deletes every scheduled geo challenge.",
+            "metadata": "Resets games' geo metadata to \"pending\" so the resolver re-runs."
+          },
+          "confirmLabel": "Type {{word}} to confirm",
+          "confirm": "Reset everything"
+        }
       }
     },
     "growth": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -713,6 +713,25 @@
           "required": "L'URL de l'image, la largeur, la hauteur et la licence sont obligatoires."
         },
         "success": "Carte manuelle enregistrée pour « {{name}} »."
+      },
+      "reset": {
+        "title": "Zone de danger — réinitialiser le scraping",
+        "subtitle": "Repart de zéro sur l'ingestion des cartes et captures. Les choix de curation (jeux activés) et les scores des joueurs sont conservés.",
+        "cta": "Tout réinitialiser",
+        "success": "Scraping réinitialisé : {{importStates}} états d'import, {{ingestFailures}} échecs, {{challenges}} défis géo, {{maps}} cartes supprimés.",
+        "dialog": {
+          "title": "Confirmer la réinitialisation",
+          "body": "Cette action est irréversible. Le défi géo quotidien renverra « aucun défi » jusqu'à ce qu'une nouvelle carte soit importée et qu'un défi soit programmé.",
+          "bullets": {
+            "importStates": "Suit tous les états d'import (RAWG : jeux, captures).",
+            "ingestFailures": "Efface les tombstones d'échec d'ingestion (Fandom, Wikidata, Steam, registry).",
+            "maps": "Supprime toutes les cartes ingérées et les captures candidates associées.",
+            "challenges": "Supprime tous les défis géo programmés.",
+            "metadata": "Remet les métadonnées géo des jeux à « pending » pour forcer une nouvelle résolution."
+          },
+          "confirmLabel": "Tapez {{word}} pour confirmer",
+          "confirm": "Réinitialiser tout"
+        }
       }
     },
     "growth": {

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -20,8 +20,10 @@ import {
     Clock,
     MinusCircle,
     Sparkles,
+    Trash2,
 } from 'lucide-react'
 import { GeoManualMapDialog } from './GeoManualMapDialog'
+import { ResetScrapingDialog } from './ResetScrapingDialog'
 
 // Per-game ingestion-state surface. Replaces the global metric-tile grid +
 // failures table from GeoAdminActions with a focused, drill-down table where
@@ -101,6 +103,8 @@ export function GeoMapsTab() {
     const [busyAction, setBusyAction] = useState<'reimport' | null>(null)
     const [message, setMessage] = useState<string | null>(null)
     const [manualUploadFor, setManualUploadFor] = useState<CuratedGame | null>(null)
+    const [resetOpen, setResetOpen] = useState(false)
+    const [resetting, setResetting] = useState(false)
 
     const reload = useCallback(async () => {
         setLoading(true)
@@ -168,9 +172,34 @@ export function GeoMapsTab() {
         void Promise.all([reload(), id !== undefined ? reloadSources(id) : Promise.resolve()])
     }
 
+    const handleResetScraping = async () => {
+        setResetting(true)
+        setMessage(null)
+        setError(null)
+        try {
+            const data = await fetchJson<{
+                importStates: number
+                ingestFailures: number
+                challenges: number
+                maps: number
+            }>('/api/admin/scraping/reset', { method: 'POST' })
+            setMessage(t('admin.geo.reset.success', data))
+            setResetOpen(false)
+            // Side panel referenced rows that no longer exist.
+            setSelectedId(null)
+            setSources(null)
+            await reload()
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setResetting(false)
+        }
+    }
+
     const selectedGame = games?.find((g) => g.id === selectedId) ?? null
 
     return (
+        <div className="space-y-4">
         <div className="grid gap-3 sm:gap-4 grid-cols-1 lg:grid-cols-5">
             {/* Left: per-game table */}
             <Card className="lg:col-span-3">
@@ -356,6 +385,45 @@ export function GeoMapsTab() {
                 }
                 onSuccess={onManualSuccess}
             />
+        </div>
+
+        {/* Danger zone: wipes scraping progress + scraped maps so the
+            ingestion pipeline starts from zero. Curation flags
+            (games.geo_curated) and player scores are preserved. */}
+        <Card className="border-destructive/40 bg-destructive/5">
+            <CardHeader className="pb-3">
+                <CardTitle className="text-sm flex items-center gap-2">
+                    <AlertTriangle className="h-4 w-4 text-destructive" aria-hidden />
+                    {t('admin.geo.reset.title')}
+                </CardTitle>
+                <CardDescription className="text-xs">
+                    {t('admin.geo.reset.subtitle')}
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setResetOpen(true)}
+                    disabled={resetting}
+                    className="gap-1.5"
+                >
+                    {resetting ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                        <Trash2 className="h-3.5 w-3.5" />
+                    )}
+                    {t('admin.geo.reset.cta')}
+                </Button>
+            </CardContent>
+        </Card>
+
+        <ResetScrapingDialog
+            isOpen={resetOpen}
+            onClose={() => setResetOpen(false)}
+            onConfirm={handleResetScraping}
+            isLoading={resetting}
+        />
         </div>
     )
 }

--- a/packages/frontend/src/components/admin/ResetScrapingDialog.tsx
+++ b/packages/frontend/src/components/admin/ResetScrapingDialog.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+
+interface ResetScrapingDialogProps {
+    isOpen: boolean
+    onClose: () => void
+    onConfirm: () => Promise<void> | void
+    isLoading?: boolean
+}
+
+// Word the operator must type to enable the destructive button. Kept as a
+// constant (not translated) so it's identical regardless of UI language —
+// muscle-memory across languages, and easier to grep for in audit logs.
+const CONFIRM_WORD = 'RESET'
+
+export function ResetScrapingDialog({
+    isOpen,
+    onClose,
+    onConfirm,
+    isLoading = false,
+}: ResetScrapingDialogProps) {
+    const { t } = useTranslation()
+    const [typed, setTyped] = useState('')
+
+    const handleClose = () => {
+        if (isLoading) return
+        setTyped('')
+        onClose()
+    }
+
+    const canConfirm = typed === CONFIRM_WORD && !isLoading
+
+    return (
+        <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+            <DialogContent className="max-w-sm sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <AlertTriangle className="h-5 w-5 text-destructive" />
+                        {t('admin.geo.reset.dialog.title')}
+                    </DialogTitle>
+                    <DialogDescription>
+                        {t('admin.geo.reset.dialog.body')}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <ul className="text-xs text-muted-foreground list-disc pl-5 space-y-1">
+                    <li>{t('admin.geo.reset.dialog.bullets.importStates')}</li>
+                    <li>{t('admin.geo.reset.dialog.bullets.ingestFailures')}</li>
+                    <li>{t('admin.geo.reset.dialog.bullets.maps')}</li>
+                    <li>{t('admin.geo.reset.dialog.bullets.challenges')}</li>
+                    <li>{t('admin.geo.reset.dialog.bullets.metadata')}</li>
+                </ul>
+
+                <div className="space-y-2">
+                    <Label htmlFor="reset-confirm-input" className="text-xs">
+                        {t('admin.geo.reset.dialog.confirmLabel', { word: CONFIRM_WORD })}
+                    </Label>
+                    <Input
+                        id="reset-confirm-input"
+                        value={typed}
+                        onChange={(e) => setTyped(e.target.value)}
+                        placeholder={CONFIRM_WORD}
+                        autoComplete="off"
+                        autoCapitalize="characters"
+                        spellCheck={false}
+                        disabled={isLoading}
+                    />
+                </div>
+
+                <DialogFooter className="flex flex-col-reverse sm:flex-row gap-2">
+                    <Button
+                        variant="outline"
+                        onClick={handleClose}
+                        disabled={isLoading}
+                        className="w-full sm:w-auto"
+                    >
+                        {t('common.cancel')}
+                    </Button>
+                    <Button
+                        variant="destructive"
+                        onClick={() => void onConfirm()}
+                        disabled={!canConfirm}
+                        className="w-full sm:w-auto"
+                    >
+                        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+                        {t('admin.geo.reset.dialog.confirm')}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}


### PR DESCRIPTION
## Summary

Two related changes around the geo daily challenge data pipeline.

### 1. Refuse placeholder image URLs (commit `b7c2528`)

The dev seed (`seeds/010_geo_elden_ring.ts`) inserts `placehold.co` screenshots and a non-existent `nocookie.net/eldenring/images/map-placeholder.jpg` map. When that data leaks into a deployment that isn't flagged `NODE_ENV=production`, the daily challenge silently rendered a placeholder image as the "screenshot" and a broken-image icon for the map (visible at `the-box.battistella.ovh/fr/geo/daily`).

- Backend `geo-game.service.ts` now refuses to serve a daily challenge whose candidate or map image points at a known placeholder host (`placehold.co`, `via.placeholder.com`, `*map-placeholder.{jpg,png,…}`). Returns `null` → 404 `NO_CHALLENGE`, which the frontend already renders as the existing "no challenge available" message.
- Mirror patterns in `lib/geo-image.ts` so `ScreenshotFrame`, `MapCanvas`, and `MapCanvasLeaflet` show a clear "unavailable" fallback if a placeholder URL or a real load error sneaks through (cached responses, mocked API mode, etc.). The CSS `background-image` map needs a hidden `<img>` probe to detect 404s.
- New i18n string `geo.daily.mapUnavailable` (FR + EN).

### 2. Admin "Reset scraping" action (commit `2ea0e4e`)

Adds a Danger zone in `Admin → Géo → Cartes` so an operator can wipe every piece of scraping progress + scraped geo data and start the ingestion pipeline from zero. Curation flags (`games.geo_curated`) and player-generated data (scores, leaderboards) are preserved.

**Backend** — `POST /api/admin/scraping/reset` (single transaction):
- delete every `import_states` row
- delete every `geo_ingest_failure` row
- reset `games.geo_metadata_status='pending'` + clear resolver outputs (`wiki_subdomain`, `wiki_page_title`, `steam_app_id`, `wikidata_qid`, `geo_metadata_resolved_at`)
- delete `geo_challenge` first (`ON DELETE RESTRICT` from `geo_screenshot_meta`), then `geo_map`. The map delete cascades through `geo_screenshot_candidate`, `geo_screenshot_meta`, `geo_pin`, and `screenshot_reports.geo_screenshot_candidate_id`.
- writes a warn-level audit log with the actor's `userId`.

**Frontend** — new `ResetScrapingDialog` requiring the operator to type `RESET` before the destructive button enables, plus a danger-zone card at the bottom of `GeoMapsTab`. New `admin.geo.reset.*` strings (FR + EN) including a per-bullet breakdown of what gets wiped.

## Test plan

- [ ] Visit `/fr/geo/daily` against a DB seeded with placeholder URLs → page now shows the existing "no challenge" message instead of a fake screenshot + broken map.
- [ ] If a placeholder URL slips into a candidate at runtime, `ScreenshotFrame` and `MapCanvas` both render the "unavailable" fallback.
- [ ] As admin: open Géo → Cartes → "Tout réinitialiser" → typed `RESET` → row counts reflect what was wiped, side panel clears, daily challenge subsequently returns `NO_CHALLENGE` until a new map ingestion + schedule runs.
- [ ] Curated games keep their `geo_curated=true` after reset; user scores in `geo_daily_score` / `geo_monthly_score` are untouched.

https://claude.ai/code/session_01Ee3CrJ992w9pCQXY9oF8uT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee3CrJ992w9pCQXY9oF8uT)_