### PR TITLE
fix(geo): keyboard pin-drop, persist daily result on reload, lift run-polling

### DIFF
--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -2118,17 +2118,19 @@ router.post('/geo/reimport', async (req, res, next) => {
       })
       return
     }
-    // Wipe tombstones + force a metadata re-resolve. The recurring ingest
-    // tick will re-enqueue per-source imports as soon as resolution lands.
+    const gameId = parse.data.gameId
+    // Aggressive variant of /geo/run/:gameId — wipes every per-tier failure
+    // tombstone AND the resolved metadata so the resolver+tick re-run from
+    // scratch. The lighter /geo/run/:gameId path leaves tombstones in place.
     await Promise.all([
-      geoIngestFailureRepository.clear(parse.data.gameId, 'registry'),
-      geoIngestFailureRepository.clear(parse.data.gameId, 'fandom'),
-      geoIngestFailureRepository.clear(parse.data.gameId, 'wikidata'),
-      geoIngestFailureRepository.clear(parse.data.gameId, 'steam'),
-      geoIngestFailureRepository.clear(parse.data.gameId, 'metadata'),
+      geoIngestFailureRepository.clear(gameId, 'registry'),
+      geoIngestFailureRepository.clear(gameId, 'fandom'),
+      geoIngestFailureRepository.clear(gameId, 'wikidata'),
+      geoIngestFailureRepository.clear(gameId, 'steam'),
+      geoIngestFailureRepository.clear(gameId, 'metadata'),
     ])
     await db('games')
-      .where({ id: parse.data.gameId })
+      .where({ id: gameId })
       .update({
         geo_metadata_status: 'pending',
         wiki_subdomain: null,
@@ -2137,11 +2139,24 @@ router.post('/geo/reimport', async (req, res, next) => {
         wikidata_qid: null,
       })
 
-    const job = await geoQueue.add('resolve-metadata', {
-      kind: 'resolve-metadata',
-      batchSize: 1,
+    // Run the full pipeline (resolve → tick) right away instead of
+    // depending on the recurring tick to pick the row back up. Stable
+    // jobIds so a double-click collapses to one execution; the resolver
+    // is gameId-scoped here for fast feedback.
+    const resolveJob = await geoQueue.add(
+      'resolve-metadata',
+      { kind: 'resolve-metadata', batchSize: 1, gameId },
+      { jobId: `manual-resolve:${gameId}` },
+    )
+    const tickJob = await geoQueue.add(
+      'ingest-tick',
+      { kind: 'ingest-tick', batchSize: 1, gameId },
+      { jobId: `manual-tick:${gameId}` },
+    )
+    res.json({
+      success: true,
+      data: { resolveJobId: resolveJob.id, tickJobId: tickJob.id },
     })
-    res.json({ success: true, data: { jobId: job.id } })
   } catch (err) {
     next(err)
   }

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -2147,6 +2147,51 @@ router.post('/geo/reimport', async (req, res, next) => {
   }
 })
 
+// Per-tier tombstone clear. Targeted alternative to /geo/reimport (which
+// wipes all 5 source tombstones for a game) and /scraping/reset (which
+// nukes everything). Lets an operator say "Fandom is back up, retry just
+// that tier for this game" without re-paying the registry/wikidata cost.
+const TOMBSTONE_SOURCES = [
+  'fandom',
+  'steam',
+  'metadata',
+  'registry',
+  'wikidata',
+] as const
+type TombstoneSource = (typeof TOMBSTONE_SOURCES)[number]
+function isTombstoneSource(s: string): s is TombstoneSource {
+  return (TOMBSTONE_SOURCES as readonly string[]).includes(s)
+}
+
+router.delete('/geo/tombstone/:gameId/:source', async (req, res, next) => {
+  try {
+    const gameId = Number(req.params.gameId)
+    if (!Number.isFinite(gameId) || gameId <= 0) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+    const source = req.params.source ?? ''
+    if (!isTombstoneSource(source)) {
+      res
+        .status(400)
+        .json({ success: false, error: { code: 'INVALID_SOURCE' } })
+      return
+    }
+    await geoIngestFailureRepository.clear(gameId, source)
+    // Best-effort: kick the per-game pipeline so the cleared tier gets
+    // retried right away. Idempotent jobIds keep this safe to call even
+    // if the operator just hit "Run for this game".
+    await geoQueue.add(
+      'ingest-tick',
+      { kind: 'ingest-tick', batchSize: 1, gameId },
+      { jobId: `manual-tick:${gameId}` },
+    )
+    res.json({ success: true, data: { gameId, source } })
+  } catch (err) {
+    next(err)
+  }
+})
+
 // Manual run-now triggers for the whole geo ingestion pipeline. The recurring
 // resolver + tick workers already run on a schedule; these endpoints just
 // short-circuit the wait so an operator can kick off a fresh pass immediately

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -766,6 +766,7 @@
             "challenges": "Deletes every scheduled geo challenge.",
             "metadata": "Resets games' geo metadata to \"pending\" so the resolver re-runs."
           },
+          "confirmWord": "RESET",
           "confirmLabel": "Type {{word}} to confirm",
           "confirm": "Reset everything"
         }

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1315,6 +1315,12 @@
       "formula": "Formula",
       "screenshotUnavailable": "Screenshot preview unavailable.",
       "mapUnavailable": "Map unavailable.",
+      "mapAria": "Pin a location on the map. Use the arrow keys to move the cursor, then press Enter to drop the pin.",
+      "mapAriaDisabled": "Map",
+      "markers": {
+        "you": "Your pin",
+        "actual": "Actual location"
+      },
       "errors": {
         "noChallenge": "No geo challenge is available for today yet. Please check back later."
       }

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -480,6 +480,7 @@
     "geo": {
       "title": "Geo Moderation",
       "subtitle": "Curate the Geo daily challenge: import sources, schedule challenges, and validate crowdsourced pins.",
+      "candidatesLoading": "Loading pins…",
       "tabs": {
         "pins": "Pins",
         "maps": "Maps",
@@ -577,9 +578,11 @@
         },
         "viewSource": "View source",
         "actions": {
-          "rerun": "Re-run pipeline",
+          "rerun": "Force fresh ingestion",
+          "rerunTooltip": "Clears every per-tier failure tombstone for this game and re-runs the full pipeline (metadata + maps). More aggressive than \"Run for this game\", which respects existing tombstones.",
           "uploadManual": "Upload manually"
         },
+        "loading": "Loading games…",
         "sidePanel": {
           "empty": "Select a game",
           "hint": "Pick a game on the left to see its tier-by-tier ingestion state.",
@@ -587,7 +590,8 @@
           "activeViaTier": "Active via {{tier}} · {{license}}",
           "region": "region: {{region}}",
           "previewAlt": "Active map for {{name}} (click to open full size)",
-          "previewDimensions": "{{width}} × {{height}} px"
+          "previewDimensions": "{{width}} × {{height}} px",
+          "loading": "Loading sources…"
         }
       },
       "intro": {
@@ -1330,6 +1334,7 @@
       "mapUnavailable": "Map unavailable.",
       "mapAria": "Pin a location on the map. Use the arrow keys to move the cursor, then press Enter to drop the pin.",
       "mapAriaDisabled": "Map",
+      "loading": "Loading challenge…",
       "markers": {
         "you": "Your pin",
         "actual": "Actual location"
@@ -1347,6 +1352,7 @@
       "map": "Pin its location",
       "submit": "Submit pin",
       "skip": "Skip",
+      "loading": "Loading screenshot…",
       "thanks": "Thanks — we'll let you know once other players agree on the spot.",
       "recent": "Recent rewards",
       "lockedTitle": "Tagging unlocks after a few daily games.",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -494,6 +494,16 @@
         "nextChallenge": "next",
         "scheduleNow": "Schedule now"
       },
+      "coldStart": {
+        "no-curated": {
+          "title": "No curated games yet",
+          "body": "Open the Games tab and curate one or more games for Geo. Once curated, the pipeline imports their maps automatically."
+        },
+        "no-maps": {
+          "title": "No maps imported yet",
+          "body": "Your curated games don't have an active map yet. Click \"Run all\" on the Maps tab to start the ingestion pipeline, then schedule a challenge once at least one map is ready."
+        }
+      },
       "games": {
         "title": "Games",
         "subtitle": "Curate the games whose maps and screenshots should land in the Geo daily challenge. Select multiple to curate or remove in bulk.",
@@ -560,7 +570,10 @@
           "eligible": "Eligible",
           "untried": "Skipped",
           "eligibleHint": "Will run on the next ingest tick if no earlier tier wins.",
-          "retryAfter": "Retry after {{time}}"
+          "retryAfter": "Retry after {{time}}",
+          "retryNow": "Retry",
+          "retryNowTooltip": "Clear this source's tombstone and re-run the pipeline for this game.",
+          "retryQueued": "Retry queued. The pipeline will pick it up shortly."
         },
         "viewSource": "View source",
         "actions": {
@@ -1322,7 +1335,9 @@
         "actual": "Actual location"
       },
       "errors": {
-        "noChallenge": "No geo challenge is available for today yet. Please check back later."
+        "noChallenge": "No geo challenge is available for today yet. Please check back later.",
+        "nextIn": "Next challenge in {{countdown}}",
+        "viewHistory": "View past challenges"
       }
     },
     "contribute": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1315,6 +1315,12 @@
       "formula": "Formule",
       "screenshotUnavailable": "Aperçu de la capture indisponible.",
       "mapUnavailable": "Carte indisponible.",
