### PR TITLE
feat(geo): switch daily challenge to manual slow rollout

### DIFF
--- a/packages/backend/migrations/20260427_geo_challenge_is_current.ts
+++ b/packages/backend/migrations/20260427_geo_challenge_is_current.ts
@@ -1,0 +1,44 @@
+import type { Knex } from 'knex'
+
+// Switches the geo daily-rotation model to a slow, manual rollout: a single
+// `is_current=true` row per tier marks the challenge currently shown on the
+// geo page. New challenges no longer auto-rotate at midnight — admins decide
+// when to release the next one. The recurring scheduler is disabled in
+// `index.ts`; the manual escape-hatch route still works and now also flips
+// the new row's `is_current` flag (rotating off whatever was previous).
+//
+// The partial unique index enforces "at most one current per tier" without
+// requiring NULL-juggling: only rows with `is_current = true` participate.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('geo_challenge', (table) => {
+    table.boolean('is_current').notNullable().defaultTo(false)
+  })
+
+  // Backfill: the most recent challenge per tier becomes the current one.
+  // Without this, /api/geo/current would 404 the moment the migration lands
+  // even though there are perfectly playable rows in the table.
+  await knex.raw(`
+    UPDATE geo_challenge gc
+    SET is_current = true
+    FROM (
+      SELECT DISTINCT ON (tier) id, tier
+      FROM geo_challenge
+      ORDER BY tier, challenge_date DESC, id DESC
+    ) latest
+    WHERE gc.id = latest.id
+  `)
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX geo_challenge_one_current_per_tier
+    ON geo_challenge (tier)
+    WHERE is_current = true
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP INDEX IF EXISTS geo_challenge_one_current_per_tier')
+  await knex.schema.alterTable('geo_challenge', (table) => {
+    table.dropColumn('is_current')
+  })
+}

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -620,12 +620,14 @@ export interface GeoScreenshotRepository {
 
 export interface GeoChallengeRepository {
   findByDate(date: string, tier?: number): Promise<GeoChallenge | null>
+  findCurrent(tier?: number): Promise<GeoChallenge | null>
   listRecent(days: number): Promise<GeoChallenge[]>
   create(data: {
     challengeDate: string
     geoScreenshotMetaId: number
     tier?: number
   }): Promise<GeoChallenge>
+  setCurrent(args: { challengeId: number; tier?: number }): Promise<void>
   findGuess(
     userId: string,
     challengeId: number,

--- a/packages/backend/src/domain/services/geo-game.service.ts
+++ b/packages/backend/src/domain/services/geo-game.service.ts
@@ -57,6 +57,10 @@ export interface GeoGameService {
     userId?: string
   }): Promise<GeoDailyChallengeView | null>
 
+  getCurrentChallenge(args: {
+    userId?: string
+  }): Promise<GeoDailyChallengeView | null>
+
   submitGuess(args: {
     userId: string
     challengeId: number
@@ -125,50 +129,66 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
   } = deps
   const log = deps.logger.child({ service: 'geo-game' })
 
+  // Hydrate a challenge row into the full view (meta + candidate + map +
+  // hasGuessed). Shared between the date-pinned `/daily/:date` lookup
+  // (used by history) and the current-challenge `/current` lookup (used
+  // by the public geo page during slow rollout).
+  async function hydrate(
+    challenge: GeoChallenge,
+    userId?: string,
+  ): Promise<GeoDailyChallengeView | null> {
+    const meta = await geoScreenshotRepository.findMetaById(challenge.geoScreenshotMetaId)
+    if (!meta) {
+      log.error({ challengeId: challenge.id }, 'challenge references missing meta')
+      return null
+    }
+
+    const candidate = await geoScreenshotRepository.findCandidateById(
+      meta.geoScreenshotCandidateId,
+    )
+    if (!candidate) {
+      log.error({ metaId: meta.id }, 'meta references missing candidate')
+      return null
+    }
+
+    const map = await geoMapRepository.findById(meta.geoMapId)
+    if (!map) {
+      log.error({ metaId: meta.id }, 'meta references missing map')
+      return null
+    }
+
+    if (isPlaceholderImageUrl(candidate.imageUrl) || isPlaceholderImageUrl(map.imageUrl)) {
+      log.error(
+        {
+          challengeId: challenge.id,
+          candidateImageUrl: candidate.imageUrl,
+          mapImageUrl: map.imageUrl,
+        },
+        'refusing to serve geo challenge backed by placeholder image URL',
+      )
+      return null
+    }
+
+    let hasGuessed = false
+    if (userId) {
+      const existing = await geoChallengeRepository.findGuess(userId, challenge.id)
+      hasGuessed = !!existing
+    }
+
+    return { challenge, meta, candidate, map, hasGuessed }
+  }
+
   return {
     async getDailyChallenge({ date, userId }) {
       const challenge = await geoChallengeRepository.findByDate(date, 1)
       if (!challenge) return null
+      return hydrate(challenge, userId)
+    },
 
-      const meta = await geoScreenshotRepository.findMetaById(challenge.geoScreenshotMetaId)
-      if (!meta) {
-        log.error({ challengeId: challenge.id }, 'challenge references missing meta')
-        return null
-      }
-
-      const candidate = await geoScreenshotRepository.findCandidateById(
-        meta.geoScreenshotCandidateId,
-      )
-      if (!candidate) {
-        log.error({ metaId: meta.id }, 'meta references missing candidate')
-        return null
-      }
-
-      const map = await geoMapRepository.findById(meta.geoMapId)
-      if (!map) {
-        log.error({ metaId: meta.id }, 'meta references missing map')
-        return null
-      }
-
-      if (isPlaceholderImageUrl(candidate.imageUrl) || isPlaceholderImageUrl(map.imageUrl)) {
-        log.error(
-          {
-            challengeId: challenge.id,
-            candidateImageUrl: candidate.imageUrl,
-            mapImageUrl: map.imageUrl,
-          },
-          'refusing to serve daily challenge backed by placeholder image URL',
-        )
-        return null
-      }
-
-      let hasGuessed = false
-      if (userId) {
-        const existing = await geoChallengeRepository.findGuess(userId, challenge.id)
-        hasGuessed = !!existing
-      }
-
-      return { challenge, meta, candidate, map, hasGuessed }
+    async getCurrentChallenge({ userId }) {
+      const challenge = await geoChallengeRepository.findCurrent(1)
+      if (!challenge) return null
+      return hydrate(challenge, userId)
     },
 
     async submitGuess({ userId, challengeId, guess, durationMs }) {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -460,10 +460,11 @@ async function start(): Promise<void> {
       logger.warn({ error: String(error) }, 'failed to enqueue referral-announcement-email job')
     }
 
-    // Schedule recurring geo daily challenge creation (00:05 UTC daily — runs
-    // shortly after the main create-daily-challenge cron so the new calendar
-    // day has rolled over before scheduleDailyGeoChallenge() picks today's
-    // date). Re-registered every boot so config changes take effect.
+    // Geo recurring jobs. Daily auto-rotation is intentionally NOT scheduled:
+    // the geo mode is in slow-rollout phase and challenges are released
+    // manually by admins via POST /api/admin/geo/schedule (or the dedicated
+    // release endpoint). Any leftover recurring scheduler from a previous
+    // boot is cleaned up here so a redeploy off the cron actually stops it.
     try {
       const existing = await geoQueue.getRepeatableJobs()
       for (const job of existing) {
@@ -475,15 +476,6 @@ async function start(): Promise<void> {
           await geoQueue.removeRepeatableByKey(job.key)
         }
       }
-      await geoQueue.add(
-        'schedule-daily-challenge',
-        { kind: 'schedule-daily-challenge' },
-        {
-          repeat: { pattern: '5 0 * * *', tz: 'UTC' }, // Cron: 00:05 UTC daily
-          jobId: 'schedule-daily-geo-challenge-recurring',
-        }
-      )
-      logger.info('scheduled recurring schedule-daily-challenge geo job (daily at 00:05 UTC)')
 
       // Auto-resolve metadata for curated games every 30 min: HEADs Fandom +
       // Steam storesearch and fills in steam_app_id / wiki_subdomain.
@@ -509,7 +501,7 @@ async function start(): Promise<void> {
       )
       logger.info('scheduled recurring ingest-tick geo job (every 15 min)')
     } catch (error) {
-      logger.warn({ error: String(error) }, 'failed to schedule recurring geo daily challenge job')
+      logger.warn({ error: String(error) }, 'failed to register recurring geo jobs')
     }
 
     // Log final repeatable jobs configuration with next run times

--- a/packages/backend/src/infrastructure/queue/workers/geo-schedule-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-schedule-logic.ts
@@ -17,20 +17,27 @@ export interface ScheduleDailyChallengeResult {
 
 /**
  * Pick a promoted (canonical) screenshot at random from any game that has
- * one and create tomorrow's — or a given date's — geo challenge. Idempotent
- * on (date, tier=1): re-runs are safe.
+ * one and create a challenge for the given date (defaults to today, since
+ * we no longer auto-rotate at midnight). Idempotent on (date, tier=1):
+ * re-runs are safe.
  *
- * Intentionally simple: the MVP pilots on a single game, so global-random
- * effectively picks among Elden Ring's promoted entries. When we open a
- * second game, this can be replaced with a rotation strategy.
+ * The slow-rollout model: this used to run from a recurring cron and
+ * stamp tomorrow's date. It is now invoked manually by an admin via
+ * POST /api/admin/geo/schedule (or the dedicated /release endpoint), and
+ * the newly created row is also marked `is_current = true` so the public
+ * /api/geo/current endpoint surfaces it immediately. Whatever was
+ * previously current is rotated off in the same transaction.
  */
 export async function scheduleDailyGeoChallenge(
   date?: string,
 ): Promise<ScheduleDailyChallengeResult> {
-  const target = date ?? isoDate(tomorrow())
+  const target = date ?? today()
 
   const existing = await geoChallengeRepository.findByDate(target, 1)
   if (existing) {
+    // Idempotent re-runs still re-promote to current — useful when an
+    // admin clicks "release again" after manually demoting via SQL.
+    await geoChallengeRepository.setCurrent({ challengeId: existing.id, tier: 1 })
     return {
       created: false,
       challengeDate: target,
@@ -81,9 +88,11 @@ export async function scheduleDailyGeoChallenge(
     tier: 1,
   })
 
+  await geoChallengeRepository.setCurrent({ challengeId: challenge.id, tier: 1 })
+
   log.info(
     { challengeDate: target, challengeId: challenge.id, metaId: meta.id },
-    'scheduled geo challenge',
+    'scheduled geo challenge (released as current)',
   )
 
   return {
@@ -94,12 +103,6 @@ export async function scheduleDailyGeoChallenge(
   }
 }
 
-function tomorrow(): Date {
-  const d = new Date()
-  d.setUTCDate(d.getUTCDate() + 1)
-  return d
-}
-
-function isoDate(d: Date): string {
-  return d.toISOString().slice(0, 10)
+function today(): string {
+  return new Date().toISOString().slice(0, 10)
 }

--- a/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
@@ -9,6 +9,7 @@ export interface GeoChallengeRow {
   challenge_date: Date
   geo_screenshot_meta_id: number
   tier: number
+  is_current: boolean
   created_at: Date
 }
 
@@ -47,6 +48,13 @@ export const geoChallengeRepository = {
     return row ? mapChallenge(row) : null
   },
 
+  async findCurrent(tier = 1): Promise<GeoChallenge | null> {
+    const row = await db('geo_challenge')
+      .where({ is_current: true, tier })
+      .first<GeoChallengeRow>()
+    return row ? mapChallenge(row) : null
+  },
+
   async listRecent(days: number): Promise<GeoChallenge[]> {
     const rows = await db('geo_challenge')
       .where('challenge_date', '>=', db.raw(`CURRENT_DATE - INTERVAL '${days} days'`))
@@ -69,6 +77,24 @@ export const geoChallengeRepository = {
       })
       .returning<GeoChallengeRow[]>('*')
     return mapChallenge(row!)
+  },
+
+  // Atomically promote `challengeId` to current and demote any existing
+  // current row in the same tier. Wrapped in a transaction because the
+  // partial unique index `geo_challenge_one_current_per_tier` would
+  // otherwise reject the second statement if run independently.
+  async setCurrent(args: { challengeId: number; tier?: number }): Promise<void> {
+    const tier = args.tier ?? 1
+    log.info({ challengeId: args.challengeId, tier }, 'setCurrent')
+    await db.transaction(async (trx) => {
+      await trx('geo_challenge')
+        .where({ tier, is_current: true })
+        .whereNot('id', args.challengeId)
+        .update({ is_current: false })
+      await trx('geo_challenge')
+        .where({ id: args.challengeId, tier })
+        .update({ is_current: true })
+    })
   },
 
   // ---- Guesses ----

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -41,6 +41,7 @@ import {
   geoScreenshotRepository,
   geoPinRepository,
   geoMapRepository,
+  geoChallengeRepository,
   geoIngestFailureRepository,
   screenshotReportRepository,
   emailLogRepository,
@@ -2593,14 +2594,44 @@ router.get('/geo/run/state', async (_req, res, next) => {
 })
 
 router.post('/geo/schedule', async (_req, res, next) => {
-  // Manual fallback: trigger the daily-challenge scheduler immediately.
-  // The recurring 00:05 UTC job is the primary path; this is an escape
-  // hatch when ops needs to refill the calendar mid-day.
+  // Primary release path during slow rollout: enqueues the scheduler,
+  // which picks a random promoted screenshot, creates today's challenge,
+  // and flips it to `is_current = true` (rotating off the previous one).
+  // Admins call this when they're ready to move on from the current
+  // game; there is intentionally no recurring cron behind it.
   try {
     const job = await geoQueue.add('schedule-daily-challenge', {
       kind: 'schedule-daily-challenge',
     })
     res.json({ success: true, data: { jobId: job.id } })
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.post('/geo/challenges/:id/release', async (req, res, next) => {
+  // Manually promote a specific existing challenge to `is_current`.
+  // Useful for re-releasing a past challenge or staging a row created
+  // out-of-band (e.g. seed data) without re-running the random picker.
+  try {
+    const id = Number(req.params.id)
+    if (!Number.isFinite(id) || id <= 0) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+
+    const recent = await geoChallengeRepository.listRecent(365)
+    const exists = recent.some((c) => c.id === id)
+    if (!exists) {
+      res.status(404).json({
+        success: false,
+        error: { code: 'CHALLENGE_NOT_FOUND', message: 'challenge not found' },
+      })
+      return
+    }
+
+    await geoChallengeRepository.setCurrent({ challengeId: id, tier: 1 })
+    res.json({ success: true, data: { challengeId: id, isCurrent: true } })
   } catch (err) {
     next(err)
   }

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -58,7 +58,28 @@ const historyQuerySchema = z.object({
   days: z.coerce.number().int().positive().max(30).optional(),
 })
 
-// ---------- Daily challenge ----------
+// ---------- Current / daily challenge ----------
+
+// Slow-rollout entrypoint: returns whichever challenge is currently flagged
+// `is_current = true`. Used by the public /geo page; admins control rollout
+// by manually releasing the next challenge instead of relying on a midnight
+// cron. Falls through to 404 NO_CHALLENGE when no row is flagged so the
+// frontend can render a "coming soon" state.
+router.get('/current', optionalAuthMiddleware, async (req, res, next) => {
+  try {
+    const view = await geoGameService.getCurrentChallenge({ userId: req.userId })
+    if (!view) {
+      res.status(404).json({
+        success: false,
+        error: { code: 'NO_CHALLENGE', message: 'no geo challenge is currently released' },
+      })
+      return
+    }
+    res.json({ success: true, data: view })
+  } catch (err) {
+    next(err)
+  }
+})
 
 router.get('/daily/:date', optionalAuthMiddleware, validateParams(dateSchema), async (req, res, next) => {
   try {

--- a/packages/frontend/e2e/geo-daily.spec.ts
+++ b/packages/frontend/e2e/geo-daily.spec.ts
@@ -35,7 +35,7 @@ test.describe('Geo Daily', () => {
 
         // Either the challenge heading or a "no challenge" 404 state is acceptable
         // — the flag is on but seeds might not include today.
-        const heading = page.getByRole('heading', { name: /daily geo|défi géo/i })
+        const heading = page.getByRole('heading', { name: /geo challenge|défi géo/i })
         const notFound = page.getByText(/no.*challenge|aucun défi/i)
         await expect(heading.or(notFound).first()).toBeVisible({ timeout: 10_000 })
     })

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -267,10 +267,10 @@
     },
     "geoAlpha": {
       "badge": "Alpha",
-      "eyebrow": "New: Geo Daily",
+      "eyebrow": "New: Geo Mode",
       "title": "Find the spot. Drop the pin.",
-      "subtitle": "A daily challenge to pinpoint where game screenshots are taken on the world map. Elden Ring is live — more worlds on the way.",
-      "cta": "Play Geo Daily",
+      "subtitle": "Pinpoint where game screenshots are taken on the world map. Elden Ring is live — more worlds rolling out as we go.",
+      "cta": "Play Geo",
       "secondary": "See the geo leaderboard"
     },
     "achievements": {
@@ -1398,7 +1398,7 @@
   },
   "geo": {
     "daily": {
-      "title": "Daily Geo Challenge",
+      "title": "Geo Challenge",
       "subtitle": "Pin the exact spot on the map where this screenshot was taken.",
       "screenshot": "Screenshot",
       "map": "Map",
@@ -1411,8 +1411,8 @@
       "mapUnavailable": "Map unavailable.",
       "loading": "Loading challenge…",
       "errors": {
-        "noChallenge": "No geo challenge is available for today yet. Please check back later.",
-        "nextIn": "Next challenge in {{countdown}}",
+        "noChallenge": "No geo game is live right now. We're rolling out new ones gradually — check back soon.",
+        "comingSoon": "New game coming soon",
         "viewHistory": "View past challenges"
       }
     },

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -267,10 +267,10 @@
     },
     "geoAlpha": {
       "badge": "Alpha",
-      "eyebrow": "Nouveau : Geo Daily",
+      "eyebrow": "Nouveau : Mode Géo",
       "title": "Trouve l'endroit. Pose l'épingle.",
-      "subtitle": "Pour l'instant, c'est Elden Ring. Plante ton épingle pile où la capture a été prise — sinon ça compte pas.",
-      "cta": "Jouer Geo Daily",
+      "subtitle": "Pour l'instant, c'est Elden Ring. Plante ton épingle pile où la capture a été prise — d'autres mondes arrivent au fil du déploiement.",
+      "cta": "Jouer Géo",
       "secondary": "Voir le classement"
     },
     "achievements": {
@@ -1398,7 +1398,7 @@
   },
   "geo": {
     "daily": {
-      "title": "Défi Géo Quotidien",
+      "title": "Défi Géo",
       "subtitle": "Épinglez l'endroit exact où cette capture a été prise.",
       "screenshot": "Capture d'écran",
       "map": "Carte",
@@ -1411,8 +1411,8 @@
       "mapUnavailable": "Carte indisponible.",
       "loading": "Chargement du défi…",
       "errors": {
-        "noChallenge": "Aucun défi géo n'est encore disponible pour aujourd'hui. Revenez plus tard.",
-        "nextIn": "Prochain défi dans {{countdown}}",
+        "noChallenge": "Aucun défi géo n'est en ligne pour le moment. On les déploie progressivement — revenez bientôt.",
+        "comingSoon": "Nouveau défi à venir",
         "viewHistory": "Voir les défis passés"
       }
     },

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -70,6 +70,10 @@ export interface GeoContributorMe {
 }
 
 export const geoApi = {
+    getCurrent(): Promise<GeoDailyView> {
+        return request<GeoDailyView>('/api/geo/current')
+    },
+
     getDaily(date: string): Promise<GeoDailyView> {
         return request<GeoDailyView>(`/api/geo/daily/${date}`)
     },

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -8,15 +8,10 @@ import { ReportCaptureDialog } from '@/components/ReportCaptureDialog'
 import { CubeBackground } from '@/components/backgrounds/CubeBackground'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { ImageOff, Loader2, MapPin, Trophy, Clock, History } from 'lucide-react'
+import { ImageOff, Loader2, MapPin, Trophy, Hourglass, History } from 'lucide-react'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
-import { useNextDailyCountdown } from '@/hooks/useNextDailyCountdown'
 import { Link } from 'react-router-dom'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
-
-function todayIso(): string {
-    return new Date().toISOString().slice(0, 10)
-}
 
 export default function GeoDailyPage() {
     const { t, i18n } = useTranslation()
@@ -32,19 +27,18 @@ export default function GeoDailyPage() {
         result,
         errorMessage,
         errorCode,
-        loadDaily,
+        loadCurrent,
         setPendingGuess,
         submitGuess,
     } = useGeoStore()
 
-    const [date] = useState(todayIso)
     // useRef's initial value runs on every render; lazy-via-useState keeps
     // Date.now() out of render while staying mount-stable.
     const [startedAt] = useState(() => Date.now())
 
     useEffect(() => {
-        loadDaily(date)
-    }, [date, loadDaily])
+        loadCurrent()
+    }, [loadCurrent])
 
     useEffect(() => {
         connectGeoSocket(session?.user?.id)
@@ -63,7 +57,7 @@ export default function GeoDailyPage() {
             <div className="container mx-auto max-w-5xl px-4 py-8 space-y-6 relative z-10">
                 <header className="space-y-1">
                     <h1 className="text-3xl font-bold tracking-tight gradient-gaming bg-clip-text text-transparent">
-                        {t('geo.daily.title', 'Daily Geo Challenge')}
+                        {t('geo.daily.title', 'Geo Challenge')}
                     </h1>
                     <p className="text-sm text-muted-foreground">
                         {t(
@@ -220,31 +214,27 @@ function ScreenshotFrame({ imageUrl }: { imageUrl: string }) {
     )
 }
 
-// Shown when /api/geo/daily/{date} returns 404 NO_CHALLENGE — usually right
-// after an admin reset or before the daily scheduler has had a chance to
-// run. Gives the player the time-to-next-challenge so they don't think the
-// game is broken, plus a path back to past results.
+// Shown when /api/geo/current returns 404 NO_CHALLENGE — i.e. no row is
+// flagged `is_current`. During slow rollout this is expected between
+// games (admins release manually, no midnight cron), so the copy and
+// missing countdown both signal "we'll release the next one when we're
+// ready" rather than "broken — try at midnight".
 function NoChallengeCard() {
     const { t } = useTranslation()
-    const { hours, minutes, seconds } = useNextDailyCountdown()
     const { localizedPath } = useLocalizedPath()
-    const pad = (n: number) => String(n).padStart(2, '0')
-    const countdown = `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`
     return (
         <Card className="border-neon-pink/40">
             <CardContent className="py-10 text-center space-y-4">
                 <div className="inline-flex items-center gap-2 rounded-full border border-neon-pink/40 bg-neon-pink/5 px-3 py-1 text-xs text-neon-pink">
-                    <Clock className="h-3.5 w-3.5" aria-hidden />
-                    <span aria-live="polite">
-                        {t('geo.daily.errors.nextIn', 'Next challenge in {{countdown}}', {
-                            countdown,
-                        })}
+                    <Hourglass className="h-3.5 w-3.5" aria-hidden />
+                    <span>
+                        {t('geo.daily.errors.comingSoon', 'New game coming soon')}
                     </span>
                 </div>
                 <p className="text-sm text-muted-foreground max-w-md mx-auto leading-relaxed">
                     {t(
                         'geo.daily.errors.noChallenge',
-                        "No geo challenge is available for today yet. Please check back later.",
+                        "No geo game is live right now. We're rolling out new ones gradually — check back soon.",
                     )}
                 </p>
                 <div className="flex justify-center">

--- a/packages/frontend/src/stores/geoStore.ts
+++ b/packages/frontend/src/stores/geoStore.ts
@@ -47,6 +47,7 @@ interface GeoState {
     latestTierUp: GeoTierUpEvent | null
 
     // Actions
+    loadCurrent: () => Promise<void>
     loadDaily: (date: string) => Promise<void>
     setPendingGuess: (p: GeoPoint | null) => void
     submitGuess: (durationMs?: number) => Promise<GeoGuessResult | null>
@@ -66,6 +67,49 @@ interface GeoState {
 }
 
 const REWARD_BUFFER_MAX = 20
+
+// Shared loader for both `loadCurrent` and `loadDaily`. Snapshots the
+// store before kicking off the fetch so we can restore the player's
+// score after a reload or route round-trip — keyed on `challenge.id`,
+// so a rotation to a new challenge correctly drops yesterday's result.
+async function loadView(
+    get: () => GeoState,
+    set: (partial: Partial<GeoState>) => void,
+    fetcher: () => Promise<{
+        challenge: GeoChallenge
+        meta: GeoScreenshotMeta
+        candidate: GeoScreenshotCandidate
+        map: GeoMap
+        hasGuessed: boolean
+    }>,
+): Promise<void> {
+    const prev = get()
+    set({ phase: 'loading', errorMessage: null, errorCode: null })
+    try {
+        const view = await fetcher()
+        const restored =
+            view.hasGuessed &&
+            prev.result !== null &&
+            prev.challenge !== null &&
+            prev.challenge.id === view.challenge.id
+        set({
+            phase: restored ? 'result' : 'playing',
+            challenge: view.challenge,
+            meta: view.meta,
+            candidate: view.candidate,
+            map: view.map,
+            hasGuessed: view.hasGuessed,
+            result: restored ? prev.result : null,
+            pendingGuess: restored ? prev.pendingGuess : null,
+        })
+    } catch (err) {
+        set({
+            phase: 'error',
+            errorMessage: getApiErrorMessage(err, i18n.t('apiErrors.default')),
+            errorCode: err instanceof GeoApiError ? err.code : null,
+        })
+    }
+}
 
 export const useGeoStore = create<GeoState>()(
     persist(
@@ -89,41 +133,12 @@ export const useGeoStore = create<GeoState>()(
     recentRewards: [],
     latestTierUp: null,
 
+    async loadCurrent() {
+        await loadView(get, set, () => geoApi.getCurrent())
+    },
+
     async loadDaily(date) {
-        // Snapshot what was rehydrated (or held in memory) before we kick off
-        // the fetch — needed so we can restore the player's score after a
-        // page reload or a route round-trip.
-        const prev = get()
-        set({ phase: 'loading', errorMessage: null, errorCode: null })
-        try {
-            const view = await geoApi.getDaily(date)
-            // Survive reload: if the backend says "you already guessed" AND
-            // we have a persisted result for this exact challenge, restore
-            // the result phase instead of dropping the player back to a
-            // fresh playing state. The challenge.id guard makes day-to-day
-            // store rollover safe — yesterday's result is ignored.
-            const restored =
-                view.hasGuessed &&
-                prev.result !== null &&
-                prev.challenge !== null &&
-                prev.challenge.id === view.challenge.id
-            set({
-                phase: restored ? 'result' : 'playing',
-                challenge: view.challenge,
-                meta: view.meta,
-                candidate: view.candidate,
-                map: view.map,
-                hasGuessed: view.hasGuessed,
-                result: restored ? prev.result : null,
-                pendingGuess: restored ? prev.pendingGuess : null,
-            })
-        } catch (err) {
-            set({
-                phase: 'error',
-                errorMessage: getApiErrorMessage(err, i18n.t('apiErrors.default')),
-                errorCode: err instanceof GeoApiError ? err.code : null,
-            })
-        }
+        await loadView(get, set, () => geoApi.getDaily(date))
     },
 
     setPendingGuess(p) {


### PR DESCRIPTION
The geo challenge auto-rotated at 00:05 UTC, which assumed a deep pool
of promoted screenshots. While we ramp content, retire the daily cron
and gate releases on an `is_current` flag flipped by admins instead.

- Add `geo_challenge.is_current` with a partial unique index
  (one current row per tier) and backfill the most recent row.
- Drop the recurring `schedule-daily-challenge` job; clean up any
  leftover schedule registered by older builds.
- Add `findCurrent` / `setCurrent` repo methods and a shared `hydrate`
  path for the new `getCurrentChallenge` service.
- Expose `GET /api/geo/current` for the public page; keep
  `/daily/:date` for history. The manual scheduler and a new
  `POST /admin/geo/challenges/:id/release` both promote a row to
  current in the same transaction.
- Frontend page now calls `loadCurrent`, drops the midnight countdown,
  and renders a "new game coming soon" state when nothing is live.
- i18n: replace daily-rotation copy in fr+en for the page header,
  empty state, and home hero CTA.