### PR TITLE
refactor(admin-geo): simplify Modération Géo workflow (3 phases)

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -497,7 +497,15 @@
         "pins": "pins",
         "errors": "errors",
         "nextChallenge": "next",
-        "scheduleNow": "Schedule now"
+        "scheduleNow": "Schedule now",
+        "mapsAria": "Open the Maps tab",
+        "pinsAria": "Jump to the pending pins queue",
+        "errorsAria": "Show recent failures",
+        "errorsPopover": {
+          "title": "Recent pipeline failures",
+          "summary": "{{queue}} queue failure(s) · {{failures}} game alert(s)",
+          "empty": "No active failures. 🎉"
+        }
       },
       "coldStart": {
         "no-curated": {
@@ -625,6 +633,7 @@
       },
       "intro": {
         "title": "How this page works",
+        "close": "Close",
         "step1Title": "1. Curate games",
         "step1Body": "Pick the games that should feed the Geo challenge in the Games tab. The ingestion pipeline then pulls their maps (Registry → Fandom → StrategyWiki → Fextralife → Wikidata → Manual) and Steam screenshots in the background.",
         "step2Title": "2. Track ingestion",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -483,23 +483,24 @@
     },
     "geo": {
       "title": "Geo Moderation",
-      "subtitle": "Curate the Geo daily challenge: import sources, schedule challenges, and validate crowdsourced pins.",
+      "subtitle": "Curate the Geo daily challenge: import sources, schedule challenges, and review crowdsourced submissions.",
       "candidatesLoading": "Loading pins…",
       "tabs": {
         "pins": "Pins",
+        "submissions": "Submissions",
         "maps": "Maps",
         "games": "Games"
       },
       "strip": {
         "loading": "Loading dataset health…",
         "error": "Could not load dataset health.",
-        "maps": "maps",
-        "pins": "pins",
-        "errors": "errors",
-        "nextChallenge": "next",
+        "maps": "maps covered",
+        "pins": "submissions",
+        "errors": "reports",
+        "nextChallenge": "next challenge",
         "scheduleNow": "Schedule now",
         "mapsAria": "Open the Maps tab",
-        "pinsAria": "Jump to the pending pins queue",
+        "pinsAria": "Jump to the submissions awaiting review",
         "errorsAria": "Show recent failures",
         "errorsPopover": {
           "title": "Recent pipeline failures",
@@ -563,7 +564,7 @@
         "title": "Maps per game",
         "subtitle": "Click a game to see which ingestion tiers ran or would run next.",
         "refresh": "Refresh",
-        "empty": "No curated games yet. Add some from the curated list in the Pins tab.",
+        "empty": "No curated games yet. Add some from the curated list in the Submissions tab.",
         "reimportQueued": "Re-run pipeline queued for \"{{name}}\".",
         "row": {
           "hasMap": "Map",
@@ -611,7 +612,7 @@
           "importWandTooltip": "Paste a wand.com map URL — the server will scrape its og:image and record it as the map for this game.",
           "viewCaptures_one": "View captures ({{count}})",
           "viewCaptures_other": "View captures ({{count}})",
-          "viewCapturesTooltip": "Open the Pins tab filtered to this game's captures."
+          "viewCapturesTooltip": "Open the Submissions tab filtered to this game's captures."
         },
         "loading": "Loading games…",
         "sidePanel": {
@@ -663,9 +664,9 @@
       },
       "statusFilter": {
         "label": "Filter by status",
-        "collecting": "Collecting",
-        "pending": "Pending",
-        "promoted": "Promoted",
+        "collecting": "Open",
+        "pending": "Awaiting review",
+        "promoted": "Made official",
         "all": "All"
       },
       "gameFilter": {
@@ -673,10 +674,54 @@
         "clear": "Clear game filter"
       },
       "statusBadge": {
-        "collecting": "Collecting",
-        "pending": "Pending",
-        "promoted": "Promoted",
-        "rejected": "Rejected"
+        "collecting": "Open",
+        "pending": "Awaiting review",
+        "promoted": "Official",
+        "rejected": "Declined"
+      },
+      "actions": {
+        "makeOfficial": "Make official",
+        "removeOfficial": "Remove official location",
+        "decline": "Decline"
+      },
+      "entities": {
+        "submission_one": "submission",
+        "submission_other": "submissions",
+        "officialLocation": "official location"
+      },
+      "submissions": "Submissions",
+      "submissionsLoading": "Loading submissions…",
+      "emptyQueue": "No submissions match this filter.",
+      "pickSubmission": "Pick a submission",
+      "pickPointForOfficial": "Click the map to set the official location",
+      "detailHintOfficial": "Pick a submission from the list to review it and set its official location.",
+      "alreadyOfficial": "Official location already set — remove it to re-pin somewhere else.",
+      "submissionRow": {
+        "pinCount_one": "{{count}} submission",
+        "pinCount_other": "{{count}} submissions",
+        "source": "source: {{source}}"
+      },
+      "guide": {
+        "title": "Moderation guide",
+        "close": "Close",
+        "step1Title": "1. Curate games",
+        "step1Body": "Pick the games that should feed the Geo challenge in the Games tab. The ingestion pipeline then pulls their maps (Registry → Fandom → StrategyWiki → Fextralife → Wikidata → Manual) and Steam screenshots in the background.",
+        "step2Title": "2. Track ingestion",
+        "step2Body": "Watch maps land tier by tier in the Maps tab. Re-run the pipeline or upload a map manually for any game still missing one.",
+        "step3Title": "3. Review submissions",
+        "step3Body": "Players send submissions guessing where each screenshot was taken. When they converge, set an official location — the Schedule button at the top will then queue the next validated screenshot for the daily challenge."
+      },
+      "declineDialog": {
+        "title": "Decline this capture?",
+        "description": "The capture will be removed from the Geo challenge: contributors won't see it anymore and it will never be picked for the daily challenge. Use for captures with no locatable spot (UI, inventory, loading screen…).",
+        "confirm": "Decline",
+        "cancel": "Cancel"
+      },
+      "removeOfficialDialog": {
+        "title": "Remove official location?",
+        "description": "This capture will return to the moderation queue. Players' submissions are kept; you'll be able to set a new official location.",
+        "confirm": "Remove",
+        "cancel": "Cancel"
       },
       "demoteDialog": {
         "title": "Demote canonical pin?",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -488,8 +488,21 @@
       "tabs": {
         "pins": "Pins",
         "submissions": "Submissions",
+        "queue": "Review queue",
+        "catalog": "Catalog",
         "maps": "Maps",
         "games": "Games"
+      },
+      "catalog": {
+        "subtoggleLabel": "Catalog sub-section",
+        "maps": "Maps",
+        "games": "Games"
+      },
+      "readiness": {
+        "ready": "Challenge ready for {{date}}",
+        "notReady": "No challenge scheduled",
+        "notReadyHint": "Run the scheduler to prepare the next daily challenge.",
+        "scheduleAction": "Schedule"
       },
       "strip": {
         "loading": "Loading dataset health…",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -484,14 +484,9 @@
     "geo": {
       "title": "Geo Moderation",
       "subtitle": "Curate the Geo daily challenge: import sources, schedule challenges, and review crowdsourced submissions.",
-      "candidatesLoading": "Loading pins…",
       "tabs": {
-        "pins": "Pins",
-        "submissions": "Submissions",
         "queue": "Review queue",
-        "catalog": "Catalog",
-        "maps": "Maps",
-        "games": "Games"
+        "catalog": "Catalog"
       },
       "catalog": {
         "subtoggleLabel": "Catalog sub-section",
@@ -511,7 +506,6 @@
         "pins": "submissions",
         "errors": "reports",
         "nextChallenge": "next challenge",
-        "scheduleNow": "Schedule now",
         "mapsAria": "Open the Maps tab",
         "pinsAria": "Jump to the submissions awaiting review",
         "errorsAria": "Show recent failures",
@@ -645,31 +639,6 @@
         "pasteUrlCta": "I have a URL — upload",
         "close": "Close"
       },
-      "intro": {
-        "title": "How this page works",
-        "close": "Close",
-        "step1Title": "1. Curate games",
-        "step1Body": "Pick the games that should feed the Geo challenge in the Games tab. The ingestion pipeline then pulls their maps (Registry → Fandom → StrategyWiki → Fextralife → Wikidata → Manual) and Steam screenshots in the background.",
-        "step2Title": "2. Track ingestion",
-        "step2Body": "Watch maps land tier by tier in the Maps tab. Re-run the pipeline or upload a map manually for any game still missing one.",
-        "step3Title": "3. Review crowdsourced pins",
-        "step3Body": "Players drop pins guessing where each screenshot was taken. When pins converge, promote a canonical location — the Schedule button at the top will then queue the next validated screenshot for the daily challenge."
-      },
-      "candidates": "Candidates",
-      "empty": "No candidates match this filter.",
-      "pins": "pins",
-      "pickOne": "Pick a candidate",
-      "pickPoint": "Click the map to set canonical coordinates",
-      "detailHint": "Select a candidate from the list to review its pins and optionally set canonical coordinates.",
-      "promote": "Promote to canonical",
-      "demote": "Demote canonical",
-      "reject": "Reject capture",
-      "alreadyPromoted": "Already promoted — demote it to re-pin with new coordinates.",
-      "candidateRow": {
-        "pinCount_one": "{{count}} pin",
-        "pinCount_other": "{{count}} pins",
-        "source": "source: {{source}}"
-      },
       "groupHeader": {
         "unknownGame": "Game #{{id}}",
         "captureCount_one": "{{count}} capture",
@@ -734,18 +703,6 @@
         "title": "Remove official location?",
         "description": "This capture will return to the moderation queue. Players' submissions are kept; you'll be able to set a new official location.",
         "confirm": "Remove",
-        "cancel": "Cancel"
-      },
-      "demoteDialog": {
-        "title": "Demote canonical pin?",
-        "description": "This screenshot will return to the collecting queue. Players' pins are kept; you'll be able to set new canonical coordinates.",
-        "confirm": "Demote",
-        "cancel": "Cancel"
-      },
-      "rejectDialog": {
-        "title": "Reject this capture?",
-        "description": "The capture will be removed from the Geo challenge: contributors won't see it anymore and it will never be picked for the daily challenge. Use for captures with no locatable spot (UI, inventory, loading screen…).",
-        "confirm": "Reject",
         "cancel": "Cancel"
       },
       "health": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -497,7 +497,15 @@
         "pins": "épingles",
         "errors": "erreurs",
         "nextChallenge": "prochain",
-        "scheduleNow": "Planifier"
+        "scheduleNow": "Planifier",
+        "mapsAria": "Voir les cartes",
+        "pinsAria": "Aller à la file des épingles à valider",
+        "errorsAria": "Voir les échecs récents",
+        "errorsPopover": {
+          "title": "Échecs récents du pipeline",
+          "summary": "{{queue}} échec(s) en file · {{failures}} alerte(s) jeu",
+          "empty": "Aucun échec actif. 🎉"
+        }
       },
       "coldStart": {
         "no-curated": {
@@ -625,6 +633,7 @@
       },
       "intro": {
         "title": "Comment cette page fonctionne",
+        "close": "Fermer",
         "step1Title": "1. Activer les jeux",
         "step1Body": "Choisissez dans l'onglet Jeux ceux qui doivent alimenter le défi Géo. Le pipeline d'ingestion récupère ensuite leurs cartes (Registre → Fandom → StrategyWiki → Fextralife → Wikidata → Manuel) et les captures Steam en arrière-plan.",
         "step2Title": "2. Suivre l'ingestion",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -484,14 +484,9 @@
     "geo": {
       "title": "Modération Géo",
       "subtitle": "Gérez le défi Géo quotidien : importez les sources, planifiez les défis et modérez les propositions communautaires.",
-      "candidatesLoading": "Chargement des épingles…",
       "tabs": {
-        "pins": "Épingles",
-        "submissions": "Propositions",
         "queue": "À examiner",
-        "catalog": "Catalogue",
-        "maps": "Cartes",
-        "games": "Jeux"
+        "catalog": "Catalogue"
       },
       "catalog": {
         "subtoggleLabel": "Sous-section du catalogue",
@@ -511,7 +506,6 @@
         "pins": "propositions",
         "errors": "signalements",
         "nextChallenge": "prochain défi",
-        "scheduleNow": "Planifier",
         "mapsAria": "Voir les cartes",
         "pinsAria": "Aller à la file des propositions à modérer",
         "errorsAria": "Voir les échecs récents",
@@ -645,31 +639,6 @@
         "pasteUrlCta": "J'ai une URL — téléverser",
         "close": "Fermer"
       },
-      "intro": {
-        "title": "Comment cette page fonctionne",
-        "close": "Fermer",
-        "step1Title": "1. Activer les jeux",
-        "step1Body": "Choisissez dans l'onglet Jeux ceux qui doivent alimenter le défi Géo. Le pipeline d'ingestion récupère ensuite leurs cartes (Registre → Fandom → StrategyWiki → Fextralife → Wikidata → Manuel) et les captures Steam en arrière-plan.",
-        "step2Title": "2. Suivre l'ingestion",
-        "step2Body": "Visualisez l'avancement niveau par niveau dans l'onglet Cartes. Relancez le pipeline ou téléversez une carte manuellement si un jeu reste sans carte.",
-        "step3Title": "3. Valider les épingles",
-        "step3Body": "Les joueurs déposent des épingles pour deviner où chaque capture a été prise. Lorsqu'elles convergent, promouvez un emplacement canonique : le bouton Planifier en haut programmera la prochaine capture validée pour le défi quotidien."
-      },
-      "candidates": "Candidats",
-      "empty": "Aucun candidat ne correspond à ce filtre.",
-      "pins": "épingles",
-      "pickOne": "Choisir un candidat",
-      "pickPoint": "Cliquez sur la carte pour définir les coordonnées canoniques",
-      "detailHint": "Sélectionnez un candidat dans la liste pour consulter ses épingles et éventuellement définir les coordonnées canoniques.",
-      "promote": "Promouvoir en canonique",
-      "demote": "Rétrograder la canonique",
-      "reject": "Rejeter la capture",
-      "alreadyPromoted": "Déjà promu — rétrogradez pour ré-épingler avec de nouvelles coordonnées.",
-      "candidateRow": {
-        "pinCount_one": "{{count}} épingle",
-        "pinCount_other": "{{count}} épingles",
-        "source": "source : {{source}}"
-      },
       "groupHeader": {
         "unknownGame": "Jeu #{{id}}",
         "captureCount_one": "{{count}} capture",
@@ -734,18 +703,6 @@
         "title": "Retirer du lieu officiel ?",
         "description": "Cette capture retournera dans la file de modération. Les propositions des joueurs sont conservées ; vous pourrez fixer un nouveau lieu officiel.",
         "confirm": "Retirer",
-        "cancel": "Annuler"
-      },
-      "demoteDialog": {
-        "title": "Rétrograder la canonique ?",
-        "description": "Cette capture retournera dans la file de collecte. Les épingles des joueurs sont conservées ; vous pourrez définir de nouvelles coordonnées canoniques.",
-        "confirm": "Rétrograder",
-        "cancel": "Annuler"
-      },
-      "rejectDialog": {
-        "title": "Rejeter cette capture ?",
-        "description": "La capture sera retirée du défi Géo : les contributeurs ne la verront plus et elle ne sera jamais sélectionnée pour le défi quotidien. À utiliser pour les captures sans emplacement repérable (interface, inventaire, écran de chargement…).",
-        "confirm": "Rejeter",
         "cancel": "Annuler"
       },
       "health": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -483,23 +483,24 @@
     },
     "geo": {
       "title": "Modération Géo",
-      "subtitle": "Gérez le défi Géo quotidien : importez les sources, planifiez les défis et validez les épingles communautaires.",
+      "subtitle": "Gérez le défi Géo quotidien : importez les sources, planifiez les défis et modérez les propositions communautaires.",
       "candidatesLoading": "Chargement des épingles…",
       "tabs": {
         "pins": "Épingles",
+        "submissions": "Propositions",
         "maps": "Cartes",
         "games": "Jeux"
       },
       "strip": {
         "loading": "Chargement de l'état du dataset…",
         "error": "Impossible de charger l'état du dataset.",
-        "maps": "cartes",
-        "pins": "épingles",
-        "errors": "erreurs",
-        "nextChallenge": "prochain",
+        "maps": "cartes couvertes",
+        "pins": "propositions",
+        "errors": "signalements",
+        "nextChallenge": "prochain défi",
         "scheduleNow": "Planifier",
         "mapsAria": "Voir les cartes",
-        "pinsAria": "Aller à la file des épingles à valider",
+        "pinsAria": "Aller à la file des propositions à modérer",
         "errorsAria": "Voir les échecs récents",
         "errorsPopover": {
           "title": "Échecs récents du pipeline",
@@ -563,7 +564,7 @@
         "title": "Cartes par jeu",
         "subtitle": "Cliquez sur un jeu pour voir quels niveaux d'ingestion ont été essayés ou seraient lancés ensuite.",
         "refresh": "Rafraîchir",
-        "empty": "Aucun jeu activé pour le moment. Ajoutez-en depuis la liste des jeux activés de l'onglet Épingles.",
+        "empty": "Aucun jeu activé pour le moment. Ajoutez-en depuis la liste des jeux activés de l'onglet Propositions.",
         "reimportQueued": "Pipeline relancé pour « {{name}} ».",
         "row": {
           "hasMap": "Carte",
@@ -611,7 +612,7 @@
           "importWandTooltip": "Collez une URL de carte wand.com — le serveur extrait son og:image et l'enregistre comme carte de ce jeu.",
           "viewCaptures_one": "Voir les captures ({{count}})",
           "viewCaptures_other": "Voir les captures ({{count}})",
-          "viewCapturesTooltip": "Ouvrir l'onglet Pins filtré sur les captures de ce jeu."
+          "viewCapturesTooltip": "Ouvrir l'onglet Propositions filtré sur les captures de ce jeu."
         },
         "loading": "Chargement des jeux…",
         "sidePanel": {
@@ -663,9 +664,9 @@
       },
       "statusFilter": {
         "label": "Filtrer par statut",
-        "collecting": "En collecte",
-        "pending": "En attente",
-        "promoted": "Promus",
+        "collecting": "Ouvert",
+        "pending": "À modérer",
+        "promoted": "Officialisés",
         "all": "Tous"
       },
       "gameFilter": {
@@ -673,10 +674,54 @@
         "clear": "Effacer le filtre par jeu"
       },
       "statusBadge": {
-        "collecting": "En collecte",
-        "pending": "En attente",
-        "promoted": "Promu",
-        "rejected": "Rejeté"
+        "collecting": "Ouvert",
+        "pending": "À modérer",
+        "promoted": "Officialisé",
+        "rejected": "Refusé"
+      },
+      "actions": {
+        "makeOfficial": "Officialiser",
+        "removeOfficial": "Retirer du lieu officiel",
+        "decline": "Refuser"
+      },
+      "entities": {
+        "submission_one": "proposition",
+        "submission_other": "propositions",
+        "officialLocation": "lieu officiel"
+      },
+      "submissions": "Propositions",
+      "submissionsLoading": "Chargement des propositions…",
+      "emptyQueue": "Aucune proposition ne correspond à ce filtre.",
+      "pickSubmission": "Choisir une proposition",
+      "pickPointForOfficial": "Cliquez sur la carte pour fixer le lieu officiel",
+      "detailHintOfficial": "Sélectionnez une proposition dans la liste pour la consulter et fixer son lieu officiel.",
+      "alreadyOfficial": "Lieu officiel déjà fixé — retirez-le pour replacer le repère.",
+      "submissionRow": {
+        "pinCount_one": "{{count}} proposition",
+        "pinCount_other": "{{count}} propositions",
+        "source": "source : {{source}}"
+      },
+      "guide": {
+        "title": "Guide de modération",
+        "close": "Fermer",
+        "step1Title": "1. Activer les jeux",
+        "step1Body": "Choisissez dans l'onglet Jeux ceux qui doivent alimenter le défi Géo. Le pipeline d'ingestion récupère ensuite leurs cartes (Registre → Fandom → StrategyWiki → Fextralife → Wikidata → Manuel) et les captures Steam en arrière-plan.",
+        "step2Title": "2. Suivre l'ingestion",
+        "step2Body": "Visualisez l'avancement niveau par niveau dans l'onglet Cartes. Relancez le pipeline ou téléversez une carte manuellement si un jeu reste sans carte.",
+        "step3Title": "3. Modérer les propositions",
+        "step3Body": "Les joueurs envoient des propositions pour deviner où chaque capture a été prise. Lorsqu'elles convergent, fixez un lieu officiel : le bouton Planifier en haut programmera la prochaine capture validée pour le défi quotidien."
+      },
+      "declineDialog": {
+        "title": "Refuser cette capture ?",
+        "description": "La capture sera retirée du défi Géo : les contributeurs ne la verront plus et elle ne sera jamais sélectionnée pour le défi quotidien. À utiliser pour les captures sans emplacement repérable (interface, inventaire, écran de chargement…).",
+        "confirm": "Refuser",
+        "cancel": "Annuler"
+      },
+      "removeOfficialDialog": {
+        "title": "Retirer du lieu officiel ?",
+        "description": "Cette capture retournera dans la file de modération. Les propositions des joueurs sont conservées ; vous pourrez fixer un nouveau lieu officiel.",
+        "confirm": "Retirer",
+        "cancel": "Annuler"
       },
       "demoteDialog": {
         "title": "Rétrograder la canonique ?",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -488,8 +488,21 @@
       "tabs": {
         "pins": "Épingles",
         "submissions": "Propositions",
+        "queue": "À examiner",
+        "catalog": "Catalogue",
         "maps": "Cartes",
         "games": "Jeux"
+      },
+      "catalog": {
+        "subtoggleLabel": "Sous-section du catalogue",
+        "maps": "Cartes",
+        "games": "Jeux"
+      },
+      "readiness": {
+        "ready": "Défi prêt pour le {{date}}",
+        "notReady": "Aucun défi programmé",
+        "notReadyHint": "Lancez la planification pour préparer le prochain défi quotidien.",
+        "scheduleAction": "Planifier"
       },
       "strip": {
         "loading": "Chargement de l'état du dataset…",

--- a/packages/frontend/src/components/admin/GeoHeaderStrip.tsx
+++ b/packages/frontend/src/components/admin/GeoHeaderStrip.tsx
@@ -1,26 +1,25 @@
 import { useTranslation } from 'react-i18next'
 import { Loader2, Map, ListChecks, AlertTriangle, CalendarClock } from 'lucide-react'
-import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import type { GeoHealth } from '@/hooks/useGeoHealth'
 
-// Persistent dataset-health indicator that replaces GeoAdminActions'
-// metric/queue tile grids. One thin line of always-visible counters that
-// the operator can scan in <1 second:
+// Persistent dataset-health indicator. One thin line of always-visible
+// counters the operator can scan in <1 second:
 //   `38/42 maps · 12 pins · 0 errors`
 //
 // Health data is owned by the parent (GeoReviewPanel) via `useGeoHealth`
-// so the cold-start banner and these counters always agree without a
-// duplicate poll.
+// so the cold-start banner, the readiness banner and these counters all
+// agree without duplicate polls.
 //
-// Counters now act as shortcuts: clicking `maps` jumps to the Maps tab,
-// clicking `pins` lands on the pending queue, and clicking `errors` opens
-// a Popover summarising the recent failures so the operator can see what
-// to chase without leaving the Géo panel.
+// Counters act as shortcuts: clicking `maps` jumps to the Catalog tab
+// on the Maps sub-section, `pins` lands on the moderation queue, and
+// `errors` opens a Popover summarising the recent failures.
+//
+// The Schedule action used to live here as a Button — it now belongs to
+// GeoReadinessBanner so the readiness state and the action that changes
+// it sit together.
 
 interface GeoHeaderStripProps {
-    onScheduleClick?: () => void
-    scheduling?: boolean
     health: GeoHealth | null
     loading: boolean
     error: boolean
@@ -38,8 +37,6 @@ interface HealthFailureRow {
 }
 
 export function GeoHeaderStrip({
-    onScheduleClick,
-    scheduling,
     health,
     loading,
     error,
@@ -116,22 +113,6 @@ export function GeoHeaderStrip({
                         tone="neutral"
                     />
                 </>
-            )}
-            {onScheduleClick && (
-                <Button
-                    size="sm"
-                    variant="ghost"
-                    className="w-full sm:w-auto sm:ml-auto h-7 text-xs"
-                    onClick={onScheduleClick}
-                    disabled={scheduling}
-                >
-                    {scheduling ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
-                    ) : (
-                        <CalendarClock className="h-3.5 w-3.5 mr-1.5" />
-                    )}
-                    {t('admin.geo.strip.scheduleNow')}
-                </Button>
             )}
         </div>
     )

--- a/packages/frontend/src/components/admin/GeoHeaderStrip.tsx
+++ b/packages/frontend/src/components/admin/GeoHeaderStrip.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { Loader2, Map, ListChecks, AlertTriangle, CalendarClock } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import type { GeoHealth } from '@/hooks/useGeoHealth'
 
 // Persistent dataset-health indicator that replaces GeoAdminActions'
@@ -11,6 +12,11 @@ import type { GeoHealth } from '@/hooks/useGeoHealth'
 // Health data is owned by the parent (GeoReviewPanel) via `useGeoHealth`
 // so the cold-start banner and these counters always agree without a
 // duplicate poll.
+//
+// Counters now act as shortcuts: clicking `maps` jumps to the Maps tab,
+// clicking `pins` lands on the pending queue, and clicking `errors` opens
+// a Popover summarising the recent failures so the operator can see what
+// to chase without leaving the Géo panel.
 
 interface GeoHeaderStripProps {
     onScheduleClick?: () => void
@@ -18,6 +24,17 @@ interface GeoHeaderStripProps {
     health: GeoHealth | null
     loading: boolean
     error: boolean
+    onMapsClick?: () => void
+    onPinsClick?: () => void
+}
+
+// `health.failures` is typed as `unknown[]` upstream so a contract drift
+// on the backend can't crash the strip. The rendered fields are best-effort.
+interface HealthFailureRow {
+    gameId?: number
+    source?: string
+    reason?: string
+    attempt?: number
 }
 
 export function GeoHeaderStrip({
@@ -26,6 +43,8 @@ export function GeoHeaderStrip({
     health,
     loading,
     error,
+    onMapsClick,
+    onPinsClick,
 }: GeoHeaderStripProps) {
     const { t, i18n } = useTranslation()
 
@@ -53,6 +72,7 @@ export function GeoHeaderStrip({
     // avoids a tile grid creeping back in.
     const errorsCount = queue.failed + (health.failures?.length ?? 0)
     const pinsToReview = queue.waiting + queue.active
+    const failures = (health.failures as HealthFailureRow[] | undefined) ?? []
 
     return (
         <div className="flex flex-wrap items-center gap-3 rounded-md border border-border/40 bg-muted/10 px-3 py-2 text-xs">
@@ -65,6 +85,8 @@ export function GeoHeaderStrip({
                         ? 'good'
                         : 'neutral'
                 }
+                onClick={onMapsClick}
+                ariaLabel={t('admin.geo.strip.mapsAria')}
             />
             <Divider />
             <Counter
@@ -72,13 +94,14 @@ export function GeoHeaderStrip({
                 value={pinsToReview}
                 label={t('admin.geo.strip.pins')}
                 tone={pinsToReview > 0 ? 'warn' : 'neutral'}
+                onClick={onPinsClick}
+                ariaLabel={t('admin.geo.strip.pinsAria')}
             />
             <Divider />
-            <Counter
-                icon={<AlertTriangle className="h-3.5 w-3.5" aria-hidden />}
-                value={errorsCount}
-                label={t('admin.geo.strip.errors')}
-                tone={errorsCount > 0 ? 'bad' : 'good'}
+            <ErrorsCounter
+                count={errorsCount}
+                failures={failures}
+                queueFailed={queue.failed}
             />
             {nextChallenge && (
                 <>
@@ -116,31 +139,121 @@ export function GeoHeaderStrip({
 
 type Tone = 'good' | 'warn' | 'bad' | 'neutral'
 
+function toneClass(tone: Tone): string {
+    return tone === 'good'
+        ? 'text-success'
+        : tone === 'warn'
+          ? 'text-warning'
+          : tone === 'bad'
+            ? 'text-destructive'
+            : 'text-foreground'
+}
+
 function Counter({
     icon,
     value,
     label,
     tone,
+    onClick,
+    ariaLabel,
 }: {
     icon: React.ReactNode
     value: string | number
     label: string
     tone: Tone
+    onClick?: () => void
+    ariaLabel?: string
 }) {
-    const valueClass =
-        tone === 'good'
-            ? 'text-success'
-            : tone === 'warn'
-              ? 'text-warning'
-              : tone === 'bad'
-                ? 'text-destructive'
-                : 'text-foreground'
-    return (
-        <span className="inline-flex items-center gap-1.5">
+    const valueClass = toneClass(tone)
+    const body = (
+        <>
             <span className={`${valueClass}`}>{icon}</span>
             <span className={`font-semibold tabular-nums ${valueClass}`}>{value}</span>
             <span className="text-muted-foreground">{label}</span>
-        </span>
+        </>
+    )
+    if (!onClick) {
+        return <span className="inline-flex items-center gap-1.5">{body}</span>
+    }
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            aria-label={ariaLabel}
+            className="inline-flex items-center gap-1.5 rounded px-1 -mx-1 hover:bg-muted/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-neon-pink"
+        >
+            {body}
+        </button>
+    )
+}
+
+// Errors get their own widget so the popover lifecycle stays scoped here:
+// the parent doesn't need to know about open state, and the trigger keeps
+// the same visual rhythm as the other counters.
+function ErrorsCounter({
+    count,
+    failures,
+    queueFailed,
+}: {
+    count: number
+    failures: HealthFailureRow[]
+    queueFailed: number
+}) {
+    const { t } = useTranslation()
+    const tone: Tone = count > 0 ? 'bad' : 'good'
+    const valueClass = toneClass(tone)
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <button
+                    type="button"
+                    aria-label={t('admin.geo.strip.errorsAria')}
+                    className="inline-flex items-center gap-1.5 rounded px-1 -mx-1 hover:bg-muted/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-neon-pink"
+                >
+                    <span className={valueClass}>
+                        <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
+                    </span>
+                    <span className={`font-semibold tabular-nums ${valueClass}`}>
+                        {count}
+                    </span>
+                    <span className="text-muted-foreground">
+                        {t('admin.geo.strip.errors')}
+                    </span>
+                </button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-80 text-xs">
+                <p className="text-sm font-semibold">
+                    {t('admin.geo.strip.errorsPopover.title')}
+                </p>
+                <p className="mt-1 text-muted-foreground">
+                    {t('admin.geo.strip.errorsPopover.summary', {
+                        queue: queueFailed,
+                        failures: failures.length,
+                    })}
+                </p>
+                {failures.length === 0 ? (
+                    <p className="mt-3 text-muted-foreground">
+                        {t('admin.geo.strip.errorsPopover.empty')}
+                    </p>
+                ) : (
+                    <ul className="mt-3 space-y-1.5 max-h-60 overflow-auto pr-1">
+                        {failures.slice(0, 12).map((f, i) => (
+                            <li
+                                key={i}
+                                className="rounded border border-border/40 bg-muted/20 px-2 py-1.5"
+                            >
+                                {t('admin.geo.health.failures.row', {
+                                    gameId: f.gameId ?? '?',
+                                    source: f.source ?? '?',
+                                    reason: f.reason ?? '?',
+                                    attempt: f.attempt ?? '?',
+                                })}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </PopoverContent>
+        </Popover>
     )
 }
 

--- a/packages/frontend/src/components/admin/GeoReadinessBanner.tsx
+++ b/packages/frontend/src/components/admin/GeoReadinessBanner.tsx
@@ -1,0 +1,89 @@
+import { useTranslation } from 'react-i18next'
+import { CalendarCheck, CalendarClock, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { GeoHealth } from '@/hooks/useGeoHealth'
+
+// Top-of-page answer to "is the next daily Géo challenge ready or not?"
+// Renders only after cold-start is past (curated > 0 AND withMap > 0) so
+// it doesn't fight GeoColdStartBanner. The Planifier action is owned here
+// rather than on the metric strip so the readiness state and the only
+// action that changes it sit together.
+//
+// State machine:
+//   - nextChallenge present  -> "Ready for {date}", neutral/positive tone
+//   - nextChallenge absent   -> "Not ready", with a Planifier button
+//
+// Backlog: when the backend exposes whether the assigned screenshot has
+// an officialised location, this banner can surface the deeper "needs
+// moderation" reason — for now `nextChallenge !== null` is the cheapest
+// signal that lines up with what the moderator actually does.
+
+interface GeoReadinessBannerProps {
+    health: GeoHealth | null
+    onSchedule: () => void
+    scheduling: boolean
+}
+
+export function GeoReadinessBanner({
+    health,
+    onSchedule,
+    scheduling,
+}: GeoReadinessBannerProps) {
+    const { t, i18n } = useTranslation()
+    if (!health) return null
+    const { curated, withMap } = health.coverage
+    // Cold-start covers these two cases with its own banner — bail so
+    // the moderator doesn't see two stacked status surfaces.
+    if (curated === 0 || withMap === 0) return null
+
+    const next = health.nextChallenge
+    if (next) {
+        const date = new Date(next.date).toLocaleDateString(i18n.language, {
+            day: '2-digit',
+            month: 'long',
+        })
+        return (
+            <div
+                className="flex items-center gap-3 rounded-md border border-success/40 bg-success/5 px-3 py-2.5 text-xs"
+                role="status"
+                aria-live="polite"
+            >
+                <CalendarCheck className="h-4 w-4 text-success shrink-0" aria-hidden />
+                <p className="font-semibold text-foreground">
+                    {t('admin.geo.readiness.ready', { date })}
+                </p>
+            </div>
+        )
+    }
+
+    return (
+        <div
+            className="flex flex-col sm:flex-row sm:items-center gap-3 rounded-md border border-warning/40 bg-warning/5 px-3 py-2.5 text-xs"
+            role="status"
+            aria-live="polite"
+        >
+            <CalendarClock className="h-4 w-4 text-warning shrink-0" aria-hidden />
+            <div className="flex-1 space-y-0.5 leading-relaxed">
+                <p className="font-semibold text-foreground">
+                    {t('admin.geo.readiness.notReady')}
+                </p>
+                <p className="text-muted-foreground">
+                    {t('admin.geo.readiness.notReadyHint')}
+                </p>
+            </div>
+            <Button
+                size="sm"
+                onClick={onSchedule}
+                disabled={scheduling}
+                className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
+            >
+                {scheduling ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                ) : (
+                    <CalendarClock className="h-3.5 w-3.5 mr-1.5" />
+                )}
+                {t('admin.geo.readiness.scheduleAction')}
+            </Button>
+        </div>
+    )
+}

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -33,6 +33,7 @@ import { GeoGamesTab } from './GeoGamesTab'
 import { GeoHeaderStrip } from './GeoHeaderStrip'
 import { GeoRunStateBanner } from './GeoRunStateBanner'
 import { GeoColdStartBanner } from './GeoColdStartBanner'
+import { GeoReadinessBanner } from './GeoReadinessBanner'
 import { useGeoRunPolling } from '@/hooks/useGeoRunPolling'
 import { useGeoHealth } from '@/hooks/useGeoHealth'
 import { useIsMobile } from '@/hooks/useIsMobile'
@@ -147,7 +148,13 @@ async function rejectCandidate(id: number): Promise<void> {
 export function GeoReviewPanel() {
     const { t } = useTranslation()
     const isMobile = useIsMobile()
-    const [activeTab, setActiveTab] = useState<'pins' | 'maps' | 'games'>('pins')
+    // Two top-level destinations: the moderation queue (the daily job) and
+    // the catalog of reference data (maps + games). The previous Pins / Maps
+    // / Games triple split by entity, which is the engineer's mental model,
+    // not the moderator's. `catalogView` tracks which catalog sub-section is
+    // open so the segmented control stays in sync without a third tab.
+    const [activeTab, setActiveTab] = useState<'queue' | 'catalog'>('queue')
+    const [catalogView, setCatalogView] = useState<'maps' | 'games'>('maps')
     // Default to the only status that needs the moderator's attention. The
     // other statuses are still reachable via the chip row, but the page
     // should not open on `collecting` (no decision possible) or `all` (mixes
@@ -275,7 +282,7 @@ export function GeoReviewPanel() {
         setGameFilter({ gameId, gameName })
         setStatusFilter('all')
         setDetail(null)
-        setActiveTab('pins')
+        setActiveTab('queue')
     }
 
     const confirmReject = async () => {
@@ -346,17 +353,24 @@ export function GeoReviewPanel() {
             </header>
 
             <GeoHeaderStrip
-                onScheduleClick={() => void triggerSchedule()}
-                scheduling={scheduling}
                 health={health}
                 loading={healthLoading}
                 error={healthError}
-                onMapsClick={() => setActiveTab('maps')}
+                onMapsClick={() => {
+                    setActiveTab('catalog')
+                    setCatalogView('maps')
+                }}
                 onPinsClick={() => {
-                    setActiveTab('pins')
+                    setActiveTab('queue')
                     setStatusFilter('pending')
                     setGameFilter(null)
                 }}
+            />
+
+            <GeoReadinessBanner
+                health={health}
+                onSchedule={() => void triggerSchedule()}
+                scheduling={scheduling}
             />
 
             <GeoColdStartBanner health={health} />
@@ -365,38 +379,66 @@ export function GeoReviewPanel() {
 
             <Tabs
                 value={activeTab}
-                onValueChange={(v) => setActiveTab(v as 'pins' | 'maps' | 'games')}
+                onValueChange={(v) => setActiveTab(v as 'queue' | 'catalog')}
                 className="space-y-4"
             >
                 <TabsList className="w-full overflow-x-auto justify-start scrollbar-hide">
-                    <TabsTrigger value="pins" className="gap-1.5 shrink-0">
+                    <TabsTrigger value="queue" className="gap-1.5 shrink-0">
                         <ListChecks className="h-3.5 w-3.5" />
-                        {t('admin.geo.tabs.submissions')}
+                        {t('admin.geo.tabs.queue')}
                     </TabsTrigger>
-                    <TabsTrigger value="maps" className="gap-1.5 shrink-0">
-                        <MapIcon className="h-3.5 w-3.5" />
-                        {t('admin.geo.tabs.maps')}
-                    </TabsTrigger>
-                    <TabsTrigger value="games" className="gap-1.5 shrink-0">
+                    <TabsTrigger value="catalog" className="gap-1.5 shrink-0">
                         <Library className="h-3.5 w-3.5" />
-                        {t('admin.geo.tabs.games')}
+                        {t('admin.geo.tabs.catalog')}
                     </TabsTrigger>
                 </TabsList>
 
-                <TabsContent value="maps" className="space-y-4">
-                    <GeoMapsTab
-                        runState={runState}
-                        runError={runError}
-                        armRunPolling={armRunPolling}
-                        onViewCaptures={viewCapturesForGame}
-                    />
+                <TabsContent value="catalog" className="space-y-4">
+                    {/* Maps and Games are both reference data; previously
+                        they each had a top-level tab. Collapsed into one
+                        Catalogue tab with a segmented sub-control so the
+                        two top tabs map to the moderator's task split:
+                        "today's queue" vs. "everything else". */}
+                    <div
+                        className="inline-flex rounded-md border border-border/40 bg-muted/20 p-0.5"
+                        role="tablist"
+                        aria-label={t('admin.geo.catalog.subtoggleLabel')}
+                    >
+                        {(['maps', 'games'] as const).map((view) => {
+                            const Icon = view === 'maps' ? MapIcon : Library
+                            const active = catalogView === view
+                            return (
+                                <button
+                                    key={view}
+                                    type="button"
+                                    role="tab"
+                                    aria-selected={active}
+                                    onClick={() => setCatalogView(view)}
+                                    className={`inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-xs transition-colors ${
+                                        active
+                                            ? 'bg-background shadow-sm text-foreground'
+                                            : 'text-muted-foreground hover:text-foreground'
+                                    }`}
+                                >
+                                    <Icon className="h-3.5 w-3.5" aria-hidden />
+                                    {t(`admin.geo.catalog.${view}`)}
+                                </button>
+                            )
+                        })}
+                    </div>
+                    {catalogView === 'maps' ? (
+                        <GeoMapsTab
+                            runState={runState}
+                            runError={runError}
+                            armRunPolling={armRunPolling}
+                            onViewCaptures={viewCapturesForGame}
+                        />
+                    ) : (
+                        <GeoGamesTab />
+                    )}
                 </TabsContent>
 
-                <TabsContent value="games" className="space-y-4">
-                    <GeoGamesTab />
-                </TabsContent>
-
-                <TabsContent value="pins" className="space-y-4">
+                <TabsContent value="queue" className="space-y-4">
             {/* Status filter */}
             <div
                 className="flex flex-wrap items-center gap-2"

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -4,11 +4,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import {
-    Collapsible,
-    CollapsibleContent,
-    CollapsibleTrigger,
-} from '@/components/ui/collapsible'
-import {
     Dialog,
     DialogContent,
     DialogDescription,
@@ -25,9 +20,8 @@ import {
 import {
     Loader2,
     Trash2,
-    Info,
+    HelpCircle,
     MapPin,
-    ChevronDown,
     Map as MapIcon,
     ListChecks,
     Library,
@@ -154,7 +148,11 @@ export function GeoReviewPanel() {
     const { t } = useTranslation()
     const isMobile = useIsMobile()
     const [activeTab, setActiveTab] = useState<'pins' | 'maps' | 'games'>('pins')
-    const [statusFilter, setStatusFilter] = useState<StatusFilter>('collecting')
+    // Default to the only status that needs the moderator's attention. The
+    // other statuses are still reachable via the chip row, but the page
+    // should not open on `collecting` (no decision possible) or `all` (mixes
+    // already-handled rows into the queue).
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>('pending')
     // Per-game filter for the Pins tab. Set when the operator clicks "Voir
     // les captures" on a Maps row so the candidate list narrows to that game.
     // Cleared via the badge in the Pins header.
@@ -227,19 +225,45 @@ export function GeoReviewPanel() {
         }
     }
 
+    // Returns the candidate the moderator should triage *after* `currentId`
+    // is removed from the visible list. Uses the same flat (group-aware)
+    // ordering the UI renders, so "next" mirrors what the eye expects.
+    // Falls back to the first row, then to nothing when the queue empties.
+    const pickNextAfter = (
+        rows: GeoScreenshotCandidate[],
+        currentId: number,
+        previousFlat: GeoScreenshotCandidate[],
+    ): GeoScreenshotCandidate | null => {
+        const flat = groupCandidatesByGame(rows).flatMap((g) => g.candidates)
+        if (flat.length === 0) return null
+        const oldIdx = previousFlat.findIndex((c) => c.id === currentId)
+        // After a successful action the row drops out of the filtered list,
+        // so the candidate now sitting at `oldIdx` IS the next one.
+        if (oldIdx >= 0 && oldIdx < flat.length) return flat[oldIdx]
+        return flat[0]
+    }
+
     const applyOverride = async () => {
         if (!detail || !pin) return
         setSaving(true)
         try {
-            await overrideCandidate(detail.candidate.id, pin)
-            // Refresh the list + clear the detail pane.
-            setDetail(null)
-            setPin(null)
+            const previousFlat = groupCandidatesByGame(candidates).flatMap(
+                (g) => g.candidates,
+            )
+            const currentId = detail.candidate.id
+            await overrideCandidate(currentId, pin)
             const rows = await fetchCandidates({
                 status: statusFilter === 'all' ? undefined : statusFilter,
                 gameId: gameFilter?.gameId,
             })
             setCandidates(rows)
+            const next = pickNextAfter(rows, currentId, previousFlat)
+            setPin(null)
+            if (next) {
+                await openDetail(next.id)
+            } else {
+                setDetail(null)
+            }
         } catch (e) {
             setError(String(e))
         } finally {
@@ -259,15 +283,24 @@ export function GeoReviewPanel() {
         setError(null)
         setSaving(true)
         try {
-            await rejectCandidate(detail.candidate.id)
+            const previousFlat = groupCandidatesByGame(candidates).flatMap(
+                (g) => g.candidates,
+            )
+            const currentId = detail.candidate.id
+            await rejectCandidate(currentId)
             setRejectOpen(false)
-            setDetail(null)
-            setPin(null)
             const rows = await fetchCandidates({
                 status: statusFilter === 'all' ? undefined : statusFilter,
                 gameId: gameFilter?.gameId,
             })
             setCandidates(rows)
+            const next = pickNextAfter(rows, currentId, previousFlat)
+            setPin(null)
+            if (next) {
+                await openDetail(next.id)
+            } else {
+                setDetail(null)
+            }
         } catch (e) {
             setError(String(e))
         } finally {
@@ -318,6 +351,12 @@ export function GeoReviewPanel() {
                 health={health}
                 loading={healthLoading}
                 error={healthError}
+                onMapsClick={() => setActiveTab('maps')}
+                onPinsClick={() => {
+                    setActiveTab('pins')
+                    setStatusFilter('pending')
+                    setGameFilter(null)
+                }}
             />
 
             <GeoColdStartBanner health={health} />
@@ -358,44 +397,6 @@ export function GeoReviewPanel() {
                 </TabsContent>
 
                 <TabsContent value="pins" className="space-y-4">
-            {/* Workflow explainer */}
-            <Collapsible open={introOpen} onOpenChange={setIntroOpen}>
-                <Card className="border-neon-pink/30 bg-linear-to-r from-neon-pink/5 via-neon-purple/5 to-transparent">
-                    <CollapsibleTrigger asChild>
-                        <button
-                            type="button"
-                            className="flex w-full items-center justify-between gap-2 px-6 py-3 text-left"
-                            aria-expanded={introOpen}
-                        >
-                            <span className="text-sm font-semibold flex items-center gap-2">
-                                <Info className="h-4 w-4 text-neon-pink" />
-                                {t('admin.geo.intro.title')}
-                            </span>
-                            <ChevronDown
-                                className={`h-4 w-4 text-muted-foreground transition-transform ${introOpen ? 'rotate-180' : ''}`}
-                                aria-hidden
-                            />
-                        </button>
-                    </CollapsibleTrigger>
-                    <CollapsibleContent>
-                        <CardContent className="pt-0">
-                            <ol className="grid gap-3 sm:grid-cols-3 text-sm">
-                                {(['step1', 'step2', 'step3'] as const).map((step) => (
-                                    <li key={step} className="space-y-1">
-                                        <p className="font-semibold text-foreground">
-                                            {t(`admin.geo.intro.${step}Title`)}
-                                        </p>
-                                        <p className="text-xs text-muted-foreground leading-relaxed">
-                                            {t(`admin.geo.intro.${step}Body`)}
-                                        </p>
-                                    </li>
-                                ))}
-                            </ol>
-                        </CardContent>
-                    </CollapsibleContent>
-                </Card>
-            </Collapsible>
-
             {/* Status filter */}
             <div
                 className="flex flex-wrap items-center gap-2"
@@ -455,9 +456,21 @@ export function GeoReviewPanel() {
                 <div className="grid gap-3 sm:gap-4 grid-cols-1 lg:grid-cols-3">
                     <Card className="lg:col-span-1">
                         <CardHeader className="pb-2 p-4 sm:p-6">
-                            <CardTitle className="text-sm">
-                                {t('admin.geo.candidates')} ({candidates.length})
-                            </CardTitle>
+                            <div className="flex items-center justify-between gap-2">
+                                <CardTitle className="text-sm">
+                                    {t('admin.geo.candidates')} ({candidates.length})
+                                </CardTitle>
+                                <Button
+                                    type="button"
+                                    size="icon"
+                                    variant="ghost"
+                                    className="h-7 w-7 text-muted-foreground hover:text-neon-pink"
+                                    onClick={() => setIntroOpen(true)}
+                                    aria-label={t('admin.geo.intro.title')}
+                                >
+                                    <HelpCircle className="h-4 w-4" />
+                                </Button>
+                            </div>
                         </CardHeader>
                         <CardContent className="space-y-4 lg:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
                             {groupCandidatesByGame(candidates).map((group) => (
@@ -576,6 +589,31 @@ export function GeoReviewPanel() {
                     </div>
                 </SheetContent>
             </Sheet>
+
+            <Dialog open={introOpen} onOpenChange={setIntroOpen}>
+                <DialogContent className="max-w-lg">
+                    <DialogHeader>
+                        <DialogTitle>{t('admin.geo.intro.title')}</DialogTitle>
+                    </DialogHeader>
+                    <ol className="grid gap-3 text-sm">
+                        {(['step1', 'step2', 'step3'] as const).map((step) => (
+                            <li key={step} className="space-y-1">
+                                <p className="font-semibold text-foreground">
+                                    {t(`admin.geo.intro.${step}Title`)}
+                                </p>
+                                <p className="text-xs text-muted-foreground leading-relaxed">
+                                    {t(`admin.geo.intro.${step}Body`)}
+                                </p>
+                            </li>
+                        ))}
+                    </ol>
+                    <DialogFooter>
+                        <Button onClick={() => setIntroOpen(false)}>
+                            {t('admin.geo.intro.close')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
 
             <Dialog open={rejectOpen} onOpenChange={(open) => !saving && setRejectOpen(open)}>
                 <DialogContent className="max-w-sm sm:max-w-md">

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -371,7 +371,7 @@ export function GeoReviewPanel() {
                 <TabsList className="w-full overflow-x-auto justify-start scrollbar-hide">
                     <TabsTrigger value="pins" className="gap-1.5 shrink-0">
                         <ListChecks className="h-3.5 w-3.5" />
-                        {t('admin.geo.tabs.pins')}
+                        {t('admin.geo.tabs.submissions')}
                     </TabsTrigger>
                     <TabsTrigger value="maps" className="gap-1.5 shrink-0">
                         <MapIcon className="h-3.5 w-3.5" />
@@ -445,7 +445,7 @@ export function GeoReviewPanel() {
                     role="status"
                     aria-live="polite"
                     aria-busy="true"
-                    aria-label={t('admin.geo.candidatesLoading')}
+                    aria-label={t('admin.geo.submissionsLoading')}
                 >
                     <Loader2
                         className="h-6 w-6 animate-spin text-neon-pink"
@@ -458,7 +458,7 @@ export function GeoReviewPanel() {
                         <CardHeader className="pb-2 p-4 sm:p-6">
                             <div className="flex items-center justify-between gap-2">
                                 <CardTitle className="text-sm">
-                                    {t('admin.geo.candidates')} ({candidates.length})
+                                    {t('admin.geo.submissions')} ({candidates.length})
                                 </CardTitle>
                                 <Button
                                     type="button"
@@ -466,7 +466,7 @@ export function GeoReviewPanel() {
                                     variant="ghost"
                                     className="h-7 w-7 text-muted-foreground hover:text-neon-pink"
                                     onClick={() => setIntroOpen(true)}
-                                    aria-label={t('admin.geo.intro.title')}
+                                    aria-label={t('admin.geo.guide.title')}
                                 >
                                     <HelpCircle className="h-4 w-4" />
                                 </Button>
@@ -508,11 +508,11 @@ export function GeoReviewPanel() {
                                                     </Badge>
                                                 </div>
                                                 <div className="mt-1 text-muted-foreground">
-                                                    {t('admin.geo.candidateRow.pinCount', {
+                                                    {t('admin.geo.submissionRow.pinCount', {
                                                         count: c.pinCount,
                                                     })}
                                                     {' · '}
-                                                    {t('admin.geo.candidateRow.source', {
+                                                    {t('admin.geo.submissionRow.source', {
                                                         source: c.source,
                                                     })}
                                                 </div>
@@ -523,7 +523,7 @@ export function GeoReviewPanel() {
                             ))}
                             {candidates.length === 0 && (
                                 <p className="text-xs text-muted-foreground">
-                                    {t('admin.geo.empty')}
+                                    {t('admin.geo.emptyQueue')}
                                 </p>
                             )}
                         </CardContent>
@@ -534,8 +534,8 @@ export function GeoReviewPanel() {
                         <CardHeader className="pb-2 p-4 sm:p-6">
                             <CardTitle className="text-sm">
                                 {detail
-                                    ? `#${detail.candidate.id} · ${t('admin.geo.candidateRow.pinCount', { count: detail.pins.length })}`
-                                    : t('admin.geo.pickOne')}
+                                    ? `#${detail.candidate.id} · ${t('admin.geo.submissionRow.pinCount', { count: detail.pins.length })}`
+                                    : t('admin.geo.pickSubmission')}
                             </CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-3 p-4 sm:p-6 pt-0 sm:pt-0">
@@ -571,8 +571,8 @@ export function GeoReviewPanel() {
                     <SheetHeader className="px-4 py-3 border-b border-border/40 text-left">
                         <SheetTitle className="text-sm font-semibold">
                             {detail
-                                ? `#${detail.candidate.id} · ${t('admin.geo.candidateRow.pinCount', { count: detail.pins.length })}`
-                                : t('admin.geo.pickOne')}
+                                ? `#${detail.candidate.id} · ${t('admin.geo.submissionRow.pinCount', { count: detail.pins.length })}`
+                                : t('admin.geo.pickSubmission')}
                         </SheetTitle>
                     </SheetHeader>
                     <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 pb-[max(env(safe-area-inset-bottom),1rem)]">
@@ -593,23 +593,23 @@ export function GeoReviewPanel() {
             <Dialog open={introOpen} onOpenChange={setIntroOpen}>
                 <DialogContent className="max-w-lg">
                     <DialogHeader>
-                        <DialogTitle>{t('admin.geo.intro.title')}</DialogTitle>
+                        <DialogTitle>{t('admin.geo.guide.title')}</DialogTitle>
                     </DialogHeader>
                     <ol className="grid gap-3 text-sm">
                         {(['step1', 'step2', 'step3'] as const).map((step) => (
                             <li key={step} className="space-y-1">
                                 <p className="font-semibold text-foreground">
-                                    {t(`admin.geo.intro.${step}Title`)}
+                                    {t(`admin.geo.guide.${step}Title`)}
                                 </p>
                                 <p className="text-xs text-muted-foreground leading-relaxed">
-                                    {t(`admin.geo.intro.${step}Body`)}
+                                    {t(`admin.geo.guide.${step}Body`)}
                                 </p>
                             </li>
                         ))}
                     </ol>
                     <DialogFooter>
                         <Button onClick={() => setIntroOpen(false)}>
-                            {t('admin.geo.intro.close')}
+                            {t('admin.geo.guide.close')}
                         </Button>
                     </DialogFooter>
                 </DialogContent>
@@ -618,9 +618,9 @@ export function GeoReviewPanel() {
             <Dialog open={rejectOpen} onOpenChange={(open) => !saving && setRejectOpen(open)}>
                 <DialogContent className="max-w-sm sm:max-w-md">
                     <DialogHeader>
-                        <DialogTitle>{t('admin.geo.rejectDialog.title')}</DialogTitle>
+                        <DialogTitle>{t('admin.geo.declineDialog.title')}</DialogTitle>
                         <DialogDescription>
-                            {t('admin.geo.rejectDialog.description')}
+                            {t('admin.geo.declineDialog.description')}
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter className="flex flex-col-reverse sm:flex-row gap-2">
@@ -629,7 +629,7 @@ export function GeoReviewPanel() {
                             onClick={() => setRejectOpen(false)}
                             disabled={saving}
                         >
-                            {t('admin.geo.rejectDialog.cancel')}
+                            {t('admin.geo.declineDialog.cancel')}
                         </Button>
                         <Button
                             variant="destructive"
@@ -637,7 +637,7 @@ export function GeoReviewPanel() {
                             disabled={saving}
                         >
                             {saving && <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />}
-                            {t('admin.geo.rejectDialog.confirm')}
+                            {t('admin.geo.declineDialog.confirm')}
                         </Button>
                     </DialogFooter>
                 </DialogContent>
@@ -646,9 +646,9 @@ export function GeoReviewPanel() {
             <Dialog open={demoteOpen} onOpenChange={(open) => !saving && setDemoteOpen(open)}>
                 <DialogContent className="max-w-sm sm:max-w-md">
                     <DialogHeader>
-                        <DialogTitle>{t('admin.geo.demoteDialog.title')}</DialogTitle>
+                        <DialogTitle>{t('admin.geo.removeOfficialDialog.title')}</DialogTitle>
                         <DialogDescription>
-                            {t('admin.geo.demoteDialog.description')}
+                            {t('admin.geo.removeOfficialDialog.description')}
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter className="flex flex-col-reverse sm:flex-row gap-2">
@@ -657,7 +657,7 @@ export function GeoReviewPanel() {
                             onClick={() => setDemoteOpen(false)}
                             disabled={saving}
                         >
-                            {t('admin.geo.demoteDialog.cancel')}
+                            {t('admin.geo.removeOfficialDialog.cancel')}
                         </Button>
                         <Button
                             variant="destructive"
@@ -665,7 +665,7 @@ export function GeoReviewPanel() {
                             disabled={saving}
                         >
                             {saving && <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />}
-                            {t('admin.geo.demoteDialog.confirm')}
+                            {t('admin.geo.removeOfficialDialog.confirm')}
                         </Button>
                     </DialogFooter>
                 </DialogContent>
@@ -704,7 +704,7 @@ function CandidateDetailBody({
     if (!detail || !detail.map) {
         return (
             <p className="text-xs text-muted-foreground">
-                {t('admin.geo.detailHint')}
+                {t('admin.geo.detailHintOfficial')}
             </p>
         )
     }
@@ -734,7 +734,7 @@ function CandidateDetailBody({
             {detail.meta ? (
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
                     <p className="text-xs text-warning">
-                        {t('admin.geo.alreadyPromoted')}
+                        {t('admin.geo.alreadyOfficial')}
                     </p>
                     <Button
                         size="sm"
@@ -744,7 +744,7 @@ function CandidateDetailBody({
                         className="w-full sm:w-auto"
                     >
                         <Trash2 className="h-3.5 w-3.5 mr-2" />
-                        {t('admin.geo.demote')}
+                        {t('admin.geo.actions.removeOfficial')}
                     </Button>
                 </div>
             ) : (
@@ -752,7 +752,7 @@ function CandidateDetailBody({
                     <span className="text-xs text-muted-foreground">
                         {pin
                             ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
-                            : t('admin.geo.pickPoint')}
+                            : t('admin.geo.pickPointForOfficial')}
                     </span>
                     <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
                         <Button
@@ -763,7 +763,7 @@ function CandidateDetailBody({
                             className="w-full sm:w-auto text-destructive border-destructive/40 hover:bg-destructive/10"
                         >
                             <Trash2 className="h-3.5 w-3.5 mr-2" />
-                            {t('admin.geo.reject')}
+                            {t('admin.geo.actions.decline')}
                         </Button>
                         <Button
                             size="sm"
@@ -774,7 +774,7 @@ function CandidateDetailBody({
                             {saving && (
                                 <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
                             )}
-                            {t('admin.geo.promote')}
+                            {t('admin.geo.actions.makeOfficial')}
                         </Button>
                     </div>
                 </div>

--- a/tasks/prd-geo-moderation-simplification.md
+++ b/tasks/prd-geo-moderation-simplification.md
@@ -1,0 +1,147 @@
+# Modération Géo — Simplification PRD
+
+**Date:** 2026-04-27
+**Branch:** `claude/simplify-admin-workflow-CeEdS`
+**Owner:** Admin tooling
+**Status:** Phase 1 in progress
+
+---
+
+## Problem
+
+The admin "Modération Géo" page (`/fr/admin?tab=geo`) is hard to use:
+
+- Two stacked tab bars (outer `Acquisition / Géo / Signalements`, then inner `Épingles / Cartes / Jeux`).
+- Inner tabs are organised by **entity** (Pins / Maps / Games), not by **task**.
+- Default landing state opens on `collecting` candidates — work that is *not yet ready* for human action.
+- A "Comment cette page fonctionne" 3-step explainer is shipped to compensate for the unintuitive IA — itself a tell.
+- Header counters ("12/45 cartes", "0 épingles", "232 erreurs") are alarming but inert: they surface problems without routing to the fix.
+- Schema words leak into the UI: "Promus / Rétrograder / Méta" describe row mutations rather than admin intent.
+- Promoting a candidate dumps the admin back to the top of the list with no auto-advance.
+
+## Goal
+
+The page should answer one question on load:
+**"Is tomorrow's daily Géo challenge ready to ship — and if not, what do I need to do right now?"**
+
+## Success metrics
+
+- Median time-to-decide per candidate < 8 s.
+- ≥ 85 % of admin Géo sessions touch only the default queue (no tab switches).
+- Help panel can be removed in Phase 3 without complaints.
+
+---
+
+## Scope
+
+### Phase 1 — Quick wins (S, ≤ 1 day, no structural risk)
+
+Ship in `claude/simplify-admin-workflow-CeEdS`.
+
+1. **Default `statusFilter` to `pending`** (`GeoReviewPanel.tsx:157`). Admins land on actionable work, not noise.
+2. **Hide the "Comment cette page fonctionne" panel behind a `?` icon button.** Same content, surfaced via a Dialog, no longer occupying the top of the flow.
+3. **Make header counters interactive** (`GeoHeaderStrip.tsx`):
+   - `maps` counter → switch to `maps` tab.
+   - `pins` counter → switch to `pins` tab with `statusFilter = 'pending'`.
+   - `errors` counter → open a Popover listing recent failures from `health.failures`.
+   - `nextChallenge` stays inert (info only).
+4. **"Promote & next" auto-advance.** After a successful override/promote, automatically open the next pending candidate in the list. If the list is exhausted, return to the empty "pick one" state. Preserve scroll position in the candidate list.
+
+**Out of scope for Phase 1:** label renames, restructure, removing tabs, removing the "Planifier" button.
+
+### Phase 2 — Vocabulary cleanup (M, 1–2 days)
+
+Rename schema-leaking terms to admin-facing words. Final rename table is in the appendix. Highlights:
+
+| Concept | Old FR | New FR | Old EN | New EN |
+|---|---|---|---|---|
+| Candidate / Pin (unified) | Candidat / Épingle | Proposition | Candidate / Pin | Submission |
+| Meta (canonical) | Méta | Lieu officiel | Meta | Official location |
+| Promote (verb) | Promouvoir | Officialiser | Promote | Make official |
+| Demote (verb) | Rétrograder | Retirer du lieu officiel | Demote | Remove from official |
+| Reject (verb) | Rejeter | Refuser | Reject | Decline |
+| Status `pending` | En attente | À modérer | Pending | Awaiting review |
+| Status `promoted` | Promus | Officialisé | Promoted | Made official |
+| Tab: Pins | Épingles | Propositions | Pins | Submissions |
+
+Also: replace 4-chip status row + game badge with a unified queue header. Add new i18n keys alongside old, migrate components, then delete old keys in a follow-up.
+
+### Phase 3 — Restructure (M–L, 3–5 days, only if Phase 1+2 don't fix it)
+
+- Collapse to **2 inner tabs**: *À examiner* (today's queue, default) + *Catalogue* (Jeux + Cartes merged — both are reference data).
+- "Planifier" + run state + errors fold into a single "État du pipeline" strip with a clear *Ready / Not ready for {date}* banner at the top.
+- `viewCapturesForGame` teleport (`GeoReviewPanel.tsx:250-254`) becomes a simple game filter on the queue.
+- `useGeoRunPolling` and `useGeoHealth` move behind a route-level visibility guard if the panel is split into routes.
+
+---
+
+## Implementation notes
+
+- **Source of truth for copy:** `packages/frontend/public/locales/fr/translation.json` under `admin.geo.*`. Mirror EN in the same commit.
+- **No backend changes for Phase 1 or Phase 2.** Existing endpoints (`GET /api/admin/geo/candidates`, `POST .../override`, `POST .../reject`, `DELETE /api/admin/geo/meta/:id`, `POST /api/admin/geo/schedule`) are tab-agnostic.
+- **Rename strategy:** add new keys, migrate components, delete old in a follow-up commit. Never rename a key in place — Crowdin/PR diff noise hides regressions.
+- **Status badge fallback** (`GeoReviewPanel.tsx:296-302`) returns the raw status when no key exists — make sure renamed status values either have a key or never reach the UI.
+
+## Risks
+
+- `viewCapturesForGame` teleport hides state across tabs; restructure must replicate or admins lose game-scoped filters silently.
+- The candidate refetch effect (`GeoReviewPanel.tsx:204-217`) keys only on `[statusFilter, gameFilter?.gameId]`, not `activeTab`; switching tabs leaves stale data for ~1 frame. Phase 1 doesn't introduce a new tab, but Phase 3 will.
+- `useIsMobile()` switches between bottom sheet and side card while sharing `pin` state; resizing across the breakpoint mid-edit drops the pin silently.
+- I18n keys: ~132 references across the three Geo files. Renames need a `grep -rn "admin\\.geo\\." packages/frontend/src` audit per commit.
+
+## Out of scope
+
+- Automating the "Planifier" cron (PM persona suggested it; cleaner as a separate worker change).
+- Splitting the JobQueuePanel out of admin (errors counter Popover is a smaller move).
+- Mobile-only redesign of the Géo page.
+
+---
+
+## Appendix A — Full rename table (Phase 2 source of truth)
+
+| Concept | Old FR | New FR | Old EN | New EN | Why |
+|---|---|---|---|---|---|
+| Candidate (entity) | Candidat | Proposition | Candidate | Submission | "Candidat" implies a person; these are user-submitted location proposals. |
+| Community pin | Épingle | Proposition | Pin | Submission | Unify with Candidate; "épingle" was overloaded with the map marker visual. |
+| Canonical pin | Méta | Lieu officiel | Meta | Official location | "Méta" is jargon; "lieu officiel" reads on first contact for moderators. |
+| Status: collecting | En collecte | Ouvert aux propositions | Collecting | Open for submissions | Active voice; says what the moderator can do. |
+| Status: pending | En attente | À modérer | Pending | Awaiting review | Calls the moderator to action. |
+| Status: promoted | Promu | Officialisé | Promoted | Made official | Matches "Lieu officiel". |
+| Status: rejected | Rejeté | Refusé | Rejected | Declined | Softer FR register, consistent with moderation tone. |
+| Status: archived | Archivé | Archivé | Archived | Archived | Already clear. |
+| Verb: promote | Promouvoir | Officialiser | Promote | Make official | Same root as the status. |
+| Verb: demote | Rétrograder | Retirer du lieu officiel | Demote | Remove from official | "Rétrograder" feels punitive. |
+| Verb: reject | Rejeter | Refuser | Reject | Decline | Mirrors status. |
+| Tab: Pins | Épingles | Propositions | Pins | Submissions | Unified entity name. |
+| Tab: Maps | Cartes | Cartes | Maps | Maps | Keep. |
+| Tab: Games | Jeux | Jeux | Games | Games | Keep. |
+| Counter: cartes | cartes | cartes couvertes | maps | maps covered | Disambiguates from Maps tab count. |
+| Counter: épingles | épingles | propositions reçues | pins | submissions received | Unified naming. |
+| Counter: erreurs | erreurs | signalements | errors | reports | "Erreurs" implied bug; these are user reports. |
+| Counter: prochain | prochain | prochaine purge | next | next purge | "Prochain" alone was contextless. |
+| Help section | Comment cette page fonctionne | Guide de modération | How this page works | Moderation guide | Reads as a reusable doc title, not a tooltip. |
+
+## Appendix B — Translation key migration plan
+
+Under `admin.geo.*`:
+
+- **Copy-only changes** (keep the keys): `statusBadge.{collecting|pending|promoted|rejected|archived}`, `statusFilter.*`, `gameFilter.*`.
+- **Structural renames** (new key, retire old):
+  - `candidateRow.*` → `submissionRow.*`
+  - `rejectDialog.*` → `declineDialog.*`
+  - `demoteDialog.*` → `removeOfficialDialog.*`
+  - `intro.*` → `guide.*`
+  - `tabs.pins` → `tabs.submissions` (`tabs.maps`, `tabs.games` keep)
+  - `strip.{maps|pins|errors|nextChallenge}` → `strip.{mapsCovered|submissionsReceived|reports|nextPurge}`
+- **New keys**:
+  - `entities.submission`, `entities.officialLocation` (used by tooltips, empty states, aria labels)
+  - `actions.{makeOfficial|removeOfficial|decline}` (replacing `promote`, `demote`, `reject`)
+
+## Appendix C — Risks before merging Phase 2
+
+- **Status badge fallback** (`GeoReviewPanel.tsx:296-302`) resolves `admin.geo.statusBadge.${status}` from the DB enum. Status enum values stay (`collecting`, `pending`, `promoted`, `rejected`, `archived`) — only the translated *copy* changes. Do NOT rename the keys themselves or untranslated DB values will leak through.
+- **E2E selectors**: Playwright specs likely use FR text like "Promouvoir", "Rejeter", "Candidat". Update locators in the same PR (`packages/frontend/e2e/admin-*.spec.ts`).
+- **Backend log/audit strings**: `admin.service.ts` and worker logs may emit `"promoted candidate ..."`. Decide explicitly: leave logs alone, UI-only rename.
+- **Wire/API names** (`candidate`, `pin`, `meta` in JSON responses and Socket events) stay unchanged this PR; rename is UI-only. Document so a follow-up PR can do the API rename behind a deprecation window.
+- **EN/FR drift**: enforce that `fr/translation.json` and `en/translation.json` ship in the same commit; consider a CI check diffing key sets.
+


### PR DESCRIPTION
## Summary

The admin Modération Géo page used to expose two stacked tab bars, four status chips, a "Comment cette page fonctionne" 3-step explainer and several schema-leaking words ("candidat", "épingle", "promouvoir", "méta"). Persona meeting (UX / PM / Engineer / Admin power user / IA) flagged the page as task-unaware: it forced moderators to assemble "what needs my decision today?" themselves.

This PR ships the 3-phase plan documented in `tasks/prd-geo-moderation-simplification.md`:

- **Phase 1** (`f22682f`) — Default `statusFilter` to `pending`; hide the help panel behind a `?` icon; make header counters interactive (maps → tab, pins → queue, errors → Popover with `health.failures`); auto-advance after Promote / Reject.
- **Phase 2** (`0323317`) — Vocabulary rename (UI-only, wire format unchanged): tab "Épingles" → "Propositions", verbs Promouvoir/Rétrograder/Rejeter → Officialiser/Retirer du lieu officiel/Refuser, status badges En attente/Promu → À modérer/Officialisé, help dialog → "Guide de modération", counter labels updated.
- **Phase 3** (`ff40d2e`) — Collapse 3 inner tabs to 2 (À examiner / Catalogue, with a Maps↔Games sub-toggle inside Catalogue); new `GeoReadinessBanner` answers "is the next daily challenge ready?" at the top of the page and owns the Planifier action.
- **Cleanup** (`6c03fbf`) — Drop 88 lines of orphaned i18n keys retired by Phases 2 + 3.

DB enum values, Socket events and REST payload field names are unchanged. UI-only refactor.

## Test plan

- [ ] Manual smoke: open `/fr/admin?tab=geo` — page lands on the moderation queue (À examiner) with `pending` filter pre-applied.
- [ ] Help: click the `?` icon next to "Propositions (N)" — Guide dialog opens with 3 steps; Close returns to queue.
- [ ] Header counters: `cartes couvertes` jumps to Catalogue + Maps; `propositions` jumps to À examiner + pending; `signalements` opens a Popover listing recent failures.
- [ ] Promote-and-next: officialise a submission — auto-advances to the next pending submission without scroll reset.
- [ ] Reject-and-next: same auto-advance behaviour after Refuser.
- [ ] Catalogue tab: segmented sub-toggle flips Cartes ↔ Jeux without remounting the panel; existing `viewCapturesForGame` from Maps still teleports to À examiner with the game filter.
- [ ] Readiness banner: with `nextChallenge` present → green "Défi prêt pour le {date}"; without → amber "Aucun défi programmé" + Planifier button (skipped during cold-start).
- [ ] Cold-start path (`coverage.curated === 0` or `withMap === 0`) still surfaces `GeoColdStartBanner`, not the readiness banner.
- [ ] EN (`/en/admin?tab=geo`) mirrors the FR copy: Submissions / Make official / Decline / Remove official location / Moderation guide.
- [ ] `npm run build` and `npm run lint` clean (validated locally; 5 pre-existing unrelated warnings).
- [ ] Playwright `geo-admin.spec.ts` — no FR text selectors were used by the spec, but a real run is recommended.

https://claude.ai/code/session_01ACGmXHJdPgHVkLAm1gvo52