### PR TITLE
fix(geo): unbreak Réessayer / Forcer ré-ingestion (INTERNAL_ERROR)

### DIFF
--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -2278,16 +2278,17 @@ router.post('/geo/reimport', async (req, res, next) => {
     // Run the full pipeline (resolve → tick) right away instead of
     // depending on the recurring tick to pick the row back up. Stable
     // jobIds so a double-click collapses to one execution; the resolver
-    // is gameId-scoped here for fast feedback.
+    // is gameId-scoped here for fast feedback. Hyphens (not colons) —
+    // BullMQ 5.x rejects 2-part colon-separated jobIds.
     const resolveJob = await geoQueue.add(
       'resolve-metadata',
       { kind: 'resolve-metadata', batchSize: 1, gameId },
-      { jobId: `manual-resolve:${gameId}` },
+      { jobId: `manual-resolve-${gameId}` },
     )
     const tickJob = await geoQueue.add(
       'ingest-tick',
       { kind: 'ingest-tick', batchSize: 1, gameId },
-      { jobId: `manual-tick:${gameId}` },
+      { jobId: `manual-tick-${gameId}` },
     )
     res.json({
       success: true,
@@ -2307,6 +2308,8 @@ const TOMBSTONE_SOURCES = [
   'steam',
   'metadata',
   'registry',
+  'strategywiki',
+  'fextralife',
   'wikidata',
 ] as const
 type TombstoneSource = (typeof TOMBSTONE_SOURCES)[number]
@@ -2335,7 +2338,7 @@ router.delete('/geo/tombstone/:gameId/:source', async (req, res, next) => {
     await geoQueue.add(
       'ingest-tick',
       { kind: 'ingest-tick', batchSize: 1, gameId },
-      { jobId: `manual-tick:${gameId}` },
+      { jobId: `manual-tick-${gameId}` },
     )
     res.json({ success: true, data: { gameId, source } })
   } catch (err) {


### PR DESCRIPTION
Two related Cartes-tab regressions surfacing as a generic INTERNAL_ERROR
banner in the admin Maps panel.

1. Three BullMQ jobIds were still using the old `name:id` shape that
   commit e74f504 swept off the rest of the geo code paths:

   - POST /api/admin/geo/reimport      → manual-resolve:{id} / manual-tick:{id}
   - DELETE /api/admin/geo/tombstone   → manual-tick:{id}

   BullMQ 5.x's `Job.validateOptions` throws "Custom Id cannot contain :"
   on any 2-part colon id (3-part is the legacy repeatable-job carve-out),
   so clicking "Forcer une ré-ingestion" or "Réessayer" on a tombstoned
   tier threw synchronously and fell through to the global 500 handler.
   Switched all three to the hyphenated form already used by /geo/run/:id.

2. TOMBSTONE_SOURCES was never extended when commit b2ef72b added the
   StrategyWiki and Fextralife tiers, so the Réessayer button rendered
   for those rows in the side panel was rejected with INVALID_SOURCE on
   the way in. Added both to the allow-list — `GeoIngestSource` in the
   repo already enumerates them, and the `clear()` call is a generic
   delete, so no other code path needed to change.

https://claude.ai/code/session_01KqDthWqXVc1Ro2k7tdFZJy