### PR TITLE
feat(geo): filter Pins tab by game and deep-link from Maps side panel

### DIFF
--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -193,13 +193,27 @@ export const geoScreenshotRepository = {
 
   async listCandidatesForReview(args: {
     status?: GeoScreenshotCandidateRow['status']
+    gameId?: number
     limit?: number
   }): Promise<GeoScreenshotCandidate[]> {
-    const { status, limit = 50 } = args
-    const q = db('geo_screenshot_candidate').orderBy('pin_count', 'desc').limit(limit)
-    if (status) q.where('status', status)
-    const rows = await q.select<GeoScreenshotCandidateRow[]>('*')
-    return rows.map(mapCandidate)
+    const { status, gameId, limit = 50 } = args
+    // Join games so the Pins list can show game names without N+1 lookups.
+    // The status/gameId filters narrow the set before the join, keeping the
+    // query cheap even at full catalog scale.
+    const q = db('geo_screenshot_candidate as gsc')
+      .leftJoin('games as g', 'g.id', 'gsc.game_id')
+      .orderBy('gsc.pin_count', 'desc')
+      .limit(limit)
+    if (status) q.where('gsc.status', status)
+    if (gameId !== undefined) q.where('gsc.game_id', gameId)
+    const rows = await q.select<Array<GeoScreenshotCandidateRow & { game_name: string | null }>>(
+      'gsc.*',
+      'g.name as game_name',
+    )
+    return rows.map((row) => ({
+      ...mapCandidate(row),
+      gameName: row.game_name ?? undefined,
+    }))
   },
 
   /**

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1511,8 +1511,19 @@ router.get('/geo/candidates', async (req, res, next) => {
   try {
     const status = typeof req.query.status === 'string' ? req.query.status : undefined
     const limit = req.query.limit ? Math.min(200, Number(req.query.limit)) : 50
+    // Optional per-game filter so the Pins tab can deep-link from the Maps
+    // tab side panel (admin clicks "Voir les captures" on a row → only that
+    // game's candidates show up). Invalid ids are ignored, keeping the
+    // unfiltered behaviour as a safe fallback.
+    const gameIdRaw =
+      typeof req.query.gameId === 'string' ? Number(req.query.gameId) : undefined
+    const gameId =
+      gameIdRaw !== undefined && Number.isFinite(gameIdRaw) && gameIdRaw > 0
+        ? gameIdRaw
+        : undefined
     const candidates = await geoScreenshotRepository.listCandidatesForReview({
       status: status as 'pending' | 'collecting' | 'promoted' | 'rejected' | undefined,
+      gameId,
       limit,
     })
     res.json({ success: true, data: candidates })

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -596,7 +596,10 @@
           "rerunTooltip": "Clears every per-tier failure tombstone for this game and re-runs the full pipeline (metadata + maps). More aggressive than \"Run for this game\", which respects existing tombstones.",
           "research": "Research",
           "researchTooltip": "Open pre-filled search links (Google, StrategyWiki, Fextralife…)",
-          "uploadManual": "Upload manually"
+          "uploadManual": "Upload manually",
+          "viewCaptures_one": "View captures ({{count}})",
+          "viewCaptures_other": "View captures ({{count}})",
+          "viewCapturesTooltip": "Open the Pins tab filtered to this game's captures."
         },
         "loading": "Loading games…",
         "sidePanel": {
@@ -645,6 +648,10 @@
         "pending": "Pending",
         "promoted": "Promoted",
         "all": "All"
+      },
+      "gameFilter": {
+        "active": "Game: {{name}}",
+        "clear": "Clear game filter"
       },
       "statusBadge": {
         "collecting": "Collecting",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -596,7 +596,10 @@
           "rerunTooltip": "Efface tous les tombstones d'échec pour ce jeu et relance la pipeline complète (résolution + cartes). Plus agressif que « Lancer pour ce jeu » qui respecte les tombstones existants.",
           "research": "Rechercher",
           "researchTooltip": "Ouvrir des liens de recherche pré-remplis (Google, StrategyWiki, Fextralife…)",
-          "uploadManual": "Téléverser manuellement"
+          "uploadManual": "Téléverser manuellement",
+          "viewCaptures_one": "Voir les captures ({{count}})",
+          "viewCaptures_other": "Voir les captures ({{count}})",
+          "viewCapturesTooltip": "Ouvrir l'onglet Pins filtré sur les captures de ce jeu."
         },
         "loading": "Chargement des jeux…",
         "sidePanel": {
@@ -645,6 +648,10 @@
         "pending": "En attente",
         "promoted": "Promus",
         "all": "Tous"
+      },
+      "gameFilter": {
+        "active": "Jeu : {{name}}",
+        "clear": "Effacer le filtre par jeu"
       },
       "statusBadge": {
         "collecting": "En collecte",

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -25,6 +25,7 @@ import {
     Zap,
     Search,
     RefreshCcw,
+    ListChecks,
 } from 'lucide-react'
 import { GeoManualMapDialog } from './GeoManualMapDialog'
 import { GeoResearchAssistantDialog } from './GeoResearchAssistantDialog'
@@ -124,9 +125,20 @@ interface GeoMapsTabProps {
     runState: GeoRunStatePayload | null
     runError: string | null
     armRunPolling: (windowMs?: number) => void
+    /**
+     * Deep-link from the Maps side panel into the Pins tab pre-filtered
+     * to the selected game's screenshot candidates. Owned by the parent
+     * because tab state and the candidate list filter live there.
+     */
+    onViewCaptures?: (gameId: number, gameName: string) => void
 }
 
