### PR TITLE
feat(geo): add StrategyWiki + Fextralife map tiers and admin research assistant

### DIFF
--- a/packages/backend/src/infrastructure/queue/queues.ts
+++ b/packages/backend/src/infrastructure/queue/queues.ts
@@ -38,6 +38,18 @@ export type GeoJobData =
       pageTitle: string
     }
   | {
+      kind: 'import-strategywiki-map'
+      gameId: number
+      gameName: string
+      slug: string
+    }
+  | {
+      kind: 'import-fextralife-map'
+      gameId: number
+      gameName: string
+      slug: string
+    }
+  | {
       kind: 'import-wikidata-map'
       gameId: number
       wikidataQid: string

--- a/packages/backend/src/infrastructure/queue/workers/geo-fextralife-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-fextralife-import-logic.ts
@@ -1,0 +1,196 @@
+import { queueLogger } from '../../logger/logger.js'
+import {
+  geoIngestFailureRepository,
+  geoMapRepository,
+} from '../../repositories/index.js'
+import { tombstoneRetryAfter } from '../../../domain/services/geo-metadata.service.js'
+import { probeImageDimensions } from './image-dimensions.js'
+
+const log = queueLogger.child({ worker: 'geo-fextralife-import' })
+
+// Fextralife (https://*.wiki.fextralife.com) hosts the highest-quality
+// Soulsborne / RPG world maps on the open web — Elden Ring, BG3,
+// Bloodborne, Dark Souls, Divinity OS 1+2, Hogwarts Legacy. Pages follow a
+// stable slug and expose an `og:image` poster meant for social embedding,
+// which is what we ingest. We deliberately don't stitch their Leaflet
+// tiles (terms-of-service ambiguity); the og:image is enough to drive a
+// guess-the-location experience.
+//
+// Strategy:
+//   1. Derive a subdomain from the game slug/name.
+//   2. HEAD-probe `/Interactive+Map`, `/World+Map`, `/Map` in order.
+//   3. GET the first 200 path; extract `og:image`.
+//   4. Probe the og:image to fill width/height; insert geo_map row.
+
+const DEFAULT_USER_AGENT =
+  'the-box-geo-importer/1.0 (+https://github.com/Wifsimster/the-box)'
+const FEXTRALIFE_LICENSE = 'Fextralife (fair use, attribution)'
+const PATH_CANDIDATES = ['Interactive+Map', 'World+Map', 'Map']
+const MIN_DIMENSION = 600
+
+export interface ImportFextralifeMapInput {
+  gameId: number
+  gameName: string
+  slug: string
+  userAgent?: string
+}
+
+export interface ImportFextralifeMapResult {
+  imported: boolean
+  geoMapId?: number
+  reason?: string
+}
+
+export async function importFextralifeMap(
+  input: ImportFextralifeMapInput,
+): Promise<ImportFextralifeMapResult> {
+  const { gameId, gameName, slug } = input
+  const ua = input.userAgent ?? DEFAULT_USER_AGENT
+
+  const existing = await geoMapRepository.findActiveByGameId(gameId)
+  if (existing) {
+    return { imported: false, geoMapId: existing.id, reason: 'map already exists' }
+  }
+
+  const subdomains = fextralifeSubdomainCandidates(gameName, slug)
+  log.info({ gameId, subdomains }, 'probing fextralife')
+
+  let hit: { subdomain: string; pagePath: string; html: string } | null = null
+  for (const sub of subdomains) {
+    const found = await probeSubdomain(sub, ua)
+    if (found) {
+      hit = found
+      break
+    }
+  }
+  if (!hit) {
+    await tombstone(gameId, 'no fextralife wiki / map page found')
+    return { imported: false, reason: 'no map page' }
+  }
+
+  const ogImage = extractOgImage(hit.html)
+  if (!ogImage) {
+    await tombstone(gameId, `og:image missing on ${hit.subdomain}/${hit.pagePath}`)
+    return { imported: false, reason: 'og:image missing' }
+  }
+
+  const dims = await probeImageDimensions(ogImage, ua)
+  if (!dims) {
+    await tombstone(gameId, `could not probe dimensions for ${ogImage}`)
+    return { imported: false, reason: 'could not probe dimensions' }
+  }
+  if (dims.width < MIN_DIMENSION || dims.height < MIN_DIMENSION) {
+    await tombstone(
+      gameId,
+      `og:image too small (${dims.width}x${dims.height}) — likely a logo, not a map`,
+    )
+    return { imported: false, reason: 'og:image too small' }
+  }
+
+  const sourceUrl = `https://${hit.subdomain}.wiki.fextralife.com/${hit.pagePath}`
+  const map = await geoMapRepository.create({
+    gameId,
+    source: 'fextralife',
+    sourceUrl,
+    imageUrl: ogImage,
+    widthPx: dims.width,
+    heightPx: dims.height,
+    license: FEXTRALIFE_LICENSE,
+    attribution: `Map © ${hit.subdomain}.wiki.fextralife.com`,
+  })
+
+  await geoIngestFailureRepository.clear(gameId, 'fextralife')
+  log.info(
+    { gameId, mapId: map.id, sub: hit.subdomain, ogImage, dims },
+    'imported fextralife map',
+  )
+  return { imported: true, geoMapId: map.id }
+}
+
+/**
+ * Derive Fextralife wiki subdomain candidates from a game's name + slug.
+ * The site's convention is alphanumeric-only (no separators): "Elden Ring"
+ * → `eldenring`, "Baldur's Gate III" → `baldursgate3`. Roman numerals are
+ * expanded to arabic to match the way Fextralife actually registers wikis.
+ */
+export function fextralifeSubdomainCandidates(
+  gameName: string,
+  slug: string,
+): string[] {
+  const out = new Set<string>()
+  const base = romanToArabic(gameName)
+  const compact = base.toLowerCase().replace(/[^a-z0-9]+/g, '')
+  if (compact) out.add(compact)
+  const compactFromSlug = slug.toLowerCase().replace(/[^a-z0-9]+/g, '')
+  if (compactFromSlug) out.add(compactFromSlug)
+  // Drop a leading "the" — "thewitcher3" ≠ "witcher3" on Fextralife.
+  if (compact.startsWith('the')) out.add(compact.slice(3))
+  if (compactFromSlug.startsWith('the')) out.add(compactFromSlug.slice(3))
+  return [...out]
+}
+
+// Conservative whitelist of roman numerals 1..20. A general-purpose roman
+// regex matches too many in-word substrings ("DIVINITY" contains "DIVI",
+// "LIVE" contains "LIV") so we hard-code the values we actually see in
+// game titles ("Baldur's Gate III", "Diablo II", "GTA IV").
+const ROMAN_NUMERALS: Record<string, string> = {
+  I: '1', II: '2', III: '3', IV: '4', V: '5', VI: '6', VII: '7', VIII: '8',
+  IX: '9', X: '10', XI: '11', XII: '12', XIII: '13', XIV: '14', XV: '15',
+  XVI: '16', XVII: '17', XVIII: '18', XIX: '19', XX: '20',
+}
+
+function romanToArabic(s: string): string {
+  return s.replace(/\b([IVX]{1,5})\b/g, (m) => ROMAN_NUMERALS[m.toUpperCase()] ?? m)
+}
+
+async function probeSubdomain(
+  subdomain: string,
+  ua: string,
+): Promise<{ subdomain: string; pagePath: string; html: string } | null> {
+  for (const path of PATH_CANDIDATES) {
+    const url = `https://${subdomain}.wiki.fextralife.com/${path}`
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': ua, Accept: 'text/html' },
+      })
+      if (!res.ok) continue
+      const text = await res.text()
+      // Fextralife sometimes serves a soft-404 page with a 200 status; gate
+      // on the page actually advertising itself as a map.
+      if (!/og:image/i.test(text)) continue
+      return { subdomain, pagePath: path, html: text }
+    } catch {
+      // Network error — try the next candidate path.
+    }
+  }
+  return null
+}
+
+// Match `<meta>` regardless of attribute order: `property` and `content` may
+// appear in either sequence depending on the CMS.
+const OG_IMAGE_FORWARD =
+  /<meta[^>]+property=["']og:image(?::secure_url|:url)?["'][^>]+content=["']([^"']+)["']/i
+const OG_IMAGE_REVERSE =
+  /<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:image(?::secure_url|:url)?["']/i
+
+export function extractOgImage(html: string): string | null {
+  const m = html.match(OG_IMAGE_FORWARD) ?? html.match(OG_IMAGE_REVERSE)
+  if (!m) return null
+  const raw = m[1]?.trim()
+  if (!raw) return null
+  // Reject relative paths (Fextralife always returns absolute URLs but be
+  // defensive — a relative URL would point at the wrong host).
+  if (!/^https?:\/\//i.test(raw)) return null
+  return raw
+}
+
+async function tombstone(gameId: number, reason: string): Promise<void> {
+  const attempt =
+    (await geoIngestFailureRepository.getAttemptCount(gameId, 'fextralife')) + 1
+  await geoIngestFailureRepository.record({
+    gameId,
+    source: 'fextralife',
+    reason,
+    retryAfter: tombstoneRetryAfter(attempt),
+  })
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -11,6 +11,7 @@ const STEAM_TARGET_CANDIDATES = 30 // stop fetching Steam shots once we have thi
 
 interface TickRow {
   id: number
+  name: string
   slug: string
   steam_app_id: number | null
   wiki_subdomain: string | null
@@ -24,6 +25,8 @@ export interface IngestTickResult {
   scanned: number
   registryEnqueued: number
   fandomEnqueued: number
+  strategyWikiEnqueued: number
+  fextralifeEnqueued: number
   wikidataEnqueued: number
   steamEnqueued: number
 }
@@ -31,9 +34,15 @@ export interface IngestTickResult {
 /**
  * One pass over curated, resolved games. For each game without an active map,
  * try the ingestion tiers in order and enqueue the first eligible job:
- *   1. `registry`  — curated GitHub Leaflet repo (if entry exists for slug)
- *   2. `fandom`    — Fandom Interactive Maps (if wiki_subdomain + map page resolved)
- *   3. `wikidata`  — Wikidata P242 locator map (if wikidata_qid resolved)
+ *   1. `registry`     — curated GitHub Leaflet repo (if entry exists for slug)
+ *   2. `fandom`       — Fandom Interactive Maps (if wiki_subdomain + map page resolved)
+ *   3. `strategywiki` — StrategyWiki MediaWiki API (CC-BY-SA, no pre-resolution)
+ *   4. `fextralife`   — Fextralife wiki og:image scrape (RPG / Soulsborne coverage)
+ *   5. `wikidata`     — Wikidata P242 locator map (if wikidata_qid resolved)
+ *
+ * Tiers 3 and 4 don't require pre-resolution — they probe the upstream API
+ * inline using the game slug + name, so a game can succeed there even if
+ * the metadata resolver couldn't find a Fandom subdomain or Wikidata Q-id.
  *
  * Tier 0 is implicit: if `geo_map` already has an active row (e.g. via
  * `manual` upload), no map-import is enqueued at all — only the Steam
@@ -57,6 +66,7 @@ export async function runGeoIngestTick(
       `
       SELECT
         g.id,
+        g.name,
         g.slug,
         g.steam_app_id,
         g.wiki_subdomain,
@@ -89,6 +99,8 @@ export async function runGeoIngestTick(
 
   let registryEnqueued = 0
   let fandomEnqueued = 0
+  let strategyWikiEnqueued = 0
+  let fextralifeEnqueued = 0
   let wikidataEnqueued = 0
   let steamEnqueued = 0
 
@@ -97,6 +109,8 @@ export async function runGeoIngestTick(
       const enqueued = await enqueueFirstAvailableMapImport(row)
       if (enqueued === 'registry') registryEnqueued++
       else if (enqueued === 'fandom') fandomEnqueued++
+      else if (enqueued === 'strategywiki') strategyWikiEnqueued++
+      else if (enqueued === 'fextralife') fextralifeEnqueued++
       else if (enqueued === 'wikidata') wikidataEnqueued++
     }
 
@@ -132,6 +146,8 @@ export async function runGeoIngestTick(
       scanned: rows.length,
       registryEnqueued,
       fandomEnqueued,
+      strategyWikiEnqueued,
+      fextralifeEnqueued,
       wikidataEnqueued,
       steamEnqueued,
     },
@@ -141,12 +157,14 @@ export async function runGeoIngestTick(
     scanned: rows.length,
     registryEnqueued,
     fandomEnqueued,
+    strategyWikiEnqueued,
+    fextralifeEnqueued,
     wikidataEnqueued,
     steamEnqueued,
   }
 }
 
-type MapTier = 'registry' | 'fandom' | 'wikidata' | null
+type MapTier = 'registry' | 'fandom' | 'strategywiki' | 'fextralife' | 'wikidata' | null
 
 async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
   // Tier 1 — registry
@@ -181,7 +199,37 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
     return 'fandom'
   }
 
-  // Tier 3 — Wikidata P242 fallback
+  // Tier 3 — StrategyWiki (no pre-resolution required; probes via opensearch)
+  if (!(await tombstoneBlocks(row.id, 'strategywiki'))) {
+    await geoQueue.add(
+      'import-strategywiki-map',
+      {
+        kind: 'import-strategywiki-map',
+        gameId: row.id,
+        gameName: row.name,
+        slug: row.slug,
+      },
+      { jobId: `auto-strategywiki-${row.id}` },
+    )
+    return 'strategywiki'
+  }
+
+  // Tier 4 — Fextralife (no pre-resolution required; probes by slug)
+  if (!(await tombstoneBlocks(row.id, 'fextralife'))) {
+    await geoQueue.add(
+      'import-fextralife-map',
+      {
+        kind: 'import-fextralife-map',
+        gameId: row.id,
+        gameName: row.name,
+        slug: row.slug,
+      },
+      { jobId: `auto-fextralife-${row.id}` },
+    )
+    return 'fextralife'
+  }
+
+  // Tier 5 — Wikidata P242 fallback
   if (row.wikidata_qid && !(await tombstoneBlocks(row.id, 'wikidata'))) {
     await geoQueue.add(
       'import-wikidata-map',
@@ -196,7 +244,13 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
 
 async function tombstoneBlocks(
   gameId: number,
-  source: 'fandom' | 'steam' | 'registry' | 'wikidata',
+  source:
+    | 'fandom'
+    | 'steam'
+    | 'registry'
+    | 'wikidata'
+    | 'strategywiki'
+    | 'fextralife',
 ): Promise<boolean> {
   const row = await db('geo_ingest_failure')
     .where({ game_id: gameId, source })

--- a/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
@@ -6,7 +6,6 @@ import {
   isMapEligibleByGenre,
   normalizeGameTitle,
   scoreMapTitle,
-  tombstoneRetryAfter,
   wikiSubdomainCandidates,
 } from '../../../domain/services/geo-metadata.service.js'
 import { resolveWikidataQid } from './geo-wikidata-import-logic.js'
@@ -103,26 +102,12 @@ export async function resolveGeoMetadataBatch(
       // Tier 1 hit short-circuits the "did we find anything" check — even if
       // Steam/Fandom/Wikidata all whiff, a curated registry entry is enough
       // to mark this game `resolved` and let the tick enqueue the import.
+      // The StrategyWiki and Fextralife tiers don't need pre-resolution
+      // (they probe upstream APIs inline using just the game name + slug),
+      // so every curated game implicitly has at least those two fallbacks
+      // — we no longer mark `unresolved` here. Per-tier tombstones still
+      // enforce backoff if every tier whiffs at import time.
       const hasRegistry = (await findRegistryEntryBySlug(row.slug)) !== null
-
-      const haveAnything =
-        hasRegistry || Boolean(steamAppId) || Boolean(wiki) || Boolean(wikidataQid)
-      if (!haveAnything) {
-        const attempt =
-          (await geoIngestFailureRepository.getAttemptCount(row.id, 'metadata')) + 1
-        await geoIngestFailureRepository.record({
-          gameId: row.id,
-          source: 'metadata',
-          reason:
-            'no registry entry, Steam appid, Fandom map, or Wikidata Q-id found',
-          retryAfter: tombstoneRetryAfter(attempt),
-        })
-        await db('games')
-          .where({ id: row.id })
-          .update({ geo_metadata_status: 'unresolved' })
-        unresolved++
-        continue
-      }
 
       await db('games')
         .where({ id: row.id })

--- a/packages/backend/src/infrastructure/queue/workers/geo-strategywiki-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-strategywiki-import-logic.ts
@@ -1,0 +1,314 @@
+import { queueLogger } from '../../logger/logger.js'
+import {
+  geoIngestFailureRepository,
+  geoMapRepository,
+} from '../../repositories/index.js'
+import { tombstoneRetryAfter } from '../../../domain/services/geo-metadata.service.js'
+
+const log = queueLogger.child({ worker: 'geo-strategywiki-import' })
+
+// StrategyWiki (https://strategywiki.org) is a CC-BY-SA-3.0 wiki of game
+// guides built on MediaWiki, with predictable Maps subpages
+// (e.g. `Diablo/Maps`, `Half-Life/Maps`). Two experts in the discovery-tier
+// brainstorm independently picked it as the highest signal-to-noise public
+// source for AAA games — the licensing is unambiguous and the API surface
+// matches the one we already use for Fandom Interactive Maps.
+//
+// Strategy (no pre-resolution required):
+//   1. opensearch the game name → top page title.
+//   2. List images on `<title>` and `<title>/Maps` via prop=images.
+//   3. Resolve each File: via prop=imageinfo, score by name + size.
+//   4. Pick the highest-scoring image, validate dimensions, write geo_map.
+
+const DEFAULT_USER_AGENT =
+  'the-box-geo-importer/1.0 (+https://github.com/Wifsimster/the-box)'
+const STRATEGYWIKI_API = 'https://strategywiki.org/w/api.php'
+const STRATEGYWIKI_LICENSE = 'CC-BY-SA-3.0'
+const MIN_IMAGE_DIMENSION = 600
+const MIN_IMAGE_AREA = 600_000
+
+export interface ImportStrategyWikiMapInput {
+  gameId: number
+  gameName: string
+  slug: string
+  userAgent?: string
+}
+
+export interface ImportStrategyWikiMapResult {
+  imported: boolean
+  geoMapId?: number
+  reason?: string
+}
+
+interface OpenSearchResponse {
+  // [query, [titles], [descriptions], [urls]]
+  0?: string
+  1?: string[]
+  2?: string[]
+  3?: string[]
+}
+
+interface ImagesResponse {
+  query?: {
+    pages?: Record<
+      string,
+      {
+        title?: string
+        images?: Array<{ title: string }>
+        missing?: ''
+      }
+    >
+  }
+}
+
+interface ImageInfoResponse {
+  query?: {
+    pages?: Record<
+      string,
+      {
+        title?: string
+        imageinfo?: Array<{
+          url: string
+          width: number
+          height: number
+          mime?: string
+          extmetadata?: {
+            LicenseShortName?: { value?: string }
+            Artist?: { value?: string }
+          }
+        }>
+        missing?: ''
+      }
+    >
+  }
+}
+
+export async function importStrategyWikiMap(
+  input: ImportStrategyWikiMapInput,
+): Promise<ImportStrategyWikiMapResult> {
+  const { gameId, gameName, slug } = input
+  const ua = input.userAgent ?? DEFAULT_USER_AGENT
+
+  const existing = await geoMapRepository.findActiveByGameId(gameId)
+  if (existing) {
+    return { imported: false, geoMapId: existing.id, reason: 'map already exists' }
+  }
+
+  log.info({ gameId, gameName }, 'looking up strategywiki page')
+
+  let pageTitle: string | null
+  try {
+    pageTitle = await resolveStrategyWikiTitle(gameName, ua)
+  } catch (err) {
+    await tombstone(gameId, `opensearch failed: ${String(err)}`)
+    return { imported: false, reason: 'opensearch failed' }
+  }
+  if (!pageTitle) {
+    await tombstone(gameId, 'no strategywiki page for game')
+    return { imported: false, reason: 'no strategywiki page' }
+  }
+
+  let candidateFiles: string[]
+  try {
+    candidateFiles = await listCandidateFiles(pageTitle, ua)
+  } catch (err) {
+    await tombstone(gameId, `images list failed: ${String(err)}`)
+    return { imported: false, reason: 'images list failed' }
+  }
+  if (candidateFiles.length === 0) {
+    await tombstone(gameId, `no map-like files on ${pageTitle}`)
+    return { imported: false, reason: 'no map files' }
+  }
+
+  let resolved: ResolvedFile | null
+  try {
+    resolved = await pickBestImage(candidateFiles, gameName, slug, ua)
+  } catch (err) {
+    await tombstone(gameId, `imageinfo failed: ${String(err)}`)
+    return { imported: false, reason: 'imageinfo failed' }
+  }
+  if (!resolved) {
+    await tombstone(gameId, 'no image cleared validation thresholds')
+    return { imported: false, reason: 'no image passed validation' }
+  }
+
+  const map = await geoMapRepository.create({
+    gameId,
+    source: 'strategywiki',
+    sourceUrl: `https://strategywiki.org/wiki/${encodeURIComponent(pageTitle)}`,
+    imageUrl: resolved.url,
+    widthPx: resolved.width,
+    heightPx: resolved.height,
+    license: resolved.license || STRATEGYWIKI_LICENSE,
+    attribution: `StrategyWiki — ${pageTitle}${resolved.artist ? ` (${resolved.artist})` : ''}`,
+  })
+
+  await geoIngestFailureRepository.clear(gameId, 'strategywiki')
+  log.info({ gameId, mapId: map.id, file: resolved.title }, 'imported strategywiki map')
+  return { imported: true, geoMapId: map.id }
+}
+
+interface ResolvedFile {
+  title: string
+  url: string
+  width: number
+  height: number
+  license: string
+  artist: string | null
+  score: number
+}
+
+async function resolveStrategyWikiTitle(
+  gameName: string,
+  ua: string,
+): Promise<string | null> {
+  // opensearch is forgiving — it returns the canonical wiki title for a
+  // game even if the user-facing name differs (e.g. "Half-Life" vs
+  // "Half Life", "GTA IV" vs "Grand Theft Auto IV").
+  const url =
+    `${STRATEGYWIKI_API}?action=opensearch&format=json&namespace=0` +
+    `&limit=5&search=${encodeURIComponent(gameName)}`
+  const res = await fetch(url, {
+    headers: { 'User-Agent': ua, Accept: 'application/json' },
+  })
+  if (!res.ok) throw new Error(`opensearch ${res.status}`)
+  const body = (await res.json()) as OpenSearchResponse
+  const titles = body[1] ?? []
+  const target = normalize(gameName)
+  return (
+    titles.find((t) => normalize(t) === target) ??
+    titles.find((t) => normalize(t).startsWith(target)) ??
+    titles[0] ??
+    null
+  )
+}
+
+async function listCandidateFiles(pageTitle: string, ua: string): Promise<string[]> {
+  // Look at both the main page and the conventional `<Title>/Maps` subpage
+  // — many older guides put the world map directly on the root page, while
+  // comprehensive guides use the subpage. Either or both may exist.
+  const titles = `${pageTitle}|${pageTitle}/Maps`
+  const url =
+    `${STRATEGYWIKI_API}?action=query&format=json&prop=images&imlimit=200` +
+    `&titles=${encodeURIComponent(titles)}`
+  const res = await fetch(url, {
+    headers: { 'User-Agent': ua, Accept: 'application/json' },
+  })
+  if (!res.ok) throw new Error(`prop=images ${res.status}`)
+  const body = (await res.json()) as ImagesResponse
+  const out = new Set<string>()
+  for (const page of Object.values(body.query?.pages ?? {})) {
+    if (page.missing !== undefined) continue
+    for (const img of page.images ?? []) {
+      if (img.title) out.add(img.title)
+    }
+  }
+  return [...out].filter(looksLikeMapFile)
+}
+
+const MAP_FILENAME_RE = /(map|maps|world|overworld|atlas|continent)/i
+const NEGATIVE_FILENAME_RE = /(icon|logo|button|hud|portrait|cover|box|wiki)/i
+
+function looksLikeMapFile(title: string): boolean {
+  // `title` is e.g. "File:Diablo_Sanctuary_world_map.png".
+  if (NEGATIVE_FILENAME_RE.test(title)) return false
+  if (!MAP_FILENAME_RE.test(title)) return false
+  // Reject obvious non-image extensions (StrategyWiki sometimes lists svg
+  // skin assets — we want raster maps Leaflet can serve directly).
+  return /\.(png|jpe?g|webp)$/i.test(title)
+}
+
+async function pickBestImage(
+  files: string[],
+  gameName: string,
+  slug: string,
+  ua: string,
+): Promise<ResolvedFile | null> {
+  // Batch up to 50 titles per imageinfo call — MediaWiki caps at 50 per
+  // request anyway and our `looksLikeMapFile` filter usually shrinks the
+  // list well below that.
+  const titles = files.slice(0, 50).join('|')
+  const url =
+    `${STRATEGYWIKI_API}?action=query&format=json&prop=imageinfo` +
+    `&iiprop=url|size|mime|extmetadata&iiurlwidth=2048` +
+    `&titles=${encodeURIComponent(titles)}`
+  const res = await fetch(url, {
+    headers: { 'User-Agent': ua, Accept: 'application/json' },
+  })
+  if (!res.ok) throw new Error(`imageinfo ${res.status}`)
+  const body = (await res.json()) as ImageInfoResponse
+
+  let best: ResolvedFile | null = null
+  for (const page of Object.values(body.query?.pages ?? {})) {
+    const info = page.imageinfo?.[0]
+    if (!page.title || !info) continue
+    if (info.width < MIN_IMAGE_DIMENSION || info.height < MIN_IMAGE_DIMENSION) continue
+    if (info.width * info.height < MIN_IMAGE_AREA) continue
+
+    const score = scoreFile(page.title, info.width, info.height, gameName, slug)
+    if (best && score <= best.score) continue
+    best = {
+      title: page.title,
+      url: info.url,
+      width: info.width,
+      height: info.height,
+      license: info.extmetadata?.LicenseShortName?.value ?? '',
+      artist: info.extmetadata?.Artist?.value ?? null,
+      score,
+    }
+  }
+  return best
+}
+
+function scoreFile(
+  fileTitle: string,
+  width: number,
+  height: number,
+  gameName: string,
+  slug: string,
+): number {
+  // Higher = better. Bonuses tuned against the failing-list games where we
+  // expect filenames like "Diablo_Sanctuary_world_map.png" or
+  // "BG3_World_Map.jpg". Aspect ratio penalty discourages tall vertical
+  // banners that are sometimes mis-tagged as `world map`.
+  let score = 0
+  const lower = fileTitle.toLowerCase()
+  const nameToken = normalize(gameName).split(' ').filter((t) => t.length >= 3)
+  for (const tok of nameToken) {
+    if (lower.includes(tok)) score += 10
+  }
+  if (lower.includes(slug.replace(/-/g, '_'))) score += 8
+  if (/world[_\s-]?map/.test(lower)) score += 30
+  if (/overworld/.test(lower)) score += 20
+  if (/atlas/.test(lower)) score += 15
+  if (/_map\b/.test(lower) || /_maps\b/.test(lower)) score += 5
+
+  // Prefer panoramic/square aspect; punish 3:1+ verticals.
+  const ar = width / height
+  if (ar >= 0.6 && ar <= 2.4) score += 10
+  else score -= 15
+
+  // Light bias toward larger images (cap so a megapixel bomb doesn't dominate).
+  score += Math.min(20, Math.log10(width * height) * 2)
+  return score
+}
+
+function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+async function tombstone(gameId: number, reason: string): Promise<void> {
+  const attempt =
+    (await geoIngestFailureRepository.getAttemptCount(gameId, 'strategywiki')) + 1
+  await geoIngestFailureRepository.record({
+    gameId,
+    source: 'strategywiki',
+    reason,
+    retryAfter: tombstoneRetryAfter(attempt),
+  })
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -4,7 +4,9 @@ import { queueLogger } from '../../logger/logger.js'
 import type { GeoJobData } from '../queues.js'
 import { evaluateConsensusForCandidate } from './geo-consensus-logic.js'
 import { importFandomMap } from './geo-fandom-import-logic.js'
+import { importFextralifeMap } from './geo-fextralife-import-logic.js'
 import { importRegistryMap } from './geo-registry-import-logic.js'
+import { importStrategyWikiMap } from './geo-strategywiki-import-logic.js'
 import { importWikidataMap } from './geo-wikidata-import-logic.js'
 import { importSteamScreenshots } from './geo-steam-import-logic.js'
 import { scheduleDailyGeoChallenge } from './geo-schedule-logic.js'
@@ -51,6 +53,22 @@ export const geoWorker = new Worker<GeoJobData>(
         gameId: data.gameId,
         wikiSubdomain: data.wikiSubdomain,
         pageTitle: data.pageTitle,
+      })
+    }
+
+    if (data.kind === 'import-strategywiki-map') {
+      return await importStrategyWikiMap({
+        gameId: data.gameId,
+        gameName: data.gameName,
+        slug: data.slug,
+      })
+    }
+
+    if (data.kind === 'import-fextralife-map') {
+      return await importFextralifeMap({
+        gameId: data.gameId,
+        gameName: data.gameName,
+        slug: data.slug,
       })
     }
 

--- a/packages/backend/src/infrastructure/queue/workers/image-dimensions.ts
+++ b/packages/backend/src/infrastructure/queue/workers/image-dimensions.ts
@@ -1,0 +1,138 @@
+// Lightweight PNG / JPEG / WEBP dimension probe used by tiers that discover
+// a map URL but get no dimensions from the upstream API (Fextralife scrapes
+// an `og:image` tag, StrategyWiki sometimes returns thumbnail metadata).
+//
+// We deliberately do NOT pull `sharp` or `image-size` — we only need width
+// and height of three formats whose headers fit in the first ~64 KiB. Doing
+// it inline keeps the backend dependency surface small and avoids a native
+// build step.
+
+const HEADER_BYTES = 65536
+
+export interface ProbedDimensions {
+  width: number
+  height: number
+  format: 'png' | 'jpeg' | 'webp'
+}
+
+export async function probeImageDimensions(
+  url: string,
+  userAgent: string,
+): Promise<ProbedDimensions | null> {
+  let buf: Uint8Array
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': userAgent,
+        Range: `bytes=0-${HEADER_BYTES - 1}`,
+        Accept: 'image/*,*/*;q=0.8',
+      },
+    })
+    if (!res.ok && res.status !== 206) return null
+    buf = new Uint8Array(await res.arrayBuffer())
+  } catch {
+    return null
+  }
+  return parseDimensions(buf)
+}
+
+export function parseDimensions(buf: Uint8Array): ProbedDimensions | null {
+  if (buf.length < 12) return null
+
+  // PNG: \x89PNG\r\n\x1a\n then IHDR with width/height as big-endian uint32
+  // at offsets 16 and 20.
+  if (
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47 &&
+    buf.length >= 24
+  ) {
+    const width = readUint32BE(buf, 16)
+    const height = readUint32BE(buf, 20)
+    if (width > 0 && height > 0) return { width, height, format: 'png' }
+    return null
+  }
+
+  // JPEG: SOI marker FFD8, then walk segments looking for SOFn (FFC0..FFCF
+  // except FFC4/FFC8/FFCC). The two bytes after the segment-length field are
+  // precision (1 byte) then height (2 bytes BE) then width (2 bytes BE).
+  if (buf[0] === 0xff && buf[1] === 0xd8) {
+    let i = 2
+    while (i < buf.length - 9) {
+      if (buf[i] !== 0xff) {
+        i++
+        continue
+      }
+      const marker = buf[i + 1]!
+      if (marker === 0xd8 || marker === 0xd9 || marker === 0x01) {
+        i += 2
+        continue
+      }
+      // SOFn frames are 0xC0..0xCF except DHT (C4), JPG (C8), DAC (CC).
+      const isSof =
+        marker >= 0xc0 &&
+        marker <= 0xcf &&
+        marker !== 0xc4 &&
+        marker !== 0xc8 &&
+        marker !== 0xcc
+      const segLen = (buf[i + 2]! << 8) | buf[i + 3]!
+      if (isSof) {
+        const height = (buf[i + 5]! << 8) | buf[i + 6]!
+        const width = (buf[i + 7]! << 8) | buf[i + 8]!
+        if (width > 0 && height > 0) return { width, height, format: 'jpeg' }
+        return null
+      }
+      i += 2 + segLen
+    }
+    return null
+  }
+
+  // WEBP: RIFF....WEBP
+  if (
+    buf.length >= 30 &&
+    buf[0] === 0x52 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x46 &&
+    buf[8] === 0x57 &&
+    buf[9] === 0x45 &&
+    buf[10] === 0x42 &&
+    buf[11] === 0x50
+  ) {
+    const chunk = String.fromCharCode(buf[12]!, buf[13]!, buf[14]!, buf[15]!)
+    if (chunk === 'VP8 ') {
+      const width = ((buf[26]! | (buf[27]! << 8)) & 0x3fff) >>> 0
+      const height = ((buf[28]! | (buf[29]! << 8)) & 0x3fff) >>> 0
+      if (width > 0 && height > 0) return { width, height, format: 'webp' }
+    }
+    if (chunk === 'VP8L' && buf.length >= 25) {
+      // Lossless: 14 bits width-1 then 14 bits height-1, little-endian.
+      const b0 = buf[21]!
+      const b1 = buf[22]!
+      const b2 = buf[23]!
+      const b3 = buf[24]!
+      const width = 1 + (((b1 & 0x3f) << 8) | b0)
+      const height =
+        1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >>> 6))
+      if (width > 0 && height > 0) return { width, height, format: 'webp' }
+    }
+    if (chunk === 'VP8X' && buf.length >= 30) {
+      // Extended: 24-bit canvas width-1 / height-1 LE at offsets 24 and 27.
+      const width = 1 + (buf[24]! | (buf[25]! << 8) | (buf[26]! << 16))
+      const height = 1 + (buf[27]! | (buf[28]! << 8) | (buf[29]! << 16))
+      if (width > 0 && height > 0) return { width, height, format: 'webp' }
+    }
+  }
+
+  return null
+}
+
+function readUint32BE(buf: Uint8Array, offset: number): number {
+  return (
+    ((buf[offset]! << 24) >>> 0) +
+    (buf[offset + 1]! << 16) +
+    (buf[offset + 2]! << 8) +
+    buf[offset + 3]!
+  )
+}

