### PR TITLE
feat(geo): run all ingestion tiers and let admin pick the active map

### DIFF
--- a/packages/backend/src/infrastructure/queue/workers/geo-fandom-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-fandom-import-logic.ts
@@ -53,10 +53,12 @@ export async function importFandomMap(
   const { gameId, wikiSubdomain, pageTitle } = input
   const ua = input.userAgent ?? DEFAULT_USER_AGENT
 
-  // Skip if we already have an active map for this game — do not create dupes.
-  const existing = await geoMapRepository.findActiveByGameId(gameId)
+  // Skip if a Fandom row already exists for this game (idempotent re-runs).
+  // Other tiers may also have produced their own candidate — we don't block
+  // on them anymore so the admin can compare maps and pick the best.
+  const existing = await geoMapRepository.findBySourceAndGameId(gameId, 'fandom')
   if (existing) {
-    return { imported: false, geoMapId: existing.id, reason: 'map already exists' }
+    return { imported: false, geoMapId: existing.id, reason: 'fandom map already imported' }
   }
 
   const url =

--- a/packages/backend/src/infrastructure/queue/workers/geo-fextralife-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-fextralife-import-logic.ts
@@ -47,9 +47,13 @@ export async function importFextralifeMap(
   const { gameId, gameName, slug } = input
   const ua = input.userAgent ?? DEFAULT_USER_AGENT
 
-  const existing = await geoMapRepository.findActiveByGameId(gameId)
+  const existing = await geoMapRepository.findBySourceAndGameId(gameId, 'fextralife')
   if (existing) {
-    return { imported: false, geoMapId: existing.id, reason: 'map already exists' }
+    return {
+      imported: false,
+      geoMapId: existing.id,
+      reason: 'fextralife map already imported',
+    }
   }
 
   const subdomains = fextralifeSubdomainCandidates(gameName, slug)

--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -32,8 +32,9 @@ export interface IngestTickResult {
 }
 
 /**
- * One pass over curated, resolved games. For each game without an active map,
- * try the ingestion tiers in order and enqueue the first eligible job:
+ * One pass over curated, resolved games. For each game we enqueue **every**
+ * eligible ingestion tier so the admin can compare results and pick the best
+ * map per game (instead of only the first tier to land winning by default):
  *   1. `registry`     — curated GitHub Leaflet repo (if entry exists for slug)
  *   2. `fandom`       — Fandom Interactive Maps (if wiki_subdomain + map page resolved)
  *   3. `strategywiki` — StrategyWiki MediaWiki API (CC-BY-SA, no pre-resolution)
@@ -44,13 +45,14 @@ export interface IngestTickResult {
  * inline using the game slug + name, so a game can succeed there even if
  * the metadata resolver couldn't find a Fandom subdomain or Wikidata Q-id.
  *
- * Tier 0 is implicit: if `geo_map` already has an active row (e.g. via
- * `manual` upload), no map-import is enqueued at all — only the Steam
- * screenshot top-up runs.
+ * The first tier to successfully insert a row becomes the default active map
+ * (so games stay playable). Subsequent tiers store their results as inactive
+ * candidates — visible in the admin Maps tab side panel where an operator
+ * can swap which one is active for the game.
  *
  * Each tier is gated by its own tombstone, so a permanently-failing tier
  * doesn't block the next one. Idempotency is preserved via deterministic
- * jobIds + the importers' own `findActiveByGameId` short-circuit.
+ * jobIds + the importers' per-source `findBySourceAndGameId` short-circuit.
  */
 export async function runGeoIngestTick(
   batchSize = DEFAULT_BATCH,
@@ -105,14 +107,12 @@ export async function runGeoIngestTick(
   let steamEnqueued = 0
 
   for (const row of rows) {
-    if (!row.active_map_id) {
-      const enqueued = await enqueueFirstAvailableMapImport(row)
-      if (enqueued === 'registry') registryEnqueued++
-      else if (enqueued === 'fandom') fandomEnqueued++
-      else if (enqueued === 'strategywiki') strategyWikiEnqueued++
-      else if (enqueued === 'fextralife') fextralifeEnqueued++
-      else if (enqueued === 'wikidata') wikidataEnqueued++
-    }
+    const enqueued = await enqueueAllEligibleMapImports(row)
+    registryEnqueued += enqueued.registry
+    fandomEnqueued += enqueued.fandom
+    strategyWikiEnqueued += enqueued.strategywiki
+    fextralifeEnqueued += enqueued.fextralife
+    wikidataEnqueued += enqueued.wikidata
 
     if (
       row.active_map_id &&
@@ -164,9 +164,23 @@ export async function runGeoIngestTick(
   }
 }
 
-type MapTier = 'registry' | 'fandom' | 'strategywiki' | 'fextralife' | 'wikidata' | null
+interface TierEnqueueTally {
+  registry: number
+  fandom: number
+  strategywiki: number
+  fextralife: number
+  wikidata: number
+}
 
-async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
+async function enqueueAllEligibleMapImports(row: TickRow): Promise<TierEnqueueTally> {
+  const tally: TierEnqueueTally = {
+    registry: 0,
+    fandom: 0,
+    strategywiki: 0,
+    fextralife: 0,
+    wikidata: 0,
+  }
+
   // Tier 1 — registry
   if (!(await tombstoneBlocks(row.id, 'registry'))) {
     const entry = await findRegistryEntryBySlug(row.slug)
@@ -176,7 +190,7 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
         { kind: 'import-registry-map', gameId: row.id, entry },
         { jobId: `auto-registry-${row.id}` },
       )
-      return 'registry'
+      tally.registry++
     }
   }
 
@@ -196,7 +210,7 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
       },
       { jobId: `auto-fandom-${row.id}` },
     )
-    return 'fandom'
+    tally.fandom++
   }
 
   // Tier 3 — StrategyWiki (no pre-resolution required; probes via opensearch)
@@ -211,7 +225,7 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
       },
       { jobId: `auto-strategywiki-${row.id}` },
     )
