### PR TITLE
feat(admin): mobile drawer UX for geo tab pins and maps panels

### DIFF
--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -36,7 +36,15 @@ import {
     tiersInFlightForGame,
     type GeoRunStatePayload,
 } from '@/hooks/useGeoRunPolling'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { fetchAdminJson as fetchJson } from '@/lib/api/admin'
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetDescription,
+} from '@/components/ui/sheet'
 
 // Per-game ingestion-state surface. Replaces the global metric-tile grid +
 // failures table from GeoAdminActions with a focused, drill-down table where
@@ -143,6 +151,7 @@ export function GeoMapsTab({
     onViewCaptures,
 }: GeoMapsTabProps) {
     const { t } = useTranslation()
+    const isMobile = useIsMobile()
     const [games, setGames] = useState<CuratedGame[] | null>(null)
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
@@ -507,206 +516,108 @@ export function GeoMapsTab({
                 </CardContent>
             </Card>
 
-            {/* Right: tier-cascade side panel */}
-            <Card className="lg:col-span-2">
+            {/* Desktop: tier-cascade side panel docked next to the list. */}
+            <Card className="hidden lg:block lg:col-span-2">
                 <CardHeader className="pb-3">
                     <CardTitle className="text-sm">
                         {selectedGame
                             ? selectedGame.name
                             : t('admin.geo.maps.sidePanel.empty')}
                     </CardTitle>
-                    {selectedGame && sources?.activeMap && (
-                        <CardDescription className="text-xs">
-                            {t('admin.geo.maps.sidePanel.activeViaTier', {
-                                tier: t(`admin.geo.maps.tiers.${sources.activeMap.source}`),
-                                license: sources.activeMap.license,
-                            })}
-                            {sources.activeMap.region && (
-                                <span className="ml-1 text-muted-foreground">
-                                    {' · '}
-                                    {t('admin.geo.maps.sidePanel.region', {
-                                        region: sources.activeMap.region,
-                                    })}
-                                </span>
-                            )}
-                        </CardDescription>
-                    )}
-                    {selectedGame && sources && !sources.activeMap && (
-                        <CardDescription className="text-xs text-warning">
-                            {t('admin.geo.maps.sidePanel.noActive')}
-                        </CardDescription>
-                    )}
+                    <SidePanelDescription
+                        selected={selectedGame !== null}
+                        sources={sources}
+                        t={t}
+                    />
                 </CardHeader>
                 <CardContent className="space-y-3">
-                    {!selectedGame ? (
-                        <p className="text-xs text-muted-foreground">
-                            {t('admin.geo.maps.sidePanel.hint')}
-                        </p>
-                    ) : sourcesLoading && !sources ? (
-                        <div
-                            className="flex justify-center py-6"
-                            role="status"
-                            aria-live="polite"
-                            aria-busy="true"
-                            aria-label={t('admin.geo.maps.sidePanel.loading')}
-                        >
-                            <Loader2
-                                className="h-4 w-4 animate-spin text-muted-foreground"
-                                aria-hidden
-                            />
-                        </div>
-                    ) : sources ? (
-                        <>
-                            {sources.activeMap && (
-                                <a
-                                    href={sources.activeMap.imageUrl}
-                                    target="_blank"
-                                    rel="noreferrer noopener"
-                                    className="block overflow-hidden rounded border border-border/40 bg-muted/10"
-                                    aria-label={t('admin.geo.maps.sidePanel.previewAlt', {
-                                        name: sources.gameName,
-                                    })}
-                                >
-                                    <img
-                                        src={sources.activeMap.imageUrl}
-                                        alt={t('admin.geo.maps.sidePanel.previewAlt', {
-                                            name: sources.gameName,
-                                        })}
-                                        loading="lazy"
-                                        className="block max-h-48 w-full object-contain bg-black/40"
-                                    />
-                                    <p className="px-2 py-1 text-[10px] text-muted-foreground">
-                                        {t('admin.geo.maps.sidePanel.previewDimensions', {
-                                            width: sources.activeMap.widthPx,
-                                            height: sources.activeMap.heightPx,
-                                        })}
-                                    </p>
-                                </a>
-                            )}
-                            <ol className="space-y-2">
-                                {sources.sources.map((s) => {
-                                    const tiers = tiersInFlightForGame(
-                                        runState,
-                                        sources.gameId,
-                                    )
-                                    // 'manual' is operator-uploaded, never a
-                                    // background job — never flag it running.
-                                    const running =
-                                        s.tier !== 'manual' &&
-                                        tiers.has(
-                                            s.tier as
-                                                | 'registry'
-                                                | 'fandom'
-                                                | 'strategywiki'
-                                                | 'fextralife'
-                                                | 'wikidata',
-                                        )
-                                    return (
-                                        <TierRow
-                                            key={s.tier}
-                                            state={s}
-                                            t={t}
-                                            running={running}
-                                            onRetry={
-                                                s.tier !== 'manual'
-                                                    ? () =>
-                                                          void handleRetryTier(
-                                                              sources.gameId,
-                                                              s.tier,
-                                                          )
-                                                    : undefined
-                                            }
-                                            retrying={retryingTier === s.tier}
-                                            onRunNow={
-                                                s.tier !== 'manual'
-                                                    ? () =>
-                                                          void handleRunTierNow(
-                                                              sources.gameId,
-                                                              s.tier,
-                                                          )
-                                                    : undefined
-                                            }
-                                            runningNow={runningTier === s.tier}
-                                            onActivate={(mapId) =>
-                                                void handleActivateMap(
-                                                    sources.gameId,
-                                                    mapId,
-                                                )
-                                            }
-                                            activatingMapId={activatingMapId}
-                                        />
-                                    )
-                                })}
-                            </ol>
-                            <div className="flex flex-col gap-2 border-t border-border/40 pt-3 sm:flex-row">
-                                <Button
-                                    size="sm"
-                                    variant="outline"
-                                    className="flex-1 border-destructive/40 text-destructive hover:text-destructive hover:bg-destructive/5"
-                                    disabled={busyAction !== null}
-                                    onClick={() => void reimport(selectedGame)}
-                                    title={t('admin.geo.maps.actions.rerunTooltip')}
-                                >
-                                    {busyAction === 'reimport' ? (
-                                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
-                                    ) : (
-                                        <RotateCw className="h-3.5 w-3.5 mr-1.5" />
-                                    )}
-                                    {t('admin.geo.maps.actions.rerun')}
-                                </Button>
-                                <Button
-                                    size="sm"
-                                    variant="outline"
-                                    className="flex-1"
-                                    onClick={() => setResearchFor(selectedGame)}
-                                    title={t('admin.geo.maps.actions.researchTooltip')}
-                                >
-                                    <Search className="h-3.5 w-3.5 mr-1.5" />
-                                    {t('admin.geo.maps.actions.research')}
-                                </Button>
-                                <Button
-                                    size="sm"
-                                    variant="outline"
-                                    className="flex-1"
-                                    onClick={() => setWandImportFor(selectedGame)}
-                                    title={t('admin.geo.maps.actions.importWandTooltip')}
-                                >
-                                    <Sparkles className="h-3.5 w-3.5 mr-1.5" />
-                                    {t('admin.geo.maps.actions.importWand')}
-                                </Button>
-                                <Button
-                                    size="sm"
-                                    variant="outline"
-                                    className="flex-1"
-                                    onClick={() => setManualUploadFor(selectedGame)}
-                                >
-                                    <Upload className="h-3.5 w-3.5 mr-1.5" />
-                                    {t('admin.geo.maps.actions.uploadManual')}
-                                </Button>
-                            </div>
-                            {onViewCaptures && (
-                                <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    className="w-full justify-center text-xs text-muted-foreground hover:text-foreground"
-                                    onClick={() =>
-                                        onViewCaptures(
-                                            selectedGame.id,
-                                            selectedGame.name,
-                                        )
-                                    }
-                                    title={t('admin.geo.maps.actions.viewCapturesTooltip')}
-                                >
-                                    <ListChecks className="h-3.5 w-3.5 mr-1.5" />
-                                    {t('admin.geo.maps.actions.viewCaptures', {
-                                        count: selectedGame.candidateCount,
-                                    })}
-                                </Button>
-                            )}
-                        </>
-                    ) : null}
+                    <SidePanelBody
+                        selectedGame={selectedGame}
+                        sources={sources}
+                        sourcesLoading={sourcesLoading}
+                        runState={runState}
+                        retryingTier={retryingTier}
+                        runningTier={runningTier}
+                        activatingMapId={activatingMapId}
+                        busyAction={busyAction}
+                        onRetryTier={handleRetryTier}
+                        onRunTierNow={handleRunTierNow}
+                        onActivateMap={handleActivateMap}
+                        onReimport={reimport}
+                        onResearch={setResearchFor}
+                        onWandImport={setWandImportFor}
+                        onManualUpload={setManualUploadFor}
+                        onViewCaptures={onViewCaptures}
+                        t={t}
+                    />
                 </CardContent>
             </Card>
+
+            {/* Mobile: same panel surfaced as a bottom drawer when a row is tapped. */}
+            <Sheet
+                open={isMobile && selectedId !== null}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setSelectedId(null)
+                        setSources(null)
+                    }
+                }}
+            >
+                <SheetContent
+                    side="bottom"
+                    className="lg:hidden h-[92vh] p-0 flex flex-col gap-0 rounded-t-xl"
+                >
+                    <SheetHeader className="px-4 py-3 border-b border-border/40 text-left">
+                        <SheetTitle className="text-sm font-semibold">
+                            {selectedGame
+                                ? selectedGame.name
+                                : t('admin.geo.maps.sidePanel.empty')}
+                        </SheetTitle>
+                        {selectedGame && sources?.activeMap && (
+                            <SheetDescription className="text-xs">
+                                {t('admin.geo.maps.sidePanel.activeViaTier', {
+                                    tier: t(`admin.geo.maps.tiers.${sources.activeMap.source}`),
+                                    license: sources.activeMap.license,
+                                })}
+                                {sources.activeMap.region && (
+                                    <span className="ml-1 text-muted-foreground">
+                                        {' · '}
+                                        {t('admin.geo.maps.sidePanel.region', {
+                                            region: sources.activeMap.region,
+                                        })}
+                                    </span>
+                                )}
+                            </SheetDescription>
+                        )}
+                        {selectedGame && sources && !sources.activeMap && (
+                            <SheetDescription className="text-xs text-warning">
+                                {t('admin.geo.maps.sidePanel.noActive')}
+                            </SheetDescription>
+                        )}
+                    </SheetHeader>
+                    <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 pb-[max(env(safe-area-inset-bottom),1rem)]">
+                        <SidePanelBody
+                            selectedGame={selectedGame}
+                            sources={sources}
+                            sourcesLoading={sourcesLoading}
+                            runState={runState}
+                            retryingTier={retryingTier}
+                            runningTier={runningTier}
+                            activatingMapId={activatingMapId}
+                            busyAction={busyAction}
+                            onRetryTier={handleRetryTier}
+                            onRunTierNow={handleRunTierNow}
+                            onActivateMap={handleActivateMap}
+                            onReimport={reimport}
+                            onResearch={setResearchFor}
+                            onWandImport={setWandImportFor}
+                            onManualUpload={setManualUploadFor}
+                            onViewCaptures={onViewCaptures}
+                            t={t}
+                        />
+                    </div>
+                </SheetContent>
+            </Sheet>
 
             <GeoManualMapDialog
                 isOpen={manualUploadFor !== null}