-export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProps) {
+export function GeoMapsTab({
+    runState,
+    runError,
+    armRunPolling,
+    onViewCaptures,
+}: GeoMapsTabProps) {
     const { t } = useTranslation()
     const [games, setGames] = useState<CuratedGame[] | null>(null)
     const [loading, setLoading] = useState(true)
@@ -648,6 +660,25 @@ export function GeoMapsTab({ runState, runError, armRunPolling }: GeoMapsTabProp
                                     {t('admin.geo.maps.actions.uploadManual')}
                                 </Button>
                             </div>
+                            {onViewCaptures && (
+                                <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    className="w-full justify-center text-xs text-muted-foreground hover:text-foreground"
+                                    onClick={() =>
+                                        onViewCaptures(
+                                            selectedGame.id,
+                                            selectedGame.name,
+                                        )
+                                    }
+                                    title={t('admin.geo.maps.actions.viewCapturesTooltip')}
+                                >
+                                    <ListChecks className="h-3.5 w-3.5 mr-1.5" />
+                                    {t('admin.geo.maps.actions.viewCaptures', {
+                                        count: selectedGame.candidateCount,
+                                    })}
+                                </Button>
+                            )}
                         </>
                     ) : null}
                 </CardContent>

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -25,6 +25,7 @@ import {
     Map,
     ListChecks,
     Library,
+    X,
 } from 'lucide-react'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { GeoMapsTab } from './GeoMapsTab'
@@ -53,8 +54,14 @@ interface CandidateDetail {
 type StatusFilter = 'collecting' | 'pending' | 'promoted' | 'all'
 const STATUS_FILTERS: StatusFilter[] = ['collecting', 'pending', 'promoted', 'all']
 
-async function fetchCandidates(status?: string): Promise<GeoScreenshotCandidate[]> {
-    const qs = status ? `?status=${encodeURIComponent(status)}` : ''
+async function fetchCandidates(args: {
+    status?: string
+    gameId?: number
+}): Promise<GeoScreenshotCandidate[]> {
+    const params = new URLSearchParams()
+    if (args.status) params.set('status', args.status)
+    if (args.gameId !== undefined) params.set('gameId', String(args.gameId))
+    const qs = params.toString() ? `?${params.toString()}` : ''
     const res = await fetch(`/api/admin/geo/candidates${qs}`, { credentials: 'include' })
     if (!res.ok) throw new Error(`list failed: ${res.status}`)
     const json = await res.json()
@@ -94,7 +101,15 @@ async function deleteMeta(metaId: number): Promise<void> {
 
 export function GeoReviewPanel() {
     const { t } = useTranslation()
+    const [activeTab, setActiveTab] = useState<'pins' | 'maps' | 'games'>('pins')
     const [statusFilter, setStatusFilter] = useState<StatusFilter>('collecting')
+    // Per-game filter for the Pins tab. Set when the operator clicks "Voir
+    // les captures" on a Maps row so the candidate list narrows to that game.
+    // Cleared via the badge in the Pins header.
+    const [gameFilter, setGameFilter] = useState<{
+        gameId: number
+        gameName: string
+    } | null>(null)
     const [candidates, setCandidates] = useState<GeoScreenshotCandidate[]>([])
     const [detail, setDetail] = useState<CandidateDetail | null>(null)
     const [pin, setPin] = useState<GeoPoint | null>(null)
@@ -136,14 +151,17 @@ export function GeoReviewPanel() {
     useEffect(() => {
         let cancelled = false
         setLoading(true)
-        fetchCandidates(statusFilter === 'all' ? undefined : statusFilter)
+        fetchCandidates({
+            status: statusFilter === 'all' ? undefined : statusFilter,
+            gameId: gameFilter?.gameId,
+        })
             .then((rows) => !cancelled && setCandidates(rows))
             .catch((e) => !cancelled && setError(String(e)))
             .finally(() => !cancelled && setLoading(false))
         return () => {
             cancelled = true
         }
-    }, [statusFilter])
+    }, [statusFilter, gameFilter?.gameId])
 
     const openDetail = async (id: number) => {
         setError(null)
@@ -164,13 +182,23 @@ export function GeoReviewPanel() {
             // Refresh the list + clear the detail pane.
             setDetail(null)
             setPin(null)
-            const rows = await fetchCandidates(statusFilter === 'all' ? undefined : statusFilter)
+            const rows = await fetchCandidates({
+                status: statusFilter === 'all' ? undefined : statusFilter,
+                gameId: gameFilter?.gameId,
+            })
             setCandidates(rows)
         } catch (e) {
             setError(String(e))
         } finally {
             setSaving(false)
         }
+    }
+
+    const viewCapturesForGame = (gameId: number, gameName: string) => {
+        setGameFilter({ gameId, gameName })
+        setStatusFilter('all')
+        setDetail(null)
+        setActiveTab('pins')
     }
 
     const confirmDemote = async () => {
@@ -222,7 +250,11 @@ export function GeoReviewPanel() {
 
             <GeoRunStateBanner state={runState} />
 
-            <Tabs defaultValue="pins" className="space-y-4">
+            <Tabs
+                value={activeTab}
+                onValueChange={(v) => setActiveTab(v as 'pins' | 'maps' | 'games')}
+                className="space-y-4"
+            >
                 <TabsList className="w-full overflow-x-auto justify-start scrollbar-hide">
                     <TabsTrigger value="pins" className="gap-1.5 shrink-0">
                         <ListChecks className="h-3.5 w-3.5" />
@@ -243,6 +275,7 @@ export function GeoReviewPanel() {
                         runState={runState}
                         runError={runError}
                         armRunPolling={armRunPolling}
+                        onViewCaptures={viewCapturesForGame}
                     />
                 </TabsContent>
 
@@ -305,6 +338,24 @@ export function GeoReviewPanel() {
                         {t(`admin.geo.statusFilter.${s}`)}
                     </Button>
                 ))}
+                {gameFilter && (
+                    <Badge
+                        variant="outline"
+                        className="ml-1 gap-1.5 border-neon-pink/40 bg-neon-pink/5 text-neon-pink"
+                    >
+                        {t('admin.geo.gameFilter.active', {
+                            name: gameFilter.gameName,
+                        })}
+                        <button
+                            type="button"
+                            onClick={() => setGameFilter(null)}
+                            aria-label={t('admin.geo.gameFilter.clear')}
+                            className="rounded hover:bg-neon-pink/10"
+                        >
+                            <X className="h-3 w-3" aria-hidden />
+                        </button>
+                    </Badge>
+                )}
             </div>
 
             {error && (
@@ -343,11 +394,15 @@ export function GeoReviewPanel() {
                                         detail?.candidate.id === c.id ? 'border-neon-pink' : ''
                                     }`}
                                 >
-                                    <div className="flex justify-between items-center">
-                                        <span className="font-mono">#{c.id}</span>
+                                    <div className="flex justify-between items-center gap-2">
+                                        <span className="truncate font-medium">
+                                            {c.gameName ?? `#${c.id}`}
+                                        </span>
                                         <Badge variant="outline">{statusLabel(c.status)}</Badge>
                                     </div>
                                     <div className="mt-1 text-muted-foreground">
+                                        <span className="font-mono">#{c.id}</span>
+                                        {' · '}
                                         {t('admin.geo.candidateRow.pinCount', { count: c.pinCount })}
                                         {' · '}
                                         {t('admin.geo.candidateRow.source', { source: c.source })}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -775,6 +775,12 @@ export interface GeoMap {
 export interface GeoScreenshotCandidate {
   id: number
   gameId: number
+  /**
+   * Set when the candidate is fetched via the admin review listing — the
+   * repository joins `games` so the Pins UI can label rows without a
+   * second round-trip per row. Per-id detail lookups don't populate it.
+   */
+  gameName?: string
   geoMapId: number
   screenshotId?: number
   imageUrl: string


### PR DESCRIPTION
Adds a "Voir les captures" button on the Maps-tab side panel that opens
the Pins tab pre-filtered to the selected game's screenshot candidates.
The candidates list now joins the games table so each row shows the game
name (instead of just the candidate id), and an active-filter badge in
the Pins header lets the operator clear the filter back to global.

Backend exposes an optional ?gameId= on GET /api/admin/geo/candidates
and the repository's listCandidatesForReview() left-joins games to fill
the new GeoScreenshotCandidate.gameName field. Detail lookups don't
populate gameName since the side panel already knows which game it
opened.

Frontend lifts Tabs state into GeoReviewPanel so viewCapturesForGame()
can switch tabs from a Maps-tab callback while resetting the status
filter to "all" (so an operator never sees an empty list right after
clicking the deep-link).