-    return 'strategywiki'
+    tally.strategywiki++
   }
 
   // Tier 4 — Fextralife (no pre-resolution required; probes by slug)
@@ -226,7 +240,7 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
       },
       { jobId: `auto-fextralife-${row.id}` },
     )
-    return 'fextralife'
+    tally.fextralife++
   }
 
   // Tier 5 — Wikidata P242 fallback
@@ -236,10 +250,10 @@ async function enqueueFirstAvailableMapImport(row: TickRow): Promise<MapTier> {
       { kind: 'import-wikidata-map', gameId: row.id, wikidataQid: row.wikidata_qid },
       { jobId: `auto-wikidata-${row.id}` },
     )
-    return 'wikidata'
+    tally.wikidata++
   }
 
-  return null
+  return tally
 }
 
 async function tombstoneBlocks(

--- a/packages/backend/src/infrastructure/queue/workers/geo-registry-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-registry-import-logic.ts
@@ -81,9 +81,13 @@ export async function importRegistryMap(
 ): Promise<ImportRegistryMapResult> {
   const { gameId, entry } = input
 
-  const existing = await geoMapRepository.findActiveByGameId(gameId)
+  const existing = await geoMapRepository.findBySourceAndGameId(gameId, 'registry')
   if (existing) {
-    return { imported: false, geoMapId: existing.id, reason: 'map already exists' }
+    return {
+      imported: false,
+      geoMapId: existing.id,
+      reason: 'registry map already imported',
+    }
   }
 
   log.info({ gameId, imageUrl: entry.imageUrl }, 'fetching registry map')

--- a/packages/backend/src/infrastructure/queue/workers/geo-strategywiki-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-strategywiki-import-logic.ts
@@ -89,9 +89,13 @@ export async function importStrategyWikiMap(
   const { gameId, gameName, slug } = input
   const ua = input.userAgent ?? DEFAULT_USER_AGENT
 
-  const existing = await geoMapRepository.findActiveByGameId(gameId)
+  const existing = await geoMapRepository.findBySourceAndGameId(gameId, 'strategywiki')
   if (existing) {
-    return { imported: false, geoMapId: existing.id, reason: 'map already exists' }
+    return {
+      imported: false,
+      geoMapId: existing.id,
+      reason: 'strategywiki map already imported',
+    }
   }
 
   log.info({ gameId, gameName }, 'looking up strategywiki page')

--- a/packages/backend/src/infrastructure/queue/workers/geo-wikidata-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-wikidata-import-logic.ts
@@ -68,9 +68,13 @@ export async function importWikidataMap(
 ): Promise<ImportWikidataMapResult> {
   const { gameId, wikidataQid } = input
 
-  const existing = await geoMapRepository.findActiveByGameId(gameId)
+  const existing = await geoMapRepository.findBySourceAndGameId(gameId, 'wikidata')
   if (existing) {
-    return { imported: false, geoMapId: existing.id, reason: 'map already exists' }
+    return {
+      imported: false,
+      geoMapId: existing.id,
+      reason: 'wikidata map already imported',
+    }
   }
 
   log.info({ gameId, wikidataQid }, 'fetching wikidata locator map')

--- a/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
@@ -61,12 +61,25 @@ export const geoMapRepository = {
     return row ? mapRow(row) : null
   },
 
-  async listByGameId(gameId: number): Promise<GeoMap[]> {
+  async findBySourceAndGameId(
+    gameId: number,
+    source: GeoMapSource,
+  ): Promise<GeoMap | null> {
+    const row = await db('geo_map')
+      .where({ game_id: gameId, source })
+      .orderBy('created_at', 'desc')
+      .first<GeoMapRow>()
+    return row ? mapRow(row) : null
+  },
+
+  async listByGameId(
+    gameId: number,
+  ): Promise<Array<GeoMap & { isActive: boolean }>> {
     const rows = await db('geo_map')
       .where({ game_id: gameId })
       .orderBy('created_at', 'desc')
       .select<GeoMapRow[]>('*')
-    return rows.map(mapRow)
+    return rows.map((r) => ({ ...mapRow(r), isActive: r.is_active }))
   },
 
   async create(data: {
@@ -82,29 +95,67 @@ export const geoMapRepository = {
     region?: string | null
     wikiMapName?: string | null
     wikiRevisionId?: number | null
+    // When omitted, the row is active only if no other active row exists for
+    // this game (transactional — multi-tier ingestion stores all results but
+    // only the first tier to land becomes the default; admins can swap later).
+    isActive?: boolean
   }): Promise<GeoMap> {
     log.info({ gameId: data.gameId, source: data.source }, 'create')
-    const [row] = await db('geo_map')
-      .insert({
-        game_id: data.gameId,
-        source: data.source,
-        source_url: data.sourceUrl ?? null,
-        image_url: data.imageUrl,
-        width_px: data.widthPx,
-        height_px: data.heightPx,
-        consensus_radius: data.consensusRadius ?? 0.03,
-        license: data.license,
-        attribution: data.attribution ?? null,
-        region: data.region ?? null,
-        wiki_map_name: data.wikiMapName ?? null,
-        wiki_revision_id: data.wikiRevisionId ?? null,
-      })
-      .returning<GeoMapRow[]>('*')
-    return mapRow(row!)
+    const row = await db.transaction(async (trx) => {
+      let isActive: boolean
+      if (data.isActive === undefined) {
+        const existingActive = await trx('geo_map')
+          .where({ game_id: data.gameId, is_active: true })
+          .first<{ id: number }>('id')
+        isActive = !existingActive
+      } else {
+        isActive = data.isActive
+      }
+      const [inserted] = await trx('geo_map')
+        .insert({
+          game_id: data.gameId,
+          source: data.source,
+          source_url: data.sourceUrl ?? null,
+          image_url: data.imageUrl,
+          width_px: data.widthPx,
+          height_px: data.heightPx,
+          consensus_radius: data.consensusRadius ?? 0.03,
+          license: data.license,
+          attribution: data.attribution ?? null,
+          region: data.region ?? null,
+          wiki_map_name: data.wikiMapName ?? null,
+          wiki_revision_id: data.wikiRevisionId ?? null,
+          is_active: isActive,
+        })
+        .returning<GeoMapRow[]>('*')
+      return inserted!
+    })
+    return mapRow(row)
   },
 
   async deactivate(id: number): Promise<void> {
     log.info({ id }, 'deactivate')
     await db('geo_map').where({ id }).update({ is_active: false })
+  },
+
+  // Atomically promote `mapId` to the active map for `gameId` and deactivate
+  // any siblings. Used by the admin "select this map" flow.
+  async setActiveForGame(gameId: number, mapId: number): Promise<GeoMap | null> {
+    log.info({ gameId, mapId }, 'setActiveForGame')
+    return await db.transaction(async (trx) => {
+      const target = await trx('geo_map')
+        .where({ id: mapId, game_id: gameId })
+        .first<GeoMapRow>()
+      if (!target) return null
+      await trx('geo_map')
+        .where({ game_id: gameId })
+        .whereNot({ id: mapId })
+        .update({ is_active: false })
+      const [updated] = await trx('geo_map')
+        .where({ id: mapId })
+        .update({ is_active: true })
+        .returning<GeoMapRow[]>('*')
+      return updated ? mapRow(updated) : null
+    })
   },
 }

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1846,8 +1846,8 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
       return
     }
 
-    const [activeMap, registryEntry, failures] = await Promise.all([
-      geoMapRepository.findActiveByGameId(id),
+    const [allMaps, registryEntry, failures] = await Promise.all([
+      geoMapRepository.listByGameId(id),
       findRegistryEntryBySlug(game.slug),
       db('geo_ingest_failure')
         .where({ game_id: id })
@@ -1862,9 +1862,43 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
         >('source', 'reason', 'attempt_count', 'last_attempt_at', 'retry_after'),
     ])
 
+    const activeMap = allMaps.find((m) => m.isActive) ?? null
+    const candidatesBySource = new Map<
+      string,
+      Array<{
+        id: number
+        imageUrl: string
+        widthPx: number
+        heightPx: number
+        license: string
+        attribution: string | null
+        sourceUrl: string | null
+        region: string | null
+        isActive: boolean
+      }>
+    >()
+    for (const m of allMaps) {
+      const list = candidatesBySource.get(m.source) ?? []
+      list.push({
+        id: m.id,
+        imageUrl: m.imageUrl,
+        widthPx: m.widthPx,
+        heightPx: m.heightPx,
+        license: m.license,
+        attribution: m.attribution ?? null,
+        sourceUrl: m.sourceUrl ?? null,
+        region: m.region ?? null,
+        isActive: m.isActive,
+      })
+      candidatesBySource.set(m.source, list)
+    }
+
     const failureBySource = new Map(failures.map((f) => [f.source, f]))
     const now = Date.now()
 
+    type TierCandidate = NonNullable<
+      ReturnType<typeof candidatesBySource.get>
+    >[number]
     const tier = (
       key:
         | 'registry'
@@ -1874,7 +1908,13 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
         | 'wikidata'
         | 'manual',
       state:
-        | { status: 'matched'; via: string; license?: string; sourceUrl?: string }
+        | {
+            status: 'matched'
+            via: string
+            license?: string
+            sourceUrl?: string
+            candidates: TierCandidate[]
+          }
         | { status: 'tombstoned'; reason: string; attempts: number; retryAfter: Date }
         | { status: 'untried'; reason?: string }
         | { status: 'eligible' },
@@ -1882,16 +1922,35 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
 
     const sources: Array<ReturnType<typeof tier>> = []
 
+    const matchedTier = (
+      key:
+        | 'registry'
+        | 'fandom'
+        | 'strategywiki'
+        | 'fextralife'
+        | 'wikidata'
+        | 'manual',
+      via: string,
+    ): ReturnType<typeof tier> | null => {
+      const list = candidatesBySource.get(key)
+      if (!list || list.length === 0) return null
+      // Surface the active candidate first when present, so the existing
+      // "matched" caption (license / sourceUrl) reflects what is currently
+      // serving in-game; siblings remain available for the admin to pick.
+      const primary = list.find((c) => c.isActive) ?? list[0]!
+      return tier(key, {
+        status: 'matched',
+        via,
+        license: primary.license,
+        sourceUrl: primary.sourceUrl ?? undefined,
+        candidates: list,
+      })
+    }
+
     // Tier 1 — Registry
-    if (activeMap?.source === 'registry') {
-      sources.push(
-        tier('registry', {
-          status: 'matched',
-          via: 'curated registry',
-          license: activeMap.license,
-          sourceUrl: activeMap.sourceUrl,
-        }),
-      )
+    const registryMatched = matchedTier('registry', 'curated registry')
+    if (registryMatched) {
+      sources.push(registryMatched)
     } else if (registryEntry) {
       const tomb = failureBySource.get('registry')
       if (tomb && tomb.retry_after.getTime() > now) {
@@ -1913,15 +1972,12 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
     }
 
     // Tier 2 — Fandom
-    if (activeMap?.source === 'fandom') {
-      sources.push(
-        tier('fandom', {
-          status: 'matched',
-          via: `${game.wiki_subdomain ?? '?'}.fandom.com`,
-          license: activeMap.license,
-          sourceUrl: activeMap.sourceUrl,
-        }),
-      )
+    const fandomMatched = matchedTier(
+      'fandom',
+      `${game.wiki_subdomain ?? '?'}.fandom.com`,
+    )
+    if (fandomMatched) {
+      sources.push(fandomMatched)
     } else if (game.wiki_subdomain && game.wiki_page_title) {
       const tomb = failureBySource.get('fandom')
       if (tomb && tomb.retry_after.getTime() > now) {
@@ -1943,15 +1999,9 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
     }
 
     // Tier 3 — StrategyWiki (probes inline, always eligible until tombstoned)
-    if (activeMap?.source === 'strategywiki') {
-      sources.push(
-        tier('strategywiki', {
-          status: 'matched',
-          via: 'strategywiki.org',
-          license: activeMap.license,
-          sourceUrl: activeMap.sourceUrl,
-        }),
-      )
+    const strategyMatched = matchedTier('strategywiki', 'strategywiki.org')
+    if (strategyMatched) {
+      sources.push(strategyMatched)
     } else {
       const tomb = failureBySource.get('strategywiki')
       if (tomb && tomb.retry_after.getTime() > now) {
@@ -1969,15 +2019,9 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
     }
 
     // Tier 4 — Fextralife (probes inline, always eligible until tombstoned)
-    if (activeMap?.source === 'fextralife') {
-      sources.push(
-        tier('fextralife', {
-          status: 'matched',
-          via: 'wiki.fextralife.com',
-          license: activeMap.license,
-          sourceUrl: activeMap.sourceUrl,
-        }),
-      )
+    const fextralifeMatched = matchedTier('fextralife', 'wiki.fextralife.com')
+    if (fextralifeMatched) {
+      sources.push(fextralifeMatched)
     } else {
       const tomb = failureBySource.get('fextralife')
       if (tomb && tomb.retry_after.getTime() > now) {
@@ -1995,15 +2039,9 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
     }
 
     // Tier 5 — Wikidata
-    if (activeMap?.source === 'wikidata') {
-      sources.push(
-        tier('wikidata', {
-          status: 'matched',
-          via: game.wikidata_qid ?? 'P242',
-          license: activeMap.license,
-          sourceUrl: activeMap.sourceUrl,
-        }),
-      )
+    const wikidataMatched = matchedTier('wikidata', game.wikidata_qid ?? 'P242')
+    if (wikidataMatched) {
+      sources.push(wikidataMatched)
     } else if (game.wikidata_qid) {
       const tomb = failureBySource.get('wikidata')
       if (tomb && tomb.retry_after.getTime() > now) {
@@ -2024,16 +2062,10 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
       )
     }
 
-    // Tier 4 — Manual
-    if (activeMap?.source === 'manual') {
-      sources.push(
-        tier('manual', {
-          status: 'matched',
-          via: 'admin upload',
-          license: activeMap.license,
-          sourceUrl: activeMap.sourceUrl,
-        }),
-      )
+    // Tier 6 — Manual
+    const manualMatched = matchedTier('manual', 'admin upload')
+    if (manualMatched) {
+      sources.push(manualMatched)
     } else {
       sources.push(tier('manual', { status: 'untried' }))
     }
@@ -2059,6 +2091,46 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
         sources,
       },
     })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Switch which geo_map row is the active one for a game. Used by the admin
+// Maps tab when multiple tiers (Fandom / StrategyWiki / Fextralife / …) have
+// produced candidate maps and the operator wants to pick the best one
+// instead of accepting whichever tier landed first.
+const setActiveMapBodySchema = z.object({
+  geoMapId: z.number().int().positive(),
+})
+
+router.post('/geo/games/:id/active-map', async (req, res, next) => {
+  try {
+    const id = Number(req.params.id)
+    if (!Number.isFinite(id) || id <= 0) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+    const parse = setActiveMapBodySchema.safeParse(req.body)
+    if (!parse.success) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: parse.error.issues[0]?.message },
+      })
+      return
+    }
+    const map = await geoMapRepository.setActiveForGame(id, parse.data.geoMapId)
+    if (!map) {
+      res.status(404).json({
+        success: false,
+        error: {
+          code: 'MAP_NOT_FOUND',
+          message: 'no geo_map row with that id for this game',
+        },
+      })
+      return
+    }
+    res.json({ success: true, data: map })
   } catch (err) {
     next(err)
   }

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -576,11 +576,16 @@
           "tombstoned_other": "Tombstoned ({{count}} attempts)",
           "eligible": "Eligible",
           "untried": "Skipped",
-          "eligibleHint": "Will run on the next ingest tick if no earlier tier wins.",
+          "active": "Active",
+          "eligibleHint": "Will run on the next ingest tick.",
           "retryAfter": "Retry after {{time}}",
           "retryNow": "Retry",
           "retryNowTooltip": "Clear this source's tombstone and re-run the pipeline for this game.",
-          "retryQueued": "Retry queued. The pipeline will pick it up shortly."
+          "retryQueued": "Retry queued. The pipeline will pick it up shortly.",
+          "useThisMap": "Use",
+          "useThisMapTooltip": "Set this map as the active one for the game.",
+          "candidatePreviewAria": "Candidate map preview (click to open full size)",
+          "activated": "Active map updated."
         },
         "viewSource": "View source",
         "actions": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -576,11 +576,16 @@
           "tombstoned_other": "Tombé ({{count}} tentatives)",
           "eligible": "Éligible",
           "untried": "Ignoré",
-          "eligibleHint": "Sera tenté à la prochaine passe si aucun niveau précédent ne réussit.",
+          "active": "Actif",
+          "eligibleHint": "Sera tenté à la prochaine passe d'ingestion.",
           "retryAfter": "Nouvel essai après {{time}}",
           "retryNow": "Réessayer",
           "retryNowTooltip": "Efface le tombstone de cette source et relance la pipeline pour ce jeu.",
-          "retryQueued": "Réessai en file. La pipeline va se relancer dans quelques secondes."
+          "retryQueued": "Réessai en file. La pipeline va se relancer dans quelques secondes.",
+          "useThisMap": "Utiliser",
+          "useThisMapTooltip": "Choisir cette carte comme carte active du jeu.",
+          "candidatePreviewAria": "Aperçu de la carte candidate (cliquez pour ouvrir en taille réelle)",
+          "activated": "Carte active mise à jour."
         },
         "viewSource": "Voir la source",
         "actions": {

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -78,6 +78,18 @@ type TierKey =
     | 'wikidata'
     | 'manual'
 
+interface TierCandidate {
+    id: number
+    imageUrl: string
+    widthPx: number
+    heightPx: number
+    license: string
+    attribution: string | null
+    sourceUrl: string | null
+    region: string | null
+    isActive: boolean
+}
+
 type TierStateBase = { tier: TierKey }
 type TierState =
     | (TierStateBase & {
@@ -85,6 +97,7 @@ type TierState =
           via: string
           license?: string
           sourceUrl?: string
+          candidates: TierCandidate[]
       })
     | (TierStateBase & {
           status: 'tombstoned'
@@ -130,6 +143,7 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
     const [runningAll, setRunningAll] = useState(false)
     const [runningGameId, setRunningGameId] = useState<number | null>(null)
     const [retryingTier, setRetryingTier] = useState<string | null>(null)
+    const [activatingMapId, setActivatingMapId] = useState<number | null>(null)
 
     const reload = useCallback(async () => {
         setLoading(true)
@@ -260,6 +274,24 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
             setError(String(e))
         } finally {
             setRetryingTier(null)
+        }
+    }
+
+    const handleActivateMap = async (gameId: number, mapId: number) => {
+        setActivatingMapId(mapId)
+        setMessage(null)
+        setError(null)
+        try {
+            await fetchJson(`/api/admin/geo/games/${gameId}/active-map`, {
+                method: 'POST',
+                body: JSON.stringify({ geoMapId: mapId }),
+            })
+            setMessage(t('admin.geo.maps.tierStatus.activated'))
+            await Promise.all([reload(), reloadSources(gameId)])
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setActivatingMapId(null)
         }
     }
 
@@ -540,6 +572,13 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
                                                     : undefined
                                             }
                                             retrying={retryingTier === s.tier}
+                                            onActivate={(mapId) =>
+                                                void handleActivateMap(
+                                                    sources.gameId,
+                                                    mapId,
+                                                )
+                                            }
+                                            activatingMapId={activatingMapId}
                                         />
                                     )
                                 })}
@@ -690,12 +729,16 @@ function TierRow({
     running,
     onRetry,
     retrying,
+    onActivate,
+    activatingMapId,
 }: {
     state: TierState
     t: ReturnType<typeof useTranslation>['t']
     running?: boolean
     onRetry?: () => void
     retrying?: boolean
+    onActivate?: (mapId: number) => void
+    activatingMapId?: number | null
 }) {
     const tierLabel = t(`admin.geo.maps.tiers.${state.tier}`)
 
@@ -722,6 +765,7 @@ function TierRow({
     }
 
     if (state.status === 'matched') {
+        const candidates = state.candidates ?? []
         return (
             <li className="rounded border border-success/30 bg-success/5 p-2.5 text-xs">
                 <div className="flex items-center justify-between gap-2">
@@ -737,15 +781,84 @@ function TierRow({
                     {state.via}
                     {state.license && ` · ${state.license}`}
                 </p>
-                {state.sourceUrl && (
-                    <a
-                        href={state.sourceUrl}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        className="text-[11px] text-primary hover:underline"
-                    >
-                        {t('admin.geo.maps.viewSource')}
-                    </a>
+                {candidates.length > 0 && (
+                    <ul className="mt-2 space-y-1.5">
+                        {candidates.map((c) => {
+                            const activating = activatingMapId === c.id
+                            return (
+                                <li
+                                    key={c.id}
+                                    className={`flex gap-2 rounded border p-1.5 ${
+                                        c.isActive
+                                            ? 'border-success/50 bg-success/10'
+                                            : 'border-border/40 bg-background/40'
+                                    }`}
+                                >
+                                    <a
+                                        href={c.imageUrl}
+                                        target="_blank"
+                                        rel="noreferrer noopener"
+                                        className="block shrink-0 overflow-hidden rounded bg-black/40"
+                                        aria-label={t(
+                                            'admin.geo.maps.tierStatus.candidatePreviewAria',
+                                        )}
+                                    >
+                                        <img
+                                            src={c.imageUrl}
+                                            alt=""
+                                            loading="lazy"
+                                            className="block h-12 w-16 object-contain"
+                                        />
+                                    </a>
+                                    <div className="min-w-0 flex-1">
+                                        <p className="text-[10px] text-muted-foreground">
+                                            {c.widthPx} × {c.heightPx} px
+                                            {c.region && ` · ${c.region}`}
+                                        </p>
+                                        {c.sourceUrl && (
+                                            <a
+                                                href={c.sourceUrl}
+                                                target="_blank"
+                                                rel="noreferrer noopener"
+                                                className="text-[10px] text-primary hover:underline"
+                                            >
+                                                {t('admin.geo.maps.viewSource')}
+                                            </a>
+                                        )}
+                                    </div>
+                                    <div className="flex shrink-0 items-center">
+                                        {c.isActive ? (
+                                            <span className="text-[10px] uppercase tracking-wide text-success px-1.5">
+                                                {t(
+                                                    'admin.geo.maps.tierStatus.active',
+                                                )}
+                                            </span>
+                                        ) : onActivate ? (
+                                            <Button
+                                                size="sm"
+                                                variant="outline"
+                                                disabled={activating}
+                                                onClick={() => onActivate(c.id)}
+                                                className="h-6 gap-1 px-2 text-[10px]"
+                                                title={t(
+                                                    'admin.geo.maps.tierStatus.useThisMapTooltip',
+                                                )}
+                                            >
+                                                {activating ? (
+                                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                                ) : (
+                                                    <CheckCircle2 className="h-3 w-3" />
+                                                )}
+                                                {t(
+                                                    'admin.geo.maps.tierStatus.useThisMap',
+                                                )}
+                                            </Button>
+                                        ) : null}
+                                    </div>
+                                </li>
+                            )
+                        })}
+                    </ul>
                 )}
             </li>
         )


### PR DESCRIPTION
Previously the geo ingest pipeline tried tiers in order (registry → fandom →
strategywiki → fextralife → wikidata) and stopped at the first match, leaving
later tiers permanently as "Eligible" so the admin couldn't compare maps. Now
every tier with no per-source row yet is enqueued on each tick; the first
result becomes the default active map and subsequent results are stored as
inactive candidates. The Maps tab side panel renders all candidates per tier
with a thumbnail + "Use this map" button so the admin can swap which one is
active for the game.

- geoMapRepository: add findBySourceAndGameId, listByGameId surfaces is_active,
  setActiveForGame transactionally swaps the active row for a game, create
  defaults to is_active = !existing-active.
- importers (registry / fandom / strategywiki / fextralife / wikidata): skip
  on per-source duplicate instead of any-active duplicate.
- geo-ingest-tick: enqueue every eligible tier per game, not just the first.
- admin /geo/games/:id/sources returns candidates[] per matched tier.
- admin POST /geo/games/:id/active-map switches the active map by geo_map id.