### PR TITLE
feat(admin): manual run for geo scraping (all + per game) with live progress

### DIFF
--- a/packages/backend/src/infrastructure/queue/queues.ts
+++ b/packages/backend/src/infrastructure/queue/queues.ts
@@ -50,8 +50,8 @@ export type GeoJobData =
       maxItems?: number
     }
   | { kind: 'schedule-daily-challenge'; date?: string }
-  | { kind: 'resolve-metadata'; batchSize?: number }
-  | { kind: 'ingest-tick'; batchSize?: number }
+  | { kind: 'resolve-metadata'; batchSize?: number; gameId?: number }
+  | { kind: 'ingest-tick'; batchSize?: number; gameId?: number }
 
 export const geoQueue = new Queue<GeoJobData>('geo-jobs', {
   connection: redisConnectionOptions,

--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -45,7 +45,13 @@ export interface IngestTickResult {
  */
 export async function runGeoIngestTick(
   batchSize = DEFAULT_BATCH,
+  gameId?: number,
 ): Promise<IngestTickResult> {
+  // When `gameId` is set the tick runs only for that single game (and ignores
+  // the LIMIT). Used by the admin "Run for this game" button so an operator
+  // can replay the cascade for a specific row without scanning the catalog.
+  const params: Array<number | null> =
+    gameId === undefined ? [null, batchSize] : [gameId, null]
   const rows = await db
     .raw<{ rows: TickRow[] }>(
       `
@@ -73,10 +79,11 @@ export async function runGeoIngestTick(
       ) c ON c.game_id = g.id
       WHERE g.geo_curated = true
         AND g.geo_metadata_status = 'resolved'
+        AND (?::int IS NULL OR g.id = ?::int)
       ORDER BY g.id
-      LIMIT ?
+      LIMIT COALESCE(?::int, 2147483647)
       `,
-      [batchSize],
+      [params[0], params[0], params[1]],
     )
     .then((res) => (res as unknown as { rows: TickRow[] }).rows)
 

--- a/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
@@ -57,22 +57,29 @@ export interface ResolveMetadataResult {
  */
 export async function resolveGeoMetadataBatch(
   batchSize = 25,
+  gameId?: number,
 ): Promise<ResolveMetadataResult> {
-  const rows = await db<CuratedGameRow>('games')
-    .where('geo_curated', true)
-    .where('geo_metadata_status', 'pending')
-    .orderBy('id')
-    .limit(batchSize)
-    .select<CuratedGameRow[]>(
-      'id',
-      'name',
-      'slug',
-      'genres',
-      'steam_app_id',
-      'wiki_subdomain',
-      'wiki_page_title',
-      'wikidata_qid',
-    )
+  // When `gameId` is set we run the resolver for that single game regardless
+  // of its current `geo_metadata_status` — manual admin runs need to re-resolve
+  // a 'resolved' or 'unresolved' game without an extra round-trip to flip the
+  // column first. Batch (recurring) runs keep the 'pending' filter so already
+  // resolved games aren't re-resolved every tick.
+  const query = db<CuratedGameRow>('games').where('geo_curated', true)
+  if (gameId === undefined) {
+    query.where('geo_metadata_status', 'pending').orderBy('id').limit(batchSize)
+  } else {
+    query.where('id', gameId)
+  }
+  const rows = await query.select<CuratedGameRow[]>(
+    'id',
+    'name',
+    'slug',
+    'genres',
+    'steam_app_id',
+    'wiki_subdomain',
+    'wiki_page_title',
+    'wikidata_qid',
+  )
 
   let resolved = 0
   let unresolved = 0

--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -75,11 +75,11 @@ export const geoWorker = new Worker<GeoJobData>(
     }
 
     if (data.kind === 'resolve-metadata') {
-      return await resolveGeoMetadataBatch(data.batchSize)
+      return await resolveGeoMetadataBatch(data.batchSize, data.gameId)
     }
 
     if (data.kind === 'ingest-tick') {
-      return await runGeoIngestTick(data.batchSize)
+      return await runGeoIngestTick(data.batchSize, data.gameId)
     }
 
     throw new Error(`unknown geo job kind: ${JSON.stringify(data)}`)

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -47,7 +47,7 @@ import {
 } from '../../infrastructure/repositories/index.js'
 import { GEO_CONSENSUS_VERSION } from '../../domain/services/index.js'
 import { isMapEligibleByGenre } from '../../domain/services/geo-metadata.service.js'
-import { geoQueue } from '../../infrastructure/queue/queues.js'
+import { geoQueue, type GeoJobData } from '../../infrastructure/queue/queues.js'
 import { findRegistryEntryBySlug } from '../../infrastructure/queue/workers/geo-registry-import-logic.js'
 
 // Cap even admin-triggered sends so a mistake or compromised admin
@@ -2142,6 +2142,139 @@ router.post('/geo/reimport', async (req, res, next) => {
       batchSize: 1,
     })
     res.json({ success: true, data: { jobId: job.id } })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Manual run-now triggers for the whole geo ingestion pipeline. The recurring
+// resolver + tick workers already run on a schedule; these endpoints just
+// short-circuit the wait so an operator can kick off a fresh pass immediately
+// after curating games or after a reset. Both jobs are idempotent — clicking
+// twice is harmless because the per-tier importers short-circuit on existing
+// rows.
+router.post('/geo/run', async (_req, res, next) => {
+  try {
+    // Large batch sizes so a single click sweeps the whole curated set.
+    const resolveJob = await geoQueue.add('resolve-metadata', {
+      kind: 'resolve-metadata',
+      batchSize: 500,
+    })
+    const tickJob = await geoQueue.add('ingest-tick', {
+      kind: 'ingest-tick',
+      batchSize: 500,
+    })
+    res.json({
+      success: true,
+      data: { resolveJobId: resolveJob.id, tickJobId: tickJob.id },
+    })
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.post('/geo/run/:gameId', async (req, res, next) => {
+  try {
+    const gameId = Number(req.params.gameId)
+    if (!Number.isFinite(gameId) || gameId <= 0) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+    // Stable jobIds so a double-click while one is still in flight collapses
+    // to a single run. BullMQ silently no-ops on duplicate ids.
+    const resolveJob = await geoQueue.add(
+      'resolve-metadata',
+      { kind: 'resolve-metadata', batchSize: 1, gameId },
+      { jobId: `manual-resolve:${gameId}` },
+    )
+    const tickJob = await geoQueue.add(
+      'ingest-tick',
+      { kind: 'ingest-tick', batchSize: 1, gameId },
+      { jobId: `manual-tick:${gameId}` },
+    )
+    res.json({
+      success: true,
+      data: { gameId, resolveJobId: resolveJob.id, tickJobId: tickJob.id },
+    })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Live-progress feed for the manual run UI. Returns active/waiting/delayed
+// geo jobs grouped by gameId so the maps tab can highlight which rows are
+// in flight at which tier. Polled at ~2s while a run is active.
+router.get('/geo/run/state', async (_req, res, next) => {
+  try {
+    const [active, waiting, delayed, counts] = await Promise.all([
+      geoQueue.getActive(0, 200),
+      geoQueue.getWaiting(0, 200),
+      geoQueue.getDelayed(0, 200),
+      geoQueue.getJobCounts(
+        'active',
+        'waiting',
+        'delayed',
+        'failed',
+        'completed',
+      ),
+    ])
+
+    const byGame: Record<
+      number,
+      Array<{ kind: GeoJobData['kind']; state: 'active' | 'waiting' | 'delayed' }>
+    > = {}
+    // Global (no-gameId) jobs surfaced separately so the UI can show "batch
+    // resolver running" alongside per-game progress.
+    const globals: Array<{
+      kind: GeoJobData['kind']
+      state: 'active' | 'waiting' | 'delayed'
+    }> = []
+
+    const sweep = (
+      jobs: typeof active,
+      state: 'active' | 'waiting' | 'delayed',
+    ) => {
+      for (const job of jobs) {
+        const data = job.data as GeoJobData
+        // Skip noise jobs unrelated to the ingest pipeline.
+        if (
+          data.kind === 'evaluate-consensus' ||
+          data.kind === 'promote-contributor-tier'
+        ) {
+          continue
+        }
+        const gameId =
+          'gameId' in data && typeof data.gameId === 'number' ? data.gameId : null
+        if (gameId === null) {
+          globals.push({ kind: data.kind, state })
+          continue
+        }
+        ;(byGame[gameId] ??= []).push({ kind: data.kind, state })
+      }
+    }
+    sweep(active, 'active')
+    sweep(waiting, 'waiting')
+    sweep(delayed, 'delayed')
+
+    // BullMQ types each `JobCountsKeyType` as optional even though
+    // `getJobCounts` always returns the keys you asked for.
+    const safeCounts = {
+      active: counts.active ?? 0,
+      waiting: counts.waiting ?? 0,
+      delayed: counts.delayed ?? 0,
+      failed: counts.failed ?? 0,
+      completed: counts.completed ?? 0,
+    }
+    const inflight = safeCounts.active + safeCounts.waiting + safeCounts.delayed
+    res.json({
+      success: true,
+      data: {
+        isActive: inflight > 0,
+        counts: safeCounts,
+        byGame,
+        globals,
+      },
+    })
   } catch (err) {
     next(err)
   }

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -714,6 +714,26 @@
         },
         "success": "Manual map saved for \"{{name}}\"."
       },
+      "run": {
+        "allCta": "Run all",
+        "allTooltip": "Runs metadata resolution and ingestion for every curated game.",
+        "running": "Running…",
+        "allQueued": "Pipeline started for every curated game.",
+        "gameQueued": "Pipeline started for \"{{name}}\".",
+        "gameTooltip": "Run for this game",
+        "gameAria": "Run pipeline for {{name}}",
+        "inFlight": "Running",
+        "tierRunning": "Running",
+        "tierRunningHint": "Job queued or in flight — the live status will refresh in a few seconds.",
+        "banner": {
+          "active_one": "{{count}} job active",
+          "active_other": "{{count}} jobs active",
+          "waiting_one": "{{count}} waiting",
+          "waiting_other": "{{count}} waiting",
+          "failed_one": "{{count}} failed",
+          "failed_other": "{{count}} failed"
+        }
+      },
       "reset": {
         "title": "Danger zone — reset scraping",
         "subtitle": "Wipes map and screenshot ingestion progress so the pipeline starts from zero. Curation flags (curated games) and player scores are kept.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -714,6 +714,26 @@
         },
         "success": "Carte manuelle enregistrée pour « {{name}} »."
       },
+      "run": {
+        "allCta": "Tout lancer",
+        "allTooltip": "Lance la résolution des métadonnées et l'ingestion pour tous les jeux curatés.",
+        "running": "En cours…",
+        "allQueued": "Lancement de la pipeline pour tous les jeux curatés.",
+        "gameQueued": "Lancement de la pipeline pour « {{name}} ».",
+        "gameTooltip": "Lancer pour ce jeu",
+        "gameAria": "Lancer la pipeline pour {{name}}",
+        "inFlight": "En cours",
+        "tierRunning": "En cours",
+        "tierRunningHint": "Job en file ou en exécution — l'état réel se mettra à jour dans quelques secondes.",
+        "banner": {
+          "active_one": "{{count}} job actif",
+          "active_other": "{{count}} jobs actifs",
+          "waiting_one": "{{count}} en attente",
+          "waiting_other": "{{count}} en attente",
+          "failed_one": "{{count}} en échec",
+          "failed_other": "{{count}} en échec"
+        }
+      },
       "reset": {
         "title": "Zone de danger — réinitialiser le scraping",
         "subtitle": "Repart de zéro sur l'ingestion des cartes et captures. Les choix de curation (jeux activés) et les scores des joueurs sont conservés.",

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
     Card,
@@ -21,9 +21,17 @@ import {
     MinusCircle,
     Sparkles,
     Trash2,
+    Play,
+    Zap,
 } from 'lucide-react'
 import { GeoManualMapDialog } from './GeoManualMapDialog'
 import { ResetScrapingDialog } from './ResetScrapingDialog'
+import {
+    isGameInFlight,
+    tiersInFlightForGame,
+    useGeoRunPolling,
+    type GeoRunStatePayload,
+} from '@/hooks/useGeoRunPolling'
 
 // Per-game ingestion-state surface. Replaces the global metric-tile grid +
 // failures table from GeoAdminActions with a focused, drill-down table where
@@ -105,6 +113,9 @@ export function GeoMapsTab() {
     const [manualUploadFor, setManualUploadFor] = useState<CuratedGame | null>(null)
     const [resetOpen, setResetOpen] = useState(false)
     const [resetting, setResetting] = useState(false)
+    const [runningAll, setRunningAll] = useState(false)
+    const [runningGameId, setRunningGameId] = useState<number | null>(null)
+    const { state: runState, error: runError, arm: armRunPolling } = useGeoRunPolling()
 
     const reload = useCallback(async () => {
         setLoading(true)
@@ -172,6 +183,48 @@ export function GeoMapsTab() {
         void Promise.all([reload(), id !== undefined ? reloadSources(id) : Promise.resolve()])
     }
 
+    // Auto-refresh the games list once a run finishes — a game flipping from
+    // 'pending' → 'resolved' or gaining `hasMap` is invisible until we re-fetch.
+    const wasActiveRef = useRef(false)
+    useEffect(() => {
+        const active = runState?.isActive ?? false
+        if (wasActiveRef.current && !active) {
+            void reload()
+            if (selectedId !== null) void reloadSources(selectedId)
+        }
+        wasActiveRef.current = active
+    }, [runState?.isActive, reload, reloadSources, selectedId])
+
+    const handleRunAll = async () => {
+        setRunningAll(true)
+        setMessage(null)
+        setError(null)
+        try {
+            await fetchJson('/api/admin/geo/run', { method: 'POST' })
+            setMessage(t('admin.geo.run.allQueued'))
+            armRunPolling()
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setRunningAll(false)
+        }
+    }
+
+    const handleRunGame = async (game: CuratedGame) => {
+        setRunningGameId(game.id)
+        setMessage(null)
+        setError(null)
+        try {
+            await fetchJson(`/api/admin/geo/run/${game.id}`, { method: 'POST' })
+            setMessage(t('admin.geo.run.gameQueued', { name: game.name }))
+            armRunPolling()
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setRunningGameId(null)
+        }
+    }
+
     const handleResetScraping = async () => {
         setResetting(true)
         setMessage(null)
@@ -213,19 +266,42 @@ export function GeoMapsTab() {
                                 {t('admin.geo.maps.subtitle')}
                             </CardDescription>
                         </div>
-                        <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() => void reload()}
-                            disabled={loading}
-                            aria-label={t('admin.geo.maps.refresh')}
-                            className="h-7 w-7 p-0"
-                        >
-                            <RefreshCw
-                                className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`}
-                            />
-                        </Button>
+                        <div className="flex items-center gap-1">
+                            <Button
+                                size="sm"
+                                variant="default"
+                                onClick={() => void handleRunAll()}
+                                disabled={runningAll || runState?.isActive}
+                                className="h-7 gap-1.5 text-xs"
+                                title={t('admin.geo.run.allTooltip')}
+                            >
+                                {runningAll || runState?.isActive ? (
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                ) : (
+                                    <Zap className="h-3.5 w-3.5" />
+                                )}
+                                {runState?.isActive
+                                    ? t('admin.geo.run.running')
+                                    : t('admin.geo.run.allCta')}
+                            </Button>
+                            <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => void reload()}
+                                disabled={loading}
+                                aria-label={t('admin.geo.maps.refresh')}
+                                className="h-7 w-7 p-0"
+                            >
+                                <RefreshCw
+                                    className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`}
+                                />
+                            </Button>
+                        </div>
                     </div>
+                    <RunStateBanner state={runState} t={t} />
+                    {runError && (
+                        <p className="text-[11px] text-destructive">{runError}</p>
+                    )}
                 </CardHeader>
                 <CardContent className="p-0">
                     {message && (
@@ -244,7 +320,10 @@ export function GeoMapsTab() {
                         </div>
                     ) : games && games.length > 0 ? (
                         <ul className="divide-y divide-border/40">
-                            {games.map((g) => (
+                            {games.map((g) => {
+                                const inflight = isGameInFlight(runState, g.id)
+                                const isThisRunning = runningGameId === g.id
+                                return (
                                 <li
                                     key={g.id}
                                     className={`px-4 py-2.5 text-xs cursor-pointer transition-colors ${
@@ -258,10 +337,42 @@ export function GeoMapsTab() {
                                         <span className="font-medium truncate">
                                             {g.name}
                                         </span>
-                                        <MapStatusBadge game={g} t={t} />
+                                        <div className="flex items-center gap-1.5 shrink-0">
+                                            {inflight && (
+                                                <Badge
+                                                    variant="outline"
+                                                    className="gap-1 text-[10px] px-1.5 py-0 border-neon-pink/40 text-neon-pink"
+                                                >
+                                                    <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                                                    {t('admin.geo.run.inFlight')}
+                                                </Badge>
+                                            )}
+                                            <MapStatusBadge game={g} t={t} />
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                disabled={isThisRunning || inflight}
+                                                onClick={(e) => {
+                                                    e.stopPropagation()
+                                                    void handleRunGame(g)
+                                                }}
+                                                aria-label={t('admin.geo.run.gameAria', {
+                                                    name: g.name,
+                                                })}
+                                                title={t('admin.geo.run.gameTooltip')}
+                                                className="h-6 w-6 p-0"
+                                            >
+                                                {isThisRunning ? (
+                                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                                ) : (
+                                                    <Play className="h-3 w-3" />
+                                                )}
+                                            </Button>
+                                        </div>
                                     </div>
                                 </li>
-                            ))}
+                                )
+                            })}
                         </ul>
                     ) : (
                         <p className="px-4 py-6 text-xs text-muted-foreground">
@@ -339,9 +450,30 @@ export function GeoMapsTab() {
                                 </a>
                             )}
                             <ol className="space-y-2">
-                                {sources.sources.map((s) => (
-                                    <TierRow key={s.tier} state={s} t={t} />
-                                ))}
+                                {sources.sources.map((s) => {
+                                    const tiers = tiersInFlightForGame(
+                                        runState,
+                                        sources.gameId,
+                                    )
+                                    // 'manual' is operator-uploaded, never a
+                                    // background job — never flag it running.
+                                    const running =
+                                        s.tier !== 'manual' &&
+                                        tiers.has(
+                                            s.tier as
+                                                | 'registry'
+                                                | 'fandom'
+                                                | 'wikidata',
+                                        )
+                                    return (
+                                        <TierRow
+                                            key={s.tier}
+                                            state={s}
+                                            t={t}
+                                            running={running}
+                                        />
+                                    )
+                                })}
                             </ol>
                             <div className="flex flex-col gap-2 border-t border-border/40 pt-3 sm:flex-row">
                                 <Button
@@ -462,11 +594,35 @@ function MapStatusBadge({
 function TierRow({
     state,
     t,
+    running,
 }: {
     state: TierState
     t: ReturnType<typeof useTranslation>['t']
+    running?: boolean
 }) {
     const tierLabel = t(`admin.geo.maps.tiers.${state.tier}`)
+
+    // While this tier's job is in flight, override status visuals with a
+    // "running" badge so the operator sees live movement instead of a stale
+    // matched/eligible/tombstoned label.
+    if (running) {
+        return (
+            <li className="rounded border border-neon-pink/40 bg-neon-pink/5 p-2.5 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium flex items-center gap-1.5">
+                        <Loader2 className="h-3 w-3 animate-spin text-neon-pink" aria-hidden />
+                        {tierLabel}
+                    </span>
+                    <span className="text-[10px] uppercase tracking-wide text-neon-pink">
+                        {t('admin.geo.run.tierRunning')}
+                    </span>
+                </div>
+                <p className="pt-1 text-[11px] text-muted-foreground leading-snug">
+                    {t('admin.geo.run.tierRunningHint')}
+                </p>
+            </li>
+        )
+    }
 
     if (state.status === 'matched') {
         return (
@@ -564,5 +720,34 @@ function TierRow({
                 </p>
             )}
         </li>
+    )
+}
+
+// Compact summary line that shows BullMQ in-flight counts during a manual
+// run. Hidden while the queue is idle so it doesn't clutter the header.
+function RunStateBanner({
+    state,
+    t,
+}: {
+    state: GeoRunStatePayload | null
+    t: ReturnType<typeof useTranslation>['t']
+}) {
+    if (!state || !state.isActive) return null
+    const { active, waiting, delayed, failed } = state.counts
+    return (
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px]">
+            <span className="inline-flex items-center gap-1 text-neon-pink">
+                <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+                {t('admin.geo.run.banner.active', { count: active })}
+            </span>
+            <span className="text-muted-foreground">
+                · {t('admin.geo.run.banner.waiting', { count: waiting + delayed })}
+            </span>
+            {failed > 0 && (
+                <span className="text-destructive">
+                    · {t('admin.geo.run.banner.failed', { count: failed })}
+                </span>
+            )}
+        </div>
     )
 }

--- a/packages/frontend/src/hooks/useGeoRunPolling.ts
+++ b/packages/frontend/src/hooks/useGeoRunPolling.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// Job kinds we care to surface in the manual-run progress UI. Mirrors the
+// backend's GeoJobData.kind minus consensus/promote-tier (those are unrelated
+// to the ingestion pipeline and the route already filters them out).
+export type GeoRunJobKind =
+    | 'resolve-metadata'
+    | 'ingest-tick'
+    | 'import-registry-map'
+    | 'import-fandom-map'
+    | 'import-wikidata-map'
+    | 'import-steam-screenshots'
+    | 'schedule-daily-challenge'
+
+export type GeoRunJobState = 'active' | 'waiting' | 'delayed'
+
+export interface GeoRunJob {
+    kind: GeoRunJobKind
+    state: GeoRunJobState
+}
+
+export interface GeoRunStatePayload {
+    isActive: boolean
+    counts: {
+        active: number
+        waiting: number
+        delayed: number
+        failed: number
+        completed: number
+    }
+    byGame: Record<number, GeoRunJob[]>
+    globals: GeoRunJob[]
+}
+
+export interface UseGeoRunPolling {
+    state: GeoRunStatePayload | null
+    error: string | null
+    /**
+     * Force a poll burst for at least `windowMs` (default 5s). Covers the
+     * lag between enqueue and the first time a fresh job shows up in
+     * BullMQ's active/waiting sets.
+     */
+    arm: (windowMs?: number) => void
+}
+
+const DEFAULT_INTERVAL_MS = 2000
+const ARM_FLOOR_MS = 5000
+
+async function fetchState(): Promise<GeoRunStatePayload> {
+    const res = await fetch('/api/admin/geo/run/state', { credentials: 'include' })
+    const json = await res.json().catch(() => ({}))
+    if (!res.ok || !json?.success) {
+        throw new Error(json?.error?.code ?? `request failed: ${res.status}`)
+    }
+    return json.data as GeoRunStatePayload
+}
+
+/**
+ * Poll while either:
+ *  - the most recent response said `isActive=true`, or
+ *  - `arm()` was called within the last `armWindowMs`.
+ *
+ * Stops on its own when both go false to avoid hammering the endpoint
+ * during quiet periods.
+ */
+export function useGeoRunPolling(intervalMs = DEFAULT_INTERVAL_MS): UseGeoRunPolling {
+    const [state, setState] = useState<GeoRunStatePayload | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    // Mutable refs so the interval callback always reads the latest values.
+    const armedUntilRef = useRef<number>(0)
+    const isActiveRef = useRef<boolean>(false)
+    // Bumping this nudges the polling effect to (re)start the interval after
+    // arm() — needed because arm() doesn't change any reactive state.
+    const [pollNonce, setPollNonce] = useState(0)
+
+    useEffect(() => {
+        isActiveRef.current = state?.isActive ?? false
+    }, [state?.isActive])
+
+    useEffect(() => {
+        let cancelled = false
+        const tick = async () => {
+            try {
+                const data = await fetchState()
+                if (cancelled) return
+                setState(data)
+                setError(null)
+            } catch (e) {
+                if (cancelled) return
+                setError(String(e))
+            }
+        }
+
+        const shouldPoll = () =>
+            Date.now() < armedUntilRef.current || isActiveRef.current
+
+        if (!shouldPoll()) return undefined
+
+        // Fire once immediately so the UI updates without waiting `intervalMs`.
+        void tick()
+        const id = window.setInterval(() => {
+            if (!shouldPoll()) {
+                window.clearInterval(id)
+                return
+            }
+            void tick()
+        }, intervalMs)
+
+        return () => {
+            cancelled = true
+            window.clearInterval(id)
+        }
+    }, [intervalMs, pollNonce, state?.isActive])
+
+    const arm = useCallback((windowMs = ARM_FLOOR_MS) => {
+        armedUntilRef.current = Date.now() + windowMs
+        setPollNonce((n) => n + 1)
+    }, [])
+
+    return { state, error, arm }
+}
+
+// Helper: which tiers are currently in flight for a given game. Maps the
+// per-source job kinds to the tier labels the maps tab already uses.
+export function tiersInFlightForGame(
+    state: GeoRunStatePayload | null,
+    gameId: number,
+): Set<'registry' | 'fandom' | 'wikidata' | 'steam' | 'metadata' | 'tick'> {
+    const out = new Set<
+        'registry' | 'fandom' | 'wikidata' | 'steam' | 'metadata' | 'tick'
+    >()
+    const jobs = state?.byGame[gameId]
+    if (!jobs) return out
+    for (const job of jobs) {
+        if (job.kind === 'import-registry-map') out.add('registry')
+        else if (job.kind === 'import-fandom-map') out.add('fandom')
+        else if (job.kind === 'import-wikidata-map') out.add('wikidata')
+        else if (job.kind === 'import-steam-screenshots') out.add('steam')
+        else if (job.kind === 'resolve-metadata') out.add('metadata')
+        else if (job.kind === 'ingest-tick') out.add('tick')
+    }
+    return out
+}
+
+export function isGameInFlight(
+    state: GeoRunStatePayload | null,
+    gameId: number,
+): boolean {
+    return (state?.byGame[gameId]?.length ?? 0) > 0
+}


### PR DESCRIPTION
Adds an admin trigger to kick the geo ingestion pipeline immediately
without waiting for the recurring tick, plus a polling-based progress
feed in the existing Maps tab.

Backend
- POST /api/admin/geo/run — enqueues `resolve-metadata` (batchSize: 500)
  + `ingest-tick` (batchSize: 500). Both jobs are idempotent, so a
  double-click is harmless.
- POST /api/admin/geo/run/:gameId — same flow scoped to one game. Stable
  jobIds (`manual-resolve:<id>`, `manual-tick:<id>`) so a second click
  while a run is in flight collapses to a single execution.
- GET /api/admin/geo/run/state — returns BullMQ active/waiting/delayed
  jobs grouped by gameId (plus a `globals` bucket for non-game jobs)
  and full queue counts. Powers the live progress UI.
- `resolveGeoMetadataBatch(batchSize, gameId?)` and
  `runGeoIngestTick(batchSize, gameId?)` accept an optional gameId.
  When set, the SQL filters to that single game and ignores the
  `geo_metadata_status='pending'`/'resolved' gating so a manual run
  always re-runs.

Frontend
- New `useGeoRunPolling` hook polls every 2s while either the most
  recent state was active or arm() was called within the last 5s,
  and stops automatically afterwards.
- GeoMapsTab gets:
  - "Run all" button in the table header (disabled while a run is in
    flight; turns into a "Running…" spinner).
  - Per-row Play button to run a single game.
  - "Running" badge next to a row when any of its tier jobs is in
    flight.
  - Per-tier "Running" overlay on TierRow that supersedes the
    matched/eligible/tombstoned label while a job is queued/active.
  - Compact RunStateBanner under the table header showing in-flight
    BullMQ counts (active / waiting / failed) while a run is active.
  - Auto-reload of the games list + selected game's sources when a
    run flips from active → idle.

i18n
- New `admin.geo.run.*` keys (FR + EN), including pluralized banner
  counts.