### PR TITLE
feat(geo): allow admins to reject unsuitable capture candidates

### DIFF
--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -116,6 +116,27 @@ export const geoScreenshotRepository = {
     await db('geo_screenshot_candidate').where({ id: candidateId }).update({ status })
   },
 
+  /**
+   * Soft-delete a candidate that isn't suitable for the geo game (e.g. a UI
+   * screenshot that has no in-world location). Marks it `rejected` and
+   * deactivates it so contributors stop seeing it and the daily picker skips
+   * it. Existing pins are kept for audit. Refuses to act if the candidate is
+   * already promoted — the admin must demote the meta first.
+   */
+  async rejectCandidate(
+    candidateId: number,
+  ): Promise<{ rejected: boolean; alreadyPromoted: boolean }> {
+    log.info({ candidateId }, 'rejectCandidate')
+    const meta = await db('geo_screenshot_meta')
+      .where({ geo_screenshot_candidate_id: candidateId })
+      .first<{ id: number }>()
+    if (meta) return { rejected: false, alreadyPromoted: true }
+    const updated = await db('geo_screenshot_candidate')
+      .where({ id: candidateId })
+      .update({ status: 'rejected', is_active: false })
+    return { rejected: updated > 0, alreadyPromoted: false }
+  },
+
   async findMetaByCandidateId(candidateId: number): Promise<GeoScreenshotMeta | null> {
     const row = await db('geo_screenshot_meta')
       .where({ geo_screenshot_candidate_id: candidateId })

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1611,6 +1611,38 @@ router.post('/geo/candidates/:id/override', async (req, res, next) => {
   }
 })
 
+router.post('/geo/candidates/:id/reject', async (req, res, next) => {
+  try {
+    const id = Number(req.params.id)
+    if (!Number.isFinite(id)) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+
+    const candidate = await geoScreenshotRepository.findCandidateById(id)
+    if (!candidate) {
+      res.status(404).json({ success: false, error: { code: 'NOT_FOUND' } })
+      return
+    }
+
+    const result = await geoScreenshotRepository.rejectCandidate(id)
+    if (result.alreadyPromoted) {
+      res.status(409).json({
+        success: false,
+        error: {
+          code: 'ALREADY_PROMOTED',
+          message: 'demote the canonical meta before rejecting the candidate',
+        },
+      })
+      return
+    }
+
+    res.json({ success: true, data: { id, rejected: result.rejected } })
+  } catch (err) {
+    next(err)
+  }
+})
+
 // Auto-ingestion is driven by recurring `resolve-metadata` and `ingest-tick`
 // jobs (see index.ts). The endpoints below give the admin a read-only view of
 // the dataset's health plus a small set of manual-override actions: flagging

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -636,6 +636,7 @@
       "detailHint": "Select a candidate from the list to review its pins and optionally set canonical coordinates.",
       "promote": "Promote to canonical",
       "demote": "Demote canonical",
+      "reject": "Reject capture",
       "alreadyPromoted": "Already promoted — demote it to re-pin with new coordinates.",
       "candidateRow": {
         "pinCount_one": "{{count}} pin",
@@ -668,6 +669,12 @@
         "title": "Demote canonical pin?",
         "description": "This screenshot will return to the collecting queue. Players' pins are kept; you'll be able to set new canonical coordinates.",
         "confirm": "Demote",
+        "cancel": "Cancel"
+      },
+      "rejectDialog": {
+        "title": "Reject this capture?",
+        "description": "The capture will be removed from the Geo challenge: contributors won't see it anymore and it will never be picked for the daily challenge. Use for captures with no locatable spot (UI, inventory, loading screen…).",
+        "confirm": "Reject",
         "cancel": "Cancel"
       },
       "health": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -636,6 +636,7 @@
       "detailHint": "Sélectionnez un candidat dans la liste pour consulter ses épingles et éventuellement définir les coordonnées canoniques.",
       "promote": "Promouvoir en canonique",
       "demote": "Rétrograder la canonique",
+      "reject": "Rejeter la capture",
       "alreadyPromoted": "Déjà promu — rétrogradez pour ré-épingler avec de nouvelles coordonnées.",
       "candidateRow": {
         "pinCount_one": "{{count}} épingle",
@@ -668,6 +669,12 @@
         "title": "Rétrograder la canonique ?",
         "description": "Cette capture retournera dans la file de collecte. Les épingles des joueurs sont conservées ; vous pourrez définir de nouvelles coordonnées canoniques.",
         "confirm": "Rétrograder",
+        "cancel": "Annuler"
+      },
+      "rejectDialog": {
+        "title": "Rejeter cette capture ?",
+        "description": "La capture sera retirée du défi Géo : les contributeurs ne la verront plus et elle ne sera jamais sélectionnée pour le défi quotidien. À utiliser pour les captures sans emplacement repérable (interface, inventaire, écran de chargement…).",
+        "confirm": "Rejeter",
         "cancel": "Annuler"
       },
       "health": {

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -132,6 +132,17 @@ async function deleteMeta(metaId: number): Promise<void> {
     }
 }
 
