### PR TITLE
fix(geo): group Pins candidates by game and reject Steam sequels

### DIFF
--- a/packages/backend/src/domain/services/geo-metadata.service.ts
+++ b/packages/backend/src/domain/services/geo-metadata.service.ts
@@ -112,6 +112,40 @@ export function normalizeGameTitle(title: string): string {
     .trim()
 }
 
+const ROMAN_NUMERAL_TOKENS = new Set<string>([
+  'i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x',
+  'xi', 'xii', 'xiii', 'xiv', 'xv', 'xvi', 'xvii', 'xviii', 'xix', 'xx',
+])
+
+/**
+ * Pull the version-like tokens from a normalized title. We treat both arabic
+ * numerals (`2`, `3`) and roman numerals (`ii`, `iii`) as version markers
+ * because Steam's storesearch returns sequels alongside the original entry —
+ * "Baldur's Gate II: Enhanced Edition" must not silently bind to a curated
+ * "Baldur's Gate" row just because it ranks first in the API response.
+ *
+ * Pure helper so the resolver stays testable without hitting Steam.
+ */
+export function extractVersionTokens(normalized: string): string[] {
+  return normalized
+    .split(/\s+/)
+    .filter((tok) => /^\d+$/.test(tok) || ROMAN_NUMERAL_TOKENS.has(tok))
+}
+
+/**
+ * True iff two version-token lists describe the same installment. The order
+ * doesn't matter ("part 2" vs "2 part") but the multiset must match — so
+ * "baldur s gate" (no tokens) only matches candidates that also have no
+ * version tokens, and "baldur s gate 3" only matches candidates whose
+ * tokens are exactly `["3"]`.
+ */
+export function versionTokensMatch(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false
+  const sortedA = [...a].sort()
+  const sortedB = [...b].sort()
+  return sortedA.every((tok, i) => tok === sortedB[i])
+}
+
 /**
  * Compute the next retry-after timestamp for a tombstoned (game, source)
  * pair using exponential backoff capped at 30 days. Attempt 1 = 1 day,

--- a/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
@@ -3,9 +3,11 @@ import { queueLogger } from '../../logger/logger.js'
 import { geoIngestFailureRepository } from '../../repositories/index.js'
 import {
   FANDOM_MAP_NAMESPACE,
+  extractVersionTokens,
   isMapEligibleByGenre,
   normalizeGameTitle,
   scoreMapTitle,
+  versionTokensMatch,
   wikiSubdomainCandidates,
 } from '../../../domain/services/geo-metadata.service.js'
 import { resolveWikidataQid } from './geo-wikidata-import-logic.js'
@@ -144,9 +146,31 @@ async function resolveSteamAppId(name: string): Promise<number | null> {
     const body = (await res.json()) as { items?: Array<{ id: number; name: string }> }
     if (!body.items?.length) return null
     const target = normalizeGameTitle(name)
-    const hit =
-      body.items.find((it) => normalizeGameTitle(it.name) === target) ?? body.items[0]
-    return hit?.id ?? null
+    // Exact normalized match always wins (handles "Game™" → "Game" trims).
+    const exact = body.items.find((it) => normalizeGameTitle(it.name) === target)
+    if (exact) return exact.id
+    // Steam's storesearch happily returns sequels alongside the original
+    // entry — searching "Baldur's Gate" returns "Baldur's Gate II: Enhanced
+    // Edition" first. Falling back to `items[0]` would silently bind the
+    // curated row to the wrong appid and pollute the candidates list with
+    // sequel screenshots. Filter to items whose version tokens match the
+    // target (no extra "ii" / "2" / "3" introduced).
+    const targetTokens = extractVersionTokens(target)
+    const compatible = body.items.find((it) =>
+      versionTokensMatch(targetTokens, extractVersionTokens(normalizeGameTitle(it.name))),
+    )
+    if (compatible) {
+      log.info(
+        { name, picked: compatible.name, appId: compatible.id },
+        'steam storesearch picked first version-compatible hit',
+      )
+      return compatible.id
+    }
+    log.warn(
+      { name, top: body.items[0]?.name },
+      'steam storesearch had no version-compatible hit',
+    )
+    return null
   } catch (err) {
     log.warn({ name, err: String(err) }, 'steam storesearch failed')
     return null

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -642,6 +642,11 @@
         "pinCount_other": "{{count}} pins",
         "source": "source: {{source}}"
       },
+      "groupHeader": {
+        "unknownGame": "Game #{{id}}",
+        "captureCount_one": "{{count}} capture",
+        "captureCount_other": "{{count}} captures"
+      },
       "statusFilter": {
         "label": "Filter by status",
         "collecting": "Collecting",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -642,6 +642,11 @@
         "pinCount_other": "{{count}} épingles",
         "source": "source : {{source}}"
       },
+      "groupHeader": {
+        "unknownGame": "Jeu #{{id}}",
+        "captureCount_one": "{{count}} capture",
+        "captureCount_other": "{{count}} captures"
+      },
       "statusFilter": {
         "label": "Filtrer par statut",
         "collecting": "En collecte",

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -54,6 +54,39 @@ interface CandidateDetail {
 type StatusFilter = 'collecting' | 'pending' | 'promoted' | 'all'
 const STATUS_FILTERS: StatusFilter[] = ['collecting', 'pending', 'promoted', 'all']
 
+interface CandidateGroup {
+    gameId: number
+    gameName: string | null
+    candidates: GeoScreenshotCandidate[]
+}
+
+// Bucket candidates by their owning game so the Pins list renders one
+// section per game instead of a flat #id list. The repository already
+// orders candidates by pin_count desc; we keep that ordering inside each
+// group, then sort groups by size (most candidates first) so the
+// busiest games stay at the top of the panel.
+function groupCandidatesByGame(
+    candidates: GeoScreenshotCandidate[],
+): CandidateGroup[] {
+    const groups = new Map<number, CandidateGroup>()
+    for (const c of candidates) {
+        const existing = groups.get(c.gameId)
+        if (existing) {
+            existing.candidates.push(c)
+        } else {
+            groups.set(c.gameId, {
+                gameId: c.gameId,
+                gameName: c.gameName ?? null,
+                candidates: [c],
+            })
+        }
+    }
+    return [...groups.values()].sort(
+        (a, b) =>
+            b.candidates.length - a.candidates.length || a.gameId - b.gameId,
+    )
+}
+
 async function fetchCandidates(args: {
     status?: string
     gameId?: number
@@ -385,29 +418,54 @@ export function GeoReviewPanel() {
                                 {t('admin.geo.candidates')} ({candidates.length})
                             </CardTitle>
                         </CardHeader>
-                        <CardContent className="space-y-2 max-h-[300px] sm:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
-                            {candidates.map((c) => (
-                                <button
-                                    key={c.id}
-                                    onClick={() => openDetail(c.id)}
-                                    className={`w-full text-left rounded border p-2 text-xs hover:bg-muted/40 ${
-                                        detail?.candidate.id === c.id ? 'border-neon-pink' : ''
-                                    }`}
-                                >
-                                    <div className="flex justify-between items-center gap-2">
-                                        <span className="truncate font-medium">
-                                            {c.gameName ?? `#${c.id}`}
+                        <CardContent className="space-y-4 max-h-[300px] sm:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
+                            {groupCandidatesByGame(candidates).map((group) => (
+                                <section key={group.gameId} className="space-y-2">
+                                    <header className="flex items-baseline justify-between gap-2 border-b border-border/40 pb-1">
+                                        <h3 className="truncate text-xs font-semibold text-foreground">
+                                            {group.gameName ??
+                                                t('admin.geo.groupHeader.unknownGame', {
+                                                    id: group.gameId,
+                                                })}
+                                        </h3>
+                                        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                                            {t('admin.geo.groupHeader.captureCount', {
+                                                count: group.candidates.length,
+                                            })}
                                         </span>
-                                        <Badge variant="outline">{statusLabel(c.status)}</Badge>
+                                    </header>
+                                    <div className="space-y-2">
+                                        {group.candidates.map((c) => (
+                                            <button
+                                                key={c.id}
+                                                onClick={() => openDetail(c.id)}
+                                                className={`w-full text-left rounded border p-2 text-xs hover:bg-muted/40 ${
+                                                    detail?.candidate.id === c.id
+                                                        ? 'border-neon-pink'
+                                                        : ''
+                                                }`}
+                                            >
+                                                <div className="flex justify-between items-center gap-2">
+                                                    <span className="truncate font-mono font-medium">
+                                                        #{c.id}
+                                                    </span>
+                                                    <Badge variant="outline">
+                                                        {statusLabel(c.status)}
+                                                    </Badge>
+                                                </div>
+                                                <div className="mt-1 text-muted-foreground">
+                                                    {t('admin.geo.candidateRow.pinCount', {
+                                                        count: c.pinCount,
+                                                    })}
+                                                    {' · '}
+                                                    {t('admin.geo.candidateRow.source', {
+                                                        source: c.source,
+                                                    })}
+                                                </div>
+                                            </button>
+                                        ))}
                                     </div>
-                                    <div className="mt-1 text-muted-foreground">
-                                        <span className="font-mono">#{c.id}</span>
-                                        {' · '}
-                                        {t('admin.geo.candidateRow.pinCount', { count: c.pinCount })}
-                                        {' · '}
-                                        {t('admin.geo.candidateRow.source', { source: c.source })}
-                                    </div>
-                                </button>
+                                </section>
                             ))}
                             {candidates.length === 0 && (
                                 <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
Two related admin-Pins fixes:

1. The Pins list rendered candidates as a flat `#id` list, so the
   operator couldn't tell which game each capture belonged to —
   especially noticeable when many Steam-sourced candidates pile up
   under the same game. Bucket candidates by `gameId` client-side and
   render one section per game with the game name as the heading
   (falls back to `Jeu #<id>` if the join is null). Most-active games
   float to the top; in-group order keeps the repository's
   pin_count-desc sort.

2. `resolveSteamAppId` previously fell back to `items[0]` when no
   normalized exact match was found, so curating "Baldur's Gate"
   silently bound the row to "Baldur's Gate II: Enhanced Edition" —
   Steam's storesearch returns the sequel first — and the importer
   then ingested BG2 screenshots as BG candidates. Filter the fallback
   to items whose version-marker tokens (arabic + roman numerals)
   match the target's, returning null when none qualify so the next
   resolver tick can retry rather than poisoning the catalog.

https://claude.ai/code/session_01UEh9NidNXY4VtWMyZGHyRF