### PR TITLE
Add geo queue job scheduling to admin panel

### DIFF
--- a/packages/backend/src/domain/ports/queue.ts
+++ b/packages/backend/src/domain/ports/queue.ts
@@ -91,3 +91,18 @@ export interface ImportQueuePort {
   getFailedCount(): Promise<number>
   getDelayedCount(): Promise<number>
 }
+
+/**
+ * Read-only slice for queues we only inspect (e.g. geoQueue's repeatable
+ * jobs surfaced in the admin job list). Avoids forcing `add()` payload
+ * compatibility across queues with different `JobData` generics.
+ */
+export interface ReadOnlyQueuePort {
+  getJobs(
+    types: BullJobState[],
+    start?: number,
+    end?: number,
+    asc?: boolean
+  ): Promise<BullJobLike[]>
+  getRepeatableJobs(start?: number, end?: number, asc?: boolean): Promise<RepeatableJobLike[]>
+}

--- a/packages/backend/src/domain/services/index.ts
+++ b/packages/backend/src/domain/services/index.ts
@@ -89,7 +89,7 @@ import { createGeoRewardService } from './geo-reward.service.js'
 import { createGeoContributorService } from './geo-contributor.service.js'
 import { createGeoGameService } from './geo-game.service.js'
 import { serviceLogger } from '../../infrastructure/logger/logger.js'