+async function rejectCandidate(id: number): Promise<void> {
+    const res = await fetch(`/api/admin/geo/candidates/${id}/reject`, {
+        method: 'POST',
+        credentials: 'include',
+    })
+    if (!res.ok) {
+        const json = await res.json().catch(() => ({}))
+        throw new Error(json?.error?.code ?? `reject failed: ${res.status}`)
+    }
+}
+
 export function GeoReviewPanel() {
     const { t } = useTranslation()
     const [activeTab, setActiveTab] = useState<'pins' | 'maps' | 'games'>('pins')
@@ -150,6 +161,7 @@ export function GeoReviewPanel() {
     const [saving, setSaving] = useState(false)
     const [error, setError] = useState<string | null>(null)
     const [demoteOpen, setDemoteOpen] = useState(false)
+    const [rejectOpen, setRejectOpen] = useState(false)
     const [introOpen, setIntroOpen] = useState(false)
     const [scheduling, setScheduling] = useState(false)
     // Owned here (not inside GeoMapsTab) so an in-flight manual run keeps
@@ -232,6 +244,27 @@ export function GeoReviewPanel() {
         setStatusFilter('all')
         setDetail(null)
         setActiveTab('pins')
+    }
+
+    const confirmReject = async () => {
+        if (!detail) return
+        setError(null)
+        setSaving(true)
+        try {
+            await rejectCandidate(detail.candidate.id)
+            setRejectOpen(false)
+            setDetail(null)
+            setPin(null)
+            const rows = await fetchCandidates({
+                status: statusFilter === 'all' ? undefined : statusFilter,
+                gameId: gameFilter?.gameId,
+            })
+            setCandidates(rows)
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setSaving(false)
+        }
     }
 
     const confirmDemote = async () => {
@@ -530,17 +563,29 @@ export function GeoReviewPanel() {
                                                     ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
                                                     : t('admin.geo.pickPoint')}
                                             </span>
-                                            <Button
-                                                size="sm"
-                                                onClick={applyOverride}
-                                                disabled={!pin || saving}
-                                                className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
-                                            >
-                                                {saving && (
-                                                    <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
-                                                )}
-                                                {t('admin.geo.promote')}
-                                            </Button>
+                                            <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    onClick={() => setRejectOpen(true)}
+                                                    disabled={saving}
+                                                    className="w-full sm:w-auto text-destructive border-destructive/40 hover:bg-destructive/10"
+                                                >
+                                                    <Trash2 className="h-3.5 w-3.5 mr-2" />
+                                                    {t('admin.geo.reject')}
+                                                </Button>
+                                                <Button
+                                                    size="sm"
+                                                    onClick={applyOverride}
+                                                    disabled={!pin || saving}
+                                                    className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
+                                                >
+                                                    {saving && (
+                                                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
+                                                    )}
+                                                    {t('admin.geo.promote')}
+                                                </Button>
+                                            </div>
                                         </div>
                                     )}
                                 </>
@@ -553,6 +598,34 @@ export function GeoReviewPanel() {
                     </Card>
                 </div>
             )}
+
+            <Dialog open={rejectOpen} onOpenChange={(open) => !saving && setRejectOpen(open)}>
+                <DialogContent className="max-w-sm sm:max-w-md">
+                    <DialogHeader>
+                        <DialogTitle>{t('admin.geo.rejectDialog.title')}</DialogTitle>
+                        <DialogDescription>
+                            {t('admin.geo.rejectDialog.description')}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter className="flex flex-col-reverse sm:flex-row gap-2">
+                        <Button
+                            variant="outline"
+                            onClick={() => setRejectOpen(false)}
+                            disabled={saving}
+                        >
+                            {t('admin.geo.rejectDialog.cancel')}
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmReject}
+                            disabled={saving}
+                        >
+                            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />}
+                            {t('admin.geo.rejectDialog.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
 
             <Dialog open={demoteOpen} onOpenChange={(open) => !saving && setDemoteOpen(open)}>
                 <DialogContent className="max-w-sm sm:max-w-md">


### PR DESCRIPTION
Adds a "Reject capture" action in the Geo review panel so admins can
discard candidates that have no locatable spot (UI screens, inventory,
loading screens) instead of being forced to pick canonical coordinates
on something that can't be geo-guessed.

- New POST /api/admin/geo/candidates/:id/reject endpoint, returns 409 if
  the candidate is already promoted (admin must demote first)
- Repository soft-deletes by setting status=rejected + is_active=false,
  so contributors no longer see it and the daily picker skips it; pins
  are kept for audit
- UI surfaces the action next to "Promote to canonical" with a
  confirmation dialog; only visible while the candidate is unpromoted