### PR TITLE
feat(geo): add RAWG as a capture provider alongside Steam

### DIFF
--- a/packages/backend/src/infrastructure/queue/queues.ts
+++ b/packages/backend/src/infrastructure/queue/queues.ts
@@ -61,6 +61,13 @@ export type GeoJobData =
       steamAppId: number
       maxItems?: number
     }
+  | {
+      kind: 'import-rawg-screenshots'
+      gameId: number
+      geoMapId: number
+      rawgId: number
+      maxItems?: number
+    }
   | { kind: 'schedule-daily-challenge'; date?: string }
   | { kind: 'resolve-metadata'; batchSize?: number; gameId?: number }
   | { kind: 'ingest-tick'; batchSize?: number; gameId?: number }

--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -1,4 +1,5 @@
 import { db } from '../../database/connection.js'
+import { env } from '../../../config/env.js'
 import { queueLogger } from '../../logger/logger.js'
 import { geoQueue } from '../queues.js'
 import { geoMapRepository } from '../../repositories/index.js'
@@ -7,13 +8,17 @@ import { findRegistryEntryBySlug } from './geo-registry-import-logic.js'
 const log = queueLogger.child({ worker: 'geo-ingest-tick' })
 
 const DEFAULT_BATCH = 25
-const STEAM_TARGET_CANDIDATES = 30 // stop fetching Steam shots once we have this many
+// Combined cap across every capture provider (Steam + RAWG). Once a game
+// has this many active candidates we stop enqueuing more — admins can
+// reject duds and the next tick will top up.
+const CAPTURE_TARGET_CANDIDATES = 30
 
 interface TickRow {
   id: number
   name: string
   slug: string
   steam_app_id: number | null
+  rawg_id: number | null
   wiki_subdomain: string | null
   wiki_page_title: string | null
   wikidata_qid: string | null
@@ -29,6 +34,7 @@ export interface IngestTickResult {
   fextralifeEnqueued: number
   wikidataEnqueued: number
   steamEnqueued: number
+  rawgEnqueued: number
 }
 
 /**
@@ -71,6 +77,7 @@ export async function runGeoIngestTick(
         g.name,
         g.slug,
         g.steam_app_id,
+        g.rawg_id,
         g.wiki_subdomain,
         g.wiki_page_title,
         g.wikidata_qid,
@@ -105,6 +112,9 @@ export async function runGeoIngestTick(
   let fextralifeEnqueued = 0
   let wikidataEnqueued = 0
   let steamEnqueued = 0
+  let rawgEnqueued = 0
+
+  const rawgEnabled = Boolean(env.RAWG_API_KEY)
 
   for (const row of rows) {
     const enqueued = await enqueueAllEligibleMapImports(row)
@@ -114,17 +124,19 @@ export async function runGeoIngestTick(
     fextralifeEnqueued += enqueued.fextralife
     wikidataEnqueued += enqueued.wikidata
 
-    if (
-      row.active_map_id &&
-      row.candidate_count < STEAM_TARGET_CANDIDATES &&
-      row.steam_app_id
-    ) {
-      const skip = await tombstoneBlocks(row.id, 'steam')
-      if (!skip) {
-        // Re-fetch the active map id off the repo so we don't pass a stale
-        // value (the SELECT above can be racing a recent map import).
-        const map = await geoMapRepository.findActiveByGameId(row.id)
-        if (map) {
+    // Capture providers (Steam + RAWG) only run once an active map exists,
+    // so pins have something to anchor to. Both are enqueued in parallel
+    // when below the combined cap — they return different screenshots
+    // (Steam = publisher store-page shots, RAWG = aggregated incl.
+    // Switch / console / mobile titles that aren't on Steam) so running
+    // both is strictly additive. (source, external_id) uniqueness in
+    // geo_screenshot_candidate prevents dupes inside each provider.
+    if (row.active_map_id && row.candidate_count < CAPTURE_TARGET_CANDIDATES) {
+      // Re-fetch the active map id off the repo so we don't pass a stale
+      // value (the SELECT above can be racing a recent map import).
+      const map = await geoMapRepository.findActiveByGameId(row.id)
+      if (map) {
+        if (row.steam_app_id && !(await tombstoneBlocks(row.id, 'steam'))) {
           await geoQueue.add(
             'import-steam-screenshots',
             {
@@ -136,6 +148,24 @@ export async function runGeoIngestTick(
             { jobId: `auto-steam-${row.id}-${map.id}` },
           )
           steamEnqueued++
+        }
+
+        if (
+          rawgEnabled &&
+          row.rawg_id &&
+          !(await tombstoneBlocks(row.id, 'rawg'))
+        ) {
+          await geoQueue.add(
+            'import-rawg-screenshots',
+            {
+              kind: 'import-rawg-screenshots',
+              gameId: row.id,
+              geoMapId: map.id,
+              rawgId: row.rawg_id,
+            },
+            { jobId: `auto-rawg-${row.id}-${map.id}` },
+          )
+          rawgEnqueued++
         }
       }
     }
@@ -150,6 +180,7 @@ export async function runGeoIngestTick(
       fextralifeEnqueued,
       wikidataEnqueued,
       steamEnqueued,
+      rawgEnqueued,
     },
     'geo-ingest-tick run',
   )
@@ -161,6 +192,7 @@ export async function runGeoIngestTick(
     fextralifeEnqueued,
     wikidataEnqueued,
     steamEnqueued,
+    rawgEnqueued,
   }
 }
 
@@ -261,6 +293,7 @@ async function tombstoneBlocks(
   source:
     | 'fandom'
     | 'steam'
+    | 'rawg'
     | 'registry'
     | 'wikidata'
     | 'strategywiki'

--- a/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
@@ -1,4 +1,5 @@
 import { db } from '../../database/connection.js'
+import { env } from '../../../config/env.js'
 import { queueLogger } from '../../logger/logger.js'
 import { geoIngestFailureRepository } from '../../repositories/index.js'
 import {
@@ -18,6 +19,7 @@ const log = queueLogger.child({ worker: 'geo-metadata-resolve' })
 const DEFAULT_USER_AGENT =
   'the-box-geo-importer/1.0 (+https://github.com/Wifsimster/the-box)'
 const STEAM_STORESEARCH = 'https://store.steampowered.com/api/storesearch/'
+const RAWG_API = 'https://api.rawg.io/api'
 const FANDOM_BASE = (sub: string) => `https://${sub}.fandom.com`
 const MAP_TITLE_PREFIX = 'Map:'
 
@@ -27,6 +29,7 @@ interface CuratedGameRow {
   slug: string
   genres: string[] | null
   steam_app_id: number | null
+  rawg_id: number | null
   wiki_subdomain: string | null
   wiki_page_title: string | null
   wikidata_qid: string | null
@@ -77,6 +80,7 @@ export async function resolveGeoMetadataBatch(
     'slug',
     'genres',
     'steam_app_id',
+    'rawg_id',
     'wiki_subdomain',
     'wiki_page_title',
     'wikidata_qid',
@@ -89,6 +93,13 @@ export async function resolveGeoMetadataBatch(
   for (const row of rows) {
     try {
       const steamAppId = row.steam_app_id ?? (await resolveSteamAppId(row.name))
+      // RAWG covers Switch / PS / Xbox / mobile titles that Steam can't,
+      // so resolving rawg_id for curated rows that don't already have one
+      // unblocks the rawg capture importer for the long tail of console
+      // exclusives (e.g. Zelda BotW). Gated on RAWG_API_KEY because the
+      // search endpoint requires it.
+      const rawgId =
+        row.rawg_id ?? (env.RAWG_API_KEY ? await resolveRawgId(row.name) : null)
       const wiki =
         row.wiki_subdomain && row.wiki_page_title
           ? { subdomain: row.wiki_subdomain, mapName: row.wiki_page_title }
@@ -115,6 +126,7 @@ export async function resolveGeoMetadataBatch(
         .where({ id: row.id })
         .update({
           steam_app_id: steamAppId,
+          rawg_id: rawgId,
           wiki_subdomain: wiki?.subdomain ?? row.wiki_subdomain,
           wiki_page_title: wiki?.mapName ?? row.wiki_page_title,
           wikidata_qid: wikidataQid ?? row.wikidata_qid,
@@ -124,7 +136,7 @@ export async function resolveGeoMetadataBatch(
       await geoIngestFailureRepository.clear(row.id, 'metadata')
       resolved++
       log.info(
-        { gameId: row.id, steamAppId, wiki, wikidataQid, hasRegistry },
+        { gameId: row.id, steamAppId, rawgId, wiki, wikidataQid, hasRegistry },
         'resolved geo metadata',
       )
     } catch (err) {
@@ -173,6 +185,49 @@ async function resolveSteamAppId(name: string): Promise<number | null> {
     return null
   } catch (err) {
     log.warn({ name, err: String(err) }, 'steam storesearch failed')
+    return null
+  }
+}
+
+async function resolveRawgId(name: string): Promise<number | null> {
+  const apiKey = env.RAWG_API_KEY
+  if (!apiKey) return null
+  try {
+    const url =
+      `${RAWG_API}/games?key=${encodeURIComponent(apiKey)}` +
+      `&search=${encodeURIComponent(name)}&page_size=10`
+    const res = await fetch(url, {
+      headers: { 'User-Agent': DEFAULT_USER_AGENT, Accept: 'application/json' },
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as {
+      results?: Array<{ id: number; name: string }>
+    }
+    if (!body.results?.length) return null
+    const target = normalizeGameTitle(name)
+    // Same disambiguation rules we apply to Steam storesearch — exact
+    // normalized match wins, otherwise the first version-token-compatible
+    // hit. Without this guard "Diablo" silently binds to "Diablo II" / III.
+    const exact = body.results.find((it) => normalizeGameTitle(it.name) === target)
+    if (exact) return exact.id
+    const targetTokens = extractVersionTokens(target)
+    const compatible = body.results.find((it) =>
+      versionTokensMatch(targetTokens, extractVersionTokens(normalizeGameTitle(it.name))),
+    )
+    if (compatible) {
+      log.info(
+        { name, picked: compatible.name, rawgId: compatible.id },
+        'rawg search picked first version-compatible hit',
+      )
+      return compatible.id
+    }
+    log.warn(
+      { name, top: body.results[0]?.name },
+      'rawg search had no version-compatible hit',
+    )
+    return null
+  } catch (err) {
+    log.warn({ name, err: String(err) }, 'rawg search failed')
     return null
   }
 }

--- a/packages/backend/src/infrastructure/queue/workers/geo-rawg-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-rawg-import-logic.ts
@@ -1,0 +1,120 @@
+import { env } from '../../../config/env.js'
+import { queueLogger } from '../../logger/logger.js'
+import {
+  geoIngestFailureRepository,
+  geoScreenshotRepository,
+} from '../../repositories/index.js'
+import { tombstoneRetryAfter } from '../../../domain/services/geo-metadata.service.js'
+
+const log = queueLogger.child({ worker: 'geo-rawg-import' })
+
+// RAWG's `/games/{id}/screenshots` returns a paginated list of screenshots
+// scraped from official sources + community uploads. Coverage is broader
+// than Steam's `appdetails` because RAWG indexes Switch / PlayStation /
+// Xbox / mobile titles too — this is the source that fixes the
+// "Zelda BotW returns 0 candidates" case where the game isn't on Steam.
+//
+// Auth: query-string `?key=<RAWG_API_KEY>`. Free tier is 20k req/month
+// with a soft 20 req/min limit; we let the worker concurrency throttle
+// us and back off on 429s.
+const RAWG_API = 'https://api.rawg.io/api'
+const DEFAULT_USER_AGENT =
+  'the-box-geo-importer/1.0 (+https://github.com/Wifsimster/the-box)'
+
+export interface ImportRawgScreenshotsInput {
+  gameId: number
+  geoMapId: number
+  rawgId: number
+  maxItems?: number
+  userAgent?: string
+}
+
+export interface ImportRawgScreenshotsResult {
+  fetched: number
+  inserted: number
+  skipped: number
+}
+
+interface RawgScreenshot {
+  id: number
+  image: string
+  width?: number
+  height?: number
+  is_deleted?: boolean
+}
+
+interface RawgScreenshotsResponse {
+  count: number
+  next: string | null
+  previous: string | null
+  results: RawgScreenshot[]
+}
+
+export async function importRawgScreenshots(
+  input: ImportRawgScreenshotsInput,
+): Promise<ImportRawgScreenshotsResult> {
+  const { gameId, geoMapId, rawgId } = input
+  const max = input.maxItems ?? 50
+  const ua = input.userAgent ?? DEFAULT_USER_AGENT
+
+  const apiKey = env.RAWG_API_KEY
+  if (!apiKey) {
+    // Caller is expected to gate on env, but fail loudly rather than silently
+    // tombstoning if a job slipped through.
+    throw new Error('RAWG_API_KEY is not configured')
+  }
+
+  const url = `${RAWG_API}/games/${rawgId}/screenshots?key=${encodeURIComponent(apiKey)}`
+  log.info({ gameId, rawgId }, 'fetching rawg screenshots')
+
+  const res = await fetch(url, {
+    headers: { 'User-Agent': ua, Accept: 'application/json' },
+  })
+  if (!res.ok) {
+    throw new Error(`rawg screenshots failed: ${res.status} ${res.statusText}`)
+  }
+  const body = (await res.json()) as RawgScreenshotsResponse
+  const shots = (body.results ?? []).filter(
+    (s) => !s.is_deleted && typeof s.image === 'string' && s.image.length > 0,
+  )
+
+  let inserted = 0
+  let skipped = 0
+  for (const shot of shots.slice(0, max)) {
+    const externalId = `rawg:${rawgId}:${shot.id}`
+    try {
+      // createCandidate uses ON CONFLICT (source, external_id) DO NOTHING, so
+      // re-running this importer is idempotent per RAWG screenshot id.
+      await geoScreenshotRepository.createCandidate({
+        gameId,
+        geoMapId,
+        imageUrl: shot.image,
+        source: 'rawg',
+        externalId,
+      })
+      inserted++
+    } catch (e) {
+      log.warn({ err: String(e), externalId }, 'failed to insert candidate')
+      skipped++
+    }
+  }
+
+  if (shots.length === 0) {
+    const attempt =
+      (await geoIngestFailureRepository.getAttemptCount(gameId, 'rawg')) + 1
+    await geoIngestFailureRepository.record({
+      gameId,
+      source: 'rawg',
+      reason: 'rawg screenshots endpoint returned no results',
+      retryAfter: tombstoneRetryAfter(attempt),
+    })
+  } else if (inserted > 0) {
+    await geoIngestFailureRepository.clear(gameId, 'rawg')
+  }
+
+  log.info(
+    { gameId, rawgId, fetched: shots.length, inserted, skipped },
+    'imported rawg screenshots',
+  )
+  return { fetched: shots.length, inserted, skipped }
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -9,6 +9,7 @@ import { importRegistryMap } from './geo-registry-import-logic.js'
 import { importStrategyWikiMap } from './geo-strategywiki-import-logic.js'
 import { importWikidataMap } from './geo-wikidata-import-logic.js'
 import { importSteamScreenshots } from './geo-steam-import-logic.js'
+import { importRawgScreenshots } from './geo-rawg-import-logic.js'
 import { scheduleDailyGeoChallenge } from './geo-schedule-logic.js'
 import { resolveGeoMetadataBatch } from './geo-metadata-resolve-logic.js'
 import { runGeoIngestTick } from './geo-ingest-tick-logic.js'
@@ -84,6 +85,15 @@ export const geoWorker = new Worker<GeoJobData>(
         gameId: data.gameId,
         geoMapId: data.geoMapId,
         steamAppId: data.steamAppId,
+        maxItems: data.maxItems,
+      })
+    }
+
+    if (data.kind === 'import-rawg-screenshots') {
+      return await importRawgScreenshots({
+        gameId: data.gameId,
+        geoMapId: data.geoMapId,
+        rawgId: data.rawgId,
         maxItems: data.maxItems,
       })
     }

--- a/packages/backend/src/infrastructure/repositories/geo-ingest-failure.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-ingest-failure.repository.ts
@@ -6,6 +6,7 @@ const log = repoLogger.child({ repository: 'geo-ingest-failure' })
 export type GeoIngestSource =
   | 'fandom'
   | 'steam'
+  | 'rawg'
   | 'metadata'
   | 'registry'
   | 'strategywiki'


### PR DESCRIPTION
Steam appdetails only covers titles published on Steam, leaving Switch /
PlayStation / Xbox / mobile exclusives (e.g. Zelda BotW) with zero
candidates. RAWG indexes those, so wiring it in as a parallel provider
broadens capture coverage without changing the active-map gate.

- New geo-rawg-import-logic worker mirrors the Steam importer; calls
  /games/{id}/screenshots, inserts each shot with source='rawg' and
  external_id='rawg:{rawgId}:{shotId}'. Idempotent via the existing
  (source, external_id) unique constraint.
- Steam and RAWG run in parallel under a shared CAPTURE_TARGET_CANDIDATES
  cap (renamed from STEAM_TARGET_CANDIDATES) so a game's combined active
  candidate count drives the stop condition.
- Metadata resolver fills missing rawg_id via RAWG search using the same
  exact-match / version-token disambiguation as Steam storesearch, gated
  on RAWG_API_KEY.
- Adds 'rawg' to GeoIngestSource so the same tombstone backoff applies
  on empty/failed responses.