### PR TITLE
fix(i18n): translate hardcoded UI strings and improve French cognates

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -36,6 +36,9 @@
     "activeFilters": "Active filters",
     "clearAll": "Clear all",
     "earned": "Earned",
+    "menu": "Menu",
+    "toggleMenu": "Toggle menu",
+    "toggleDetails": "Toggle details",
     "rankBadge": {
       "first": "1st place",
       "second": "2nd place",
@@ -101,6 +104,7 @@
       "next": "Next screenshot"
     },
     "screenshots": "screenshots",
+    "screenshotPlaceholder": "Screenshot will appear here",
     "round": "Round",
     "score": "Score",
     "time": "Time",
@@ -921,12 +925,15 @@
         "releaseYear": "Release Year",
         "metacritic": "Metascore",
         "developer": "Developer",
+        "developerPlaceholder": "Studio Name",
         "publisher": "Publisher",
+        "publisherPlaceholder": "Publisher Name",
         "genres": "Genres",
         "genresPlaceholder": "Action, RPG, ...",
         "platforms": "Platforms",
         "platformsPlaceholder": "PC, PlayStation, ...",
-        "coverImageUrl": "Cover Image URL"
+        "coverImageUrl": "Cover Image URL",
+        "coverPreviewAlt": "Cover preview"
       },
       "messages": {
         "created": "Game created successfully",
@@ -1200,6 +1207,12 @@
       "achievements": "Start playing to unlock achievements!",
       "achievementPoints": "Earn points by unlocking achievements!"
     },
+    "tooltips": {
+      "totalScoreDescription": "Sum of all your game scores",
+      "currentStreakDescription": "Consecutive days played",
+      "unlockedAchievementsTitle": "Unlocked achievements",
+      "earnedOfTotal": "{{earned}}/{{total}} achievements earned"
+    },
     "tabs": {
       "overview": "Overview",
       "achievements": "Achievements",
@@ -1331,6 +1344,11 @@
       "placeholder": "Tag screenshots to earn hint tokens and a Crowdsourcer tier.",
       "unlockLabel": "Contribute unlocks after",
       "unlockDays": "days played"
+    },
+    "map": {
+      "ariaPin": "Pin location on the map",
+      "labelYou": "You",
+      "labelActual": "Actual"
     }
   },
   "apiErrors": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -36,6 +36,9 @@
     "activeFilters": "Filtres actifs",
     "clearAll": "Tout effacer",
     "earned": "Obtenu",
+    "menu": "Menu",
+    "toggleMenu": "Ouvrir/fermer le menu",
+    "toggleDetails": "Afficher/masquer les détails",
     "rankBadge": {
       "first": "1re place",
       "second": "2e place",
@@ -101,7 +104,8 @@
       "next": "Capture suivante"
     },
     "screenshots": "captures",
-    "round": "Round",
+    "screenshotPlaceholder": "La capture apparaîtra ici",
+    "round": "Manche",
     "score": "Score",
     "time": "Temps",
     "guessPlaceholder": "Nom du jeu...",