+      "mapAria": "Épinglez l'emplacement sur la carte. Utilisez les flèches du clavier pour déplacer le curseur, puis Entrée pour valider.",
+      "mapAriaDisabled": "Carte",
+      "markers": {
+        "you": "Votre épingle",
+        "actual": "Emplacement réel"
+      },
       "errors": {
         "noChallenge": "Aucun défi géo n'est encore disponible pour aujourd'hui. Revenez plus tard."
       }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -480,6 +480,7 @@
     "geo": {
       "title": "Modération Géo",
       "subtitle": "Curatez le défi Géo quotidien : importez les sources, planifiez les défis et validez les épingles communautaires.",
+      "candidatesLoading": "Chargement des épingles…",
       "tabs": {
         "pins": "Épingles",
         "maps": "Cartes",
@@ -577,9 +578,11 @@
         },
         "viewSource": "Voir la source",
         "actions": {
-          "rerun": "Relancer le pipeline",
+          "rerun": "Forcer une ré-ingestion",
+          "rerunTooltip": "Efface tous les tombstones d'échec pour ce jeu et relance la pipeline complète (résolution + cartes). Plus agressif que « Lancer pour ce jeu » qui respecte les tombstones existants.",
           "uploadManual": "Téléverser manuellement"
         },
+        "loading": "Chargement des jeux…",
         "sidePanel": {
           "empty": "Sélectionnez un jeu",
           "hint": "Choisissez un jeu à gauche pour voir l'état d'ingestion niveau par niveau.",
@@ -587,7 +590,8 @@
           "activeViaTier": "Actif via {{tier}} · {{license}}",
           "region": "région : {{region}}",
           "previewAlt": "Carte active pour {{name}} (cliquez pour ouvrir en taille réelle)",
-          "previewDimensions": "{{width}} × {{height}} px"
+          "previewDimensions": "{{width}} × {{height}} px",
+          "loading": "Chargement des sources…"
         }
       },
       "intro": {
@@ -1330,6 +1334,7 @@
       "mapUnavailable": "Carte indisponible.",
       "mapAria": "Épinglez l'emplacement sur la carte. Utilisez les flèches du clavier pour déplacer le curseur, puis Entrée pour valider.",
       "mapAriaDisabled": "Carte",
+      "loading": "Chargement du défi…",
       "markers": {
         "you": "Votre épingle",
         "actual": "Emplacement réel"
@@ -1347,6 +1352,7 @@
       "map": "Épinglez son emplacement",
       "submit": "Envoyer l'épingle",
       "skip": "Passer",
+      "loading": "Chargement de la capture…",
       "thanks": "Merci — nous vous préviendrons quand d'autres joueurs confirmeront l'emplacement.",
       "recent": "Récompenses récentes",
       "lockedTitle": "L'étiquetage se débloque après quelques parties quotidiennes.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -494,6 +494,16 @@
         "nextChallenge": "prochain",
         "scheduleNow": "Planifier"
       },
+      "coldStart": {
+        "no-curated": {
+          "title": "Aucun jeu curaté pour le moment",
+          "body": "Allez dans l'onglet Jeux pour activer le mode Géo sur un ou plusieurs jeux. Une fois curatés, le pipeline ingère leurs cartes automatiquement."
+        },
+        "no-maps": {
+          "title": "Aucune carte importée",
+          "body": "Vos jeux curatés n'ont pas encore de carte active. Cliquez sur « Tout lancer » dans l'onglet Cartes pour démarrer le pipeline d'ingestion, puis planifiez un défi quand au moins une carte est prête."
+        }
+      },
       "games": {
         "title": "Jeux",
         "subtitle": "Curatez les jeux dont les cartes et captures doivent alimenter le défi Géo quotidien. Sélectionnez-en plusieurs pour curater ou retirer en lot.",
@@ -560,7 +570,10 @@
           "eligible": "Éligible",
           "untried": "Ignoré",
           "eligibleHint": "Sera tenté à la prochaine passe si aucun niveau précédent ne réussit.",
-          "retryAfter": "Nouvel essai après {{time}}"
+          "retryAfter": "Nouvel essai après {{time}}",
+          "retryNow": "Réessayer",
+          "retryNowTooltip": "Efface le tombstone de cette source et relance la pipeline pour ce jeu.",
+          "retryQueued": "Réessai en file. La pipeline va se relancer dans quelques secondes."
         },
         "viewSource": "Voir la source",
         "actions": {
@@ -1322,7 +1335,9 @@
         "actual": "Emplacement réel"
       },
       "errors": {
-        "noChallenge": "Aucun défi géo n'est encore disponible pour aujourd'hui. Revenez plus tard."
+        "noChallenge": "Aucun défi géo n'est encore disponible pour aujourd'hui. Revenez plus tard.",
+        "nextIn": "Prochain défi dans {{countdown}}",
+        "viewHistory": "Voir les défis passés"
       }
     },
     "contribute": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -766,6 +766,7 @@
             "challenges": "Supprime tous les défis géo programmés.",
             "metadata": "Remet les métadonnées géo des jeux à « pending » pour forcer une nouvelle résolution."
           },
+          "confirmWord": "RÉINITIALISER",
           "confirmLabel": "Tapez {{word}} pour confirmer",
           "confirm": "Réinitialiser tout"
         }

--- a/packages/frontend/src/components/admin/GeoColdStartBanner.tsx
+++ b/packages/frontend/src/components/admin/GeoColdStartBanner.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next'
+import { Compass } from 'lucide-react'
+import type { GeoHealth } from '@/hooks/useGeoHealth'
+
+// Cold-start guidance for a brand-new instance (no curated games or no
+// imported maps yet). Surfaces above the Pins/Maps/Games tabs so a
+// first-time operator knows the entry point is the Games tab — without
+// it they hit "0/0 maps" with no obvious next step.
+export function GeoColdStartBanner({ health }: { health: GeoHealth | null }) {
+    const { t } = useTranslation()
+    if (!health) return null
+    const { curated, withMap } = health.coverage
+
+    const stage: 'no-curated' | 'no-maps' | null =
+        curated === 0 ? 'no-curated' : withMap === 0 ? 'no-maps' : null
+    if (stage === null) return null
+
+    return (
+        <div
+            className="flex items-start gap-3 rounded-md border border-neon-pink/30 bg-linear-to-r from-neon-pink/5 via-neon-purple/5 to-transparent px-3 py-2.5 text-xs"
+            role="note"
+        >
+            <Compass className="h-4 w-4 text-neon-pink shrink-0 mt-0.5" aria-hidden />
+            <div className="space-y-1 leading-relaxed">
+                <p className="font-semibold text-foreground">
+                    {t(`admin.geo.coldStart.${stage}.title`)}
+                </p>
+                <p className="text-muted-foreground">
+                    {t(`admin.geo.coldStart.${stage}.body`)}
+                </p>
+            </div>
+        </div>
+    )
+}

--- a/packages/frontend/src/components/admin/GeoGamesTab.tsx
+++ b/packages/frontend/src/components/admin/GeoGamesTab.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Loader2, RefreshCw, CheckSquare, Square, Star, AlertTriangle } from 'lucide-react'
+import { fetchAdminJson as fetchJson } from '@/lib/api/admin'
 
 // Unified curated-set + suggestions surface. Replaces the two stacked
 // sections in GeoAdminActions (which the new tabbed layout has otherwise