-import { importQueue } from '../../infrastructure/queue/queues.js'
+import { importQueue, geoQueue } from '../../infrastructure/queue/queues.js'
 import {
   achievementRepository,
   challengeRepository,
@@ -120,6 +120,7 @@ export const dailyLoginService = createDailyLoginService({
 export const jobService = createJobService({
   logger: serviceLogger,
   importQueue,
+  geoQueue,
 })
 
 export const leaderboardService = createLeaderboardService({

--- a/packages/backend/src/domain/services/job.service.ts
+++ b/packages/backend/src/domain/services/job.service.ts
@@ -1,5 +1,10 @@
 import type { Job, JobType, JobData, JobStatus } from '@the-box/types'
-import type { DomainLogger, ImportQueuePort, BullJobLike } from '../ports/index.js'
+import type {
+  DomainLogger,
+  ImportQueuePort,
+  ReadOnlyQueuePort,
+  BullJobLike,
+} from '../ports/index.js'
 
 async function mapBullJobToJob(
   bullJob: BullJobLike,
@@ -68,13 +73,17 @@ export interface JobService {
 export interface JobServiceDeps {
   logger: DomainLogger
   importQueue: ImportQueuePort
+  // Optional secondary queue whose repeatable jobs should also surface in
+  // the admin job list. Read-only here: triggering geo jobs goes through
+  // the dedicated `/api/admin/geo/schedule` route.
+  geoQueue?: ReadOnlyQueuePort
 }
 
 /**
  * Create a JobService with injected dependencies.
  */
 export function createJobService(deps: JobServiceDeps): JobService {
-  const { importQueue } = deps
+  const { importQueue, geoQueue } = deps
   const log = deps.logger.child({ service: 'job' })
 
   return {
@@ -191,13 +200,30 @@ export function createJobService(deps: JobServiceDeps): JobService {
     },
 
     async getRecurringJobs() {
-      const repeatableJobs = await importQueue.getRepeatableJobs()
+      const [importRepeats, importActive] = await Promise.all([
+        importQueue.getRepeatableJobs(),
+        importQueue.getJobs(['active']),
+      ])
 
-      // Get active jobs to check if any recurring job is currently running
-      const activeJobs = await importQueue.getJobs(['active'])
-      const activeJobNames = new Set(activeJobs.map(j => j.name))
+      const allRepeats = [...importRepeats]
+      const allActive = [...importActive]
 
-      return repeatableJobs.map(job => ({
+      if (geoQueue) {
+        const [geoRepeats, geoActive] = await Promise.all([
+          geoQueue.getRepeatableJobs(),
+          geoQueue.getJobs(['active']),
+        ])
+        // Surface only the operator-facing geo job. `resolve-metadata` and
+        // `ingest-tick` are background plumbing — admins shouldn't see them
+        // in the manual run-now list alongside the daily challenge.
+        const geoSurfaced = new Set(['schedule-daily-challenge'])
+        allRepeats.push(...geoRepeats.filter(j => geoSurfaced.has(j.name)))
+        allActive.push(...geoActive.filter(j => geoSurfaced.has(j.name)))
+      }
+
+      const activeJobNames = new Set(allActive.map(j => j.name))
+
+      return allRepeats.map(job => ({
         id: job.id || job.key,
         name: job.name,
         pattern: job.pattern || null,

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -854,6 +854,8 @@
       "syncRunning": "Syncing new games...",
       "createDailyChallenge": "Create Daily Challenge (Metascore ≥ 85)",
       "dailyChallengeRunning": "Creating daily challenge...",
+      "scheduleDailyGeoChallenge": "Schedule Daily Geo Challenge",
+      "scheduleDailyGeoChallengeRunning": "Scheduling daily geo challenge...",
       "cleanupAnonymousUsersRunning": "Cleaning up anonymous users...",
       "atMidnight": "Midnight UTC",
       "weeklySunday2am": "Sunday 2 AM UTC (weekly)",
@@ -885,6 +887,7 @@
       "running": "Running",
       "descriptions": {
         "createDailyChallenge": "Automatically creates a new daily challenge with high-quality games (Metascore ≥ 85). Users can participate in a new challenge every day.",
+        "scheduleDailyGeoChallenge": "Schedules the daily Geo challenge by picking a random promoted screenshot. Idempotent: re-running does not replace an already-scheduled challenge.",
         "syncAllGames": "Synchronizes the entire game database with the RAWG API to keep information up-to-date (ratings, screenshots, metadata).",
         "cleanupAnonymousUsers": "Removes inactive anonymous user accounts to optimize the database and free up space.",
         "clearDailyData": "Clears all game session data for the current day's daily challenge. This allows users to replay the challenge.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -854,6 +854,8 @@
       "syncRunning": "Synchronisation en cours...",
       "createDailyChallenge": "Création défi quotidien (Metascore ≥ 85)",
       "dailyChallengeRunning": "Création du défi en cours...",
+      "scheduleDailyGeoChallenge": "Planifier le défi Géo du jour",
+      "scheduleDailyGeoChallengeRunning": "Planification du défi Géo en cours...",
       "cleanupAnonymousUsersRunning": "Nettoyage des utilisateurs anonymes...",
       "atMidnight": "Minuit UTC",
       "weeklySunday2am": "Dimanche 2h UTC (hebdo)",
@@ -885,6 +887,7 @@
       "running": "En cours",
       "descriptions": {
         "createDailyChallenge": "Crée automatiquement un nouveau défi quotidien avec des jeux de haute qualité (Metascore ≥ 85). Les utilisateurs peuvent participer chaque jour à un nouveau challenge.",
+        "scheduleDailyGeoChallenge": "Planifie le défi Géo quotidien en sélectionnant une capture promue au hasard. Idempotent : ré-exécuter ne remplace pas le défi déjà programmé.",
         "syncAllGames": "Synchronise l'intégralité de la base de données de jeux avec l'API RAWG pour maintenir les informations à jour (notes, captures, métadonnées).",
         "cleanupAnonymousUsers": "Supprime les comptes utilisateurs anonymes inactifs pour optimiser la base de données et libérer de l'espace.",
         "clearDailyData": "Efface toutes les données de session de jeu pour le défi quotidien du jour. Permet aux utilisateurs de rejouer le défi.",

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -22,7 +22,7 @@ import {
     Info,
     MapPin,
     ChevronDown,
-    Map,
+    Map as MapIcon,
     ListChecks,
     Library,
     X,
@@ -294,7 +294,7 @@ export function GeoReviewPanel() {
                         {t('admin.geo.tabs.pins')}
                     </TabsTrigger>
                     <TabsTrigger value="maps" className="gap-1.5 shrink-0">
-                        <Map className="h-3.5 w-3.5" />
+                        <MapIcon className="h-3.5 w-3.5" />
                         {t('admin.geo.tabs.maps')}
                     </TabsTrigger>
                     <TabsTrigger value="games" className="gap-1.5 shrink-0">

--- a/packages/frontend/src/components/admin/JobList.tsx
+++ b/packages/frontend/src/components/admin/JobList.tsx
@@ -29,6 +29,7 @@ import {
   Users,
   Trash2,
   AlertTriangle,
+  MapPin,
 } from 'lucide-react'
 
 function formatRelativeTime(dateString: string): string {
@@ -71,6 +72,7 @@ function formatCronPattern(pattern: string, t: (key: string) => string): string 
 function getJobTranslationKey(jobName: string): string {
   const keyMap: Record<string, string> = {
     'create-daily-challenge': 'admin.jobs.createDailyChallenge',
+    'schedule-daily-challenge': 'admin.jobs.scheduleDailyGeoChallenge',
     'sync-all-games': 'admin.jobs.syncAllGames',
     'cleanup-anonymous-users': 'admin.jobs.cleanupAnonymousUsers',
     'create-weekly-tournament': 'admin.jobs.createWeeklyTournament',
@@ -90,6 +92,7 @@ function getJobTranslationKey(jobName: string): string {
 function getJobRunningTranslationKey(jobName: string): string {
   const keyMap: Record<string, string> = {
     'create-daily-challenge': 'admin.jobs.dailyChallengeRunning',
+    'schedule-daily-challenge': 'admin.jobs.scheduleDailyGeoChallengeRunning',
     'sync-all-games': 'admin.jobs.syncAllRunning',
     'cleanup-anonymous-users': 'admin.jobs.cleanupAnonymousUsersRunning',
     'create-weekly-tournament': 'admin.jobs.createWeeklyTournamentRunning',
@@ -115,6 +118,11 @@ function getJobMetadata(jobName: string, t: (key: string) => string) {
     'create-daily-challenge': {
       description: t('admin.jobs.descriptions.createDailyChallenge'),
       icon: <Calendar className="h-4 w-4" />,
+      category: 'Challenge',
+    },
+    'schedule-daily-challenge': {
+      description: t('admin.jobs.descriptions.scheduleDailyGeoChallenge'),
+      icon: <MapPin className="h-4 w-4" />,
       category: 'Challenge',
     },
     'sync-all-games': {
@@ -191,6 +199,7 @@ export function JobList() {
     isLoading,
     recurringJobs,
     triggerDailyChallengeJob,
+    triggerScheduleDailyGeoChallengeJob,
     triggerSyncAllJob,
     cancelActiveSyncAll,
     triggerCleanupAnonymousUsersJob,
@@ -238,6 +247,8 @@ export function JobList() {
     try {
       if (jobName === 'create-daily-challenge') {
         await triggerDailyChallengeJob()
+      } else if (jobName === 'schedule-daily-challenge') {
+        await triggerScheduleDailyGeoChallengeJob()
       } else if (jobName === 'sync-all-games') {
         await triggerSyncAllJob()
       } else if (jobName === 'cleanup-anonymous-users') {

--- a/packages/frontend/src/lib/api/admin.ts
+++ b/packages/frontend/src/lib/api/admin.ts
@@ -183,6 +183,21 @@ export const adminApi = {
   },
 
   /**
+   * Trigger the daily geo-pin challenge scheduler (manual run-now).
+   * Mirrors triggerDailyChallenge but targets the geo-jobs queue.
+   */
+  async triggerScheduleDailyGeoChallenge(): Promise<{ jobId: string }> {
+    const response = await fetch('/api/admin/geo/schedule', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    return handleResponse<{ jobId: string }>(response)
+  },
+
+  /**
    * Start cleanup-anonymous-users job (manual trigger)
    */
   async triggerCleanupAnonymousUsers(): Promise<{ job: Job }> {

--- a/packages/frontend/src/stores/adminStore.ts
+++ b/packages/frontend/src/stores/adminStore.ts
@@ -94,6 +94,7 @@ interface AdminState {
   fetchStats: () => Promise<void>
   fetchRecurringJobs: () => Promise<void>
   triggerDailyChallengeJob: () => Promise<void>
+  triggerScheduleDailyGeoChallengeJob: () => Promise<void>
   triggerSyncAllJob: () => Promise<void>
   cancelActiveSyncAll: () => Promise<void>
   triggerCleanupAnonymousUsersJob: () => Promise<void>
@@ -273,6 +274,16 @@ export const useAdminStore = create<AdminState>()(
           get().fetchJobs()
         } catch (err) {
           console.error('Failed to trigger daily challenge job:', err)
+          throw err
+        }
+      },
+
+      triggerScheduleDailyGeoChallengeJob: async () => {
+        try {
+          await adminApi.triggerScheduleDailyGeoChallenge()
+          get().fetchJobs()
+        } catch (err) {
+          console.error('Failed to trigger schedule-daily-geo-challenge job:', err)
           throw err
         }
       },


### PR DESCRIPTION
## Summary
This PR integrates the geo queue's repeatable jobs into the admin job management interface, allowing administrators to manually trigger the daily geo challenge scheduler alongside other recurring jobs.

## Key Changes

- **Backend**:
  - Created new `ReadOnlyQueuePort` interface to safely expose queue inspection methods without requiring full queue compatibility across different job data types
  - Extended `JobService` to accept an optional `geoQueue` dependency
  - Updated `getRecurringJobs()` to aggregate repeatable and active jobs from both import and geo queues
  - Implemented filtering to surface only operator-facing geo jobs (`schedule-daily-challenge`) while hiding internal background jobs (`resolve-metadata`, `ingest-tick`)
  - Wired `geoQueue` into the service factory

- **Frontend**:
  - Added `triggerScheduleDailyGeoChallenge()` API endpoint for manual job triggering
  - Extended admin store with `triggerScheduleDailyGeoChallengeJob()` action
  - Updated `JobList` component to handle the new geo challenge job with proper UI integration (MapPin icon)
  - Added job name mapping and translation keys for the new job type
  - Added English and French translations for the job label and description

## Implementation Details

- The geo queue is optional (`geoQueue?`) to maintain backward compatibility
- Only the `schedule-daily-challenge` job from the geo queue is surfaced to admins; background plumbing jobs are filtered out
- The `ReadOnlyQueuePort` interface prevents accidental coupling of queue implementations with different `JobData` generics
- Job descriptions clarify that the geo challenge scheduler is idempotent

https://claude.ai/code/session_017uAKPNL6EC5vba6cenxzJm