### PR TITLE
feat(geo): let players skip challenges they don't recognize

### DIFF
--- a/packages/backend/migrations/20260427_geo_guess_skip.ts
+++ b/packages/backend/migrations/20260427_geo_guess_skip.ts
@@ -1,0 +1,35 @@
+import type { Knex } from 'knex'
+
+// Adds an `is_skip` flag to `geo_guess`. A skip is a deliberate
+// "I don't recognize this game" — written as a real row so the existing
+// PK `(user_id, geo_challenge_id)` keeps locking the slot for the day
+// (no skip-then-guess after asking Discord), but excluded from the
+// community-average aggregate (`getChallengeStats`) and from the
+// `geo_leaderboard_daily` / `geo_leaderboard_monthly` upserts so it
+// neither pollutes the average nor counts toward leaderboard rankings.
+//
+// Storing skips in the same table beats a sibling `geo_skip` table:
+// a single uniqueness check covers "one terminal action per challenge"
+// and `findGuess` keeps its existing signature.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('geo_guess', (table) => {
+    table.boolean('is_skip').notNullable().defaultTo(false)
+  })
+
+  // Partial index keeps the AVG(score) / COUNT(*) aggregate in
+  // `getChallengeStats` cheap as the table grows: the stats query only
+  // looks at attempted rows, so the index doesn't waste pages on skips.
+  await knex.raw(`
+    CREATE INDEX geo_guess_attempted_by_challenge
+    ON geo_guess (geo_challenge_id)
+    WHERE is_skip = false
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP INDEX IF EXISTS geo_guess_attempted_by_challenge')
+  await knex.schema.alterTable('geo_guess', (table) => {
+    table.dropColumn('is_skip')
+  })
+}

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -641,6 +641,7 @@ export interface GeoChallengeRepository {
     score: number
     score_version: number
     duration_ms: number | null
+    is_skip: boolean
     created_at: Date
   } | null>
   recordGuess(data: {
@@ -652,6 +653,7 @@ export interface GeoChallengeRepository {
     scoreVersion: number
     durationMs?: number
   }): Promise<GeoGuessResult>
+  recordSkip(data: { userId: string; geoChallengeId: number }): Promise<void>
   upsertDaily(args: { challengeDate: string; userId: string; score: number }): Promise<void>
   upsertMonthly(args: { period: string; userId: string; scoreDelta: number }): Promise<void>
   topDaily(challengeDate: string, limit?: number): Promise<GeoLeaderboardEntry[]>

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -21,6 +21,7 @@ import type {
   UserInventory,
   UserInventoryItem,
   GeoChallenge,
+  GeoChallengeWithStatus,
   GeoContributorStats,
   GeoContributorTier,
   GeoContributorTierThreshold,
@@ -622,6 +623,7 @@ export interface GeoChallengeRepository {
   findByDate(date: string, tier?: number): Promise<GeoChallenge | null>
   findCurrent(tier?: number): Promise<GeoChallenge | null>
   listRecent(days: number): Promise<GeoChallenge[]>
+  listRecentWithStatus(days: number, userId?: string): Promise<GeoChallengeWithStatus[]>
   create(data: {
     challengeDate: string
     geoScreenshotMetaId: number

--- a/packages/backend/src/domain/services/geo-game.service.ts
+++ b/packages/backend/src/domain/services/geo-game.service.ts
@@ -68,6 +68,8 @@ export interface GeoGameService {
     durationMs?: number
   }): Promise<GeoGuessResult>
 
+  submitSkip(args: { userId: string; challengeId: number }): Promise<void>
+
   getLeaderboardDaily(date: string, limit?: number): Promise<GeoLeaderboardEntry[]>
   getLeaderboardMonthly(period: string, limit?: number): Promise<GeoLeaderboardEntry[]>
 
@@ -244,6 +246,29 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
       const stats = await geoChallengeRepository.getChallengeStats(challengeId)
 
       return { ...result, averageScore: stats.averageScore, playerCount: stats.playerCount }
+    },
+
+    async submitSkip({ userId, challengeId }) {
+      // Skip shares the daily slot with submitGuess: same uniqueness
+      // check, same `ALREADY_GUESSED` 409. This kills the
+      // skip-then-ask-Discord-then-resubmit exploit and keeps a single
+      // terminal action per challenge per user.
+      const existing = await geoChallengeRepository.findGuess(userId, challengeId)
+      if (existing) {
+        throw new GeoGameError('already guessed this challenge', 'ALREADY_GUESSED')
+      }
+
+      const challenge = await (async () => {
+        const rows = await geoChallengeRepository.listRecent(30)
+        return rows.find((c) => c.id === challengeId) ?? null
+      })()
+      if (!challenge) {
+        throw new GeoGameError('challenge not found', 'CHALLENGE_NOT_FOUND')
+      }
+
+      await geoChallengeRepository.recordSkip({ userId, geoChallengeId: challengeId })
+      // Deliberately no `upsertDaily` / `upsertMonthly` — a skip is a
+      // non-attempt and must never appear on the leaderboard.
     },
 
     getLeaderboardDaily(date, limit) {

--- a/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
@@ -1,6 +1,12 @@
 import { db } from '../database/connection.js'
 import { repoLogger } from '../logger/logger.js'
-import type { GeoChallenge, GeoGuessResult, GeoLeaderboardEntry, GeoPoint } from '@the-box/types'
+import type {
+  GeoChallenge,
+  GeoChallengeWithStatus,
+  GeoGuessResult,
+  GeoLeaderboardEntry,
+  GeoPoint,
+} from '@the-box/types'
 
 const log = repoLogger.child({ repository: 'geo-challenge' })
 
@@ -62,6 +68,40 @@ export const geoChallengeRepository = {
       .orderBy('challenge_date', 'desc')
       .select<GeoChallengeRow[]>('*')
     return rows.map(mapChallenge)
+  },
+
+  // Same window as `listRecent` but enriched with the player's
+  // play-status so the frontend can find the next unplayed challenge in
+  // a single round-trip. A guess OR a skip both flip `has_guessed` to
+  // true (the day's slot is closed either way). Anonymous callers get
+  // `hasGuessed = false` for every row.
+  async listRecentWithStatus(
+    days: number,
+    userId?: string,
+  ): Promise<GeoChallengeWithStatus[]> {
+    const query = db('geo_challenge')
+      .where('challenge_date', '>=', db.raw(`CURRENT_DATE - INTERVAL '${days} days'`))
+      .orderBy('challenge_date', 'desc')
+
+    if (!userId) {
+      const rows = await query.select<GeoChallengeRow[]>('*')
+      return rows.map((r) => ({ ...mapChallenge(r), hasGuessed: false }))
+    }
+
+    const rows = await query
+      .leftJoin('geo_guess', function joinGuess() {
+        this.on('geo_guess.geo_challenge_id', '=', 'geo_challenge.id').andOn(
+          'geo_guess.user_id',
+          '=',
+          db.raw('?', [userId]),
+        )
+      })
+      .select<Array<GeoChallengeRow & { guess_id: number | null }>>(
+        'geo_challenge.*',
+        db.raw('geo_guess.id AS guess_id'),
+      )
+
+    return rows.map((r) => ({ ...mapChallenge(r), hasGuessed: r.guess_id !== null }))
   },
 
   async create(data: {

--- a/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
@@ -23,6 +23,7 @@ export interface GeoGuessRow {
   score: number
   score_version: number
   duration_ms: number | null
+  is_skip: boolean
   created_at: Date
 }
 
@@ -153,16 +154,36 @@ export const geoChallengeRepository = {
     }
   },
 
+  // Records a "skip" — the player declared they don't recognize the
+  // game. Stored in `geo_guess` with `is_skip = true` so the PK
+  // `(user_id, geo_challenge_id)` keeps locking the daily slot
+  // (preventing skip-then-guess), but excluded from `getChallengeStats`
+  // and never upserted to the leaderboards.
+  async recordSkip(data: { userId: string; geoChallengeId: number }): Promise<void> {
+    log.info({ userId: data.userId, challengeId: data.geoChallengeId }, 'recordSkip')
+    await db('geo_guess').insert({
+      user_id: data.userId,
+      geo_challenge_id: data.geoChallengeId,
+      x: 0,
+      y: 0,
+      distance: 0,
+      score: 0,
+      score_version: 0,
+      duration_ms: null,
+      is_skip: true,
+    })
+  },
+
   // ---- Challenge stats ----
 
-  // Average + player count across all guesses recorded for the challenge.
-  // Used by the result block to show the player how their score compares
-  // to the community on this same challenge.
+  // Average + player count across all *attempted* guesses for the
+  // challenge — skips are excluded so the comparison the player sees
+  // reflects only people who actually tried, not people who passed.
   async getChallengeStats(
     challengeId: number,
   ): Promise<{ averageScore: number; playerCount: number }> {
     const row = await db('geo_guess')
-      .where({ geo_challenge_id: challengeId })
+      .where({ geo_challenge_id: challengeId, is_skip: false })
       .select<{ avg: string | null; count: string | null }>(
         db.raw('AVG(score) AS avg'),
         db.raw('COUNT(*) AS count'),

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -105,7 +105,7 @@ router.get('/daily/:date', optionalAuthMiddleware, validateParams(dateSchema), a
 router.get('/history', optionalAuthMiddleware, validateQuery(historyQuerySchema), async (req, res, next) => {
   try {
     const { days = 7 } = req.query as unknown as { days?: number }
-    const data = await geoChallengeRepository.listRecent(days)
+    const data = await geoChallengeRepository.listRecentWithStatus(days, req.userId)
     res.json({ success: true, data })
   } catch (err) {
     next(err)

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -45,6 +45,10 @@ const guessBodySchema = z.object({
   durationMs: z.number().int().nonnegative().optional(),
 })
 
+const skipBodySchema = z.object({
+  challengeId: z.number().int().positive(),
+})
+
 const pinBodySchema = z.object({
   geoScreenshotCandidateId: z.number().int().positive(),
   pin: pointSchema,
@@ -132,6 +136,25 @@ router.post('/guess', authMiddleware, validateBody(guessBodySchema), async (req,
   } catch (err) {
     if (err instanceof GeoGameError) {
       const status = err.code === 'ALREADY_GUESSED' ? 409 : err.code === 'INVALID_POINT' ? 400 : 404
+      res.status(status).json({ success: false, error: { code: err.code, message: err.message } })
+      return
+    }
+    next(err)
+  }
+})
+
+// "I don't recognize this game" — locks the daily slot but doesn't
+// score and doesn't touch the leaderboard tables. No socket emit
+// because there's no leaderboard delta to push.
+router.post('/skip', authMiddleware, validateBody(skipBodySchema), async (req, res, next) => {
+  try {
+    const userId = req.userId!
+    const { challengeId } = req.body as z.infer<typeof skipBodySchema>
+    await geoGameService.submitSkip({ userId, challengeId })
+    res.json({ success: true, data: { skipped: true } })
+  } catch (err) {
+    if (err instanceof GeoGameError) {
+      const status = err.code === 'ALREADY_GUESSED' ? 409 : 404
       res.status(status).json({ success: false, error: { code: err.code, message: err.message } })
       return
     }

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1434,6 +1434,12 @@
       "average": "Average",
       "players": "{{count}} players",
       "comparisonAria": "Your score vs. average",
+      "skip": {
+        "action": "Skip",
+        "tooltip": "I don't recognize this game",
+        "title": "Skipped",
+        "body": "No score recorded — this challenge won't count toward the leaderboard for you."
+      },
       "screenshotUnavailable": "Screenshot preview unavailable.",
       "mapUnavailable": "Map unavailable.",
       "loading": "Loading challenge…",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1440,6 +1440,12 @@
         "title": "Skipped",
         "body": "No score recorded — this challenge won't count toward the leaderboard for you."
       },
+      "next": {
+        "action": "Next geo guess",
+        "casualNote": "Practice round — won't affect your leaderboard rank.",
+        "exhausted": "You've played every recent geo challenge. Come back tomorrow for a new one.",
+        "viewLeaderboard": "View leaderboard"
+      },
       "screenshotUnavailable": "Screenshot preview unavailable.",
       "mapUnavailable": "Map unavailable.",
       "loading": "Loading challenge…",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1440,6 +1440,12 @@
         "title": "Passé",
         "body": "Aucun score enregistré — ce défi ne comptera pas dans le classement pour vous."
       },
+      "next": {
+        "action": "Défi géo suivant",
+        "casualNote": "Manche d'entraînement — n'affectera pas votre classement.",
+        "exhausted": "Vous avez joué tous les défis géo récents. Revenez demain pour un nouveau.",
+        "viewLeaderboard": "Voir le classement"
+      },
       "screenshotUnavailable": "Aperçu de la capture indisponible.",
       "mapUnavailable": "Carte indisponible.",
       "loading": "Chargement du défi…",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1434,6 +1434,12 @@
       "average": "Moyenne",
       "players": "{{count}} joueurs",
       "comparisonAria": "Votre score comparé à la moyenne",
+      "skip": {
+        "action": "Passer",
+        "tooltip": "Je ne reconnais pas ce jeu",
+        "title": "Passé",
+        "body": "Aucun score enregistré — ce défi ne comptera pas dans le classement pour vous."
+      },
       "screenshotUnavailable": "Aperçu de la capture indisponible.",
       "mapUnavailable": "Carte indisponible.",
       "loading": "Chargement du défi…",

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -93,6 +93,13 @@ export const geoApi = {
         })
     },
 
+    submitSkip(input: { challengeId: number }): Promise<{ skipped: boolean }> {
+        return request<{ skipped: boolean }>('/api/geo/skip', {
+            method: 'POST',
+            body: JSON.stringify(input),
+        })
+    },
+
     leaderboardDaily(date: string): Promise<GeoLeaderboardEntry[]> {
         return request<GeoLeaderboardEntry[]>(`/api/geo/leaderboard/${date}`)
     },

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -1,5 +1,6 @@
 import type {
     GeoChallenge,
+    GeoChallengeWithStatus,
     GeoContributorStats,
     GeoContributorTier,
     GeoContributorTierThreshold,
@@ -78,8 +79,8 @@ export const geoApi = {
         return request<GeoDailyView>(`/api/geo/daily/${date}`)
     },
 
-    getHistory(days = 7): Promise<GeoChallenge[]> {
-        return request<GeoChallenge[]>(`/api/geo/history?days=${days}`)
+    getHistory(days = 7): Promise<GeoChallengeWithStatus[]> {
+        return request<GeoChallengeWithStatus[]>(`/api/geo/history?days=${days}`)
     },
 
     submitGuess(input: {

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -8,7 +8,7 @@ import { ReportCaptureDialog } from '@/components/ReportCaptureDialog'
 import { CubeBackground } from '@/components/backgrounds/CubeBackground'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { ImageOff, Loader2, MapPin, Trophy, Hourglass, History } from 'lucide-react'
+import { ImageOff, Loader2, MapPin, Trophy, Hourglass, History, SkipForward } from 'lucide-react'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
 import { Link } from 'react-router-dom'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
@@ -25,11 +25,13 @@ export default function GeoDailyPage() {
         hasGuessed,
         pendingGuess,
         result,
+        wasSkipped,
         errorMessage,
         errorCode,
         loadCurrent,
         setPendingGuess,
         submitGuess,
+        skipChallenge,
     } = useGeoStore()
 
     // useRef's initial value runs on every render; lazy-via-useState keeps
@@ -45,10 +47,15 @@ export default function GeoDailyPage() {
     }, [session?.user?.id])
 
     const canSubmit = phase === 'playing' && !!pendingGuess && !hasGuessed
+    const canSkip = phase === 'playing' && !hasGuessed
 
     const handleSubmit = async () => {
         const duration = Date.now() - startedAt
         await submitGuess(duration)
+    }
+
+    const handleSkip = async () => {
+        await skipChallenge()
     }
 
     return (
@@ -96,7 +103,7 @@ export default function GeoDailyPage() {
                     </Card>
                 )}
 
-                {challenge && meta && candidate && map && (phase === 'playing' || phase === 'submitting' || phase === 'result') && (
+                {challenge && meta && candidate && map && (phase === 'playing' || phase === 'submitting' || phase === 'result' || phase === 'skipped') && (
                     <div className="grid gap-6 lg:grid-cols-2">
                         <Card>
                             <CardHeader className="pb-2 flex-row items-center justify-between space-y-0">
@@ -127,36 +134,69 @@ export default function GeoDailyPage() {
                                     heightPx={map.heightPx}
                                     pin={pendingGuess ?? result?.guess ?? null}
                                     canonical={result?.canonical ?? null}
-                                    disabled={hasGuessed || phase === 'submitting' || phase === 'result'}
+                                    disabled={hasGuessed || phase === 'submitting' || phase === 'result' || phase === 'skipped'}
                                     onPin={setPendingGuess}
                                     showGuessLine={phase === 'result'}
                                 />
 
-                                <div className="flex items-center justify-between">
+                                <div className="flex items-center justify-between gap-2">
                                     <span className="text-xs text-muted-foreground">
                                         {pendingGuess
                                             ? `(${pendingGuess.x.toFixed(3)}, ${pendingGuess.y.toFixed(3)})`
                                             : t('geo.daily.hint', 'Click the map to drop a pin')}
                                     </span>
-                                    <Button
-                                        onClick={handleSubmit}
-                                        disabled={!canSubmit}
-                                        className="gradient-gaming hover:opacity-90"
-                                    >
-                                        {phase === 'submitting' && (
-                                            <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                                        )}
-                                        {t('geo.daily.submit', 'Submit guess')}
-                                    </Button>
+                                    <div className="flex items-center gap-2">
+                                        <Button
+                                            onClick={handleSkip}
+                                            disabled={!canSkip}
+                                            variant="ghost"
+                                            size="sm"
+                                            title={t(
+                                                'geo.daily.skip.tooltip',
+                                                "I don't recognize this game",
+                                            )}
+                                        >
+                                            <SkipForward className="h-4 w-4 mr-1.5" aria-hidden />
+                                            {t('geo.daily.skip.action', 'Skip')}
+                                        </Button>
+                                        <Button
+                                            onClick={handleSubmit}
+                                            disabled={!canSubmit}
+                                            className="gradient-gaming hover:opacity-90"
+                                        >
+                                            {phase === 'submitting' && (
+                                                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                                            )}
+                                            {t('geo.daily.submit', 'Submit guess')}
+                                        </Button>
+                                    </div>
                                 </div>
 
                                 {result && <ResultBlock result={result} t={t} language={i18n.language} />}
+                                {phase === 'skipped' && wasSkipped && <SkipResultBlock t={t} />}
                             </CardContent>
                         </Card>
                     </div>
                 )}
             </div>
         </>
+    )
+}
+
+function SkipResultBlock({ t }: { t: ReturnType<typeof useTranslation>['t'] }) {
+    return (
+        <div className="rounded-lg border bg-card/50 p-4 space-y-2">
+            <div className="flex items-center gap-2 text-muted-foreground font-medium">
+                <SkipForward className="h-4 w-4" aria-hidden />
+                <span>{t('geo.daily.skip.title', 'Skipped')}</span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+                {t(
+                    'geo.daily.skip.body',
+                    "No score recorded — this challenge won't count toward the leaderboard for you.",
+                )}
+            </p>
+        </div>
     )
 }
 

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -8,7 +8,7 @@ import { ReportCaptureDialog } from '@/components/ReportCaptureDialog'
 import { CubeBackground } from '@/components/backgrounds/CubeBackground'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { ImageOff, Loader2, MapPin, Trophy, Hourglass, History, SkipForward } from 'lucide-react'
+import { ImageOff, Loader2, MapPin, Trophy, Hourglass, History, SkipForward, ArrowRight } from 'lucide-react'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
 import { Link } from 'react-router-dom'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
@@ -32,6 +32,7 @@ export default function GeoDailyPage() {
         setPendingGuess,
         submitGuess,
         skipChallenge,
+        loadNextUnplayed,
     } = useGeoStore()
 
     // useRef's initial value runs on every render; lazy-via-useState keeps
@@ -56,6 +57,10 @@ export default function GeoDailyPage() {
 
     const handleSkip = async () => {
         await skipChallenge()
+    }
+
+    const handleNext = async () => {
+        await loadNextUnplayed()
     }
 
     return (
@@ -92,16 +97,22 @@ export default function GeoDailyPage() {
                     <NoChallengeCard />
                 )}
 
-                {phase === 'error' && errorCode !== 'NO_CHALLENGE' && (
-                    <Card>
-                        <CardContent
-                            className="py-10 text-center text-sm text-destructive"
-                            role="alert"
-                        >
-                            {errorMessage ?? t('common.error', 'Error')}
-                        </CardContent>
-                    </Card>
+                {phase === 'error' && errorCode === 'NO_NEXT_UNPLAYED' && (
+                    <NoMoreUnplayedCard />
                 )}
+
+                {phase === 'error' &&
+                    errorCode !== 'NO_CHALLENGE' &&
+                    errorCode !== 'NO_NEXT_UNPLAYED' && (
+                        <Card>
+                            <CardContent
+                                className="py-10 text-center text-sm text-destructive"
+                                role="alert"
+                            >
+                                {errorMessage ?? t('common.error', 'Error')}
+                            </CardContent>
+                        </Card>
+                    )}
 
                 {challenge && meta && candidate && map && (phase === 'playing' || phase === 'submitting' || phase === 'result' || phase === 'skipped') && (
                     <div className="grid gap-6 lg:grid-cols-2">
@@ -174,6 +185,23 @@ export default function GeoDailyPage() {
 
                                 {result && <ResultBlock result={result} t={t} language={i18n.language} />}
                                 {phase === 'skipped' && wasSkipped && <SkipResultBlock t={t} />}
+                                {(phase === 'result' || phase === 'skipped') && (
+                                    <Button
+                                        onClick={handleNext}
+                                        className="gradient-gaming hover:opacity-90 w-full"
+                                    >
+                                        {t('geo.daily.next.action', 'Next geo guess')}
+                                        <ArrowRight className="h-4 w-4 ml-2" aria-hidden />
+                                    </Button>
+                                )}
+                                {(phase === 'result' || phase === 'skipped') && (
+                                    <p className="text-xs text-muted-foreground text-center">
+                                        {t(
+                                            'geo.daily.next.casualNote',
+                                            "Practice round — won't affect your leaderboard rank.",
+                                        )}
+                                    </p>
+                                )}
                             </CardContent>
                         </Card>
                     </div>
@@ -331,6 +359,41 @@ function ScreenshotFrame({ imageUrl }: { imageUrl: string }) {
             className="w-full rounded-lg border"
             onError={() => setErrored(true)}
         />
+    )
+}
+
+// Shown after a "Next geo guess" tap when the player has already
+// played every challenge in the last 7 days. Rather than a destructive
+// error, offer onward navigation — leaderboard for context, history
+// for review.
+function NoMoreUnplayedCard() {
+    const { t } = useTranslation()
+    const { localizedPath } = useLocalizedPath()
+    return (
+        <Card className="border-neon-pink/40">
+            <CardContent className="py-10 text-center space-y-4">
+                <p className="text-sm text-muted-foreground max-w-md mx-auto leading-relaxed">
+                    {t(
+                        'geo.daily.next.exhausted',
+                        "You've played every recent geo challenge. Come back tomorrow for a new one.",
+                    )}
+                </p>
+                <div className="flex justify-center gap-2">
+                    <Button asChild variant="outline" size="sm">
+                        <Link to={localizedPath('/history')}>
+                            <History className="h-3.5 w-3.5 mr-1.5" aria-hidden />
+                            {t('geo.daily.errors.viewHistory', 'View past challenges')}
+                        </Link>
+                    </Button>
+                    <Button asChild variant="outline" size="sm">
+                        <Link to={localizedPath('/geo/leaderboard')}>
+                            <Trophy className="h-3.5 w-3.5 mr-1.5" aria-hidden />
+                            {t('geo.daily.next.viewLeaderboard', 'View leaderboard')}
+                        </Link>
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
     )
 }
 

--- a/packages/frontend/src/stores/geoStore.ts
+++ b/packages/frontend/src/stores/geoStore.ts
@@ -15,7 +15,14 @@ import { geoApi, GeoApiError, type GeoContributorMe } from '../lib/api/geo'
 import { getApiErrorMessage } from '../lib/api-errors'
 import i18n from '../lib/i18n'
 
-type Phase = 'idle' | 'loading' | 'playing' | 'submitting' | 'result' | 'error'
+type Phase =
+    | 'idle'
+    | 'loading'
+    | 'playing'
+    | 'submitting'
+    | 'result'
+    | 'skipped'
+    | 'error'
 
 interface GeoState {
     // Daily challenge flow
@@ -27,6 +34,10 @@ interface GeoState {
     hasGuessed: boolean
     pendingGuess: GeoPoint | null
     result: GeoGuessResult | null
+    // Sticky flag for "player skipped this challenge" so a reload during
+    // the skipped phase can restore the SkipResultBlock without resurrecting
+    // a (non-existent) score. Cleared whenever a new challenge loads.
+    wasSkipped: boolean
     errorMessage: string | null
     errorCode: string | null
 
@@ -51,6 +62,7 @@ interface GeoState {
     loadDaily: (date: string) => Promise<void>
     setPendingGuess: (p: GeoPoint | null) => void
     submitGuess: (durationMs?: number) => Promise<GeoGuessResult | null>
+    skipChallenge: () => Promise<boolean>
     loadLeaderboardDaily: (date: string) => Promise<void>
     loadLeaderboardMonthly: (period: string) => Promise<void>
 
@@ -87,20 +99,20 @@ async function loadView(
     set({ phase: 'loading', errorMessage: null, errorCode: null })
     try {
         const view = await fetcher()
-        const restored =
-            view.hasGuessed &&
-            prev.result !== null &&
-            prev.challenge !== null &&
-            prev.challenge.id === view.challenge.id
+        const sameChallenge =
+            prev.challenge !== null && prev.challenge.id === view.challenge.id
+        const restoredResult = view.hasGuessed && sameChallenge && prev.result !== null
+        const restoredSkip = view.hasGuessed && sameChallenge && prev.wasSkipped
         set({
-            phase: restored ? 'result' : 'playing',
+            phase: restoredResult ? 'result' : restoredSkip ? 'skipped' : 'playing',
             challenge: view.challenge,
             meta: view.meta,
             candidate: view.candidate,
             map: view.map,
             hasGuessed: view.hasGuessed,
-            result: restored ? prev.result : null,
-            pendingGuess: restored ? prev.pendingGuess : null,
+            result: restoredResult ? prev.result : null,
+            wasSkipped: restoredSkip,
+            pendingGuess: restoredResult ? prev.pendingGuess : null,
         })
     } catch (err) {
         set({
@@ -122,6 +134,7 @@ export const useGeoStore = create<GeoState>()(
     hasGuessed: false,
     pendingGuess: null,
     result: null,
+    wasSkipped: false,
     errorMessage: null,
     errorCode: null,
     leaderboardDaily: [],
@@ -156,7 +169,7 @@ export const useGeoStore = create<GeoState>()(
                 guess: pendingGuess,
                 durationMs,
             })
-            set({ phase: 'result', result, hasGuessed: true })
+            set({ phase: 'result', result, hasGuessed: true, wasSkipped: false })
             return result
         } catch (err) {
             set({
@@ -164,6 +177,30 @@ export const useGeoStore = create<GeoState>()(
                 errorMessage: getApiErrorMessage(err),
             })
             return null
+        }
+    },
+
+    async skipChallenge() {
+        const { challenge } = get()
+        if (!challenge) return false
+
+        set({ phase: 'submitting', errorMessage: null })
+        try {
+            await geoApi.submitSkip({ challengeId: challenge.id })
+            set({
+                phase: 'skipped',
+                hasGuessed: true,
+                wasSkipped: true,
+                result: null,
+                pendingGuess: null,
+            })
+            return true
+        } catch (err) {
+            set({
+                phase: 'error',
+                errorMessage: getApiErrorMessage(err),
+            })
+            return false
         }
     },
 
@@ -263,6 +300,7 @@ export const useGeoStore = create<GeoState>()(
             hasGuessed: false,
             pendingGuess: null,
             result: null,
+            wasSkipped: false,
             errorMessage: null,
             errorCode: null,
             currentCandidate: null,
@@ -282,6 +320,7 @@ export const useGeoStore = create<GeoState>()(
                 result: state.result,
                 hasGuessed: state.hasGuessed,
                 pendingGuess: state.pendingGuess,
+                wasSkipped: state.wasSkipped,
             }),
         },
     ),

--- a/packages/frontend/src/stores/geoStore.ts
+++ b/packages/frontend/src/stores/geoStore.ts
@@ -63,6 +63,7 @@ interface GeoState {
     setPendingGuess: (p: GeoPoint | null) => void
     submitGuess: (durationMs?: number) => Promise<GeoGuessResult | null>
     skipChallenge: () => Promise<boolean>
+    loadNextUnplayed: () => Promise<boolean>
     loadLeaderboardDaily: (date: string) => Promise<void>
     loadLeaderboardMonthly: (period: string) => Promise<void>
 
@@ -199,6 +200,40 @@ export const useGeoStore = create<GeoState>()(
             set({
                 phase: 'error',
                 errorMessage: getApiErrorMessage(err),
+            })
+            return false
+        }
+    },
+
+    async loadNextUnplayed() {
+        // Pull the catch-up window and pick the most recent challenge
+        // the player hasn't yet guessed or skipped. Excludes the
+        // current challenge so the CTA doesn't loop the player back to
+        // the screen they just finished.
+        const { challenge: currentChallenge } = get()
+        try {
+            const history = await geoApi.getHistory(7)
+            const next = history.find(
+                (c) => !c.hasGuessed && c.id !== currentChallenge?.id,
+            )
+            if (!next) {
+                set({
+                    phase: 'error',
+                    errorCode: 'NO_NEXT_UNPLAYED',
+                    errorMessage: i18n.t(
+                        'geo.daily.next.exhausted',
+                        "You've played every recent geo challenge.",
+                    ),
+                })
+                return false
+            }
+            await loadView(get, set, () => geoApi.getDaily(next.challengeDate))
+            return true
+        } catch (err) {
+            set({
+                phase: 'error',
+                errorMessage: getApiErrorMessage(err),
+                errorCode: err instanceof GeoApiError ? err.code : null,
             })
             return false
         }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -809,6 +809,15 @@ export interface GeoChallenge {
   tier: number
 }
 
+// Sibling shape returned by the userId-aware history endpoint so the
+// frontend can find the next unplayed challenge without an extra
+// per-challenge round-trip. `hasGuessed` is true if the player has
+// already submitted *or* skipped this challenge — both block today's
+// slot symmetrically.
+export interface GeoChallengeWithStatus extends GeoChallenge {
+  hasGuessed: boolean
+}
+
 export interface GeoGuessInput {
   geoChallengeId: number
   guess: GeoPoint


### PR DESCRIPTION
Adds an "I don't recognize this game" skip action on the geo daily
challenge. A skip locks the day's slot for that player (same
ALREADY_GUESSED 409 lock as a normal guess, so no skip-then-ask-Discord
exploit) but is excluded from the community average and never written to
the daily/monthly leaderboards. Keeps the comparison the player sees on
the result block representative of people who actually attempted.

- Migration: is_skip BOOLEAN on geo_guess + partial index for the stats
  aggregate.
- Repository: recordSkip() inserts a marker row; getChallengeStats now
  filters skips out of AVG/COUNT.
- Service: submitSkip() shares the findGuess uniqueness check with
  submitGuess; deliberately skips upsertDaily / upsertMonthly.
- API: POST /api/geo/skip { challengeId } -> 200 / 409 / 404.
- Frontend: ghost Skip button next to Submit, new 'skipped' phase,
  SkipResultBlock, persisted wasSkipped flag for reload restore.
- i18n: geo.daily.skip.{action,tooltip,title,body} in EN and FR.

https://claude.ai/code/session_015Vc86QRbnMYWhzBJvU9293