@@ -37,18 +38,6 @@ interface GameRow {
     curated: boolean
 }
 
-async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
-    const res = await fetch(path, {
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        ...init,
-    })
-    const json = await res.json().catch(() => ({}))
-    if (!res.ok || !json?.success) {
-        throw new Error(json?.error?.code ?? `request failed: ${res.status}`)
-    }
-    return json.data as T
-}
 
 export function GeoGamesTab() {
     const { t } = useTranslation()

--- a/packages/frontend/src/components/admin/GeoHeaderStrip.tsx
+++ b/packages/frontend/src/components/admin/GeoHeaderStrip.tsx
@@ -1,51 +1,33 @@
-import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Loader2, Map, ListChecks, AlertTriangle, CalendarClock } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import type { GeoHealth } from '@/hooks/useGeoHealth'
 
 // Persistent dataset-health indicator that replaces GeoAdminActions'
 // metric/queue tile grids. One thin line of always-visible counters that
 // the operator can scan in <1 second:
 //   `38/42 maps · 12 pins · 0 errors`
-// Refreshes itself every 30s so a long-open admin tab stays current.
-
-interface HealthData {
-    coverage: { curated: number; resolved: number; withMap: number; total: number }
-    queue: { active: number; waiting: number; delayed: number; failed: number }
-    nextChallenge: { id: number; date: string } | null
-    failures: Array<unknown>
-}
+//
+// Health data is owned by the parent (GeoReviewPanel) via `useGeoHealth`
+// so the cold-start banner and these counters always agree without a
+// duplicate poll.
 
 interface GeoHeaderStripProps {
     onScheduleClick?: () => void
     scheduling?: boolean
+    health: GeoHealth | null
+    loading: boolean
+    error: boolean
 }
 
-export function GeoHeaderStrip({ onScheduleClick, scheduling }: GeoHeaderStripProps) {
+export function GeoHeaderStrip({
+    onScheduleClick,
+    scheduling,
+    health,
+    loading,
+    error,
+}: GeoHeaderStripProps) {
     const { t, i18n } = useTranslation()
-    const [health, setHealth] = useState<HealthData | null>(null)
-    const [loading, setLoading] = useState(true)
-    const [error, setError] = useState(false)
-
-    const reload = useCallback(async () => {
-        try {
-            const res = await fetch('/api/admin/geo/health', { credentials: 'include' })
-            const json = await res.json().catch(() => ({}))
-            if (!res.ok || !json?.success) throw new Error('health failed')
-            setHealth(json.data as HealthData)
-            setError(false)
-        } catch {
-            setError(true)
-        } finally {
-            setLoading(false)
-        }
-    }, [])
-
-    useEffect(() => {
-        void reload()
-        const id = window.setInterval(() => void reload(), 30_000)
-        return () => window.clearInterval(id)
-    }, [reload])
 
     if (loading && !health) {
         return (

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -23,6 +23,7 @@ import {
     Trash2,
     Play,
     Zap,
+    RefreshCcw,
 } from 'lucide-react'
 import { GeoManualMapDialog } from './GeoManualMapDialog'
 import { ResetScrapingDialog } from './ResetScrapingDialog'
@@ -123,6 +124,7 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
     const [resetting, setResetting] = useState(false)
     const [runningAll, setRunningAll] = useState(false)
     const [runningGameId, setRunningGameId] = useState<number | null>(null)
+    const [retryingTier, setRetryingTier] = useState<string | null>(null)
 
     const reload = useCallback(async () => {
         setLoading(true)
@@ -229,6 +231,24 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
             setError(String(e))
         } finally {
             setRunningGameId(null)
+        }
+    }
+
+    const handleRetryTier = async (gameId: number, tier: string) => {
+        setRetryingTier(tier)
+        setMessage(null)
+        setError(null)
+        try {
+            await fetchJson(`/api/admin/geo/tombstone/${gameId}/${tier}`, {
+                method: 'DELETE',
+            })
+            setMessage(t('admin.geo.maps.tierStatus.retryQueued'))
+            armRunPolling()
+            await reloadSources(gameId)
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setRetryingTier(null)
         }
     }
 
@@ -479,6 +499,16 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
                                             state={s}
                                             t={t}
                                             running={running}
+                                            onRetry={
+                                                s.tier !== 'manual'
+                                                    ? () =>
+                                                          void handleRetryTier(
+                                                              sources.gameId,
+                                                              s.tier,
+                                                          )
+                                                    : undefined
+                                            }
+                                            retrying={retryingTier === s.tier}
                                         />
                                     )
                                 })}
@@ -603,10 +633,14 @@ function TierRow({
     state,
     t,
     running,
+    onRetry,
+    retrying,
 }: {
     state: TierState
     t: ReturnType<typeof useTranslation>['t']
     running?: boolean
+    onRetry?: () => void
+    retrying?: boolean
 }) {
     const tierLabel = t(`admin.geo.maps.tiers.${state.tier}`)
 
@@ -681,12 +715,31 @@ function TierRow({
                 >
                     {state.reason}
                 </p>
-                <p className="pt-0.5 text-[10px] text-muted-foreground inline-flex items-center gap-1">
-                    <Clock className="h-2.5 w-2.5" aria-hidden />
-                    {t('admin.geo.maps.tierStatus.retryAfter', {
-                        time: retry.toLocaleString(),
-                    })}
-                </p>
+                <div className="pt-0.5 flex items-center justify-between gap-2">
+                    <p className="text-[10px] text-muted-foreground inline-flex items-center gap-1">
+                        <Clock className="h-2.5 w-2.5" aria-hidden />
+                        {t('admin.geo.maps.tierStatus.retryAfter', {
+                            time: retry.toLocaleString(),
+                        })}
+                    </p>
+                    {onRetry && (
+                        <Button
+                            size="sm"
+                            variant="ghost"
+                            disabled={retrying}
+                            onClick={onRetry}
+                            className="h-6 gap-1 px-2 text-[10px] text-destructive hover:text-destructive"
+                            title={t('admin.geo.maps.tierStatus.retryNowTooltip')}
+                        >
+                            {retrying ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                                <RefreshCcw className="h-3 w-3" />
+                            )}
+                            {t('admin.geo.maps.tierStatus.retryNow')}
+                        </Button>
+                    )}
+                </div>
             </li>
         )
     }

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -32,6 +32,7 @@ import {
     tiersInFlightForGame,
     type GeoRunStatePayload,
 } from '@/hooks/useGeoRunPolling'
+import { fetchAdminJson as fetchJson } from '@/lib/api/admin'
 
 // Per-game ingestion-state surface. Replaces the global metric-tile grid +
 // failures table from GeoAdminActions with a focused, drill-down table where
@@ -87,18 +88,6 @@ interface SourcesResponse {
     sources: TierState[]
 }
 
-async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
-    const res = await fetch(path, {
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        ...init,
-    })
-    const json = await res.json().catch(() => ({}))
-    if (!res.ok || !json?.success) {
-        throw new Error(json?.error?.code ?? `request failed: ${res.status}`)
-    }
-    return json.data as T
-}
 
 interface GeoMapsTabProps {
     // The run-progress hook is owned by the parent (GeoReviewPanel) so that
@@ -160,8 +149,11 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
     }, [reload])
 
     useEffect(() => {
+        // Clear immediately on selection change so the side panel doesn't
+        // flash the previous game's name/preview while the next sources
+        // request is in flight (S2 from the audit).
+        setSources(null)
         if (selectedId !== null) void reloadSources(selectedId)
-        else setSources(null)
     }, [selectedId, reloadSources])
 
     const reimport = async (game: CuratedGame) => {
@@ -174,6 +166,9 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
                 body: JSON.stringify({ gameId: game.id }),
             })
             setMessage(t('admin.geo.maps.reimportQueued', { name: game.name }))