--- a/packages/backend/src/infrastructure/repositories/geo-ingest-failure.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-ingest-failure.repository.ts
@@ -8,6 +8,8 @@ export type GeoIngestSource =
   | 'steam'
   | 'metadata'
   | 'registry'
+  | 'strategywiki'
+  | 'fextralife'
   | 'wikidata'
 
 export interface GeoIngestFailureRow {

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1866,7 +1866,13 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
     const now = Date.now()
 
     const tier = (
-      key: 'registry' | 'fandom' | 'wikidata' | 'manual',
+      key:
+        | 'registry'
+        | 'fandom'
+        | 'strategywiki'
+        | 'fextralife'
+        | 'wikidata'
+        | 'manual',
       state:
         | { status: 'matched'; via: string; license?: string; sourceUrl?: string }
         | { status: 'tombstoned'; reason: string; attempts: number; retryAfter: Date }
@@ -1936,7 +1942,59 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
       )
     }
 
-    // Tier 3 — Wikidata
+    // Tier 3 — StrategyWiki (probes inline, always eligible until tombstoned)
+    if (activeMap?.source === 'strategywiki') {
+      sources.push(
+        tier('strategywiki', {
+          status: 'matched',
+          via: 'strategywiki.org',
+          license: activeMap.license,
+          sourceUrl: activeMap.sourceUrl,
+        }),
+      )
+    } else {
+      const tomb = failureBySource.get('strategywiki')
+      if (tomb && tomb.retry_after.getTime() > now) {
+        sources.push(
+          tier('strategywiki', {
+            status: 'tombstoned',
+            reason: tomb.reason,
+            attempts: tomb.attempt_count,
+            retryAfter: tomb.retry_after,
+          }),
+        )
+      } else {
+        sources.push(tier('strategywiki', { status: 'eligible' }))
+      }
+    }
+
+    // Tier 4 — Fextralife (probes inline, always eligible until tombstoned)
+    if (activeMap?.source === 'fextralife') {
+      sources.push(
+        tier('fextralife', {
+          status: 'matched',
+          via: 'wiki.fextralife.com',
+          license: activeMap.license,
+          sourceUrl: activeMap.sourceUrl,
+        }),
+      )
+    } else {
+      const tomb = failureBySource.get('fextralife')
+      if (tomb && tomb.retry_after.getTime() > now) {
+        sources.push(
+          tier('fextralife', {
+            status: 'tombstoned',
+            reason: tomb.reason,
+            attempts: tomb.attempt_count,
+            retryAfter: tomb.retry_after,
+          }),
+        )
+      } else {
+        sources.push(tier('fextralife', { status: 'eligible' }))
+      }
+    }
+
+    // Tier 5 — Wikidata
     if (activeMap?.source === 'wikidata') {
       sources.push(
         tier('wikidata', {
@@ -2123,6 +2181,8 @@ router.post('/geo/reimport', async (req, res, next) => {
     await Promise.all([
       geoIngestFailureRepository.clear(parse.data.gameId, 'registry'),
       geoIngestFailureRepository.clear(parse.data.gameId, 'fandom'),
+      geoIngestFailureRepository.clear(parse.data.gameId, 'strategywiki'),
+      geoIngestFailureRepository.clear(parse.data.gameId, 'fextralife'),
       geoIngestFailureRepository.clear(parse.data.gameId, 'wikidata'),
       geoIngestFailureRepository.clear(parse.data.gameId, 'steam'),
       geoIngestFailureRepository.clear(parse.data.gameId, 'metadata'),
@@ -2416,6 +2476,8 @@ router.post('/geo/maps/manual', async (req, res, next) => {
     await Promise.all([
       geoIngestFailureRepository.clear(data.gameId, 'registry'),
       geoIngestFailureRepository.clear(data.gameId, 'fandom'),
+      geoIngestFailureRepository.clear(data.gameId, 'strategywiki'),
+      geoIngestFailureRepository.clear(data.gameId, 'fextralife'),
       geoIngestFailureRepository.clear(data.gameId, 'wikidata'),
     ])
 

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -553,9 +553,11 @@
         "tiers": {
           "registry": "Tier 1 — Registry",
           "fandom": "Tier 2 — Fandom",
-          "wikidata": "Tier 3 — Wikidata",
+          "strategywiki": "Tier 3 — StrategyWiki",
+          "fextralife": "Tier 4 — Fextralife",
+          "wikidata": "Tier 5 — Wikidata",
           "steam": "Steam",
-          "manual": "Tier 4 — Manual"
+          "manual": "Tier 6 — Manual"
         },
         "tierStatus": {
           "matched": "Matched",
@@ -569,6 +571,8 @@
         "viewSource": "View source",
         "actions": {
           "rerun": "Re-run pipeline",
+          "research": "Research",
+          "researchTooltip": "Open pre-filled search links (Google, StrategyWiki, Fextralife…)",
           "uploadManual": "Upload manually"
         },
         "sidePanel": {
@@ -581,10 +585,16 @@
           "previewDimensions": "{{width}} × {{height}} px"
         }
       },
+      "research": {
+        "title": "Research a map for {{name}}",
+        "description": "Pre-filled search links — open one in a new tab, copy a usable image URL, then come back here to upload it.",
+        "pasteUrlCta": "I have a URL — upload",
+        "close": "Close"
+      },
       "intro": {
         "title": "How this page works",
         "step1Title": "1. Curate games",
-        "step1Body": "Pick the games that should feed the Geo challenge in the Games tab. The ingestion pipeline then pulls their maps (Registry → Fandom → Wikidata → Manual) and Steam screenshots in the background.",
+        "step1Body": "Pick the games that should feed the Geo challenge in the Games tab. The ingestion pipeline then pulls their maps (Registry → Fandom → StrategyWiki → Fextralife → Wikidata → Manual) and Steam screenshots in the background.",
         "step2Title": "2. Track ingestion",
         "step2Body": "Watch maps land tier by tier in the Maps tab. Re-run the pipeline or upload a map manually for any game still missing one.",
         "step3Title": "3. Review crowdsourced pins",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -553,9 +553,11 @@
         "tiers": {
           "registry": "Niveau 1 — Registre",
           "fandom": "Niveau 2 — Fandom",
-          "wikidata": "Niveau 3 — Wikidata",
+          "strategywiki": "Niveau 3 — StrategyWiki",
+          "fextralife": "Niveau 4 — Fextralife",
+          "wikidata": "Niveau 5 — Wikidata",
           "steam": "Steam",
-          "manual": "Niveau 4 — Manuel"
+          "manual": "Niveau 6 — Manuel"
         },
         "tierStatus": {
           "matched": "Trouvé",
@@ -569,6 +571,8 @@
         "viewSource": "Voir la source",
         "actions": {
           "rerun": "Relancer le pipeline",
+          "research": "Rechercher",
+          "researchTooltip": "Ouvrir des liens de recherche pré-remplis (Google, StrategyWiki, Fextralife…)",
           "uploadManual": "Téléverser manuellement"
         },
         "sidePanel": {
@@ -581,10 +585,16 @@
           "previewDimensions": "{{width}} × {{height}} px"
         }
       },
+      "research": {
+        "title": "Rechercher une carte pour {{name}}",
+        "description": "Liens de recherche pré-remplis. Ouvrez-en un dans un nouvel onglet, copiez l'URL d'une image utilisable, puis revenez ici pour téléverser la carte.",
+        "pasteUrlCta": "J'ai une URL — téléverser",
+        "close": "Fermer"
+      },
       "intro": {
         "title": "Comment cette page fonctionne",
         "step1Title": "1. Curater les jeux",
-        "step1Body": "Choisissez dans l'onglet Jeux ceux qui doivent alimenter le défi Géo. Le pipeline d'ingestion récupère ensuite leurs cartes (Registre → Fandom → Wikidata → Manuel) et les captures Steam en arrière-plan.",
+        "step1Body": "Choisissez dans l'onglet Jeux ceux qui doivent alimenter le défi Géo. Le pipeline d'ingestion récupère ensuite leurs cartes (Registre → Fandom → StrategyWiki → Fextralife → Wikidata → Manuel) et les captures Steam en arrière-plan.",
         "step2Title": "2. Suivre l'ingestion",
         "step2Body": "Visualisez l'avancement niveau par niveau dans l'onglet Cartes. Relancez le pipeline ou téléversez une carte manuellement si un jeu reste sans carte.",
         "step3Title": "3. Valider les épingles",

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -23,8 +23,10 @@ import {
     Trash2,
     Play,
     Zap,
+    Search,
 } from 'lucide-react'
 import { GeoManualMapDialog } from './GeoManualMapDialog'
+import { GeoResearchAssistantDialog } from './GeoResearchAssistantDialog'
 import { ResetScrapingDialog } from './ResetScrapingDialog'
 import {
     isGameInFlight,
@@ -51,7 +53,14 @@ interface CuratedGame {
 
 interface ActiveMapInfo {
     id: number
-    source: 'registry' | 'fandom' | 'wikidata' | 'steam' | 'manual'
+    source:
+        | 'registry'
+        | 'fandom'
+        | 'strategywiki'
+        | 'fextralife'
+        | 'wikidata'
+        | 'steam'
+        | 'manual'
     imageUrl: string
     license: string
     attribution: string | null
@@ -60,7 +69,13 @@ interface ActiveMapInfo {
     region?: string | null
 }
 
-type TierKey = 'registry' | 'fandom' | 'wikidata' | 'manual'
+type TierKey =
+    | 'registry'
+    | 'fandom'
+    | 'strategywiki'
+    | 'fextralife'
+    | 'wikidata'
+    | 'manual'
 
 type TierStateBase = { tier: TierKey }
 type TierState =
@@ -111,6 +126,7 @@ export function GeoMapsTab() {
     const [busyAction, setBusyAction] = useState<'reimport' | null>(null)
     const [message, setMessage] = useState<string | null>(null)
     const [manualUploadFor, setManualUploadFor] = useState<CuratedGame | null>(null)
+    const [researchFor, setResearchFor] = useState<CuratedGame | null>(null)
     const [resetOpen, setResetOpen] = useState(false)
     const [resetting, setResetting] = useState(false)
     const [runningAll, setRunningAll] = useState(false)
@@ -463,6 +479,8 @@ export function GeoMapsTab() {
                                             s.tier as
                                                 | 'registry'
                                                 | 'fandom'
+                                                | 'strategywiki'
+                                                | 'fextralife'
                                                 | 'wikidata',
                                         )
                                     return (
@@ -494,6 +512,16 @@ export function GeoMapsTab() {
                                     size="sm"
                                     variant="outline"
                                     className="flex-1"
+                                    onClick={() => setResearchFor(selectedGame)}
+                                    title={t('admin.geo.maps.actions.researchTooltip')}
+                                >
+                                    <Search className="h-3.5 w-3.5 mr-1.5" />
+                                    {t('admin.geo.maps.actions.research')}
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    className="flex-1"
                                     onClick={() => setManualUploadFor(selectedGame)}
                                 >
                                     <Upload className="h-3.5 w-3.5 mr-1.5" />
@@ -516,6 +544,19 @@ export function GeoMapsTab() {
                     }
                 }
                 onSuccess={onManualSuccess}
+            />
+
+            <GeoResearchAssistantDialog
+                isOpen={researchFor !== null}
+                onClose={() => setResearchFor(null)}
+                game={
+                    researchFor && {
+                        id: researchFor.id,
+                        name: researchFor.name,
+                        slug: researchFor.slug,
+                    }
+                }
+                onPickManualUpload={() => setManualUploadFor(researchFor)}
             />
         </div>
 

--- a/packages/frontend/src/components/admin/GeoResearchAssistantDialog.tsx
+++ b/packages/frontend/src/components/admin/GeoResearchAssistantDialog.tsx
@@ -1,0 +1,149 @@
+import { useTranslation } from 'react-i18next'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { ExternalLink, Sparkles } from 'lucide-react'
+
+// Surfaced from the GeoMapsTab side panel when a curated game still has no
+// active map. Saves the admin from typing the same six search URLs by hand
+// every time a tier-cascade run whiffs. Each link opens in a new tab,
+// pre-filled with the game's name or kebab-case slug.
+
+interface ResearchSource {
+    key: string
+    label: string
+    description: string
+    url: (gameName: string, slug: string) => string
+}
+
+const SOURCES: ResearchSource[] = [
+    {
+        key: 'google',
+        label: 'Google Images',
+        description: 'Broad image search — fastest path to "is there ANY map".',
+        url: (name) =>
+            `https://www.google.com/search?tbm=isch&q=${encodeURIComponent(`${name} world map`)}`,
+    },
+    {
+        key: 'strategywiki',
+        label: 'StrategyWiki',
+        description: 'CC-BY-SA wiki with structured /Maps subpages.',
+        url: (name) =>
+            `https://strategywiki.org/w/index.php?search=${encodeURIComponent(name)}`,
+    },
+    {
+        key: 'fextralife',
+        label: 'Fextralife wiki',
+        description: 'Best signal for Soulsborne / RPG / open-world titles.',
+        url: (_name, slug) => {
+            // Fextralife uses compact alphanumeric subdomains. Best-effort.
+            const compact = slug.replace(/[^a-z0-9]+/gi, '').toLowerCase()
+            return compact
+                ? `https://${compact}.wiki.fextralife.com/Interactive+Map`
+                : 'https://fextralife.com/wikis/'
+        },
+    },
+    {
+        key: 'mapgenie',
+        label: 'Map Genie',
+        description: 'High-quality Leaflet maps; check the og:image preview.',
+        url: (_name, slug) => `https://mapgenie.io/${slug}`,
+    },
+    {
+        key: 'commons',
+        label: 'Wikimedia Commons',
+        description: 'License-clean maps; filter by Category:Maps_of_<Game>.',
+        url: (name) =>
+            `https://commons.wikimedia.org/w/index.php?search=${encodeURIComponent(`Map of ${name}`)}&title=Special:MediaSearch&go=Go&type=image`,
+    },
+    {
+        key: 'reddit',
+        label: 'Reddit',
+        description: 'Fan-uploaded HD maps; image posts only.',
+        url: (name) =>
+            `https://www.reddit.com/search/?q=${encodeURIComponent(`${name} world map`)}&type=link&sort=top&t=all`,
+    },
+]
+
+interface GeoResearchAssistantDialogProps {
+    isOpen: boolean
+    onClose: () => void
+    game: { id: number; name: string; slug: string } | null
+    onPickManualUpload: () => void
+}
+
+export function GeoResearchAssistantDialog({
+    isOpen,
+    onClose,
+    game,
+    onPickManualUpload,
+}: GeoResearchAssistantDialogProps) {
+    const { t } = useTranslation()
+    if (!game) return null
+    return (
+        <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2 text-base">
+                        <Sparkles className="h-4 w-4 text-neon-pink" aria-hidden />
+                        {t('admin.geo.research.title', { name: game.name })}
+                    </DialogTitle>
+                    <DialogDescription className="text-xs">
+                        {t('admin.geo.research.description')}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <ul className="space-y-1.5">
+                    {SOURCES.map((s) => (
+                        <li key={s.key}>
+                            <a
+                                href={s.url(game.name, game.slug)}
+                                target="_blank"
+                                rel="noreferrer noopener"
+                                className="group flex items-start gap-2 rounded-md border border-border/40 bg-muted/10 p-2.5 text-xs transition-colors hover:border-primary/40 hover:bg-primary/5"
+                            >
+                                <ExternalLink
+                                    className="mt-0.5 h-3.5 w-3.5 text-muted-foreground group-hover:text-primary"
+                                    aria-hidden
+                                />
+                                <div className="min-w-0 flex-1">
+                                    <p className="font-medium">{s.label}</p>
+                                    <p className="text-[11px] text-muted-foreground">
+                                        {s.description}
+                                    </p>
+                                </div>
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+
+                <div className="flex flex-col gap-2 border-t border-border/40 pt-3 sm:flex-row">
+                    <Button
+                        size="sm"
+                        variant="default"
+                        className="flex-1"
+                        onClick={() => {
+                            onClose()
+                            onPickManualUpload()
+                        }}
+                    >
+                        {t('admin.geo.research.pasteUrlCta')}
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        className="flex-1"
+                        onClick={onClose}
+                    >
+                        {t('admin.geo.research.close')}
+                    </Button>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/packages/frontend/src/hooks/useGeoRunPolling.ts
+++ b/packages/frontend/src/hooks/useGeoRunPolling.ts
@@ -8,6 +8,8 @@ export type GeoRunJobKind =
     | 'ingest-tick'
     | 'import-registry-map'
     | 'import-fandom-map'
+    | 'import-strategywiki-map'
+    | 'import-fextralife-map'
     | 'import-wikidata-map'
     | 'import-steam-screenshots'
     | 'schedule-daily-challenge'
@@ -122,18 +124,28 @@ export function useGeoRunPolling(intervalMs = DEFAULT_INTERVAL_MS): UseGeoRunPol
 
 // Helper: which tiers are currently in flight for a given game. Maps the
 // per-source job kinds to the tier labels the maps tab already uses.
+export type InFlightTier =
+    | 'registry'
+    | 'fandom'
+    | 'strategywiki'
+    | 'fextralife'
+    | 'wikidata'
+    | 'steam'
+    | 'metadata'
+    | 'tick'
+
 export function tiersInFlightForGame(
     state: GeoRunStatePayload | null,
     gameId: number,
-): Set<'registry' | 'fandom' | 'wikidata' | 'steam' | 'metadata' | 'tick'> {
-    const out = new Set<
-        'registry' | 'fandom' | 'wikidata' | 'steam' | 'metadata' | 'tick'
-    >()
+): Set<InFlightTier> {
+    const out = new Set<InFlightTier>()
     const jobs = state?.byGame[gameId]
     if (!jobs) return out
     for (const job of jobs) {
         if (job.kind === 'import-registry-map') out.add('registry')
         else if (job.kind === 'import-fandom-map') out.add('fandom')
+        else if (job.kind === 'import-strategywiki-map') out.add('strategywiki')
+        else if (job.kind === 'import-fextralife-map') out.add('fextralife')
         else if (job.kind === 'import-wikidata-map') out.add('wikidata')
         else if (job.kind === 'import-steam-screenshots') out.add('steam')
         else if (job.kind === 'resolve-metadata') out.add('metadata')

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -741,7 +741,14 @@ export interface GeoPoint {
   y: number
 }
 
-export type GeoMapSource = 'registry' | 'fandom' | 'wikidata' | 'steam' | 'manual'
+export type GeoMapSource =
+  | 'registry'
+  | 'fandom'
+  | 'strategywiki'
+  | 'fextralife'
+  | 'wikidata'
+  | 'steam'
+  | 'manual'
 
 export interface GeoMap {
   id: number


### PR DESCRIPTION
Map ingestion was hitting only 3/16 curated AAA games (Sans carte on the
admin Maps tab). Adds two zero-resolution tiers that probe public APIs
inline using the game name + slug, plus a research-assistant dialog so
admins don't have to hand-type six search URLs when automation whiffs.

Pipeline cascade is now:
  1. Registry      (curated GitHub repos, MIT/CC)
  2. Fandom        (Interactive Maps via getmap)
  3. StrategyWiki  (CC-BY-SA via MediaWiki API + opensearch)
  4. Fextralife    (og:image scrape from Interactive+Map page)
  5. Wikidata P242 (Commons locator map)
  6. Manual        (admin upload)

StrategyWiki and Fextralife don't need pre-resolution — they probe upstream
inline — so the metadata resolver no longer marks games 'unresolved' when
Steam/Fandom/Wikidata all whiff. Per-tier tombstones still enforce backoff.

Other changes:
- New `image-dimensions.ts` parses PNG / JPEG / WEBP headers from the first
  64 KiB without pulling sharp/image-size (Fextralife's og:image returns no
  dimensions from the API).
- Admin tier-diagnostic side panel renders the two new tiers.
- Manual run + reimport endpoints clear the new tombstones.
- i18n strings (FR + EN) for the new tier labels and the research dialog.