@@ -787,6 +698,247 @@ export function GeoMapsTab({
             isLoading={resetting}
         />
         </div>
+    )
+}
+
+// Renders the description line under the side panel title (active tier +
+// license, or "no active map" warning). Shared by the desktop card header
+// and the mobile sheet header so both surfaces stay in lock-step.
+function SidePanelDescription({
+    selected,
+    sources,
+    t,
+}: {
+    selected: boolean
+    sources: SourcesResponse | null
+    t: ReturnType<typeof useTranslation>['t']
+}) {
+    if (!selected) return null
+    if (sources?.activeMap) {
+        return (
+            <CardDescription className="text-xs">
+                {t('admin.geo.maps.sidePanel.activeViaTier', {
+                    tier: t(`admin.geo.maps.tiers.${sources.activeMap.source}`),
+                    license: sources.activeMap.license,
+                })}
+                {sources.activeMap.region && (
+                    <span className="ml-1 text-muted-foreground">
+                        {' · '}
+                        {t('admin.geo.maps.sidePanel.region', {
+                            region: sources.activeMap.region,
+                        })}
+                    </span>
+                )}
+            </CardDescription>
+        )
+    }
+    if (sources && !sources.activeMap) {
+        return (
+            <CardDescription className="text-xs text-warning">
+                {t('admin.geo.maps.sidePanel.noActive')}
+            </CardDescription>
+        )
+    }
+    return null
+}
+
+interface SidePanelBodyProps {
+    selectedGame: CuratedGame | null
+    sources: SourcesResponse | null
+    sourcesLoading: boolean
+    runState: GeoRunStatePayload | null
+    retryingTier: string | null
+    runningTier: string | null
+    activatingMapId: number | null
+    busyAction: 'reimport' | null
+    onRetryTier: (gameId: number, tier: string) => void | Promise<void>
+    onRunTierNow: (gameId: number, tier: string) => void | Promise<void>
+    onActivateMap: (gameId: number, mapId: number) => void | Promise<void>
+    onReimport: (game: CuratedGame) => void | Promise<void>
+    onResearch: (game: CuratedGame) => void
+    onWandImport: (game: CuratedGame) => void
+    onManualUpload: (game: CuratedGame) => void
+    onViewCaptures?: (gameId: number, gameName: string) => void
+    t: ReturnType<typeof useTranslation>['t']
+}
+
+// Inner content of the tier-cascade side panel — extracted so the desktop
+// docked card and the mobile bottom sheet render the exact same body.
+function SidePanelBody({
+    selectedGame,
+    sources,
+    sourcesLoading,
+    runState,
+    retryingTier,
+    runningTier,
+    activatingMapId,
+    busyAction,
+    onRetryTier,
+    onRunTierNow,
+    onActivateMap,
+    onReimport,
+    onResearch,
+    onWandImport,
+    onManualUpload,
+    onViewCaptures,
+    t,
+}: SidePanelBodyProps) {
+    if (!selectedGame) {
+        return (
+            <p className="text-xs text-muted-foreground">
+                {t('admin.geo.maps.sidePanel.hint')}
+            </p>
+        )
+    }
+    if (sourcesLoading && !sources) {
+        return (
+            <div
+                className="flex justify-center py-6"
+                role="status"
+                aria-live="polite"
+                aria-busy="true"
+                aria-label={t('admin.geo.maps.sidePanel.loading')}
+            >
+                <Loader2
+                    className="h-4 w-4 animate-spin text-muted-foreground"
+                    aria-hidden
+                />
+            </div>
+        )
+    }
+    if (!sources) return null
+    return (
+        <>
+            {sources.activeMap && (
+                <a
+                    href={sources.activeMap.imageUrl}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="block overflow-hidden rounded border border-border/40 bg-muted/10"
+                    aria-label={t('admin.geo.maps.sidePanel.previewAlt', {
+                        name: sources.gameName,
+                    })}
+                >
+                    <img
+                        src={sources.activeMap.imageUrl}
+                        alt={t('admin.geo.maps.sidePanel.previewAlt', {
+                            name: sources.gameName,
+                        })}
+                        loading="lazy"
+                        className="block max-h-48 w-full object-contain bg-black/40"
+                    />
+                    <p className="px-2 py-1 text-[10px] text-muted-foreground">
+                        {t('admin.geo.maps.sidePanel.previewDimensions', {
+                            width: sources.activeMap.widthPx,
+                            height: sources.activeMap.heightPx,
+                        })}
+                    </p>
+                </a>
+            )}
+            <ol className="space-y-2">
+                {sources.sources.map((s) => {
+                    const tiers = tiersInFlightForGame(runState, sources.gameId)
+                    // 'manual' is operator-uploaded, never a background job —
+                    // never flag it running.
+                    const running =
+                        s.tier !== 'manual' &&
+                        tiers.has(
+                            s.tier as
+                                | 'registry'
+                                | 'fandom'
+                                | 'strategywiki'
+                                | 'fextralife'
+                                | 'wikidata',
+                        )
+                    return (
+                        <TierRow
+                            key={s.tier}
+                            state={s}
+                            t={t}
+                            running={running}
+                            onRetry={
+                                s.tier !== 'manual'
+                                    ? () => void onRetryTier(sources.gameId, s.tier)
+                                    : undefined
+                            }
+                            retrying={retryingTier === s.tier}
+                            onRunNow={
+                                s.tier !== 'manual'
+                                    ? () => void onRunTierNow(sources.gameId, s.tier)
+                                    : undefined
+                            }
+                            runningNow={runningTier === s.tier}
+                            onActivate={(mapId) =>
+                                void onActivateMap(sources.gameId, mapId)
+                            }
+                            activatingMapId={activatingMapId}
+                        />
+                    )
+                })}
+            </ol>
+            <div className="flex flex-col gap-2 border-t border-border/40 pt-3 sm:flex-row">
+                <Button
+                    size="sm"
+                    variant="outline"
+                    className="flex-1 border-destructive/40 text-destructive hover:text-destructive hover:bg-destructive/5"
+                    disabled={busyAction !== null}
+                    onClick={() => void onReimport(selectedGame)}
+                    title={t('admin.geo.maps.actions.rerunTooltip')}
+                >
+                    {busyAction === 'reimport' ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                    ) : (
+                        <RotateCw className="h-3.5 w-3.5 mr-1.5" />
+                    )}
+                    {t('admin.geo.maps.actions.rerun')}
+                </Button>
+                <Button
+                    size="sm"
+                    variant="outline"
+                    className="flex-1"
+                    onClick={() => onResearch(selectedGame)}
+                    title={t('admin.geo.maps.actions.researchTooltip')}
+                >
+                    <Search className="h-3.5 w-3.5 mr-1.5" />
+                    {t('admin.geo.maps.actions.research')}
+                </Button>
+                <Button
+                    size="sm"
+                    variant="outline"
+                    className="flex-1"
+                    onClick={() => onWandImport(selectedGame)}
+                    title={t('admin.geo.maps.actions.importWandTooltip')}
+                >
+                    <Sparkles className="h-3.5 w-3.5 mr-1.5" />
+                    {t('admin.geo.maps.actions.importWand')}
+                </Button>
+                <Button
+                    size="sm"
+                    variant="outline"
+                    className="flex-1"
+                    onClick={() => onManualUpload(selectedGame)}
+                >
+                    <Upload className="h-3.5 w-3.5 mr-1.5" />
+                    {t('admin.geo.maps.actions.uploadManual')}
+                </Button>
+            </div>
+            {onViewCaptures && (
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    className="w-full justify-center text-xs text-muted-foreground hover:text-foreground"
+                    onClick={() =>
+                        onViewCaptures(selectedGame.id, selectedGame.name)
+                    }
+                    title={t('admin.geo.maps.actions.viewCapturesTooltip')}
+                >
+                    <ListChecks className="h-3.5 w-3.5 mr-1.5" />
+                    {t('admin.geo.maps.actions.viewCaptures', {
+                        count: selectedGame.candidateCount,
+                    })}
+                </Button>
+            )}
+        </>
     )
 }
 

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -17,6 +17,12 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog'
 import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet'