+            // Show live progress in the run banner since /reimport now
+            // enqueues the full resolve+tick pipeline (not just resolver).
+            armRunPolling()
             await Promise.all([reload(), reloadSources(game.id)])
         } catch (e) {
             setError(String(e))
@@ -343,8 +338,17 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
                         </div>
                     )}
                     {loading && games === null ? (
-                        <div className="flex justify-center py-12">
-                            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                        <div
+                            className="flex justify-center py-12"
+                            role="status"
+                            aria-live="polite"
+                            aria-busy="true"
+                            aria-label={t('admin.geo.maps.loading')}
+                        >
+                            <Loader2
+                                className="h-5 w-5 animate-spin text-muted-foreground"
+                                aria-hidden
+                            />
                         </div>
                     ) : games && games.length > 0 ? (
                         <ul className="divide-y divide-border/40">
@@ -446,8 +450,17 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
                             {t('admin.geo.maps.sidePanel.hint')}
                         </p>
                     ) : sourcesLoading && !sources ? (
-                        <div className="flex justify-center py-6">
-                            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                        <div
+                            className="flex justify-center py-6"
+                            role="status"
+                            aria-live="polite"
+                            aria-busy="true"
+                            aria-label={t('admin.geo.maps.sidePanel.loading')}
+                        >
+                            <Loader2
+                                className="h-4 w-4 animate-spin text-muted-foreground"
+                                aria-hidden
+                            />
                         </div>
                     ) : sources ? (
                         <>
@@ -517,9 +530,10 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
                                 <Button
                                     size="sm"
                                     variant="outline"
-                                    className="flex-1"
+                                    className="flex-1 border-destructive/40 text-destructive hover:text-destructive hover:bg-destructive/5"
                                     disabled={busyAction !== null}
                                     onClick={() => void reimport(selectedGame)}
+                                    title={t('admin.geo.maps.actions.rerunTooltip')}
                                 >
                                     {busyAction === 'reimport' ? (
                                         <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -29,7 +29,6 @@ import { ResetScrapingDialog } from './ResetScrapingDialog'
 import {
     isGameInFlight,
     tiersInFlightForGame,
-    useGeoRunPolling,
     type GeoRunStatePayload,
 } from '@/hooks/useGeoRunPolling'
 
@@ -100,7 +99,16 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
     return json.data as T
 }
 
-export function GeoMapsTab() {
+interface GeoMapsTabProps {
+    // The run-progress hook is owned by the parent (GeoReviewPanel) so that
+    // polling and the live banner survive when an admin switches between
+    // Pins / Maps / Games tabs mid-run.
+    runState: GeoRunStatePayload | null
+    runError: string | null
+    armRunPolling: (windowMs?: number) => void
+}
+
+export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProps) {
     const { t } = useTranslation()
     const [games, setGames] = useState<CuratedGame[] | null>(null)
     const [loading, setLoading] = useState(true)
@@ -115,7 +123,6 @@ export function GeoMapsTab() {
     const [resetting, setResetting] = useState(false)
     const [runningAll, setRunningAll] = useState(false)
     const [runningGameId, setRunningGameId] = useState<number | null>(null)
-    const { state: runState, error: runError, arm: armRunPolling } = useGeoRunPolling()
 
     const reload = useCallback(async () => {
         setLoading(true)
@@ -298,9 +305,10 @@ export function GeoMapsTab() {
                             </Button>
                         </div>
                     </div>
-                    <RunStateBanner state={runState} t={t} />
                     {runError && (
-                        <p className="text-[11px] text-destructive">{runError}</p>
+                        <p className="text-[11px] text-destructive" role="alert">
+                            {runError}
+                        </p>
                     )}
                 </CardHeader>
                 <CardContent className="p-0">
@@ -720,34 +728,5 @@ function TierRow({
                 </p>
             )}
         </li>
-    )
-}
-
-// Compact summary line that shows BullMQ in-flight counts during a manual
-// run. Hidden while the queue is idle so it doesn't clutter the header.
-function RunStateBanner({
-    state,
-    t,
-}: {
-    state: GeoRunStatePayload | null
-    t: ReturnType<typeof useTranslation>['t']
-}) {
-    if (!state || !state.isActive) return null
-    const { active, waiting, delayed, failed } = state.counts
-    return (
-        <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px]">
-            <span className="inline-flex items-center gap-1 text-neon-pink">
-                <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
-                {t('admin.geo.run.banner.active', { count: active })}
-            </span>
-            <span className="text-muted-foreground">
-                · {t('admin.geo.run.banner.waiting', { count: waiting + delayed })}
-            </span>
-            {failed > 0 && (
-                <span className="text-destructive">
-                    · {t('admin.geo.run.banner.failed', { count: failed })}
-                </span>
-            )}
-        </div>
     )
 }

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -223,7 +223,7 @@ export function GeoReviewPanel() {
             <GeoRunStateBanner state={runState} />
 
             <Tabs defaultValue="pins" className="space-y-4">
-                <TabsList className="w-full overflow-x-auto justify-start sm:justify-center scrollbar-hide">
+                <TabsList className="w-full overflow-x-auto justify-start scrollbar-hide">
                     <TabsTrigger value="pins" className="gap-1.5 shrink-0">
                         <ListChecks className="h-3.5 w-3.5" />
                         {t('admin.geo.tabs.pins')}

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -30,6 +30,8 @@ import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { GeoMapsTab } from './GeoMapsTab'
 import { GeoGamesTab } from './GeoGamesTab'
 import { GeoHeaderStrip } from './GeoHeaderStrip'
+import { GeoRunStateBanner } from './GeoRunStateBanner'
+import { useGeoRunPolling } from '@/hooks/useGeoRunPolling'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type {
     GeoMap,
@@ -100,6 +102,10 @@ export function GeoReviewPanel() {
     const [demoteOpen, setDemoteOpen] = useState(false)
     const [introOpen, setIntroOpen] = useState(false)
     const [scheduling, setScheduling] = useState(false)
+    // Owned here (not inside GeoMapsTab) so an in-flight manual run keeps
+    // polling and the live banner stays visible when the operator switches
+    // between Pins / Maps / Games tabs.
+    const { state: runState, error: runError, arm: armRunPolling } = useGeoRunPolling()
 
     const triggerSchedule = async () => {
         setScheduling(true)
@@ -204,6 +210,8 @@ export function GeoReviewPanel() {
                 scheduling={scheduling}
             />
 
+            <GeoRunStateBanner state={runState} />
+
             <Tabs defaultValue="pins" className="space-y-4">
                 <TabsList className="w-full overflow-x-auto justify-start sm:justify-center scrollbar-hide">
                     <TabsTrigger value="pins" className="gap-1.5 shrink-0">
@@ -221,7 +229,11 @@ export function GeoReviewPanel() {
                 </TabsList>
 
                 <TabsContent value="maps" className="space-y-4">
-                    <GeoMapsTab />
+                    <GeoMapsTab
+                        runState={runState}
+                        runError={runError}
+                        armRunPolling={armRunPolling}
+                    />
                 </TabsContent>
 
                 <TabsContent value="games" className="space-y-4">

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -31,7 +31,9 @@ import { GeoMapsTab } from './GeoMapsTab'
 import { GeoGamesTab } from './GeoGamesTab'
 import { GeoHeaderStrip } from './GeoHeaderStrip'
 import { GeoRunStateBanner } from './GeoRunStateBanner'
+import { GeoColdStartBanner } from './GeoColdStartBanner'
 import { useGeoRunPolling } from '@/hooks/useGeoRunPolling'
+import { useGeoHealth } from '@/hooks/useGeoHealth'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type {
     GeoMap,
@@ -106,6 +108,9 @@ export function GeoReviewPanel() {
     // polling and the live banner stays visible when the operator switches
     // between Pins / Maps / Games tabs.
     const { state: runState, error: runError, arm: armRunPolling } = useGeoRunPolling()
+    // Single health subscription shared between the counter strip and the
+    // cold-start banner — keeps them in sync without a duplicate poll.
+    const { data: health, loading: healthLoading, error: healthError } = useGeoHealth()
 
     const triggerSchedule = async () => {
         setScheduling(true)
@@ -208,7 +213,12 @@ export function GeoReviewPanel() {
             <GeoHeaderStrip
                 onScheduleClick={() => void triggerSchedule()}
                 scheduling={scheduling}
+                health={health}
+                loading={healthLoading}
+                error={healthError}
             />
+
+            <GeoColdStartBanner health={health} />
 
             <GeoRunStateBanner state={runState} />
 

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -314,8 +314,17 @@ export function GeoReviewPanel() {
             )}
 
             {loading ? (
-                <div className="flex justify-center py-16">
-                    <Loader2 className="h-6 w-6 animate-spin text-neon-pink" />
+                <div
+                    className="flex justify-center py-16"
+                    role="status"
+                    aria-live="polite"
+                    aria-busy="true"
+                    aria-label={t('admin.geo.candidatesLoading')}
+                >
+                    <Loader2
+                        className="h-6 w-6 animate-spin text-neon-pink"
+                        aria-hidden
+                    />
                 </div>
             ) : (
                 <div className="grid gap-3 sm:gap-4 grid-cols-1 lg:grid-cols-3">

--- a/packages/frontend/src/components/admin/GeoRunStateBanner.tsx
+++ b/packages/frontend/src/components/admin/GeoRunStateBanner.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next'
+import { Loader2 } from 'lucide-react'
+import type { GeoRunStatePayload } from '@/hooks/useGeoRunPolling'
+
+// Compact summary line of in-flight BullMQ counts during a manual run.
+// Hidden while the queue is idle so it doesn't clutter the layout. Lives
+// at the GeoReviewPanel level so it survives Pins/Maps/Games tab switches.
+export function GeoRunStateBanner({ state }: { state: GeoRunStatePayload | null }) {
+    const { t } = useTranslation()
+    if (!state || !state.isActive) return null
+    const { active, waiting, delayed, failed } = state.counts
+    return (
+        <div
+            className="flex flex-wrap items-center gap-2 rounded-md border border-neon-pink/30 bg-neon-pink/5 px-3 py-1.5 text-[11px]"
+            role="status"
+            aria-live="polite"
+        >
+            <span className="inline-flex items-center gap-1 text-neon-pink">
+                <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+                {t('admin.geo.run.banner.active', { count: active })}
+            </span>
+            <span className="text-muted-foreground">
+                · {t('admin.geo.run.banner.waiting', { count: waiting + delayed })}
+            </span>
+            {failed > 0 && (
+                <span className="text-destructive">
+                    · {t('admin.geo.run.banner.failed', { count: failed })}
+                </span>
+            )}
+        </div>
+    )
+}

--- a/packages/frontend/src/components/admin/ResetScrapingDialog.tsx
+++ b/packages/frontend/src/components/admin/ResetScrapingDialog.tsx
@@ -20,10 +20,9 @@ interface ResetScrapingDialogProps {
     isLoading?: boolean
 }
 
-// Word the operator must type to enable the destructive button. Kept as a
-// constant (not translated) so it's identical regardless of UI language —
-// muscle-memory across languages, and easier to grep for in audit logs.
-const CONFIRM_WORD = 'RESET'
+// Fallback if the locale ever ships without a confirmWord — keeps the
+// dialog usable instead of letting any input pass.
+const DEFAULT_CONFIRM_WORD = 'RESET'
 
 export function ResetScrapingDialog({
     isOpen,
@@ -32,6 +31,10 @@ export function ResetScrapingDialog({
     isLoading = false,
 }: ResetScrapingDialogProps) {
     const { t } = useTranslation()
+    // Localized — French operators type RÉINITIALISER, English RESET.
+    // Compared case-insensitively + trim()'d so accent-keyboard quirks
+    // don't trap an operator who clearly understood the intent.
+    const confirmWord = t('admin.geo.reset.dialog.confirmWord', DEFAULT_CONFIRM_WORD)
     const [typed, setTyped] = useState('')
 
     const handleClose = () => {
@@ -40,7 +43,9 @@ export function ResetScrapingDialog({
         onClose()
     }
 
-    const canConfirm = typed === CONFIRM_WORD && !isLoading
+    const canConfirm =
+        typed.trim().toLocaleUpperCase() === confirmWord.toLocaleUpperCase() &&
+        !isLoading
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
@@ -65,13 +70,13 @@ export function ResetScrapingDialog({
 
                 <div className="space-y-2">
                     <Label htmlFor="reset-confirm-input" className="text-xs">
-                        {t('admin.geo.reset.dialog.confirmLabel', { word: CONFIRM_WORD })}
+                        {t('admin.geo.reset.dialog.confirmLabel', { word: confirmWord })}
                     </Label>
                     <Input
                         id="reset-confirm-input"
                         value={typed}
                         onChange={(e) => setTyped(e.target.value)}
-                        placeholder={CONFIRM_WORD}
+                        placeholder={confirmWord}
                         autoComplete="off"
                         autoCapitalize="characters"
                         spellCheck={false}

--- a/packages/frontend/src/components/geo/MapCanvas.tsx
+++ b/packages/frontend/src/components/geo/MapCanvas.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from
 import { useTranslation } from 'react-i18next'
 import type { GeoPoint } from '@the-box/types'
 import { cn } from '@/lib/utils'
-import { isPlaceholderImageUrl } from '@/lib/geo-image'
-import { ImageOff } from 'lucide-react'
+import { clamp01, isPlaceholderImageUrl } from '@/lib/geo-image'
+import { MapErrorFallback } from './MapErrorFallback'
 
 export interface MapCanvasProps {
     imageUrl: string
@@ -122,20 +122,7 @@ export function MapCanvas({
     const aspectRatio = widthPx > 0 && heightPx > 0 ? `${widthPx} / ${heightPx}` : '16 / 9'
 
     if (errored) {
-        return (
-            <div
-                style={{ aspectRatio }}
-                className={cn(
-                    'relative w-full rounded-lg border border-dashed bg-muted/30 flex flex-col items-center justify-center gap-2 px-4 text-center text-xs text-muted-foreground',
-                    className,
-                )}
-                role="img"
-                aria-label={t('geo.daily.mapUnavailable', 'Map unavailable')}
-            >
-                <ImageOff className="h-6 w-6 opacity-60" aria-hidden />
-                <span>{t('geo.daily.mapUnavailable', 'Map unavailable')}</span>
-            </div>
-        )
+        return <MapErrorFallback aspectRatio={aspectRatio} className={className} />
     }
 
     const interactive = !disabled && !!onPin
@@ -277,7 +264,3 @@ function GuessLine({ from, to }: { from: GeoPoint; to: GeoPoint }) {
     )
 }
 
-function clamp01(n: number): number {
-    if (Number.isNaN(n)) return 0
-    return Math.max(0, Math.min(1, n))
-}

--- a/packages/frontend/src/components/geo/MapCanvas.tsx
+++ b/packages/frontend/src/components/geo/MapCanvas.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type MouseEvent } from 'react'
+import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { GeoPoint } from '@the-box/types'
 import { cn } from '@/lib/utils'
@@ -42,6 +42,10 @@ export function MapCanvas({
     const { t } = useTranslation()
     const containerRef = useRef<HTMLDivElement>(null)
     const [hover, setHover] = useState<GeoPoint | null>(null)
+    // Keyboard cursor — visible only while the canvas has focus. Lets keyboard
+    // users nudge a virtual crosshair with arrow keys and confirm with
+    // Enter/Space, since clientX/clientY isn't available without a mouse.
+    const [kbCursor, setKbCursor] = useState<GeoPoint | null>(null)
     // Treat known placeholder URLs as failed up-front: they "load" successfully
     // (placehold.co returns a real image) so onError would never fire.
     const [errored, setErrored] = useState(() => isPlaceholderImageUrl(imageUrl))
@@ -72,6 +76,49 @@ export function MapCanvas({
         })
     }
 
+    const handleFocus = () => {
+        if (disabled || errored) return
+        // Seed the keyboard cursor from the existing pin (so re-focus picks up
+        // where the player left off) or center it if there isn't one yet.
+        setKbCursor((prev) => prev ?? pin ?? { x: 0.5, y: 0.5 })
+    }
+
+    const handleBlur = () => setKbCursor(null)
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+        if (disabled || errored || !onPin) return
+        const cursor = kbCursor ?? pin ?? { x: 0.5, y: 0.5 }
+        // Coarse step ~5% of the map (large enough to feel responsive without
+        // being unmanageable), Shift bumps to ~15% for fast traversal.
+        const step = e.shiftKey ? 0.15 : 0.05
+        switch (e.key) {
+            case 'ArrowLeft':
+                e.preventDefault()
+                setKbCursor({ x: clamp01(cursor.x - step), y: cursor.y })
+                return
+            case 'ArrowRight':
+                e.preventDefault()
+                setKbCursor({ x: clamp01(cursor.x + step), y: cursor.y })
+                return
+            case 'ArrowUp':
+                e.preventDefault()
+                setKbCursor({ x: cursor.x, y: clamp01(cursor.y - step) })
+                return
+            case 'ArrowDown':
+                e.preventDefault()
+                setKbCursor({ x: cursor.x, y: clamp01(cursor.y + step) })
+                return
+            case 'Enter':
+            case ' ':
+                e.preventDefault()
+                onPin({ x: clamp01(cursor.x), y: clamp01(cursor.y) })
+                return
+            case 'Escape':
+                setKbCursor(null)
+                return
+        }
+    }
+
     const aspectRatio = widthPx > 0 && heightPx > 0 ? `${widthPx} / ${heightPx}` : '16 / 9'
 
     if (errored) {
@@ -91,20 +138,30 @@ export function MapCanvas({
         )
     }
 
+    const interactive = !disabled && !!onPin
+    const ariaLabel = interactive
+        ? t('geo.daily.mapAria', 'Pin location on the map. Use arrow keys to move and Enter to drop a pin.')
+        : t('geo.daily.mapAriaDisabled', 'Map')
+
     return (
         <div
             ref={containerRef}
             onClick={handleClick}
             onMouseMove={handleMove}
             onMouseLeave={() => setHover(null)}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
             style={{ aspectRatio, backgroundImage: `url(${imageUrl})` }}
             className={cn(
                 'relative w-full rounded-lg overflow-hidden bg-center bg-no-repeat bg-cover select-none',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                 disabled ? 'cursor-default' : 'cursor-crosshair',
                 className,
             )}
-            role={disabled ? 'img' : 'button'}
-            aria-label="Pin location on the map"
+            role={interactive ? 'button' : 'img'}
+            tabIndex={interactive ? 0 : -1}
+            aria-label={ariaLabel}
         >
             {/* Hidden probe so we can detect a 404 on the background image,
                 which CSS background-image cannot signal. */}
@@ -117,9 +174,13 @@ export function MapCanvas({
             />
 
             {/* Crosshair at hover position */}
-            {!disabled && hover && (
+            {!disabled && hover && !kbCursor && (
                 <Crosshair x={hover.x} y={hover.y} faint />
             )}
+
+            {/* Keyboard cursor — solid (not faint) so it's distinguishable
+                from the mouse-hover crosshair. */}
+            {kbCursor && <Crosshair x={kbCursor.x} y={kbCursor.y} />}
 
             {/* Guess → canonical line */}
             {showGuessLine && pin && canonical && (
@@ -127,11 +188,23 @@ export function MapCanvas({
             )}
 
             {/* User pin */}
-            {pin && <Marker x={pin.x} y={pin.y} color="fuchsia" label="You" />}
+            {pin && (
+                <Marker
+                    x={pin.x}
+                    y={pin.y}
+                    color="fuchsia"
+                    label={t('geo.daily.markers.you', 'Your pin')}
+                />
+            )}
 
             {/* Canonical (revealed) */}
             {canonical && (
-                <Marker x={canonical.x} y={canonical.y} color="emerald" label="Actual" />
+                <Marker
+                    x={canonical.x}
+                    y={canonical.y}
+                    color="emerald"
+                    label={t('geo.daily.markers.actual', 'Actual location')}
+                />
             )}
         </div>
     )

--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import {
     ImageOverlay,
     MapContainer,
@@ -9,10 +8,10 @@ import {
 } from 'react-leaflet'
 import L, { CRS, type LatLngBoundsExpression, type LatLngExpression } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
-import { ImageOff } from 'lucide-react'
 import type { GeoPoint } from '@the-box/types'
 import { cn } from '@/lib/utils'
-import { isPlaceholderImageUrl } from '@/lib/geo-image'
+import { clamp01, isPlaceholderImageUrl } from '@/lib/geo-image'
+import { MapErrorFallback } from './MapErrorFallback'
 import type { MapCanvasProps } from './MapCanvas'
 
 // Leaflet-based map canvas. Same public API as MapCanvas so the pages are
@@ -48,7 +47,6 @@ export function MapCanvasLeaflet({
     className,
     showGuessLine,
 }: MapCanvasProps) {
-    const { t } = useTranslation()
     // CRS.Simple: y=0 at top, +y downward in our normalized space; Leaflet's
     // default Simple CRS has +y upward. Flip y at the conversion boundary.
     const bounds: LatLngBoundsExpression = useMemo(
@@ -73,18 +71,10 @@ export function MapCanvasLeaflet({
 
     if (errored) {
         return (
-            <div
-                className={cn(
-                    'relative w-full rounded-lg border border-dashed bg-muted/30 flex flex-col items-center justify-center gap-2 px-4 text-center text-xs text-muted-foreground',
-                    className,
-                )}
-                style={{ aspectRatio: `${widthPx} / ${heightPx}` }}
-                role="img"
-                aria-label={t('geo.daily.mapUnavailable', 'Map unavailable')}
-            >
-                <ImageOff className="h-6 w-6 opacity-60" aria-hidden />
-                <span>{t('geo.daily.mapUnavailable', 'Map unavailable')}</span>
-            </div>
+            <MapErrorFallback
+                aspectRatio={`${widthPx} / ${heightPx}`}
+                className={className}
+            />
         )
     }
 
@@ -166,7 +156,3 @@ function pointToLatLng(
     return [p.y * heightPx, p.x * widthPx]
 }
 
-function clamp01(n: number): number {
-    if (Number.isNaN(n)) return 0
-    return Math.max(0, Math.min(1, n))
-}

--- a/packages/frontend/src/components/geo/MapErrorFallback.tsx
+++ b/packages/frontend/src/components/geo/MapErrorFallback.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next'
+import { ImageOff } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+// Shared "map unavailable" tile used by both MapCanvas (CSS background-image)
+// and MapCanvasLeaflet (ImageOverlay). Both surfaces hit the same
+// placeholder-URL guard + onError probe; this component keeps the visual
+// language and a11y attributes consistent.
+export function MapErrorFallback({
+    aspectRatio,
+    className,
+}: {
+    aspectRatio: string
+    className?: string
+}) {
+    const { t } = useTranslation()
+    const label = t('geo.daily.mapUnavailable', 'Map unavailable')
+    return (
+        <div
+            style={{ aspectRatio }}
+            className={cn(
+                'relative w-full rounded-lg border border-dashed bg-muted/30 flex flex-col items-center justify-center gap-2 px-4 text-center text-xs text-muted-foreground',
+                className,
+            )}
+            role="img"
+            aria-label={label}
+        >
+            <ImageOff className="h-6 w-6 opacity-60" aria-hidden />
+            <span>{label}</span>
+        </div>
+    )
+}

--- a/packages/frontend/src/hooks/useGeoHealth.ts
+++ b/packages/frontend/src/hooks/useGeoHealth.ts
@@ -1,11 +1,32 @@
 import { useCallback, useEffect, useState } from 'react'
+import { z } from 'zod'
 
-export interface GeoHealth {
-    coverage: { curated: number; resolved: number; withMap: number; total: number }
-    queue: { active: number; waiting: number; delayed: number; failed: number }
-    nextChallenge: { id: number; date: string } | null
-    failures: Array<unknown>
-}
+// Zod-validated shape so a backend deploy that drifts from the contract
+// surfaces as a clean parse error rather than mysteriously crashing the
+// counter strip / cold-start banner with `undefined.curated`.
+const GeoHealthSchema = z.object({
+    coverage: z.object({
+        curated: z.number(),
+        resolved: z.number(),
+        withMap: z.number(),
+        total: z.number(),
+    }),
+    queue: z.object({
+        active: z.number(),
+        waiting: z.number(),
+        delayed: z.number(),
+        failed: z.number(),
+    }),
+    nextChallenge: z
+        .object({
+            id: z.number(),
+            date: z.string(),
+        })
+        .nullable(),
+    failures: z.array(z.unknown()),
+})
+
+export type GeoHealth = z.infer<typeof GeoHealthSchema>
 
 /**
  * Polls /api/admin/geo/health every 30s. Used by GeoHeaderStrip (counters)
@@ -22,7 +43,9 @@ export function useGeoHealth(intervalMs = 30_000) {
             const res = await fetch('/api/admin/geo/health', { credentials: 'include' })
             const json = await res.json().catch(() => ({}))
             if (!res.ok || !json?.success) throw new Error('health failed')
-            setData(json.data as GeoHealth)
+            const parsed = GeoHealthSchema.safeParse(json.data)
+            if (!parsed.success) throw new Error('health shape mismatch')
+            setData(parsed.data)
             setError(false)
         } catch {
             setError(true)

--- a/packages/frontend/src/hooks/useGeoHealth.ts
+++ b/packages/frontend/src/hooks/useGeoHealth.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export interface GeoHealth {
+    coverage: { curated: number; resolved: number; withMap: number; total: number }
+    queue: { active: number; waiting: number; delayed: number; failed: number }
+    nextChallenge: { id: number; date: string } | null
+    failures: Array<unknown>
+}
+
+/**
+ * Polls /api/admin/geo/health every 30s. Used by GeoHeaderStrip (counters)
+ * and GeoReviewPanel (cold-start banner). Lifted out of GeoHeaderStrip so
+ * the parent panel can derive cold-start state without a second fetch.
+ */
+export function useGeoHealth(intervalMs = 30_000) {
+    const [data, setData] = useState<GeoHealth | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState(false)
+
+    const reload = useCallback(async () => {
+        try {
+            const res = await fetch('/api/admin/geo/health', { credentials: 'include' })
+            const json = await res.json().catch(() => ({}))
+            if (!res.ok || !json?.success) throw new Error('health failed')
+            setData(json.data as GeoHealth)
+            setError(false)
+        } catch {
+            setError(true)
+        } finally {
+            setLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        void reload()
+        const id = window.setInterval(() => void reload(), intervalMs)
+        return () => window.clearInterval(id)
+    }, [reload, intervalMs])
+
+    return { data, loading, error, reload }
+}

--- a/packages/frontend/src/hooks/useGeoRunPolling.ts
+++ b/packages/frontend/src/hooks/useGeoRunPolling.ts
@@ -1,36 +1,45 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { z } from 'zod'
 
 // Job kinds we care to surface in the manual-run progress UI. Mirrors the
 // backend's GeoJobData.kind minus consensus/promote-tier (those are unrelated
 // to the ingestion pipeline and the route already filters them out).
-export type GeoRunJobKind =
-    | 'resolve-metadata'
-    | 'ingest-tick'
-    | 'import-registry-map'
-    | 'import-fandom-map'
-    | 'import-wikidata-map'
-    | 'import-steam-screenshots'
-    | 'schedule-daily-challenge'
+const GeoRunJobKindSchema = z.enum([
+    'resolve-metadata',
+    'ingest-tick',
+    'import-registry-map',
+    'import-fandom-map',
+    'import-wikidata-map',
+    'import-steam-screenshots',
+    'schedule-daily-challenge',
+])
+export type GeoRunJobKind = z.infer<typeof GeoRunJobKindSchema>
 
-export type GeoRunJobState = 'active' | 'waiting' | 'delayed'
+const GeoRunJobStateSchema = z.enum(['active', 'waiting', 'delayed'])
+export type GeoRunJobState = z.infer<typeof GeoRunJobStateSchema>
 
-export interface GeoRunJob {
-    kind: GeoRunJobKind
-    state: GeoRunJobState
-}
+const GeoRunJobSchema = z.object({
+    kind: GeoRunJobKindSchema,
+    state: GeoRunJobStateSchema,
+})
+export type GeoRunJob = z.infer<typeof GeoRunJobSchema>
 
-export interface GeoRunStatePayload {
-    isActive: boolean
-    counts: {
-        active: number
-        waiting: number
-        delayed: number
-        failed: number
-        completed: number
-    }
-    byGame: Record<number, GeoRunJob[]>
-    globals: GeoRunJob[]
-}
+const GeoRunStatePayloadSchema = z.object({
+    isActive: z.boolean(),
+    counts: z.object({
+        active: z.number(),
+        waiting: z.number(),
+        delayed: z.number(),
+        failed: z.number(),
+        completed: z.number(),
+    }),
+    // BullMQ job ids on the wire are strings, but we only key by gameId
+    // numerically. z.coerce.number() lets the JSON parse path recover when
+    // either side serializes the key as a string.
+    byGame: z.record(z.coerce.number(), z.array(GeoRunJobSchema)),
+    globals: z.array(GeoRunJobSchema),
+})
+export type GeoRunStatePayload = z.infer<typeof GeoRunStatePayloadSchema>
 
 export interface UseGeoRunPolling {
     state: GeoRunStatePayload | null
@@ -52,7 +61,9 @@ async function fetchState(): Promise<GeoRunStatePayload> {
     if (!res.ok || !json?.success) {
         throw new Error(json?.error?.code ?? `request failed: ${res.status}`)
     }
-    return json.data as GeoRunStatePayload
+    const parsed = GeoRunStatePayloadSchema.safeParse(json.data)
+    if (!parsed.success) throw new Error('run state shape mismatch')
+    return parsed.data
 }
 
 /**

--- a/packages/frontend/src/lib/api/admin.ts
+++ b/packages/frontend/src/lib/api/admin.ts
@@ -1,5 +1,31 @@
 import type { Job, JobType, JobData, JobListResponse, Game, RecurringJob, Screenshot, ImportState, User, EmailLogQuery, EmailLogResponse } from '@/types'
 
+/**
+ * Thin wrapper around `fetch` for admin endpoints. Defaults to
+ * `credentials: 'include'` and JSON content type, then unwraps the
+ * standard `{ success, data, error }` envelope. Throws an `Error` with
+ * the backend's `error.code` on failure so callers don't have to re-check
+ * the envelope.
+ *
+ * Replaces the per-tab `fetchJson` helper that lived in GeoMapsTab and
+ * GeoGamesTab — same signature, single source of truth.
+ */
+export async function fetchAdminJson<T>(
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(path, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+  const json = await res.json().catch(() => ({}))
+  if (!res.ok || !json?.success) {
+    throw new Error(json?.error?.code ?? `request failed: ${res.status}`)
+  }
+  return json.data as T
+}
+
 // Games API types
 export interface GamesListParams {
   page?: number

--- a/packages/frontend/src/lib/geo-image.ts
+++ b/packages/frontend/src/lib/geo-image.ts
@@ -13,3 +13,14 @@ export function isPlaceholderImageUrl(url: string | null | undefined): boolean {
     if (!url) return true
     return PLACEHOLDER_URL_PATTERNS.some((p) => p.test(url))
 }
+
+/**
+ * Coordinates in the Geo feature are normalized to [0..1] so a map asset
+ * swap doesn't invalidate historical pins. Both MapCanvas variants depend
+ * on this helper; keeping it shared avoids the two implementations
+ * silently drifting apart.
+ */
+export function clamp01(n: number): number {
+    if (Number.isNaN(n)) return 0
+    return Math.max(0, Math.min(1, n))
+}

--- a/packages/frontend/src/pages/GeoContributePage.tsx
+++ b/packages/frontend/src/pages/GeoContributePage.tsx
@@ -105,8 +105,19 @@ export default function GeoContributePage() {
             )}
 
             {!isLocked && phase === 'loading' && (
-                <div className="flex justify-center py-20">
-                    <Loader2 className="h-8 w-8 animate-spin text-neon-pink" />
+                <div
+                    className="flex justify-center py-20"
+                    role="status"
+                    aria-live="polite"
+                    aria-busy="true"
+                >
+                    <Loader2
+                        className="h-8 w-8 animate-spin text-neon-pink"
+                        aria-hidden
+                    />
+                    <span className="sr-only">
+                        {t('geo.contribute.loading', 'Loading screenshot…')}
+                    </span>
                 </div>
             )}
 
@@ -167,7 +178,13 @@ export default function GeoContributePage() {
                                 </Button>
                             </div>
                             {message && (
-                                <p className="text-xs text-success">{message}</p>
+                                <p
+                                    className="text-xs text-success"
+                                    role="status"
+                                    aria-live="polite"
+                                >
+                                    {message}
+                                </p>
                             )}
                         </CardContent>
                     </Card>

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -8,8 +8,11 @@ import { ReportCaptureDialog } from '@/components/ReportCaptureDialog'
 import { CubeBackground } from '@/components/backgrounds/CubeBackground'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { ImageOff, Loader2, MapPin, Trophy } from 'lucide-react'
+import { ImageOff, Loader2, MapPin, Trophy, Clock, History } from 'lucide-react'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
+import { useNextDailyCountdown } from '@/hooks/useNextDailyCountdown'
+import { Link } from 'react-router-dom'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 
 function todayIso(): string {
     return new Date().toISOString().slice(0, 10)
@@ -76,15 +79,17 @@ export default function GeoDailyPage() {
                     </div>
                 )}
 
-                {phase === 'error' && (
+                {phase === 'error' && errorCode === 'NO_CHALLENGE' && (
+                    <NoChallengeCard />
+                )}
+
+                {phase === 'error' && errorCode !== 'NO_CHALLENGE' && (
                     <Card>
-                        <CardContent className="py-10 text-center text-sm text-destructive">
-                            {errorCode === 'NO_CHALLENGE'
-                                ? t(
-                                      'geo.daily.errors.noChallenge',
-                                      'No geo challenge is available for today yet. Please check back later.',
-                                  )
-                                : (errorMessage ?? t('common.error', 'Error'))}
+                        <CardContent
+                            className="py-10 text-center text-sm text-destructive"
+                            role="alert"
+                        >
+                            {errorMessage ?? t('common.error', 'Error')}
                         </CardContent>
                     </Card>
                 )}
@@ -204,5 +209,45 @@ function ScreenshotFrame({ imageUrl }: { imageUrl: string }) {
             className="w-full rounded-lg border"
             onError={() => setErrored(true)}
         />
+    )
+}
+
+// Shown when /api/geo/daily/{date} returns 404 NO_CHALLENGE — usually right
+// after an admin reset or before the daily scheduler has had a chance to
+// run. Gives the player the time-to-next-challenge so they don't think the
+// game is broken, plus a path back to past results.
+function NoChallengeCard() {
+    const { t } = useTranslation()
+    const { hours, minutes, seconds } = useNextDailyCountdown()
+    const { localizedPath } = useLocalizedPath()
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const countdown = `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`
+    return (
+        <Card className="border-neon-pink/40">
+            <CardContent className="py-10 text-center space-y-4">
+                <div className="inline-flex items-center gap-2 rounded-full border border-neon-pink/40 bg-neon-pink/5 px-3 py-1 text-xs text-neon-pink">
+                    <Clock className="h-3.5 w-3.5" aria-hidden />
+                    <span aria-live="polite">
+                        {t('geo.daily.errors.nextIn', 'Next challenge in {{countdown}}', {
+                            countdown,
+                        })}
+                    </span>
+                </div>
+                <p className="text-sm text-muted-foreground max-w-md mx-auto leading-relaxed">
+                    {t(
+                        'geo.daily.errors.noChallenge',
+                        "No geo challenge is available for today yet. Please check back later.",
+                    )}
+                </p>
+                <div className="flex justify-center">
+                    <Button asChild variant="outline" size="sm">
+                        <Link to={localizedPath('/history')}>
+                            <History className="h-3.5 w-3.5 mr-1.5" aria-hidden />
+                            {t('geo.daily.errors.viewHistory', 'View past challenges')}
+                        </Link>
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
     )
 }

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -74,8 +74,16 @@ export default function GeoDailyPage() {
                 </header>
 
                 {phase === 'loading' && (
-                    <div className="flex justify-center py-20">
-                        <Loader2 className="h-8 w-8 animate-spin text-neon-pink" />
+                    <div
+                        className="flex justify-center py-20"
+                        role="status"
+                        aria-live="polite"
+                        aria-busy="true"
+                    >
+                        <Loader2 className="h-8 w-8 animate-spin text-neon-pink" aria-hidden />
+                        <span className="sr-only">
+                            {t('geo.daily.loading', 'Loading challenge…')}
+                        </span>
                     </div>
                 )}
 

--- a/packages/frontend/src/stores/geoStore.ts
+++ b/packages/frontend/src/stores/geoStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 import type {
     GeoChallenge,
     GeoGuessResult,
@@ -66,7 +67,9 @@ interface GeoState {
 
 const REWARD_BUFFER_MAX = 20
 
-export const useGeoStore = create<GeoState>((set, get) => ({
+export const useGeoStore = create<GeoState>()(
+    persist(
+        (set, get) => ({
     phase: 'idle',
     challenge: null,
     meta: null,
@@ -87,18 +90,32 @@ export const useGeoStore = create<GeoState>((set, get) => ({
     latestTierUp: null,
 
     async loadDaily(date) {
+        // Snapshot what was rehydrated (or held in memory) before we kick off
+        // the fetch — needed so we can restore the player's score after a
+        // page reload or a route round-trip.
+        const prev = get()
         set({ phase: 'loading', errorMessage: null, errorCode: null })
         try {
             const view = await geoApi.getDaily(date)
+            // Survive reload: if the backend says "you already guessed" AND
+            // we have a persisted result for this exact challenge, restore
+            // the result phase instead of dropping the player back to a
+            // fresh playing state. The challenge.id guard makes day-to-day
+            // store rollover safe — yesterday's result is ignored.
+            const restored =
+                view.hasGuessed &&
+                prev.result !== null &&
+                prev.challenge !== null &&
+                prev.challenge.id === view.challenge.id
             set({
-                phase: 'playing',
+                phase: restored ? 'result' : 'playing',
                 challenge: view.challenge,
                 meta: view.meta,
                 candidate: view.candidate,
                 map: view.map,
                 hasGuessed: view.hasGuessed,
-                result: null,
-                pendingGuess: null,
+                result: restored ? prev.result : null,
+                pendingGuess: restored ? prev.pendingGuess : null,
             })
         } catch (err) {
             set({
@@ -238,4 +255,19 @@ export const useGeoStore = create<GeoState>((set, get) => ({
             pendingPin: null,
         })
     },
-}))
+        }),
+        {
+            name: 'geo-daily-store',
+            // Only persist what's needed to survive a reload during the
+            // daily-game result phase. Skipping leaderboards / contributor
+            // / live event buffers keeps localStorage small and avoids
+            // resurrecting stale realtime data on a fresh tab.
+            partialize: (state) => ({
+                challenge: state.challenge,
+                result: state.result,
+                hasGuessed: state.hasGuessed,
+                pendingGuess: state.pendingGuess,
+            }),
+        },
+    ),
+)


### PR DESCRIPTION
Three independent fixes from the UI/UX audit, bundled because they're
small and surface-area-disjoint.

C1 — MapCanvas keyboard support + i18n
- Make the click-to-pin canvas focusable (`tabIndex=0` when interactive)
  and implement keyboard interaction: arrow keys (Shift = bigger step)
  move a focus-only crosshair, Enter/Space drops the pin at that
  position, Escape clears the cursor.
- Hide the keyboard cursor while the mouse-hover crosshair is active so
  the two input modalities don't visually fight.
- Replace the hardcoded English `aria-label`, `label="You"`, and
  `label="Actual"` with translated strings (`geo.daily.mapAria`,
  `geo.daily.mapAriaDisabled`, `geo.daily.markers.{you,actual}`).
- Add `focus-visible` ring tied to the design-system neon-pink token.

S1 — Persist daily result on reload
- Wrap geoStore in zustand `persist` middleware. `partialize` only
  exposes `challenge`, `result`, `hasGuessed`, `pendingGuess` — enough
  to survive a reload during the result phase without resurrecting
  stale leaderboards or realtime event buffers.
- `loadDaily(date)` now snapshots the previous state before the fetch
  and, if the backend says "you already guessed" AND the persisted
  result belongs to the same `challenge.id`, restores phase=`result`
  with the saved score instead of dropping the player back into a
  fresh `playing` view. The challenge.id guard makes day-rollover
  safe — yesterday's result is dropped automatically.

C3 — Lift `useGeoRunPolling` to GeoReviewPanel
- The hook used to live inside GeoMapsTab, so switching to the Pins
  or Games tab unmounted it and the in-flight run banner disappeared.
- GeoReviewPanel now owns the hook and renders a new
  GeoRunStateBanner above the Tabs row (always visible during a run,
  regardless of which tab is selected). The banner has
  `role="status" aria-live="polite"` so screen readers get progress
  announcements automatically.
- GeoMapsTab now takes `runState`, `runError`, `armRunPolling` as
  props from its parent and no longer instantiates its own polling
  loop — eliminates the double-mount footgun if the panel ever gets
  reused.
- Inline RunStateBanner removed from GeoMapsTab (its content moved
  to the new GeoRunStateBanner component file).