### PR TITLE
feat(report): add "too easy" reason to screenshot signalement

### DIFF
--- a/packages/backend/migrations/20260425_screenshot_reports.ts
+++ b/packages/backend/migrations/20260425_screenshot_reports.ts
@@ -31,7 +31,7 @@ export async function up(knex: Knex): Promise<void> {
     table
       .string('reason', 50)
       .notNullable()
-      .comment('wrong_game | low_quality | not_recognizable | inappropriate | other')
+      .comment('wrong_game | low_quality | not_recognizable | inappropriate | too_easy | other')
     table.text('details').nullable()
     table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
 

--- a/packages/backend/src/presentation/routes/screenshot-report.routes.ts
+++ b/packages/backend/src/presentation/routes/screenshot-report.routes.ts
@@ -13,6 +13,7 @@ const SCREENSHOT_REPORT_REASONS = [
   'low_quality',
   'not_recognizable',
   'inappropriate',
+  'too_easy',
   'other',
 ] as const satisfies readonly ScreenshotReportReason[]
 

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1481,6 +1481,7 @@
       "low_quality": "Low-quality image",
       "not_recognizable": "Not recognizable / no usable landmark",
       "inappropriate": "Inappropriate content",
+      "too_easy": "Too easy",
       "other": "Other"
     }
   }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1481,6 +1481,7 @@
       "low_quality": "Image de mauvaise qualité",
       "not_recognizable": "Non reconnaissable / aucun repère utile",
       "inappropriate": "Contenu inapproprié",
+      "too_easy": "Trop facile",
       "other": "Autre"
     }
   }

--- a/packages/frontend/src/components/ReportCaptureDialog.tsx
+++ b/packages/frontend/src/components/ReportCaptureDialog.tsx
@@ -28,6 +28,7 @@ const REPORT_REASONS = [
     'low_quality',
     'not_recognizable',
     'inappropriate',
+    'too_easy',
     'other',
 ] as const satisfies readonly ScreenshotReportReason[]
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -894,4 +894,5 @@ export type ScreenshotReportReason =
   | 'low_quality'
   | 'not_recognizable'
   | 'inappropriate'
+  | 'too_easy'
   | 'other'


### PR DESCRIPTION
Adds a new `too_easy` value to ScreenshotReportReason so users can flag
captures that are too easy alongside the existing wrong_game / low_quality
/ not_recognizable / inappropriate / other choices. Updates the shared
type, backend Zod enum, frontend dialog list, migration column comment,
and EN/FR translations.

https://claude.ai/code/session_01KPGm95bpMor3upS9F219iF