@@ -421,7 +425,7 @@
   "admin": {
     "title": "Administration",
     "tabs": {
-      "import": "Import",
+      "import": "Importer",
       "jobs": "Tâches",
       "games": "Jeux",
       "challenges": "Défis",
@@ -884,12 +888,15 @@
         "releaseYear": "Année de sortie",
         "metacritic": "Metascore",
         "developer": "Développeur",
+        "developerPlaceholder": "Nom du studio",
         "publisher": "Éditeur",
+        "publisherPlaceholder": "Nom de l'éditeur",
         "genres": "Genres",
         "genresPlaceholder": "Action, RPG, ...",
         "platforms": "Plateformes",
         "platformsPlaceholder": "PC, PlayStation, ...",
-        "coverImageUrl": "URL de l'image de couverture"
+        "coverImageUrl": "URL de l'image de couverture",
+        "coverPreviewAlt": "Aperçu de la couverture"
       },
       "messages": {
         "created": "Jeu créé avec succès",
@@ -1200,6 +1207,12 @@
       "achievements": "Commencez à jouer pour débloquer des succès !",
       "achievementPoints": "Gagnez des points en débloquant des succès !"
     },
+    "tooltips": {
+      "totalScoreDescription": "Cumul de tous vos scores de jeu",
+      "currentStreakDescription": "Jours consécutifs de jeu",
+      "unlockedAchievementsTitle": "Succès débloqués",
+      "earnedOfTotal": "{{earned}}/{{total}} succès obtenus"
+    },
     "tabs": {
       "overview": "Aperçu",
       "achievements": "Succès",
@@ -1331,6 +1344,11 @@
       "placeholder": "Étiquetez des captures pour gagner des jetons et un palier Contributeur.",
       "unlockLabel": "Contribution débloquée après",
       "unlockDays": "jours joués"
+    },
+    "map": {
+      "ariaPin": "Épinglez l'emplacement sur la carte",
+      "labelYou": "Vous",
+      "labelActual": "Réel"
     }
   },
   "apiErrors": {

--- a/packages/frontend/src/components/admin/GameForm.tsx
+++ b/packages/frontend/src/components/admin/GameForm.tsx
@@ -259,7 +259,7 @@ export function GameForm({
                   <FormItem>
                     <FormLabel>{t('admin.games.form.developer')}</FormLabel>
                     <FormControl>
-                      <Input {...field} placeholder="Studio Name" disabled={isLoading} />
+                      <Input {...field} placeholder={t('admin.games.form.developerPlaceholder')} disabled={isLoading} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -272,7 +272,7 @@ export function GameForm({
                   <FormItem>
                     <FormLabel>{t('admin.games.form.publisher')}</FormLabel>
                     <FormControl>
-                      <Input {...field} placeholder="Publisher Name" disabled={isLoading} />
+                      <Input {...field} placeholder={t('admin.games.form.publisherPlaceholder')} disabled={isLoading} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -329,7 +329,7 @@ export function GameForm({
                       {field.value && !imageError ? (
                         <img
                           src={field.value}
-                          alt="Cover preview"
+                          alt={t('admin.games.form.coverPreviewAlt')}
                           className="w-full h-full object-cover"
                           onError={() => setImageError(true)}
                         />

--- a/packages/frontend/src/components/admin/JobList.tsx
+++ b/packages/frontend/src/components/admin/JobList.tsx
@@ -350,7 +350,7 @@ export function JobList() {
                                     className={`h-4 w-4 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''
                                       }`}
                                   />
-                                  <span className="sr-only">Toggle details</span>
+                                  <span className="sr-only">{t('common.toggleDetails')}</span>
                                 </Button>
                               </CollapsibleTrigger>
 

--- a/packages/frontend/src/components/game/ScreenshotViewer.tsx
+++ b/packages/frontend/src/components/game/ScreenshotViewer.tsx
@@ -161,7 +161,7 @@ export function ScreenshotViewer({
             exit={{ opacity: 0 }}
             className="absolute inset-0 flex items-center justify-center bg-linear-to-br from-neon-purple/20 to-neon-pink/20 z-20"
           >
-            <p className="text-muted-foreground">Screenshot will appear here</p>
+            <p className="text-muted-foreground">{t('game.screenshotPlaceholder')}</p>
           </motion.div>
         </AnimatePresence>
       )}

--- a/packages/frontend/src/components/geo/MapCanvas.tsx
+++ b/packages/frontend/src/components/geo/MapCanvas.tsx
@@ -104,7 +104,7 @@ export function MapCanvas({
                 className,
             )}
             role={disabled ? 'img' : 'button'}
-            aria-label="Pin location on the map"
+            aria-label={t('geo.map.ariaPin')}
         >
             {/* Hidden probe so we can detect a 404 on the background image,
                 which CSS background-image cannot signal. */}
@@ -127,11 +127,11 @@ export function MapCanvas({
             )}
 
             {/* User pin */}
-            {pin && <Marker x={pin.x} y={pin.y} color="fuchsia" label="You" />}
+            {pin && <Marker x={pin.x} y={pin.y} color="fuchsia" label={t('geo.map.labelYou')} />}
 
             {/* Canonical (revealed) */}
             {canonical && (
-                <Marker x={canonical.x} y={canonical.y} color="emerald" label="Actual" />
+                <Marker x={canonical.x} y={canonical.y} color="emerald" label={t('geo.map.labelActual')} />
             )}
         </div>
     )

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -120,14 +120,14 @@ export function Header() {
         <div className="flex md:hidden">
           <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="sm" aria-label="Toggle menu">
+              <Button variant="ghost" size="sm" aria-label={t('common.toggleMenu')}>
                 <Menu className="h-5 w-5" />
-                <span className="sr-only">Toggle menu</span>
+                <span className="sr-only">{t('common.toggleMenu')}</span>
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="w-[280px] sm:w-[320px]">
               <SheetHeader>
-                <SheetTitle className="text-left">Menu</SheetTitle>
+                <SheetTitle className="text-left">{t('common.menu')}</SheetTitle>
               </SheetHeader>
               <div className="flex flex-col gap-2 mt-6">
                 <NavigationLinks isMobile={true} t={t} localizedPath={localizedPath} onMobileClick={() => setMobileMenuOpen(false)} />

--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -536,12 +536,12 @@ export default function GamePage() {
                   <SheetTrigger asChild>
                     <Button variant="ghost" size="sm" className="h-8 px-2">
                       <Menu className="h-4 w-4" />
-                      <span className="sr-only">Toggle menu</span>
+                      <span className="sr-only">{t('common.toggleMenu')}</span>
                     </Button>
                   </SheetTrigger>
                   <SheetContent side="left" className="w-70 sm:w-80">
                     <SheetHeader>
-                      <SheetTitle className="text-left">Menu</SheetTitle>
+                      <SheetTitle className="text-left">{t('common.menu')}</SheetTitle>
                     </SheetHeader>
                     <div className="flex flex-col gap-2 mt-6">
                       <Button variant="ghost" size="sm" asChild className="w-full justify-start">

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -186,7 +186,7 @@ export default function ProfilePage() {
                                                 <TooltipContent>
                                                     <div className="text-center">
                                                         <p className="font-semibold">{t('profile.totalScore')}</p>
-                                                        <p className="text-xs text-muted-foreground mt-1">Cumul de tous vos scores de jeu</p>
+                                                        <p className="text-xs text-muted-foreground mt-1">{t('profile.tooltips.totalScoreDescription')}</p>
                                                     </div>
                                                 </TooltipContent>
                                             </TooltipRoot>
@@ -211,7 +211,7 @@ export default function ProfilePage() {
                                                 <TooltipContent>
                                                     <div className="text-center">
                                                         <p className="font-semibold">{t('profile.currentStreak')}</p>
-                                                        <p className="text-xs text-muted-foreground mt-1">Jours consécutifs de jeu</p>
+                                                        <p className="text-xs text-muted-foreground mt-1">{t('profile.tooltips.currentStreakDescription')}</p>
                                                     </div>
                                                 </TooltipContent>
                                             </TooltipRoot>
@@ -235,8 +235,8 @@ export default function ProfilePage() {
                                                 </TooltipTrigger>
                                                 <TooltipContent>
                                                     <div className="text-center">
-                                                        <p className="font-semibold">Succès débloqués</p>
-                                                        <p className="text-xs text-muted-foreground mt-1">{earnedCount}/{totalCount} succès obtenus</p>
+                                                        <p className="font-semibold">{t('profile.tooltips.unlockedAchievementsTitle')}</p>
+                                                        <p className="text-xs text-muted-foreground mt-1">{t('profile.tooltips.earnedOfTotal', { earned: earnedCount, total: totalCount })}</p>
                                                     </div>
                                                 </TooltipContent>
                                             </TooltipRoot>


### PR DESCRIPTION
Wire previously hardcoded strings through useTranslation so they respect
the active locale: profile tooltips (stuck in French), the screenshot
placeholder, admin GameForm placeholders + cover alt, geo MapCanvas
aria-label and pin labels, the mobile menu toggle/title in Header and
GamePage, and the JobList toggle-details sr-only.

Replace the EN-equivalent French value for game.round (Manche) and
admin.tabs.import (Importer). Adds matching keys to both translation
files; key trees stay in parity (1103 keys each).