### PR TITLE
fix(geo): replace colons in BullMQ jobIds with hyphens

### DIFF
--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -119,7 +119,7 @@ export async function runGeoIngestTick(
               geoMapId: map.id,
               steamAppId: row.steam_app_id,
             },
-            { jobId: `auto-steam:${row.id}:${map.id}` },
+            { jobId: `auto-steam-${row.id}-${map.id}` },
           )
           steamEnqueued++
         }
@@ -156,7 +156,7 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
       await geoQueue.add(
         'import-registry-map',
         { kind: 'import-registry-map', gameId: row.id, entry },
-        { jobId: `auto-registry:${row.id}` },
+        { jobId: `auto-registry-${row.id}` },
       )
       return 'registry'
     }
@@ -176,7 +176,7 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
         wikiSubdomain: row.wiki_subdomain,
         pageTitle: row.wiki_page_title,
       },
-      { jobId: `auto-fandom:${row.id}` },
+      { jobId: `auto-fandom-${row.id}` },
     )
     return 'fandom'
   }
@@ -186,7 +186,7 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
     await geoQueue.add(
       'import-wikidata-map',
       { kind: 'import-wikidata-map', gameId: row.id, wikidataQid: row.wikidata_qid },
-      { jobId: `auto-wikidata:${row.id}` },
+      { jobId: `auto-wikidata-${row.id}` },
     )
     return 'wikidata'
   }

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -2181,16 +2181,19 @@ router.post('/geo/run/:gameId', async (req, res, next) => {
       return
     }
     // Stable jobIds so a double-click while one is still in flight collapses
-    // to a single run. BullMQ silently no-ops on duplicate ids.
+    // to a single run. BullMQ silently no-ops on duplicate ids. Hyphens (not
+    // colons) — BullMQ's `Job.validateOptions` throws on jobIds containing
+    // `:` unless they have exactly 3 colon-separated parts (a legacy
+    // repeatable-job carve-out).
     const resolveJob = await geoQueue.add(
       'resolve-metadata',
       { kind: 'resolve-metadata', batchSize: 1, gameId },
-      { jobId: `manual-resolve:${gameId}` },
+      { jobId: `manual-resolve-${gameId}` },
     )
     const tickJob = await geoQueue.add(
       'ingest-tick',
       { kind: 'ingest-tick', batchSize: 1, gameId },
-      { jobId: `manual-tick:${gameId}` },
+      { jobId: `manual-tick-${gameId}` },
     )
     res.json({
       success: true,


### PR DESCRIPTION
BullMQ 5.x's `Job.validateOptions` throws "Custom Id cannot contain :"
on any jobId containing `:` unless it has exactly 3 colon-separated
parts (a legacy carve-out for repeatable jobs). The single-game admin
"Run" route was enqueuing `manual-resolve:<id>` and `manual-tick:<id>`
— two-part — so every click failed synchronously and surfaced as
INTERNAL_ERROR. The same shape was used for `auto-registry:<id>`,
`auto-fandom:<id>`, and `auto-wikidata:<id>` in the ingest-tick
worker, which silently broke the tier cascade and left curated games
stuck on "Sans carte". Switching all of these to hyphen-separated
ids preserves the dedupe semantics (one job per game per tier) and
gets the validation to pass. `auto-steam:<id>:<map>` happened to be
3-part so it was accepted, but it's normalized too for consistency.