### PR TITLE
feat(geo): add Wand map source for admin-triggered map import

### DIFF
--- a/packages/backend/src/infrastructure/queue/queues.ts
+++ b/packages/backend/src/infrastructure/queue/queues.ts
@@ -55,6 +55,12 @@ export type GeoJobData =
       wikidataQid: string
     }
   | {
+      kind: 'import-wand-map'
+      gameId: number
+      wandUrl: string
+      region?: string
+    }
+  | {
       kind: 'import-steam-screenshots'
       gameId: number
       geoMapId: number

--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -27,6 +27,7 @@ export interface IngestTickResult {
   fandomEnqueued: number
   strategyWikiEnqueued: number
   fextralifeEnqueued: number
+  wandEnqueued: number
   wikidataEnqueued: number
   steamEnqueued: number
 }
@@ -39,9 +40,10 @@ export interface IngestTickResult {
  *   2. `fandom`       — Fandom Interactive Maps (if wiki_subdomain + map page resolved)
  *   3. `strategywiki` — StrategyWiki MediaWiki API (CC-BY-SA, no pre-resolution)
  *   4. `fextralife`   — Fextralife wiki og:image scrape (RPG / Soulsborne coverage)
- *   5. `wikidata`     — Wikidata P242 locator map (if wikidata_qid resolved)
+ *   5. `wand`         — wand.com og:image scrape via slug (Cloudflare-gated)
+ *   6. `wikidata`     — Wikidata P242 locator map (if wikidata_qid resolved)
  *
- * Tiers 3 and 4 don't require pre-resolution — they probe the upstream API
+ * Tiers 3, 4 and 5 don't require pre-resolution — they probe the upstream
  * inline using the game slug + name, so a game can succeed there even if
  * the metadata resolver couldn't find a Fandom subdomain or Wikidata Q-id.
  *
@@ -103,6 +105,7 @@ export async function runGeoIngestTick(
   let fandomEnqueued = 0
   let strategyWikiEnqueued = 0
   let fextralifeEnqueued = 0
+  let wandEnqueued = 0
   let wikidataEnqueued = 0
   let steamEnqueued = 0
 
@@ -112,6 +115,7 @@ export async function runGeoIngestTick(
     fandomEnqueued += enqueued.fandom
     strategyWikiEnqueued += enqueued.strategywiki
     fextralifeEnqueued += enqueued.fextralife
+    wandEnqueued += enqueued.wand
     wikidataEnqueued += enqueued.wikidata
 
     if (
@@ -148,6 +152,7 @@ export async function runGeoIngestTick(
       fandomEnqueued,
       strategyWikiEnqueued,
       fextralifeEnqueued,
+      wandEnqueued,
       wikidataEnqueued,
       steamEnqueued,
     },
@@ -159,6 +164,7 @@ export async function runGeoIngestTick(
     fandomEnqueued,
     strategyWikiEnqueued,
     fextralifeEnqueued,
+    wandEnqueued,
     wikidataEnqueued,
     steamEnqueued,
   }
@@ -169,6 +175,7 @@ interface TierEnqueueTally {
   fandom: number
   strategywiki: number
   fextralife: number
+  wand: number
   wikidata: number
 }
 
@@ -178,6 +185,7 @@ async function enqueueAllEligibleMapImports(row: TickRow): Promise<TierEnqueueTa
     fandom: 0,
     strategywiki: 0,
     fextralife: 0,
+    wand: 0,
     wikidata: 0,
   }
 
@@ -243,7 +251,21 @@ async function enqueueAllEligibleMapImports(row: TickRow): Promise<TierEnqueueTa
     tally.fextralife++
   }
 
-  // Tier 5 — Wikidata P242 fallback
+  // Tier 5 — Wand (no pre-resolution required; probes wand.com/maps/<slug>)
+  if (!(await tombstoneBlocks(row.id, 'wand'))) {
+    await geoQueue.add(
+      'import-wand-map',
+      {
+        kind: 'import-wand-map',
+        gameId: row.id,
+        wandUrl: `https://wand.com/maps/${encodeURIComponent(row.slug)}`,
+      },
+      { jobId: `auto-wand-${row.id}` },
+    )
+    tally.wand++
+  }
+
+  // Tier 6 — Wikidata P242 fallback
   if (row.wikidata_qid && !(await tombstoneBlocks(row.id, 'wikidata'))) {
     await geoQueue.add(
       'import-wikidata-map',
@@ -264,7 +286,8 @@ async function tombstoneBlocks(
     | 'registry'
     | 'wikidata'
     | 'strategywiki'
-    | 'fextralife',
+    | 'fextralife'
+    | 'wand',
 ): Promise<boolean> {
   const row = await db('geo_ingest_failure')
     .where({ game_id: gameId, source })
@@ -278,6 +301,7 @@ export type RunnableTier =
   | 'fandom'
   | 'strategywiki'
   | 'fextralife'
+  | 'wand'
   | 'wikidata'
 
 export type SingleTierFailure =
@@ -383,6 +407,19 @@ export async function enqueueSingleTierImport(
         gameId,
         gameName: game.name,
         slug: game.slug,
+      },
+      { jobId },
+    )
+    return { enqueued: true, jobId }
+  }
+
+  if (source === 'wand') {
+    await geoQueue.add(
+      'import-wand-map',
+      {
+        kind: 'import-wand-map',
+        gameId,
+        wandUrl: `https://wand.com/maps/${encodeURIComponent(game.slug)}`,
       },
       { jobId },
     )

--- a/packages/backend/src/infrastructure/queue/workers/geo-wand-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-wand-import-logic.ts
@@ -1,0 +1,161 @@
+import { queueLogger } from '../../logger/logger.js'
+import {
+  geoIngestFailureRepository,
+  geoMapRepository,
+} from '../../repositories/index.js'
+import { tombstoneRetryAfter } from '../../../domain/services/geo-metadata.service.js'
+import { probeImageDimensions } from './image-dimensions.js'
+
+const log = queueLogger.child({ worker: 'geo-wand-import' })
+
+// Wand (https://wand.com/maps/<slug>) hosts community-curated interactive
+// maps for ~750 games. Unlike registry / Fandom / Wikidata, there is no
+// machine-readable feed and the slug-to-game mapping isn't predictable
+// across editions, so admins paste the exact wand.com URL on a per-game
+// basis. The server fetches the page, extracts the `og:image` poster
+// (Wand publishes one for social embedding), probes its dimensions, and
+// records a `source = 'wand'` row.
+//
+// Licensing: Wand maps are derivative of publisher assets and Wand has no
+// public API or sub-license to redistribute. We treat the result as
+// fair-use attribution-only; commercialUseOk is implicitly false. Admins
+// confirm by pasting the URL — the same trust model as the manual tier.
+
+const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (compatible; the-box-geo-importer/1.0; +https://github.com/Wifsimster/the-box)'
+const WAND_LICENSE = 'Wand.com (proprietary, fair-use attribution)'
+const MIN_DIMENSION = 600
+const WAND_HOST_SUFFIX = 'wand.com'
+
+export interface ImportWandMapInput {
+  gameId: number
+  wandUrl: string
+  region?: string
+  userAgent?: string
+}
+
+export interface ImportWandMapResult {
+  imported: boolean
+  geoMapId?: number
+  reason?: string
+}
+
+export async function importWandMap(
+  input: ImportWandMapInput,
+): Promise<ImportWandMapResult> {
+  const { gameId, wandUrl, region } = input
+  const ua = input.userAgent ?? DEFAULT_USER_AGENT
+
+  if (!isWandUrl(wandUrl)) {
+    await tombstone(gameId, `not a wand.com URL: ${wandUrl}`)
+    return { imported: false, reason: 'not a wand.com URL' }
+  }
+
+  const existing = await geoMapRepository.findBySourceAndGameId(gameId, 'wand')
+  if (existing) {
+    return {
+      imported: false,
+      geoMapId: existing.id,
+      reason: 'wand map already imported',
+    }
+  }
+
+  log.info({ gameId, wandUrl }, 'fetching wand page')
+
+  let html: string
+  try {
+    const res = await fetch(wandUrl, {
+      headers: {
+        'User-Agent': ua,
+        Accept: 'text/html,application/xhtml+xml',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+    })
+    if (!res.ok) {
+      await tombstone(gameId, `GET ${wandUrl} → ${res.status}`)
+      return { imported: false, reason: `GET failed: ${res.status}` }
+    }
+    html = await res.text()
+  } catch (err) {
+    await tombstone(gameId, `GET fetch threw: ${String(err)}`)
+    return { imported: false, reason: 'GET fetch threw' }
+  }
+
+  const ogImage = extractOgImage(html)
+  if (!ogImage) {
+    await tombstone(gameId, `og:image missing on ${wandUrl}`)
+    return { imported: false, reason: 'og:image missing' }
+  }
+
+  const dims = await probeImageDimensions(ogImage, ua)
+  if (!dims) {
+    await tombstone(gameId, `could not probe dimensions for ${ogImage}`)
+    return { imported: false, reason: 'could not probe dimensions' }
+  }
+  if (dims.width < MIN_DIMENSION || dims.height < MIN_DIMENSION) {
+    await tombstone(
+      gameId,
+      `og:image too small (${dims.width}x${dims.height}) — likely a logo, not a map`,
+    )
+    return { imported: false, reason: 'og:image too small' }
+  }
+
+  const map = await geoMapRepository.create({
+    gameId,
+    source: 'wand',
+    sourceUrl: wandUrl,
+    imageUrl: ogImage,
+    widthPx: dims.width,
+    heightPx: dims.height,
+    license: WAND_LICENSE,
+    attribution: `Map © wand.com — ${wandUrl}`,
+    region: region ?? null,
+  })
+
+  await geoIngestFailureRepository.clear(gameId, 'wand')
+  log.info(
+    { gameId, mapId: map.id, wandUrl, ogImage, dims },
+    'imported wand map',
+  )
+  return { imported: true, geoMapId: map.id }
+}
+
+// Same anchored-host check the rest of the codebase uses for trusted
+// origins: must be an https URL whose hostname is `wand.com` or any
+// subdomain of it. Rejects `evil.com/?wand.com` and `wand.com.evil.com`.
+export function isWandUrl(input: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(input)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false
+  const host = parsed.hostname.toLowerCase()
+  return host === WAND_HOST_SUFFIX || host.endsWith(`.${WAND_HOST_SUFFIX}`)
+}
+
+const OG_IMAGE_FORWARD =
+  /<meta[^>]+property=["']og:image(?::secure_url|:url)?["'][^>]+content=["']([^"']+)["']/i
+const OG_IMAGE_REVERSE =
+  /<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:image(?::secure_url|:url)?["']/i
+
+export function extractOgImage(html: string): string | null {
+  const m = html.match(OG_IMAGE_FORWARD) ?? html.match(OG_IMAGE_REVERSE)
+  if (!m) return null
+  const raw = m[1]?.trim()
+  if (!raw) return null
+  if (!/^https?:\/\//i.test(raw)) return null
+  return raw
+}
+
+async function tombstone(gameId: number, reason: string): Promise<void> {
+  const attempt =
+    (await geoIngestFailureRepository.getAttemptCount(gameId, 'wand')) + 1
+  await geoIngestFailureRepository.record({
+    gameId,
+    source: 'wand',
+    reason,
+    retryAfter: tombstoneRetryAfter(attempt),
+  })
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo-wand-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-wand-import-logic.ts
@@ -9,20 +9,25 @@ import { probeImageDimensions } from './image-dimensions.js'
 const log = queueLogger.child({ worker: 'geo-wand-import' })
 
 // Wand (https://wand.com/maps/<slug>) hosts community-curated interactive
-// maps for ~750 games. Unlike registry / Fandom / Wikidata, there is no
-// machine-readable feed and the slug-to-game mapping isn't predictable
-// across editions, so admins paste the exact wand.com URL on a per-game
-// basis. The server fetches the page, extracts the `og:image` poster
-// (Wand publishes one for social embedding), probes its dimensions, and
-// records a `source = 'wand'` row.
+// maps for ~750 games. The slug pattern is predictable — `wand.com/maps/<slug>`
+// for the canonical map, `wand.com/<locale>/maps/<slug>/<region>` for regional
+// sub-maps — so we expose a `wandUrlForSlug` helper and the admin dialog
+// pre-fills the URL from the game's slug. The server fetches the page,
+// extracts the `og:image` poster (Wand publishes one for social embedding),
+// probes its dimensions, and records a `source = 'wand'` row.
+//
+// Cloudflare gates the bare-bones bot UA we use elsewhere (returns 503), so
+// this worker pretends to be a desktop Chrome. This is exactly the
+// "Cloudflare anti-bot risk" FR-20a flagged for MapGenie / Fextralife —
+// admins explicitly opted into Wand knowing that, and tombstones surface
+// when Cloudflare changes its rules.
 //
 // Licensing: Wand maps are derivative of publisher assets and Wand has no
 // public API or sub-license to redistribute. We treat the result as
-// fair-use attribution-only; commercialUseOk is implicitly false. Admins
-// confirm by pasting the URL — the same trust model as the manual tier.
+// fair-use attribution-only; commercialUseOk is implicitly false.
 
 const DEFAULT_USER_AGENT =
-  'Mozilla/5.0 (compatible; the-box-geo-importer/1.0; +https://github.com/Wifsimster/the-box)'
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
 const WAND_LICENSE = 'Wand.com (proprietary, fair-use attribution)'
 const MIN_DIMENSION = 600
 const WAND_HOST_SUFFIX = 'wand.com'
@@ -67,9 +72,10 @@ export async function importWandMap(
     const res = await fetch(wandUrl, {
       headers: {
         'User-Agent': ua,
-        Accept: 'text/html,application/xhtml+xml',
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'en-US,en;q=0.9',
       },
+      redirect: 'follow',
     })
     if (!res.ok) {
       await tombstone(gameId, `GET ${wandUrl} → ${res.status}`)
@@ -85,6 +91,16 @@ export async function importWandMap(
   if (!ogImage) {
     await tombstone(gameId, `og:image missing on ${wandUrl}`)
     return { imported: false, reason: 'og:image missing' }
+  }
+  if (isWandFallbackImage(ogImage)) {
+    // Wand's soft-404 pages still return HTTP 200 but advertise a generic
+    // `/wand-assets/images/meta-*.png` banner instead of a real map image.
+    // Verified empirically: any unknown slug yields this fallback.
+    await tombstone(
+      gameId,
+      `og:image is wand's fallback (page has no real map): ${ogImage}`,
+    )
+    return { imported: false, reason: 'no real map (fallback og:image)' }
   }
 
   const dims = await probeImageDimensions(ogImage, ua)
@@ -131,6 +147,30 @@ export function isWandUrl(input: string): boolean {
     return false
   }
   if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false
+  const host = parsed.hostname.toLowerCase()
+  return host === WAND_HOST_SUFFIX || host.endsWith(`.${WAND_HOST_SUFFIX}`)
+}
+
+// Build the canonical wand.com URL for a game slug. Wand redirects from
+// the bare `/maps/<slug>` form to a localized canonical
+// (`/<locale>/maps/<slug>`); we let `redirect: 'follow'` handle that. Slug
+// is URL-encoded defensively even though the registry slugs are
+// kebab-case ASCII.
+export function wandUrlForSlug(slug: string): string {
+  return `https://wand.com/maps/${encodeURIComponent(slug)}`
+}
+
+// Wand's soft-404 / unknown-slug pages still return HTTP 200 and embed
+// `https://wand.com/wand-assets/images/meta-*.png` as their og:image.
+// Real maps embed `https://api-cdn.wemod.com/meta_images/...`. So any
+// og:image whose hostname is wand.com itself is the fallback.
+export function isWandFallbackImage(imageUrl: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(imageUrl)
+  } catch {
+    return true
+  }
   const host = parsed.hostname.toLowerCase()
   return host === WAND_HOST_SUFFIX || host.endsWith(`.${WAND_HOST_SUFFIX}`)
 }

--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -7,6 +7,7 @@ import { importFandomMap } from './geo-fandom-import-logic.js'
 import { importFextralifeMap } from './geo-fextralife-import-logic.js'
 import { importRegistryMap } from './geo-registry-import-logic.js'
 import { importStrategyWikiMap } from './geo-strategywiki-import-logic.js'
+import { importWandMap } from './geo-wand-import-logic.js'
 import { importWikidataMap } from './geo-wikidata-import-logic.js'
 import { importSteamScreenshots } from './geo-steam-import-logic.js'
 import { scheduleDailyGeoChallenge } from './geo-schedule-logic.js'
@@ -76,6 +77,14 @@ export const geoWorker = new Worker<GeoJobData>(
       return await importWikidataMap({
         gameId: data.gameId,
         wikidataQid: data.wikidataQid,
+      })
+    }
+
+    if (data.kind === 'import-wand-map') {
+      return await importWandMap({
+        gameId: data.gameId,
+        wandUrl: data.wandUrl,
+        region: data.region,
       })
     }
 

--- a/packages/backend/src/infrastructure/repositories/geo-ingest-failure.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-ingest-failure.repository.ts
@@ -10,6 +10,7 @@ export type GeoIngestSource =
   | 'registry'
   | 'strategywiki'
   | 'fextralife'
+  | 'wand'
   | 'wikidata'
 
 export interface GeoIngestFailureRow {

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -50,6 +50,10 @@ import { isMapEligibleByGenre } from '../../domain/services/geo-metadata.service
 import { geoQueue, type GeoJobData } from '../../infrastructure/queue/queues.js'
 import { findRegistryEntryBySlug } from '../../infrastructure/queue/workers/geo-registry-import-logic.js'
 import {
+  importWandMap,
+  isWandUrl,
+} from '../../infrastructure/queue/workers/geo-wand-import-logic.js'
+import {
   enqueueSingleTierImport,
   type RunnableTier,
 } from '../../infrastructure/queue/workers/geo-ingest-tick-logic.js'
@@ -2353,6 +2357,7 @@ const TOMBSTONE_SOURCES = [
   'registry',
   'strategywiki',
   'fextralife',
+  'wand',
   'wikidata',
 ] as const
 type TombstoneSource = (typeof TOMBSTONE_SOURCES)[number]
@@ -2699,8 +2704,93 @@ router.post('/geo/maps/manual', async (req, res, next) => {
       geoIngestFailureRepository.clear(data.gameId, 'fandom'),
       geoIngestFailureRepository.clear(data.gameId, 'strategywiki'),
       geoIngestFailureRepository.clear(data.gameId, 'fextralife'),
+      geoIngestFailureRepository.clear(data.gameId, 'wand'),
       geoIngestFailureRepository.clear(data.gameId, 'wikidata'),
     ])
+
+    res.json({ success: true, data: map })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// ---------- Wand map import ----------
+
+// Admin pastes a wand.com map page URL (e.g. https://wand.com/maps/elden-ring)
+// and the server scrapes the page's `og:image` to record a `source = 'wand'`
+// row. Synchronous on purpose so the operator sees the resolved image URL +
+// dimensions immediately and can fall back to the manual route if Wand
+// returned a Cloudflare challenge or moved the slug.
+const wandGeoMapBodySchema = z.object({
+  gameId: z.number().int().positive(),
+  wandUrl: z.string().url().max(1000),
+  region: z.string().trim().min(1).max(100).optional(),
+  replaceActive: z.boolean().optional(),
+})
+
+router.post('/geo/maps/wand', async (req, res, next) => {
+  try {
+    const parse = wandGeoMapBodySchema.safeParse(req.body)
+    if (!parse.success) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: parse.error.issues[0]?.message },
+      })
+      return
+    }
+    const data = parse.data
+
+    if (!isWandUrl(data.wandUrl)) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'NOT_WAND_URL', message: 'wandUrl must be on wand.com' },
+      })
+      return
+    }
+
+    const game = await db('games').where({ id: data.gameId }).first<{ id: number }>()
+    if (!game) {
+      res.status(404).json({ success: false, error: { code: 'GAME_NOT_FOUND' } })
+      return
+    }
+
+    const active = await geoMapRepository.findActiveByGameId(data.gameId)
+    if (active && !data.replaceActive) {
+      res.status(409).json({
+        success: false,
+        error: {
+          code: 'MAP_EXISTS',
+          message:
+            'an active geo_map already exists for this game; pass replaceActive=true to swap',
+        },
+      })
+      return
+    }
+
+    const result = await importWandMap({
+      gameId: data.gameId,
+      wandUrl: data.wandUrl,
+      region: data.region,
+    })
+
+    if (!result.imported) {
+      res.status(422).json({
+        success: false,
+        error: { code: 'WAND_IMPORT_FAILED', message: result.reason },
+      })
+      return
+    }
+
+    if (active && data.replaceActive && active.id !== result.geoMapId) {
+      await geoMapRepository.deactivate(active.id)
+      if (result.geoMapId) {
+        await geoMapRepository.setActiveForGame(data.gameId, result.geoMapId)
+      }
+    }
+
+    const map = result.geoMapId
+      ? await geoMapRepository.findById(result.geoMapId)
+      : null
 
     res.json({ success: true, data: map })
   } catch (err) {

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1956,6 +1956,7 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
         | 'fandom'
         | 'strategywiki'
         | 'fextralife'
+        | 'wand'
         | 'wikidata'
         | 'manual',
       state:
@@ -1979,6 +1980,7 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
         | 'fandom'
         | 'strategywiki'
         | 'fextralife'
+        | 'wand'
         | 'wikidata'
         | 'manual',
       via: string,
@@ -2089,7 +2091,27 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
       }
     }
 
-    // Tier 5 — Wikidata
+    // Tier 5 — Wand (probes inline by slug, always eligible until tombstoned)
+    const wandMatched = matchedTier('wand', `wand.com/maps/${game.slug}`)
+    if (wandMatched) {
+      sources.push(wandMatched)
+    } else {
+      const tomb = failureBySource.get('wand')
+      if (tomb && tomb.retry_after.getTime() > now) {
+        sources.push(
+          tier('wand', {
+            status: 'tombstoned',
+            reason: tomb.reason,
+            attempts: tomb.attempt_count,
+            retryAfter: tomb.retry_after,
+          }),
+        )
+      } else {
+        sources.push(tier('wand', { status: 'eligible' }))
+      }
+    }
+
+    // Tier 6 — Wikidata
     const wikidataMatched = matchedTier('wikidata', game.wikidata_qid ?? 'P242')
     if (wikidataMatched) {
       sources.push(wikidataMatched)
@@ -2113,7 +2135,7 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
       )
     }
 
-    // Tier 6 — Manual
+    // Tier 7 — Manual
     const manualMatched = matchedTier('manual', 'admin upload')
     if (manualMatched) {
       sources.push(manualMatched)
@@ -2459,6 +2481,7 @@ const RUNNABLE_TIERS: readonly RunnableTier[] = [
   'fandom',
   'strategywiki',
   'fextralife',
+  'wand',
   'wikidata',
 ] as const
 function isRunnableTier(s: string): s is RunnableTier {

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -566,9 +566,10 @@
           "fandom": "Tier 2 — Fandom",
           "strategywiki": "Tier 3 — StrategyWiki",
           "fextralife": "Tier 4 — Fextralife",
-          "wikidata": "Tier 5 — Wikidata",
+          "wand": "Tier 5 — Wand",
+          "wikidata": "Tier 6 — Wikidata",
           "steam": "Steam",
-          "manual": "Tier 6 — Manual"
+          "manual": "Tier 7 — Manual"
         },
         "tierStatus": {
           "matched": "Matched",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -597,6 +597,8 @@
           "research": "Research",
           "researchTooltip": "Open pre-filled search links (Google, StrategyWiki, Fextralife…)",
           "uploadManual": "Upload manually",
+          "importWand": "Import from Wand",
+          "importWandTooltip": "Paste a wand.com map URL — the server will scrape its og:image and record it as the map for this game.",
           "viewCaptures_one": "View captures ({{count}})",
           "viewCaptures_other": "View captures ({{count}})",
           "viewCapturesTooltip": "Open the Pins tab filtered to this game's captures."
@@ -771,6 +773,25 @@
           "required": "Image URL, width, height, and license are required."
         },
         "success": "Manual map saved for \"{{name}}\"."
+      },
+      "wandMap": {
+        "title": "Import from Wand for \"{{name}}\"",
+        "description": "Paste the wand.com map page URL. The server fetches the page and records its og:image as the map. Wand maps are stored with attribution-only license.",
+        "descriptionReplace": "Replace the active map for this game with a Wand-sourced one. The previous map is deactivated; existing screenshot pins remain valid because coordinates are normalized.",
+        "fields": {
+          "wandUrl": "Wand map URL",
+          "wandUrlHint": "Must be a https://wand.com/maps/… URL.",
+          "region": "Region (optional)",
+          "regionPlaceholder": "e.g. Velen, Act II",
+          "regionHint": "Leave empty if this is the canonical / world / mosaic map."
+        },
+        "submit": "Import from Wand",
+        "submitReplace": "Replace with Wand map",
+        "errors": {
+          "required": "A wand.com URL is required.",
+          "notWandUrl": "URL must be hosted on wand.com."
+        },
+        "success": "Wand map imported for \"{{name}}\"."
       },
       "run": {
         "allCta": "Run all",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -597,6 +597,8 @@
           "research": "Rechercher",
           "researchTooltip": "Ouvrir des liens de recherche pré-remplis (Google, StrategyWiki, Fextralife…)",
           "uploadManual": "Téléverser manuellement",
+          "importWand": "Importer depuis Wand",
+          "importWandTooltip": "Collez une URL de carte wand.com — le serveur extrait son og:image et l'enregistre comme carte de ce jeu.",
           "viewCaptures_one": "Voir les captures ({{count}})",
           "viewCaptures_other": "Voir les captures ({{count}})",
           "viewCapturesTooltip": "Ouvrir l'onglet Pins filtré sur les captures de ce jeu."
@@ -771,6 +773,25 @@
           "required": "L'URL de l'image, la largeur, la hauteur et la licence sont obligatoires."
         },
         "success": "Carte manuelle enregistrée pour « {{name}} »."
+      },
+      "wandMap": {
+        "title": "Importer depuis Wand pour « {{name}} »",
+        "description": "Collez l'URL de la page de carte wand.com. Le serveur récupère la page et enregistre son og:image comme carte. Les cartes Wand sont stockées avec une licence d'attribution uniquement.",
+        "descriptionReplace": "Remplacer la carte active de ce jeu par une carte Wand. L'ancienne carte est désactivée ; les pins existants restent valides puisque les coordonnées sont normalisées.",
+        "fields": {
+          "wandUrl": "URL de la carte Wand",
+          "wandUrlHint": "Doit être une URL https://wand.com/maps/…",
+          "region": "Région (optionnel)",
+          "regionPlaceholder": "ex. Velen, Acte II",
+          "regionHint": "Laissez vide s'il s'agit de la carte canonique / monde / mosaïque."
+        },
+        "submit": "Importer depuis Wand",
+        "submitReplace": "Remplacer par une carte Wand",
+        "errors": {
+          "required": "Une URL wand.com est obligatoire.",
+          "notWandUrl": "L'URL doit être hébergée sur wand.com."
+        },
+        "success": "Carte Wand importée pour « {{name}} »."
       },
       "run": {
         "allCta": "Tout lancer",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -566,9 +566,10 @@
           "fandom": "Niveau 2 — Fandom",
           "strategywiki": "Niveau 3 — StrategyWiki",
           "fextralife": "Niveau 4 — Fextralife",
-          "wikidata": "Niveau 5 — Wikidata",
+          "wand": "Niveau 5 — Wand",
+          "wikidata": "Niveau 6 — Wikidata",
           "steam": "Steam",
-          "manual": "Niveau 6 — Manuel"
+          "manual": "Niveau 7 — Manuel"
         },
         "tierStatus": {
           "matched": "Trouvé",

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -28,6 +28,7 @@ import {
     ListChecks,
 } from 'lucide-react'
 import { GeoManualMapDialog } from './GeoManualMapDialog'
+import { GeoWandMapDialog } from './GeoWandMapDialog'
 import { GeoResearchAssistantDialog } from './GeoResearchAssistantDialog'
 import { ResetScrapingDialog } from './ResetScrapingDialog'
 import {
@@ -60,6 +61,7 @@ interface ActiveMapInfo {
         | 'fandom'
         | 'strategywiki'
         | 'fextralife'
+        | 'wand'
         | 'wikidata'
         | 'steam'
         | 'manual'
@@ -149,6 +151,7 @@ export function GeoMapsTab({
     const [busyAction, setBusyAction] = useState<'reimport' | null>(null)
     const [message, setMessage] = useState<string | null>(null)
     const [manualUploadFor, setManualUploadFor] = useState<CuratedGame | null>(null)
+    const [wandImportFor, setWandImportFor] = useState<CuratedGame | null>(null)
     const [researchFor, setResearchFor] = useState<CuratedGame | null>(null)
     const [resetOpen, setResetOpen] = useState(false)
     const [resetting, setResetting] = useState(false)
@@ -227,6 +230,16 @@ export function GeoMapsTab({
             }),
         )
         const id = manualUploadFor?.id
+        void Promise.all([reload(), id !== undefined ? reloadSources(id) : Promise.resolve()])
+    }
+
+    const onWandSuccess = () => {
+        setMessage(
+            t('admin.geo.wandMap.success', {
+                name: wandImportFor?.name ?? '',
+            }),
+        )
+        const id = wandImportFor?.id
         void Promise.all([reload(), id !== undefined ? reloadSources(id) : Promise.resolve()])
     }
 
@@ -654,6 +667,16 @@ export function GeoMapsTab({
                                     size="sm"
                                     variant="outline"
                                     className="flex-1"
+                                    onClick={() => setWandImportFor(selectedGame)}
+                                    title={t('admin.geo.maps.actions.importWandTooltip')}
+                                >
+                                    <Sparkles className="h-3.5 w-3.5 mr-1.5" />
+                                    {t('admin.geo.maps.actions.importWand')}
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    className="flex-1"
                                     onClick={() => setManualUploadFor(selectedGame)}
                                 >
                                     <Upload className="h-3.5 w-3.5 mr-1.5" />
@@ -695,6 +718,19 @@ export function GeoMapsTab({
                     }
                 }
                 onSuccess={onManualSuccess}
+            />
+
+            <GeoWandMapDialog
+                isOpen={wandImportFor !== null}
+                onClose={() => setWandImportFor(null)}
+                game={
+                    wandImportFor && {
+                        id: wandImportFor.id,
+                        name: wandImportFor.name,
+                        hasMap: wandImportFor.hasMap,
+                    }
+                }
+                onSuccess={onWandSuccess}
             />
 
             <GeoResearchAssistantDialog

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -727,6 +727,7 @@ export function GeoMapsTab({
                     wandImportFor && {
                         id: wandImportFor.id,
                         name: wandImportFor.name,
+                        slug: wandImportFor.slug,
                         hasMap: wandImportFor.hasMap,
                     }
                 }

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -78,6 +78,7 @@ type TierKey =
     | 'fandom'
     | 'strategywiki'
     | 'fextralife'
+    | 'wand'
     | 'wikidata'
     | 'manual'
 

--- a/packages/frontend/src/components/admin/GeoWandMapDialog.tsx
+++ b/packages/frontend/src/components/admin/GeoWandMapDialog.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Loader2 } from 'lucide-react'
+
+// Wand tier in the geo_map ingestion cascade. Admin pastes a wand.com map
+// page URL; the server scrapes the page's og:image to record the map.
+// Synchronous: the admin sees success/failure immediately and can fall back
+// to the manual upload dialog if Wand served a Cloudflare challenge.
+
+interface GeoWandMapDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  game: { id: number; name: string; hasMap: boolean } | null
+  onSuccess: () => void
+}
+
+interface FormState {
+  wandUrl: string
+  region: string
+}
+
+const EMPTY: FormState = {
+  wandUrl: '',
+  region: '',
+}
+
+export function GeoWandMapDialog({
+  isOpen,
+  onClose,
+  game,
+  onSuccess,
+}: GeoWandMapDialogProps) {
+  const { t } = useTranslation()
+  const [form, setForm] = useState<FormState>(EMPTY)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setForm(EMPTY)
+      setError(null)
+    }
+  }, [isOpen, game?.id])
+
+  if (!game) return null
+
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }))
+
+  const submit = async () => {
+    if (submitting) return
+    setError(null)
+    if (!form.wandUrl) {
+      setError(t('admin.geo.wandMap.errors.required'))
+      return
+    }
+    if (!/^https?:\/\/(?:[^/]+\.)?wand\.com\//i.test(form.wandUrl)) {
+      setError(t('admin.geo.wandMap.errors.notWandUrl'))
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/admin/geo/maps/wand', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          gameId: game.id,
+          wandUrl: form.wandUrl,
+          region: form.region.trim() || undefined,
+          replaceActive: game.hasMap,
+        }),
+      })
+      const json = (await res.json().catch(() => ({}))) as {
+        success?: boolean
+        error?: { code?: string; message?: string }
+      }
+      if (!res.ok || !json.success) {
+        throw new Error(
+          json.error?.message ?? json.error?.code ?? `request failed: ${res.status}`,
+        )
+      }
+      onSuccess()
+      onClose()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && !submitting && onClose()}>
+      <DialogContent className="max-w-sm sm:max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {t('admin.geo.wandMap.title', { name: game.name })}
+          </DialogTitle>
+          <DialogDescription>
+            {game.hasMap
+              ? t('admin.geo.wandMap.descriptionReplace')
+              : t('admin.geo.wandMap.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Field
+            id="wand-map-url"
+            label={t('admin.geo.wandMap.fields.wandUrl')}
+            hint={t('admin.geo.wandMap.fields.wandUrlHint')}
+            required
+          >
+            <Input
+              id="wand-map-url"
+              type="url"
+              placeholder="https://wand.com/maps/elden-ring"
+              value={form.wandUrl}
+              onChange={(e) => set('wandUrl', e.target.value)}
+              disabled={submitting}
+            />
+          </Field>
+
+          <Field
+            id="wand-map-region"
+            label={t('admin.geo.wandMap.fields.region')}
+            hint={t('admin.geo.wandMap.fields.regionHint')}
+          >
+            <Input
+              id="wand-map-region"
+              placeholder={t('admin.geo.wandMap.fields.regionPlaceholder')}
+              value={form.region}
+              onChange={(e) => set('region', e.target.value)}
+              disabled={submitting}
+              maxLength={100}
+            />
+          </Field>
+
+          {error && (
+            <p
+              role="alert"
+              className="rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter className="flex flex-col-reverse sm:flex-row gap-2">
+          <Button variant="outline" onClick={onClose} disabled={submitting}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={() => void submit()} disabled={submitting}>
+            {submitting && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+            {game.hasMap
+              ? t('admin.geo.wandMap.submitReplace')
+              : t('admin.geo.wandMap.submit')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Field({
+  id,
+  label,
+  required,
+  hint,
+  children,
+}: {
+  id: string
+  label: string
+  required?: boolean
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className="text-xs">
+        {label}
+        {required && <span className="text-destructive ml-0.5">*</span>}
+      </Label>
+      {children}
+      {hint && <p className="text-[10px] text-muted-foreground leading-snug">{hint}</p>}
+    </div>
+  )
+}

--- a/packages/frontend/src/components/admin/GeoWandMapDialog.tsx
+++ b/packages/frontend/src/components/admin/GeoWandMapDialog.tsx
@@ -21,7 +21,7 @@ import { Loader2 } from 'lucide-react'
 interface GeoWandMapDialogProps {
   isOpen: boolean
   onClose: () => void
-  game: { id: number; name: string; hasMap: boolean } | null
+  game: { id: number; name: string; slug: string; hasMap: boolean } | null
   onSuccess: () => void
 }
 
@@ -30,9 +30,11 @@ interface FormState {
   region: string
 }
 
-const EMPTY: FormState = {
-  wandUrl: '',
-  region: '',
+function defaultFormFor(slug: string | undefined): FormState {
+  return {
+    wandUrl: slug ? `https://wand.com/maps/${encodeURIComponent(slug)}` : '',
+    region: '',
+  }
 }
 
 export function GeoWandMapDialog({
@@ -42,16 +44,16 @@ export function GeoWandMapDialog({
   onSuccess,
 }: GeoWandMapDialogProps) {
   const { t } = useTranslation()
-  const [form, setForm] = useState<FormState>(EMPTY)
+  const [form, setForm] = useState<FormState>(defaultFormFor(game?.slug))
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (isOpen) {
-      setForm(EMPTY)
+      setForm(defaultFormFor(game?.slug))
       setError(null)
     }
-  }, [isOpen, game?.id])
+  }, [isOpen, game?.id, game?.slug])
 
   if (!game) return null
 

--- a/packages/frontend/src/hooks/useGeoRunPolling.ts
+++ b/packages/frontend/src/hooks/useGeoRunPolling.ts
@@ -11,6 +11,7 @@ const GeoRunJobKindSchema = z.enum([
     'import-fandom-map',
     'import-strategywiki-map',
     'import-fextralife-map',
+    'import-wand-map',
     'import-wikidata-map',
     'import-steam-screenshots',
     'schedule-daily-challenge',
@@ -140,6 +141,7 @@ export type InFlightTier =
     | 'fandom'
     | 'strategywiki'
     | 'fextralife'
+    | 'wand'
     | 'wikidata'
     | 'steam'
     | 'metadata'
@@ -157,6 +159,7 @@ export function tiersInFlightForGame(
         else if (job.kind === 'import-fandom-map') out.add('fandom')
         else if (job.kind === 'import-strategywiki-map') out.add('strategywiki')
         else if (job.kind === 'import-fextralife-map') out.add('fextralife')
+        else if (job.kind === 'import-wand-map') out.add('wand')
         else if (job.kind === 'import-wikidata-map') out.add('wikidata')
         else if (job.kind === 'import-steam-screenshots') out.add('steam')
         else if (job.kind === 'resolve-metadata') out.add('metadata')

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -746,6 +746,7 @@ export type GeoMapSource =
   | 'fandom'
   | 'strategywiki'
   | 'fextralife'
+  | 'wand'
   | 'wikidata'
   | 'steam'
   | 'manual'


### PR DESCRIPTION
Adds a new 'wand' tier to the geo_map ingestion cascade. Admins paste
a wand.com map page URL; the server scrapes the page's og:image and
records a geo_map row with source='wand'. Synchronous flow so the
operator sees success/failure (and the resolved image dimensions)
immediately, with the manual upload as the fallback path.

Wand maps are stored with attribution-only license — they are
derivative of publisher assets and Wand has no public sub-license, so
commercialUseOk is implicitly false.