+import {
     Loader2,
     Trash2,
     Info,
@@ -35,6 +41,7 @@ import { GeoRunStateBanner } from './GeoRunStateBanner'
 import { GeoColdStartBanner } from './GeoColdStartBanner'
 import { useGeoRunPolling } from '@/hooks/useGeoRunPolling'
 import { useGeoHealth } from '@/hooks/useGeoHealth'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type {
     GeoMap,
@@ -145,6 +152,7 @@ async function rejectCandidate(id: number): Promise<void> {
 
 export function GeoReviewPanel() {
     const { t } = useTranslation()
+    const isMobile = useIsMobile()
     const [activeTab, setActiveTab] = useState<'pins' | 'maps' | 'games'>('pins')
     const [statusFilter, setStatusFilter] = useState<StatusFilter>('collecting')
     // Per-game filter for the Pins tab. Set when the operator clicks "Voir
@@ -451,7 +459,7 @@ export function GeoReviewPanel() {
                                 {t('admin.geo.candidates')} ({candidates.length})
                             </CardTitle>
                         </CardHeader>
-                        <CardContent className="space-y-4 max-h-[300px] sm:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
+                        <CardContent className="space-y-4 lg:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
                             {groupCandidatesByGame(candidates).map((group) => (
                                 <section key={group.gameId} className="space-y-2">
                                     <header className="flex items-baseline justify-between gap-2 border-b border-border/40 pb-1">
@@ -472,8 +480,8 @@ export function GeoReviewPanel() {
                                             <button
                                                 key={c.id}
                                                 onClick={() => openDetail(c.id)}
-                                                className={`w-full text-left rounded border p-2 text-xs hover:bg-muted/40 ${
-                                                    detail?.candidate.id === c.id
+                                                className={`w-full text-left rounded border p-2 text-xs hover:bg-muted/40 active:bg-muted/60 ${
+                                                    detail?.candidate.id === c.id && !isMobile
                                                         ? 'border-neon-pink'
                                                         : ''
                                                 }`}
@@ -508,7 +516,8 @@ export function GeoReviewPanel() {
                         </CardContent>
                     </Card>
 
-                    <Card className="lg:col-span-2">
+                    {/* Desktop: side-by-side detail card */}
+                    <Card className="hidden lg:block lg:col-span-2">
                         <CardHeader className="pb-2 p-4 sm:p-6">
                             <CardTitle className="text-sm">
                                 {detail
@@ -517,87 +526,56 @@ export function GeoReviewPanel() {
                             </CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-3 p-4 sm:p-6 pt-0 sm:pt-0">
-                            {detail && detail.map ? (
-                                <>
-                                    <img
-                                        src={detail.candidate.imageUrl}
-                                        alt={`Candidate ${detail.candidate.id}`}
-                                        className="w-full rounded border max-h-48 object-contain bg-black/20"
-                                    />
-                                    <GeoMapCanvas
-                                        imageUrl={detail.map.imageUrl}
-                                        widthPx={detail.map.widthPx}
-                                        heightPx={detail.map.heightPx}
-                                        pin={pin}
-                                        canonical={
-                                            detail.meta
-                                                ? {
-                                                      x: detail.meta.canonical.x,
-                                                      y: detail.meta.canonical.y,
-                                                  }
-                                                : null
-                                        }
-                                        onPin={setPin}
-                                        disabled={!!detail.meta}
-                                    />
-                                    {detail.meta ? (
-                                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
-                                            <p className="text-xs text-warning">
-                                                {t('admin.geo.alreadyPromoted')}
-                                            </p>
-                                            <Button
-                                                size="sm"
-                                                variant="destructive"
-                                                onClick={() => setDemoteOpen(true)}
-                                                disabled={saving}
-                                                className="w-full sm:w-auto"
-                                            >
-                                                <Trash2 className="h-3.5 w-3.5 mr-2" />
-                                                {t('admin.geo.demote')}
-                                            </Button>
-                                        </div>
-                                    ) : (
-                                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                                            <span className="text-xs text-muted-foreground">
-                                                {pin
-                                                    ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
-                                                    : t('admin.geo.pickPoint')}
-                                            </span>
-                                            <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-                                                <Button
-                                                    size="sm"
-                                                    variant="outline"
-                                                    onClick={() => setRejectOpen(true)}
-                                                    disabled={saving}
-                                                    className="w-full sm:w-auto text-destructive border-destructive/40 hover:bg-destructive/10"
-                                                >
-                                                    <Trash2 className="h-3.5 w-3.5 mr-2" />
-                                                    {t('admin.geo.reject')}
-                                                </Button>
-                                                <Button
-                                                    size="sm"
-                                                    onClick={applyOverride}
-                                                    disabled={!pin || saving}
-                                                    className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
-                                                >
-                                                    {saving && (
-                                                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
-                                                    )}
-                                                    {t('admin.geo.promote')}
-                                                </Button>
-                                            </div>
-                                        </div>
-                                    )}
-                                </>
-                            ) : (
-                                <p className="text-xs text-muted-foreground">
-                                    {t('admin.geo.detailHint')}
-                                </p>
-                            )}
+                            <CandidateDetailBody
+                                detail={detail}
+                                pin={pin}
+                                setPin={setPin}
+                                saving={saving}
+                                onPromote={applyOverride}
+                                onReject={() => setRejectOpen(true)}
+                                onDemote={() => setDemoteOpen(true)}
+                                t={t}
+                            />
                         </CardContent>
                     </Card>
                 </div>
             )}
+
+            {/* Mobile: bottom drawer for candidate detail */}
+            <Sheet
+                open={isMobile && detail !== null}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setDetail(null)
+                        setPin(null)
+                    }
+                }}
+            >
+                <SheetContent
+                    side="bottom"
+                    className="lg:hidden h-[92vh] p-0 flex flex-col gap-0 rounded-t-xl"
+                >
+                    <SheetHeader className="px-4 py-3 border-b border-border/40 text-left">
+                        <SheetTitle className="text-sm font-semibold">
+                            {detail
+                                ? `#${detail.candidate.id} · ${t('admin.geo.candidateRow.pinCount', { count: detail.pins.length })}`
+                                : t('admin.geo.pickOne')}
+                        </SheetTitle>
+                    </SheetHeader>
+                    <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 pb-[max(env(safe-area-inset-bottom),1rem)]">
+                        <CandidateDetailBody
+                            detail={detail}
+                            pin={pin}
+                            setPin={setPin}
+                            saving={saving}
+                            onPromote={applyOverride}
+                            onReject={() => setRejectOpen(true)}
+                            onDemote={() => setDemoteOpen(true)}
+                            t={t}
+                        />
+                    </div>
+                </SheetContent>
+            </Sheet>
 
             <Dialog open={rejectOpen} onOpenChange={(open) => !saving && setRejectOpen(open)}>
                 <DialogContent className="max-w-sm sm:max-w-md">
@@ -657,5 +635,112 @@ export function GeoReviewPanel() {
                 </TabsContent>
             </Tabs>
         </div>
+    )
+}
+
+interface CandidateDetailBodyProps {
+    detail: CandidateDetail | null
+    pin: GeoPoint | null
+    setPin: (p: GeoPoint | null) => void
+    saving: boolean
+    onPromote: () => void | Promise<void>
+    onReject: () => void
+    onDemote: () => void
+    t: ReturnType<typeof useTranslation>['t']
+}
+
+// Shared body for the candidate detail view — rendered inside the desktop
+// side-card and the mobile bottom sheet. Keeps the pin canvas, image,
+// status text and action buttons in one place so the two surfaces never
+// drift.
+function CandidateDetailBody({
+    detail,
+    pin,
+    setPin,
+    saving,
+    onPromote,
+    onReject,
+    onDemote,
+    t,
+}: CandidateDetailBodyProps) {
+    if (!detail || !detail.map) {
+        return (
+            <p className="text-xs text-muted-foreground">
+                {t('admin.geo.detailHint')}
+            </p>
+        )
+    }
+    return (
+        <>
+            <img
+                src={detail.candidate.imageUrl}
+                alt={`Candidate ${detail.candidate.id}`}
+                className="w-full rounded border max-h-48 object-contain bg-black/20"
+            />
+            <GeoMapCanvas
+                imageUrl={detail.map.imageUrl}
+                widthPx={detail.map.widthPx}
+                heightPx={detail.map.heightPx}
+                pin={pin}
+                canonical={
+                    detail.meta
+                        ? {
+                              x: detail.meta.canonical.x,
+                              y: detail.meta.canonical.y,
+                          }
+                        : null
+                }
+                onPin={setPin}
+                disabled={!!detail.meta}
+            />
+            {detail.meta ? (
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
+                    <p className="text-xs text-warning">
+                        {t('admin.geo.alreadyPromoted')}
+                    </p>
+                    <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={onDemote}
+                        disabled={saving}
+                        className="w-full sm:w-auto"
+                    >
+                        <Trash2 className="h-3.5 w-3.5 mr-2" />
+                        {t('admin.geo.demote')}
+                    </Button>
+                </div>
+            ) : (
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                    <span className="text-xs text-muted-foreground">
+                        {pin
+                            ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
+                            : t('admin.geo.pickPoint')}
+                    </span>
+                    <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={onReject}
+                            disabled={saving}
+                            className="w-full sm:w-auto text-destructive border-destructive/40 hover:bg-destructive/10"
+                        >
+                            <Trash2 className="h-3.5 w-3.5 mr-2" />
+                            {t('admin.geo.reject')}
+                        </Button>
+                        <Button
+                            size="sm"
+                            onClick={() => void onPromote()}
+                            disabled={!pin || saving}
+                            className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
+                        >
+                            {saving && (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
+                            )}
+                            {t('admin.geo.promote')}
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </>
     )
 }


### PR DESCRIPTION
Replaces the cramped stacked layout on small screens with bottom-sheet
drawers so reviewing pins and inspecting tier-cascade sources keeps the
list visible and gives the detail view full-screen real-estate. Desktop
keeps the side-by-side cards. Extracts CandidateDetailBody and
SidePanelBody so both surfaces render the exact same content.