### PR TITLE
Multi-map support for geo daily challenges

### DIFF
--- a/packages/backend/migrations/20260428_geo_multi_map.ts
+++ b/packages/backend/migrations/20260428_geo_multi_map.ts
@@ -1,0 +1,76 @@
+import type { Knex } from 'knex'
+
+// Multi-map per game: a single game can now have N enabled `geo_map` rows
+// (e.g. BG3 → Nautiloid + Wilderness + Shadow-Cursed Lands + Baldur's Gate).
+//
+// Schema-level changes are minimal because the existing model already
+// references one map per candidate / meta. What changes:
+//
+//   1. `geo_map.is_capture_default` — exactly one map per game can be the
+//      default target for Steam/RAWG capture. The ingest tick used to read
+//      `is_active = true` for that role; with multi-map that's ambiguous,
+//      so capture targeting moves to its own column. Backfilled from the
+//      currently-active row per game so single-map games keep behaving
+//      identically.
+//
+//   2. `geo_guess.geo_map_id_picked` — records which map the player chose
+//      from the chooser. Lets us answer "how often do players pick the
+//      wrong map?" without bolting on a side table later. Nullable for
+//      backwards compatibility with rows recorded before the chooser
+//      shipped.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('geo_map', (table) => {
+    table
+      .boolean('is_capture_default')
+      .notNullable()
+      .defaultTo(false)
+      .comment(
+        'When true, Steam/RAWG capture providers attach new candidates to this map. At most one row per game_id may be true.',
+      )
+  })
+
+  // Partial unique index instead of a full unique constraint so most rows
+  // (false) don't conflict with each other.
+  await knex.raw(`
+    CREATE UNIQUE INDEX geo_map_one_capture_default_per_game
+    ON geo_map (game_id)
+    WHERE is_capture_default = true
+  `)
+
+  // Backfill: every game that has at least one active map gets exactly one
+  // capture-default — picking the most-recently-created active row, which
+  // matches the row `findActiveByGameId` would have returned.
+  await knex.raw(`
+    UPDATE geo_map
+    SET is_capture_default = true
+    WHERE id IN (
+      SELECT DISTINCT ON (game_id) id
+      FROM geo_map
+      WHERE is_active = true
+      ORDER BY game_id, created_at DESC
+    )
+  `)
+
+  await knex.schema.alterTable('geo_guess', (table) => {
+    table
+      .integer('geo_map_id_picked')
+      .nullable()
+      .references('id')
+      .inTable('geo_map')
+      .onDelete('SET NULL')
+      .comment(
+        'Map the player picked from the chooser. NULL for legacy rows recorded before multi-map shipped.',
+      )
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('geo_guess', (table) => {
+    table.dropColumn('geo_map_id_picked')
+  })
+  await knex.raw('DROP INDEX IF EXISTS geo_map_one_capture_default_per_game')
+  await knex.schema.alterTable('geo_map', (table) => {
+    table.dropColumn('is_capture_default')
+  })
+}

--- a/packages/backend/seeds/010_geo_elden_ring.ts
+++ b/packages/backend/seeds/010_geo_elden_ring.ts
@@ -93,6 +93,10 @@ export async function seed(knex: Knex): Promise<void> {
         license: MAP.license,
         attribution: MAP.attribution,
         is_active: true,
+        // Multi-map mode anchors Steam/RAWG capture on the explicit
+        // capture-default row. Seed games have a single enabled map, so
+        // it owns the role.
+        is_capture_default: true,
         created_at: now,
       })
       .returning<{ id: number }[]>('id')

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -592,7 +592,19 @@ export interface FunnelEventRepository {
 
 export interface GeoMapRepository {
   findById(id: number): Promise<GeoMap | null>
+  // Legacy single-map lookup, kept for callers (ingest tick fallback,
+  // contribute pick) that don't yet need multi-map awareness. Returns the
+  // most recently created enabled map for the game.
   findActiveByGameId(gameId: number): Promise<GeoMap | null>
+  findFirstEnabledByGameId(gameId: number): Promise<GeoMap | null>
+  findCaptureDefaultByGameId(gameId: number): Promise<GeoMap | null>
+  // All maps (any state) for admin listings.
+  listByGameId(
+    gameId: number,
+  ): Promise<Array<GeoMap & { isActive: boolean }>>
+  // Enabled maps the daily-challenge chooser surfaces to players.
+  listEnabledByGameId(gameId: number): Promise<GeoMap[]>
+  findEnabledById(gameId: number, mapId: number): Promise<GeoMap | null>
 }
 
 export interface GeoScreenshotRepository {
@@ -654,6 +666,8 @@ export interface GeoChallengeRepository {
     score: number
     scoreVersion: number
     durationMs?: number
+    geoMapIdPicked?: number | null
+    wrongMap?: boolean
   }): Promise<GeoGuessResult>
   recordSkip(data: { userId: string; geoChallengeId: number }): Promise<void>
   upsertDaily(args: { challengeDate: string; userId: string; score: number }): Promise<void>

--- a/packages/backend/src/domain/services/geo-game.service.ts
+++ b/packages/backend/src/domain/services/geo-game.service.ts
@@ -24,6 +24,7 @@ export class GeoGameError extends Error {
       | 'CHALLENGE_NOT_FOUND'
       | 'ALREADY_GUESSED'
       | 'INVALID_POINT'
+      | 'INVALID_MAP'
       | 'NO_CANDIDATE'
       | 'CONTRIBUTE_RATE_LIMIT'
       | 'CONTRIBUTE_NOT_UNLOCKED',
@@ -44,10 +45,17 @@ export interface GeoDailyChallengeView {
   challenge: GeoChallenge
   meta: GeoScreenshotMeta
   // Exposed for the frontend map renderer; avoids hand-rolling image-proxy
-  // endpoints. The candidate's own imageUrl is the screenshot; the map
+  // endpoints. The candidate's own imageUrl is the screenshot; each map
   // carries its own image + dimensions for coordinate normalization.
   candidate: GeoScreenshotCandidate
-  map: GeoMap
+  // All enabled maps for the challenge's game. The chooser surfaces these
+  // to the player; client-side, the canvas renders whichever the player
+  // has selected. Always at least one entry.
+  maps: GeoMap[]
+  // The map the screenshot canonically belongs to. Only populated AFTER
+  // the player has guessed (so the in-progress response can't leak the
+  // answer to anyone reading the network panel).
+  map?: GeoMap
   hasGuessed: boolean
 }
 
@@ -64,6 +72,11 @@ export interface GeoGameService {
   submitGuess(args: {
     userId: string
     challengeId: number
+    // Optional only for backwards compatibility with single-map games:
+    // when the challenge's game has > 1 enabled map, missing/invalid
+    // values throw `INVALID_MAP`. Single-map games auto-resolve to the
+    // only enabled row.
+    geoMapId?: number
     guess: GeoPoint
     durationMs?: number
   }): Promise<GeoGuessResult>
@@ -131,10 +144,15 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
   } = deps
   const log = deps.logger.child({ service: 'geo-game' })
 
-  // Hydrate a challenge row into the full view (meta + candidate + map +
+  // Hydrate a challenge row into the full view (meta + candidate + maps +
   // hasGuessed). Shared between the date-pinned `/daily/:date` lookup
   // (used by history) and the current-challenge `/current` lookup (used
   // by the public geo page during slow rollout).
+  //
+  // Multi-map mode: returns every enabled map for the challenge's game
+  // so the player can pick. The correct map (the one the screenshot
+  // belongs to) is only included AFTER the player has guessed — keeping
+  // it out of the in-progress payload kills the trivial DevTools cheat.
   async function hydrate(
     challenge: GeoChallenge,
     userId?: string,
@@ -153,18 +171,29 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
       return null
     }
 
-    const map = await geoMapRepository.findById(meta.geoMapId)
-    if (!map) {
+    const correctMap = await geoMapRepository.findById(meta.geoMapId)
+    if (!correctMap) {
       log.error({ metaId: meta.id }, 'meta references missing map')
       return null
     }
 
-    if (isPlaceholderImageUrl(candidate.imageUrl) || isPlaceholderImageUrl(map.imageUrl)) {
+    let maps = await geoMapRepository.listEnabledByGameId(candidate.gameId)
+    // The canonical map is always part of the chooser, even if an admin
+    // has temporarily disabled it after a meta was promoted — without
+    // this, the player would see a chooser missing the correct answer.
+    if (!maps.some((m) => m.id === correctMap.id)) {
+      maps = [...maps, correctMap]
+    }
+
+    if (
+      isPlaceholderImageUrl(candidate.imageUrl) ||
+      maps.every((m) => isPlaceholderImageUrl(m.imageUrl))
+    ) {
       log.error(
         {
           challengeId: challenge.id,
           candidateImageUrl: candidate.imageUrl,
-          mapImageUrl: map.imageUrl,
+          mapImageUrls: maps.map((m) => m.imageUrl),
         },
         'refusing to serve geo challenge backed by placeholder image URL',
       )
@@ -177,7 +206,15 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
       hasGuessed = !!existing
     }
 
-    return { challenge, meta, candidate, map, hasGuessed }
+    return {
+      challenge,
+      meta,
+      candidate,
+      maps,
+      // Reveal only after the player has finalized their attempt.
+      map: hasGuessed ? correctMap : undefined,
+      hasGuessed,
+    }
   }
 
   return {
@@ -193,7 +230,7 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
       return hydrate(challenge, userId)
     },
 
-    async submitGuess({ userId, challengeId, guess, durationMs }) {
+    async submitGuess({ userId, challengeId, geoMapId, guess, durationMs }) {
       if (!validPoint(guess)) {
         throw new GeoGameError('guess must have x and y in [0..1]', 'INVALID_POINT')
       }
@@ -217,7 +254,46 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
         throw new GeoGameError('challenge has no canonical location', 'CHALLENGE_NOT_FOUND')
       }
 
-      const { distance, score, scoreVersion } = geoScoringService.score(guess, meta.canonical)
+      const candidate = await geoScreenshotRepository.findCandidateById(
+        meta.geoScreenshotCandidateId,
+      )
+      if (!candidate) {
+        throw new GeoGameError('challenge has no candidate', 'CHALLENGE_NOT_FOUND')
+      }
+
+      // Resolve which map the player picked. Single-map games auto-select
+      // (legacy clients can submit without `geoMapId`); multi-map games
+      // require the field to be a currently-enabled map of the game.
+      const enabledMaps = await geoMapRepository.listEnabledByGameId(candidate.gameId)
+      let pickedMapId = geoMapId
+      if (pickedMapId == null) {
+        if (enabledMaps.length <= 1) {
+          pickedMapId = enabledMaps[0]?.id ?? meta.geoMapId
+        } else {
+          throw new GeoGameError(
+            'this game has multiple maps; geoMapId is required',
+            'INVALID_MAP',
+          )
+        }
+      } else if (!enabledMaps.some((m) => m.id === pickedMapId)) {
+        // Allow the canonical map even if it's been disabled mid-game so
+        // a player who picks the (still-rendered) correct answer is not
+        // penalized by an admin's flip — anything else is rejected.
+        if (pickedMapId !== meta.geoMapId) {
+          throw new GeoGameError(
+            'geoMapId does not belong to the challenge game',
+            'INVALID_MAP',
+          )
+        }
+      }
+
+      const wrongMap = pickedMapId !== meta.geoMapId
+
+      const { distance, score, scoreVersion } = geoScoringService.score(
+        guess,
+        meta.canonical,
+        { wrongMap },
+      )
 
       const result = await geoChallengeRepository.recordGuess({
         userId,
@@ -227,6 +303,8 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
         score,
         scoreVersion,
         durationMs,
+        geoMapIdPicked: pickedMapId,
+        wrongMap,
       })
 
       await geoChallengeRepository.upsertDaily({

--- a/packages/backend/src/domain/services/geo-scoring.service.ts
+++ b/packages/backend/src/domain/services/geo-scoring.service.ts
@@ -3,7 +3,12 @@ import type { GeoPoint } from '@the-box/types'
 
 // Current scoring formula version. Bump whenever constants below change so
 // historical scores remain comparable via `geo_guess.score_version`.
-export const GEO_SCORE_VERSION = 1
+//
+// v2 introduces the wrong-map penalty: when the player picks a map that the
+// screenshot doesn't belong to, distance is floored to 1.0 (effectively
+// max distance), which the existing decay maps to ~1 point. No other
+// constants change, so v1 distances remain directly comparable.
+export const GEO_SCORE_VERSION = 2
 
 // Maximum points awarded for a perfect pin (distance 0).
 export const GEO_SCORE_MAX = 2000
@@ -38,10 +43,26 @@ export interface GeoScoringResult {
   distance: number
   score: number
   scoreVersion: number
+  // True when the player picked the wrong map and the distance was
+  // floored to 1.0 before scoring. Surfaced so the route can copy the
+  // flag onto the persisted guess and the result reveal.
+  wrongMap: boolean
+}
+
+export interface GeoScoringOptions {
+  // Set when the player's chosen map doesn't match the screenshot's
+  // canonical map. Floors distance to 1.0, which the existing decay
+  // collapses to ~1 point — the same as a wildly off pin on the right
+  // map, with no new constants to bump the formula version for.
+  wrongMap?: boolean
 }
 
 export interface GeoScoringService {
-  score(guess: GeoPoint, canonical: GeoPoint): GeoScoringResult
+  score(
+    guess: GeoPoint,
+    canonical: GeoPoint,
+    opts?: GeoScoringOptions,
+  ): GeoScoringResult
 }
 
 export interface GeoScoringServiceDeps {
@@ -52,11 +73,13 @@ export function createGeoScoringService(deps: GeoScoringServiceDeps): GeoScoring
   const log = deps.logger.child({ service: 'geo-scoring' })
 
   return {
-    score(guess, canonical) {
-      const distance = geoDistance(guess, canonical)
+    score(guess, canonical, opts) {
+      const wrongMap = !!opts?.wrongMap
+      const rawDistance = geoDistance(guess, canonical)
+      const distance = wrongMap ? 1 : rawDistance
       const score = geoScoreFromDistance(distance)
-      log.debug({ guess, canonical, distance, score }, 'scored guess')
-      return { distance, score, scoreVersion: GEO_SCORE_VERSION }
+      log.debug({ guess, canonical, distance, score, wrongMap }, 'scored guess')
+      return { distance, score, scoreVersion: GEO_SCORE_VERSION, wrongMap }
     },
   }
 }

--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -86,10 +86,16 @@ export async function runGeoIngestTick(
         m.id AS active_map_id,
         COALESCE(c.cnt, 0) AS candidate_count
       FROM games g
+      -- Multi-map: capture providers anchor pins to the explicit
+      -- is_capture_default row, not just any active map. For single-map
+      -- games the migration backfilled is_capture_default = is_active so
+      -- behavior is unchanged. We also fall back to any enabled map (in
+      -- created_at desc order) for games that haven\'t yet been promoted --
+      -- preserves the previous first-to-land-becomes-default feel.
       LEFT JOIN LATERAL (
         SELECT id FROM geo_map
         WHERE game_id = g.id AND is_active = true
-        ORDER BY created_at DESC
+        ORDER BY is_capture_default DESC, created_at DESC
         LIMIT 1
       ) m ON true
       LEFT JOIN (
@@ -136,9 +142,13 @@ export async function runGeoIngestTick(
     // both is strictly additive. (source, external_id) uniqueness in
     // geo_screenshot_candidate prevents dupes inside each provider.
     if (row.active_map_id && row.candidate_count < CAPTURE_TARGET_CANDIDATES) {
-      // Re-fetch the active map id off the repo so we don't pass a stale
-      // value (the SELECT above can be racing a recent map import).
-      const map = await geoMapRepository.findActiveByGameId(row.id)
+      // Re-fetch off the repo so we don't pass a stale id (the SELECT
+      // above can be racing a recent map import). Multi-map mode prefers
+      // the capture-default row; falls back to any enabled map for
+      // games that haven't yet had a default promoted.
+      const map =
+        (await geoMapRepository.findCaptureDefaultByGameId(row.id)) ??
+        (await geoMapRepository.findFirstEnabledByGameId(row.id))
       if (map) {
         if (row.steam_app_id && !(await tombstoneBlocks(row.id, 'steam'))) {
           await geoQueue.add(

--- a/packages/backend/src/infrastructure/queue/workers/geo-schedule-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-schedule-logic.ts
@@ -48,7 +48,11 @@ export async function scheduleDailyGeoChallenge(
   }
 
   // Global random over all promoted metas whose candidate is still active
-  // (i.e. not deactivated by user reports). RANDOM() is fine at pilot scale.
+  // (i.e. not deactivated by user reports) AND whose owning map is still
+  // enabled. The map filter matters in multi-map mode: an admin can
+  // disable a region (say, BG3 Nautiloid) without us needing to also
+  // archive every screenshot pinned to it — the schedule picker simply
+  // skips them. RANDOM() is fine at pilot scale.
   type Row = { id: number; game_id: number }
   const rows = await db<Row>('geo_screenshot_meta')
     .join(
@@ -56,7 +60,9 @@ export async function scheduleDailyGeoChallenge(
       'geo_screenshot_meta.geo_screenshot_candidate_id',
       'geo_screenshot_candidate.id',
     )
+    .join('geo_map', 'geo_screenshot_meta.geo_map_id', 'geo_map.id')
     .where('geo_screenshot_candidate.is_active', true)
+    .andWhere('geo_map.is_active', true)
     .orderByRaw('RANDOM()')
     .limit(1)
     .select<Row[]>(

--- a/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
@@ -155,6 +155,11 @@ export const geoChallengeRepository = {
     score: number
     scoreVersion: number
     durationMs?: number
+    // Map the player picked from the chooser. Persisted for analytics
+    // ("how often do players pick the wrong map?"). Optional so legacy
+    // single-map call sites keep working until they're updated.
+    geoMapIdPicked?: number | null
+    wrongMap?: boolean
   }): Promise<GeoGuessResult> {
     log.info(
       { userId: data.userId, challengeId: data.geoChallengeId, score: data.score },
@@ -170,6 +175,7 @@ export const geoChallengeRepository = {
       score: data.score,
       score_version: data.scoreVersion,
       duration_ms: data.durationMs ?? null,
+      geo_map_id_picked: data.geoMapIdPicked ?? null,
     })
 
     const meta = await db('geo_challenge')
@@ -179,9 +185,10 @@ export const geoChallengeRepository = {
         'geo_screenshot_meta.id',
       )
       .where('geo_challenge.id', data.geoChallengeId)
-      .select<{ canonical_x: number; canonical_y: number }>(
+      .select<{ canonical_x: number; canonical_y: number; geo_map_id: number }>(
         'geo_screenshot_meta.canonical_x',
         'geo_screenshot_meta.canonical_y',
+        'geo_screenshot_meta.geo_map_id',
       )
       .first()
 
@@ -191,6 +198,8 @@ export const geoChallengeRepository = {
       distance: data.distance,
       score: data.score,
       scoreVersion: data.scoreVersion,
+      correctMapId: meta?.geo_map_id,
+      wrongMap: data.wrongMap,
     }
   },
 

--- a/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
@@ -19,6 +19,7 @@ export interface GeoMapRow {
   wiki_map_name: string | null
   wiki_revision_id: string | number | null
   is_active: boolean
+  is_capture_default: boolean
   created_at: Date
 }
 
@@ -44,19 +45,43 @@ function mapRow(row: GeoMapRow): GeoMap {
     region: row.region ?? undefined,
     wikiMapName: row.wiki_map_name ?? undefined,
     wikiRevisionId: revision,
+    isCaptureDefault: row.is_capture_default,
   }
 }
 
+export type DisableResult =
+  | { ok: true; map: GeoMap }
+  | { ok: false; reason: 'NOT_FOUND' | 'LAST_ENABLED' }
+
 export const geoMapRepository = {
   async findById(id: number): Promise<GeoMap | null> {
-    const row = await db('geo_map').where({ id, is_active: true }).first<GeoMapRow>()
+    // No `is_active` filter: callers (challenge hydrate, candidate detail)
+    // need the map even if an admin temporarily disabled it after a meta
+    // was promoted. A separate filter on enabled maps is provided by
+    // `listEnabledByGameId` for the chooser.
+    const row = await db('geo_map').where({ id }).first<GeoMapRow>()
     return row ? mapRow(row) : null
   },
 
-  async findActiveByGameId(gameId: number): Promise<GeoMap | null> {
+  // First enabled map for a game. Kept for legacy single-map callers
+  // (`pickContributionTarget`, ingest tick when no capture default is set).
+  // Multi-map callers should prefer `listEnabledByGameId`.
+  async findFirstEnabledByGameId(gameId: number): Promise<GeoMap | null> {
     const row = await db('geo_map')
       .where({ game_id: gameId, is_active: true })
       .orderBy('created_at', 'desc')
+      .first<GeoMapRow>()
+    return row ? mapRow(row) : null
+  },
+
+  // Back-compat alias — old call sites still reference this name.
+  async findActiveByGameId(gameId: number): Promise<GeoMap | null> {
+    return this.findFirstEnabledByGameId(gameId)
+  },
+
+  async findCaptureDefaultByGameId(gameId: number): Promise<GeoMap | null> {
+    const row = await db('geo_map')
+      .where({ game_id: gameId, is_capture_default: true })
       .first<GeoMapRow>()
     return row ? mapRow(row) : null
   },
@@ -82,6 +107,23 @@ export const geoMapRepository = {
     return rows.map((r) => ({ ...mapRow(r), isActive: r.is_active }))
   },
 
+  // Enabled = playable: the chooser surfaces these for a daily challenge,
+  // and the schedule picker only draws candidates whose map is enabled.
+  async listEnabledByGameId(gameId: number): Promise<GeoMap[]> {
+    const rows = await db('geo_map')
+      .where({ game_id: gameId, is_active: true })
+      .orderBy('created_at', 'asc')
+      .select<GeoMapRow[]>('*')
+    return rows.map(mapRow)
+  },
+
+  async findEnabledById(gameId: number, mapId: number): Promise<GeoMap | null> {
+    const row = await db('geo_map')
+      .where({ id: mapId, game_id: gameId, is_active: true })
+      .first<GeoMapRow>()
+    return row ? mapRow(row) : null
+  },
+
   async create(data: {
     gameId: number
     source: GeoMapSource
@@ -95,22 +137,22 @@ export const geoMapRepository = {
     region?: string | null
     wikiMapName?: string | null
     wikiRevisionId?: number | null
-    // When omitted, the row is active only if no other active row exists for
-    // this game (transactional — multi-tier ingestion stores all results but
-    // only the first tier to land becomes the default; admins can swap later).
+    // When omitted, defaults to false. Multi-map mode no longer auto-flips
+    // the first-to-land row to active — admins explicitly enable maps from
+    // the Cartes side panel. Pass `isActive: true` to short-circuit (used
+    // by manual upload + the seed).
     isActive?: boolean
   }): Promise<GeoMap> {
     log.info({ gameId: data.gameId, source: data.source }, 'create')
     const row = await db.transaction(async (trx) => {
-      let isActive: boolean
-      if (data.isActive === undefined) {
-        const existingActive = await trx('geo_map')
-          .where({ game_id: data.gameId, is_active: true })
-          .first<{ id: number }>('id')
-        isActive = !existingActive
-      } else {
-        isActive = data.isActive
-      }
+      const isActive = data.isActive ?? false
+      // Promote to capture-default only if the game has none yet — keeps
+      // the very first map a game ever gets pointing capture providers
+      // somewhere sensible without overriding explicit admin choices.
+      const existingCaptureDefault = await trx('geo_map')
+        .where({ game_id: data.gameId, is_capture_default: true })
+        .first<{ id: number }>('id')
+      const isCaptureDefault = isActive && !existingCaptureDefault
       const [inserted] = await trx('geo_map')
         .insert({
           game_id: data.gameId,
@@ -126,6 +168,7 @@ export const geoMapRepository = {
           wiki_map_name: data.wikiMapName ?? null,
           wiki_revision_id: data.wikiRevisionId ?? null,
           is_active: isActive,
+          is_capture_default: isCaptureDefault,
         })
         .returning<GeoMapRow[]>('*')
       return inserted!
@@ -135,27 +178,119 @@ export const geoMapRepository = {
 
   async deactivate(id: number): Promise<void> {
     log.info({ id }, 'deactivate')
-    await db('geo_map').where({ id }).update({ is_active: false })
+    await db('geo_map').where({ id }).update({ is_active: false, is_capture_default: false })
   },
 
-  // Atomically promote `mapId` to the active map for `gameId` and deactivate
-  // any siblings. Used by the admin "select this map" flow.
-  async setActiveForGame(gameId: number, mapId: number): Promise<GeoMap | null> {
-    log.info({ gameId, mapId }, 'setActiveForGame')
+  // Multi-map enable: flip just this row to enabled. If the game had no
+  // enabled maps before this call, also promote it to capture-default so
+  // ingest has a target.
+  async enableForGame(gameId: number, mapId: number): Promise<GeoMap | null> {
+    log.info({ gameId, mapId }, 'enableForGame')
     return await db.transaction(async (trx) => {
       const target = await trx('geo_map')
         .where({ id: mapId, game_id: gameId })
         .first<GeoMapRow>()
       if (!target) return null
-      await trx('geo_map')
-        .where({ game_id: gameId })
+      const otherEnabled = await trx('geo_map')
+        .where({ game_id: gameId, is_active: true })
         .whereNot({ id: mapId })
-        .update({ is_active: false })
+        .first<{ id: number }>('id')
       const [updated] = await trx('geo_map')
         .where({ id: mapId })
-        .update({ is_active: true })
+        .update({
+          is_active: true,
+          // Only promote to capture-default if there isn't another
+          // enabled sibling that already holds the role.
+          ...(otherEnabled ? {} : { is_capture_default: true }),
+        })
         .returning<GeoMapRow[]>('*')
       return updated ? mapRow(updated) : null
     })
+  },
+
+  // Multi-map disable: flip a single row off. Refuses if it would leave
+  // the game with zero enabled maps. If we disable the current capture
+  // default and a sibling exists, the sibling is promoted (most-recently
+  // enabled wins).
+  async disableForGame(gameId: number, mapId: number): Promise<DisableResult> {
+    log.info({ gameId, mapId }, 'disableForGame')
+    return await db.transaction(async (trx) => {
+      const target = await trx('geo_map')
+        .where({ id: mapId, game_id: gameId })
+        .first<GeoMapRow>()
+      if (!target) return { ok: false as const, reason: 'NOT_FOUND' as const }
+
+      const remainingEnabled = await trx('geo_map')
+        .where({ game_id: gameId, is_active: true })
+        .whereNot({ id: mapId })
+        .count<{ count: string }[]>({ count: '*' })
+        .first()
+      if (Number(remainingEnabled?.count ?? 0) === 0) {
+        return { ok: false as const, reason: 'LAST_ENABLED' as const }
+      }
+
+      const [updated] = await trx('geo_map')
+        .where({ id: mapId })
+        .update({ is_active: false, is_capture_default: false })
+        .returning<GeoMapRow[]>('*')
+
+      // If the disabled row was the capture default, hand the role to the
+      // most-recently-created enabled sibling. The partial unique index
+      // `geo_map_one_capture_default_per_game` ensures we never end up
+      // with two defaults.
+      if (target.is_capture_default) {
+        const heir = await trx('geo_map')
+          .where({ game_id: gameId, is_active: true })
+          .orderBy('created_at', 'desc')
+          .first<GeoMapRow>()
+        if (heir) {
+          await trx('geo_map')
+            .where({ id: heir.id })
+            .update({ is_capture_default: true })
+        }
+      }
+
+      return updated
+        ? { ok: true as const, map: mapRow(updated) }
+        : { ok: false as const, reason: 'NOT_FOUND' as const }
+    })
+  },
+
+  // Atomically pick the new capture-default for a game. The partial unique
+  // index keeps us honest: clear all rows for the game first, then set
+  // the target.
+  async setCaptureDefault(gameId: number, mapId: number): Promise<GeoMap | null> {
+    log.info({ gameId, mapId }, 'setCaptureDefault')
+    return await db.transaction(async (trx) => {
+      const target = await trx('geo_map')
+        .where({ id: mapId, game_id: gameId, is_active: true })
+        .first<GeoMapRow>()
+      if (!target) return null
+      await trx('geo_map')
+        .where({ game_id: gameId })
+        .update({ is_capture_default: false })
+      const [updated] = await trx('geo_map')
+        .where({ id: mapId })
+        .update({ is_capture_default: true })
+        .returning<GeoMapRow[]>('*')
+      return updated ? mapRow(updated) : null
+    })
+  },
+
+  async updateRegion(mapId: number, region: string | null): Promise<GeoMap | null> {
+    log.info({ mapId, region }, 'updateRegion')
+    const trimmed = region == null ? null : region.trim() || null
+    const [updated] = await db('geo_map')
+      .where({ id: mapId })
+      .update({ region: trimmed })
+      .returning<GeoMapRow[]>('*')
+    return updated ? mapRow(updated) : null
+  },
+
+  // Deprecated alias for `enableForGame` — kept so any cached frontend
+  // calling the old `/active-map` endpoint keeps working through one
+  // release. New code should call `enableForGame`.
+  async setActiveForGame(gameId: number, mapId: number): Promise<GeoMap | null> {
+    return this.enableForGame(gameId, mapId)
   },
 }

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1914,7 +1914,6 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
         >('source', 'reason', 'attempt_count', 'last_attempt_at', 'retry_after'),
     ])
 
-    const activeMap = allMaps.find((m) => m.isActive) ?? null
     const candidatesBySource = new Map<
       string,
       Array<{
@@ -2144,24 +2143,37 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
       sources.push(tier('manual', { status: 'untried' }))
     }
 
+    // Multi-map: enabledMaps is the new authoritative list the admin UI
+    // renders. `activeMap` is kept on the wire for one release so a
+    // stale frontend keeps working — it now carries the capture-default
+    // row (the one Steam/RAWG attaches to), which is the closest analog
+    // to the legacy single-active row.
+    const enabledMaps = allMaps.filter((m) => m.isActive)
+    const captureDefault =
+      enabledMaps.find((m) => m.isCaptureDefault) ?? enabledMaps[0] ?? null
+    const mapSummary = (m: (typeof allMaps)[number]) => ({
+      id: m.id,
+      source: m.source,
+      imageUrl: m.imageUrl,
+      license: m.license,
+      attribution: m.attribution,
+      widthPx: m.widthPx,
+      heightPx: m.heightPx,
+      region: m.region,
+      isCaptureDefault: !!m.isCaptureDefault,
+    })
+
     res.json({
       success: true,
       data: {
         gameId: game.id,
         gameName: game.name,
         slug: game.slug,
-        activeMap: activeMap
-          ? {
-              id: activeMap.id,
-              source: activeMap.source,
-              imageUrl: activeMap.imageUrl,
-              license: activeMap.license,
-              attribution: activeMap.attribution,
-              widthPx: activeMap.widthPx,
-              heightPx: activeMap.heightPx,
-              region: activeMap.region,
-            }
-          : null,
+        // Deprecated: kept for back-compat; consumers should switch to
+        // `enabledMaps` and `captureDefaultMap`.
+        activeMap: captureDefault ? mapSummary(captureDefault) : null,
+        enabledMaps: enabledMaps.map(mapSummary),
+        captureDefaultMap: captureDefault ? mapSummary(captureDefault) : null,
         sources,
       },
     })
@@ -2170,22 +2182,22 @@ router.get('/geo/games/:id/sources', async (req, res, next) => {
   }
 })
 
-// Switch which geo_map row is the active one for a game. Used by the admin
-// Maps tab when multiple tiers (Fandom / StrategyWiki / Fextralife / …) have
-// produced candidate maps and the operator wants to pick the best one
-// instead of accepting whichever tier landed first.
-const setActiveMapBodySchema = z.object({
+// Multi-map: enable a specific geo_map row for a game. Multiple maps can
+// be enabled simultaneously (BG3 → Nautiloid + Wilderness + …). When the
+// game had zero enabled maps before this call the same map is also
+// promoted to capture-default so ingest has a target.
+const enableMapBodySchema = z.object({
   geoMapId: z.number().int().positive(),
 })
 
-router.post('/geo/games/:id/active-map', async (req, res, next) => {
+router.post('/geo/games/:id/maps/enable', async (req, res, next) => {
   try {
     const id = Number(req.params.id)
     if (!Number.isFinite(id) || id <= 0) {
       res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
       return
     }
-    const parse = setActiveMapBodySchema.safeParse(req.body)
+    const parse = enableMapBodySchema.safeParse(req.body)
     if (!parse.success) {
       res.status(400).json({
         success: false,
@@ -2193,7 +2205,7 @@ router.post('/geo/games/:id/active-map', async (req, res, next) => {
       })
       return
     }
-    const map = await geoMapRepository.setActiveForGame(id, parse.data.geoMapId)
+    const map = await geoMapRepository.enableForGame(id, parse.data.geoMapId)
     if (!map) {
       res.status(404).json({
         success: false,
@@ -2201,6 +2213,146 @@ router.post('/geo/games/:id/active-map', async (req, res, next) => {
           code: 'MAP_NOT_FOUND',
           message: 'no geo_map row with that id for this game',
         },
+      })
+      return
+    }
+    res.json({ success: true, data: map })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Multi-map: disable a single map. Refuses with 409 LAST_ENABLED if it
+// would leave the game with zero enabled maps. The capture-default role
+// is auto-handed to a sibling if the disabled row held it.
+router.post('/geo/games/:id/maps/disable', async (req, res, next) => {
+  try {
+    const id = Number(req.params.id)
+    if (!Number.isFinite(id) || id <= 0) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+    const parse = enableMapBodySchema.safeParse(req.body)
+    if (!parse.success) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: parse.error.issues[0]?.message },
+      })
+      return
+    }
+    const result = await geoMapRepository.disableForGame(id, parse.data.geoMapId)
+    if (!result.ok) {
+      const status = result.reason === 'NOT_FOUND' ? 404 : 409
+      res.status(status).json({
+        success: false,
+        error: {
+          code: result.reason,
+          message:
+            result.reason === 'LAST_ENABLED'
+              ? 'cannot disable the last enabled map for a game'
+              : 'no geo_map row with that id for this game',
+        },
+      })
+      return
+    }
+    res.json({ success: true, data: result.map })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Multi-map: pick which enabled map Steam/RAWG capture providers attach
+// new candidates to. At most one row per game holds the role; the partial
+// unique index `geo_map_one_capture_default_per_game` enforces it.
+router.post('/geo/games/:id/maps/capture-default', async (req, res, next) => {
+  try {
+    const id = Number(req.params.id)
+    if (!Number.isFinite(id) || id <= 0) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+    const parse = enableMapBodySchema.safeParse(req.body)
+    if (!parse.success) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: parse.error.issues[0]?.message },
+      })
+      return
+    }
+    const map = await geoMapRepository.setCaptureDefault(id, parse.data.geoMapId)
+    if (!map) {
+      res.status(404).json({
+        success: false,
+        error: {
+          code: 'MAP_NOT_FOUND',
+          message: 'map must be enabled for this game before becoming capture default',
+        },
+      })
+      return
+    }
+    res.json({ success: true, data: map })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Inline region edit. Sending an empty string or null clears the region
+// (game collapses back to a single "world map" presentation).
+const updateMapBodySchema = z.object({
+  region: z.string().max(100).nullable().optional(),
+})
+
+router.patch('/geo/maps/:mapId', async (req, res, next) => {
+  try {
+    const mapId = Number(req.params.mapId)
+    if (!Number.isFinite(mapId) || mapId <= 0) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+    const parse = updateMapBodySchema.safeParse(req.body)
+    if (!parse.success) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: parse.error.issues[0]?.message },
+      })
+      return
+    }
+    const updated =
+      parse.data.region !== undefined
+        ? await geoMapRepository.updateRegion(mapId, parse.data.region ?? null)
+        : await geoMapRepository.findById(mapId)
+    if (!updated) {
+      res.status(404).json({ success: false, error: { code: 'MAP_NOT_FOUND' } })
+      return
+    }
+    res.json({ success: true, data: updated })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Deprecated: routes through to `/maps/enable` for one release so a stale
+// frontend keeps working. Remove next release.
+router.post('/geo/games/:id/active-map', async (req, res, next) => {
+  try {
+    const id = Number(req.params.id)
+    if (!Number.isFinite(id) || id <= 0) {
+      res.status(400).json({ success: false, error: { code: 'INVALID_ID' } })
+      return
+    }
+    const parse = enableMapBodySchema.safeParse(req.body)
+    if (!parse.success) {
+      res.status(400).json({
+        success: false,
+        error: { code: 'VALIDATION_ERROR', message: parse.error.issues[0]?.message },
+      })
+      return
+    }
+    const map = await geoMapRepository.enableForGame(id, parse.data.geoMapId)
+    if (!map) {
+      res.status(404).json({
+        success: false,
+        error: { code: 'MAP_NOT_FOUND' },
       })
       return
     }
@@ -2719,23 +2871,13 @@ router.post('/geo/maps/manual', async (req, res, next) => {
       return
     }
 
-    if (data.replaceActive) {
-      const active = await geoMapRepository.findActiveByGameId(data.gameId)
-      if (active) await geoMapRepository.deactivate(active.id)
-    } else {
-      const active = await geoMapRepository.findActiveByGameId(data.gameId)
-      if (active) {
-        res.status(409).json({
-          success: false,
-          error: {
-            code: 'MAP_EXISTS',
-            message:
-              'an active geo_map already exists for this game; pass replaceActive=true to swap',
-          },
-        })
-        return
-      }
-    }
+    // Multi-map mode: a game can have many enabled maps. The legacy
+    // `replaceActive` body flag now means "enable this new map after
+    // creating it"; without it, the row is created disabled and the
+    // admin enables it from the Cartes panel. This intentionally stops
+    // throwing MAP_EXISTS — that 409 is what blocked operators from
+    // adding a second region in the first place.
+    const enableImmediately = !!data.replaceActive
 
     const map = await geoMapRepository.create({
       gameId: data.gameId,
@@ -2748,7 +2890,14 @@ router.post('/geo/maps/manual', async (req, res, next) => {
       attribution: data.attribution,
       consensusRadius: data.consensusRadius,
       region: data.region,
+      isActive: enableImmediately,
     })
+
+    if (enableImmediately) {
+      // create() already inserts is_active=true, but enableForGame also
+      // promotes to capture-default when the game had no enabled siblings.
+      await geoMapRepository.enableForGame(data.gameId, map.id)
+    }
 
     // Also clear all ingest tombstones for this game — manual upload is the
     // operator saying "I've solved this", so the auto-pipeline shouldn't keep
@@ -2808,19 +2957,11 @@ router.post('/geo/maps/wand', async (req, res, next) => {
       return
     }
 
-    const active = await geoMapRepository.findActiveByGameId(data.gameId)
-    if (active && !data.replaceActive) {
-      res.status(409).json({
-        success: false,
-        error: {
-          code: 'MAP_EXISTS',
-          message:
-            'an active geo_map already exists for this game; pass replaceActive=true to swap',
-        },
-      })
-      return
-    }
-
+    // Multi-map: a game can have many enabled maps simultaneously. The
+    // legacy `replaceActive` flag now means "enable the imported map and
+    // deactivate the previously-enabled siblings" (back-compat for
+    // operators who explicitly want a swap). Without it, the wand
+    // import lands as inactive — admin enables it from the Cartes panel.
     const result = await importWandMap({
       gameId: data.gameId,
       wandUrl: data.wandUrl,
@@ -2835,11 +2976,18 @@ router.post('/geo/maps/wand', async (req, res, next) => {
       return
     }
 
-    if (active && data.replaceActive && active.id !== result.geoMapId) {
-      await geoMapRepository.deactivate(active.id)
-      if (result.geoMapId) {
-        await geoMapRepository.setActiveForGame(data.gameId, result.geoMapId)
+    if (data.replaceActive && result.geoMapId) {
+      // Disable currently-enabled siblings so the freshly imported row
+      // is the only one playable. Multi-map sibling-aware: skips itself.
+      const enabled = await geoMapRepository.listEnabledByGameId(data.gameId)
+      for (const sibling of enabled) {
+        if (sibling.id !== result.geoMapId) {
+          // Best-effort disable; swallow LAST_ENABLED since we're about
+          // to enable the new map below.
+          await geoMapRepository.deactivate(sibling.id)
+        }
       }
+      await geoMapRepository.enableForGame(data.gameId, result.geoMapId)
     }
 
     const map = result.geoMapId

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -41,6 +41,10 @@ const pointSchema = z.object({
 
 const guessBodySchema = z.object({
   challengeId: z.number().int().positive(),
+  // Required for multi-map games; optional for single-map (the service
+  // auto-resolves to the only enabled map). Validated server-side
+  // against the challenge's game.
+  geoMapId: z.number().int().positive().optional(),
   guess: pointSchema,
   durationMs: z.number().int().nonnegative().optional(),
 })
@@ -117,10 +121,11 @@ router.get('/history', optionalAuthMiddleware, validateQuery(historyQuerySchema)
 router.post('/guess', authMiddleware, validateBody(guessBodySchema), async (req, res, next) => {
   try {
     const userId = req.userId!
-    const { challengeId, guess, durationMs } = req.body as z.infer<typeof guessBodySchema>
+    const { challengeId, geoMapId, guess, durationMs } = req.body as z.infer<typeof guessBodySchema>
     const result = await geoGameService.submitGuess({
       userId,
       challengeId,
+      geoMapId,
       guess,
       durationMs,
     })
@@ -135,7 +140,12 @@ router.post('/guess', authMiddleware, validateBody(guessBodySchema), async (req,
     res.json({ success: true, data: result })
   } catch (err) {
     if (err instanceof GeoGameError) {
-      const status = err.code === 'ALREADY_GUESSED' ? 409 : err.code === 'INVALID_POINT' ? 400 : 404
+      const status =
+        err.code === 'ALREADY_GUESSED'
+          ? 409
+          : err.code === 'INVALID_POINT' || err.code === 'INVALID_MAP'
+            ? 400
+            : 404
       res.status(status).json({ success: false, error: { code: err.code, message: err.message } })
       return
     }

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -631,6 +631,21 @@
           "previewAlt": "Active map for {{name}} (click to open full size)",
           "previewDimensions": "{{width}} × {{height}} px",
           "loading": "Loading sources…"
+        },
+        "multi": {
+          "enabledTitle": "Enabled maps",
+          "enabledCount_one": "{{count}} enabled",
+          "enabledCount_other": "{{count}} enabled",
+          "disable": "Disable map",
+          "disableAction": "Disable",
+          "disabled": "Map disabled.",
+          "disableLastBlocked": "Cannot disable the last enabled map for a game.",
+          "captureDefaultBadge": "Capture default",
+          "captureDefaultAction": "Default",
+          "setCaptureDefault": "Set as Steam/RAWG capture target",
+          "captureDefaultSet": "Capture default updated.",
+          "regionEdit": "Edit region",
+          "regionEditPlaceholder": "Region — e.g. Act II"
         }
       },
       "research": {
@@ -1453,6 +1468,21 @@
         "noChallenge": "No geo game is live right now. We're rolling out new ones gradually — check back soon.",
         "comingSoon": "New game coming soon",
         "viewHistory": "View past challenges"
+      },
+      "chooseMap": {
+        "title": "Which map?",
+        "hint": "Pick the map this screenshot is on, then drop a pin.",
+        "required": "Pick a map above before dropping a pin.",
+        "worldFallback": "World map",
+        "correct": "Correct map",
+        "incorrect": "Wrong map"
+      },
+      "wrongMap": {
+        "banner": "Wrong map — score floored.",
+        "chip": "Wrong map"
+      },
+      "reveal": {
+        "correctMap": "Correct map: {{region}}"
       }
     },
     "contribute": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -631,6 +631,21 @@
           "previewAlt": "Carte active pour {{name}} (cliquez pour ouvrir en taille réelle)",
           "previewDimensions": "{{width}} × {{height}} px",
           "loading": "Chargement des sources…"
+        },
+        "multi": {
+          "enabledTitle": "Cartes activées",
+          "enabledCount_one": "{{count}} activée",
+          "enabledCount_other": "{{count}} activées",
+          "disable": "Désactiver la carte",
+          "disableAction": "Désactiver",
+          "disabled": "Carte désactivée.",
+          "disableLastBlocked": "Impossible de désactiver la dernière carte activée d'un jeu.",
+          "captureDefaultBadge": "Cible des captures",
+          "captureDefaultAction": "Définir comme cible",
+          "setCaptureDefault": "Définir comme cible des captures Steam/RAWG",
+          "captureDefaultSet": "Cible des captures mise à jour.",
+          "regionEdit": "Modifier la région",
+          "regionEditPlaceholder": "Région — ex. Acte II"
         }
       },
       "research": {
@@ -1453,6 +1468,21 @@
         "noChallenge": "Aucun défi géo n'est en ligne pour le moment. On les déploie progressivement — revenez bientôt.",
         "comingSoon": "Nouveau défi à venir",
         "viewHistory": "Voir les défis passés"
+      },
+      "chooseMap": {
+        "title": "Quelle carte ?",
+        "hint": "Choisissez la carte où se trouve la capture, puis posez votre épingle.",
+        "required": "Choisissez une carte avant de poser une épingle.",
+        "worldFallback": "Carte du monde",
+        "correct": "Bonne carte",
+        "incorrect": "Mauvaise carte"
+      },
+      "wrongMap": {
+        "banner": "Mauvaise carte — score plancher.",
+        "chip": "Mauvaise carte"
+      },
+      "reveal": {
+        "correctMap": "Bonne carte : {{region}}"
       }
     },
     "contribute": {

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -79,6 +79,9 @@ interface ActiveMapInfo {
     widthPx: number
     heightPx: number
     region?: string | null
+    // Multi-map: marks the row Steam/RAWG capture providers attach new
+    // candidates to. Exactly one map per game holds the role.
+    isCaptureDefault?: boolean
 }
 
 type TierKey =
@@ -124,7 +127,13 @@ interface SourcesResponse {
     gameId: number
     gameName: string
     slug: string
+    // Deprecated: identical to `captureDefaultMap`. Kept for the desktop
+    // preview block until the multi-map refactor of that section lands.
     activeMap: ActiveMapInfo | null
+    // All maps a player would see in the chooser today. Always includes
+    // the capture default; for a single-map game it has length 1.
+    enabledMaps?: ActiveMapInfo[]
+    captureDefaultMap?: ActiveMapInfo | null
     sources: TierState[]
 }
 
@@ -331,17 +340,89 @@ export function GeoMapsTab({
         }
     }
 
+    // Multi-map mode: "activate" a map = enable it. The legacy endpoint
+    // (`/active-map`) is kept on the backend as an alias; this path uses
+    // the explicit enable so multiple maps can be enabled in turn.
     const handleActivateMap = async (gameId: number, mapId: number) => {
         setActivatingMapId(mapId)
         setMessage(null)
         setError(null)
         try {
-            await fetchJson(`/api/admin/geo/games/${gameId}/active-map`, {
+            await fetchJson(`/api/admin/geo/games/${gameId}/maps/enable`, {
                 method: 'POST',
                 body: JSON.stringify({ geoMapId: mapId }),
             })
             setMessage(t('admin.geo.maps.tierStatus.activated'))
             await Promise.all([reload(), reloadSources(gameId)])
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setActivatingMapId(null)
+        }
+    }
+
+    const handleDisableMap = async (gameId: number, mapId: number) => {
+        setActivatingMapId(mapId)
+        setMessage(null)
+        setError(null)
+        try {
+            await fetchJson(`/api/admin/geo/games/${gameId}/maps/disable`, {
+                method: 'POST',
+                body: JSON.stringify({ geoMapId: mapId }),
+            })
+            setMessage(t('admin.geo.maps.multi.disabled', 'Map disabled.'))
+            await Promise.all([reload(), reloadSources(gameId)])
+        } catch (e) {
+            const message = String(e)
+            if (message.includes('LAST_ENABLED')) {
+                setError(
+                    t(
+                        'admin.geo.maps.multi.disableLastBlocked',
+                        'Cannot disable the last enabled map for a game.',
+                    ),
+                )
+            } else {
+                setError(message)
+            }
+        } finally {
+            setActivatingMapId(null)
+        }
+    }
+
+    const handleSetCaptureDefault = async (gameId: number, mapId: number) => {
+        setActivatingMapId(mapId)
+        setMessage(null)
+        setError(null)
+        try {
+            await fetchJson(`/api/admin/geo/games/${gameId}/maps/capture-default`, {
+                method: 'POST',
+                body: JSON.stringify({ geoMapId: mapId }),
+            })
+            setMessage(
+                t('admin.geo.maps.multi.captureDefaultSet', 'Capture default updated.'),
+            )
+            await reloadSources(gameId)
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setActivatingMapId(null)
+        }
+    }
+
+    const handleUpdateRegion = async (
+        gameId: number,
+        mapId: number,
+        region: string | null,
+    ) => {
+        setActivatingMapId(mapId)
+        setMessage(null)
+        setError(null)
+        try {
+            await fetchJson(`/api/admin/geo/maps/${mapId}`, {
+                method: 'PATCH',
+                body: JSON.stringify({ region }),
+            })
+            await reloadSources(gameId)
         } catch (e) {
             setError(String(e))
         } finally {
@@ -543,6 +624,9 @@ export function GeoMapsTab({
                         onRetryTier={handleRetryTier}
                         onRunTierNow={handleRunTierNow}
                         onActivateMap={handleActivateMap}
+                        onDisableMap={handleDisableMap}
+                        onSetCaptureDefault={handleSetCaptureDefault}
+                        onUpdateRegion={handleUpdateRegion}
                         onReimport={reimport}
                         onResearch={setResearchFor}
                         onWandImport={setWandImportFor}
@@ -608,6 +692,9 @@ export function GeoMapsTab({
                             onRetryTier={handleRetryTier}
                             onRunTierNow={handleRunTierNow}
                             onActivateMap={handleActivateMap}
+                            onDisableMap={handleDisableMap}
+                            onSetCaptureDefault={handleSetCaptureDefault}
+                            onUpdateRegion={handleUpdateRegion}
                             onReimport={reimport}
                             onResearch={setResearchFor}
                             onWandImport={setWandImportFor}
@@ -754,6 +841,13 @@ interface SidePanelBodyProps {
     onRetryTier: (gameId: number, tier: string) => void | Promise<void>
     onRunTierNow: (gameId: number, tier: string) => void | Promise<void>
     onActivateMap: (gameId: number, mapId: number) => void | Promise<void>
+    onDisableMap: (gameId: number, mapId: number) => void | Promise<void>
+    onSetCaptureDefault: (gameId: number, mapId: number) => void | Promise<void>
+    onUpdateRegion: (
+        gameId: number,
+        mapId: number,
+        region: string | null,
+    ) => void | Promise<void>
     onReimport: (game: CuratedGame) => void | Promise<void>
     onResearch: (game: CuratedGame) => void
     onWandImport: (game: CuratedGame) => void
@@ -776,6 +870,9 @@ function SidePanelBody({
     onRetryTier,
     onRunTierNow,
     onActivateMap,
+    onDisableMap,
+    onSetCaptureDefault,
+    onUpdateRegion,
     onReimport,
     onResearch,
     onWandImport,
@@ -807,34 +904,18 @@ function SidePanelBody({
         )
     }
     if (!sources) return null
+    const enabledMaps = sources.enabledMaps ?? (sources.activeMap ? [sources.activeMap] : [])
     return (
         <>
-            {sources.activeMap && (
-                <a
-                    href={sources.activeMap.imageUrl}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                    className="block overflow-hidden rounded border border-border/40 bg-muted/10"
-                    aria-label={t('admin.geo.maps.sidePanel.previewAlt', {
-                        name: sources.gameName,
-                    })}
-                >
-                    <img
-                        src={sources.activeMap.imageUrl}
-                        alt={t('admin.geo.maps.sidePanel.previewAlt', {
-                            name: sources.gameName,
-                        })}
-                        loading="lazy"
-                        className="block max-h-48 w-full object-contain bg-black/40"
-                    />
-                    <p className="px-2 py-1 text-[10px] text-muted-foreground">
-                        {t('admin.geo.maps.sidePanel.previewDimensions', {
-                            width: sources.activeMap.widthPx,
-                            height: sources.activeMap.heightPx,
-                        })}
-                    </p>
-                </a>
-            )}
+            <EnabledMapsPanel
+                gameId={sources.gameId}
+                enabledMaps={enabledMaps}
+                activatingMapId={activatingMapId}
+                onDisable={onDisableMap}
+                onSetCaptureDefault={onSetCaptureDefault}
+                onUpdateRegion={onUpdateRegion}
+                t={t}
+            />
             <ol className="space-y-2">
                 {sources.sources.map((s) => {
                     const tiers = tiersInFlightForGame(runState, sources.gameId)
@@ -939,6 +1020,193 @@ function SidePanelBody({
                 </Button>
             )}
         </>
+    )
+}
+
+// Multi-map: lists every enabled map for the game with per-map controls
+// (disable, promote to capture-default, edit region inline). Renders nothing
+// when the game has no enabled map yet — the tier cascade below still
+// surfaces the "Use this map" affordance on per-source candidates.
+function EnabledMapsPanel({
+    gameId,
+    enabledMaps,
+    activatingMapId,
+    onDisable,
+    onSetCaptureDefault,
+    onUpdateRegion,
+    t,
+}: {
+    gameId: number
+    enabledMaps: ActiveMapInfo[]
+    activatingMapId: number | null
+    onDisable: (gameId: number, mapId: number) => void | Promise<void>
+    onSetCaptureDefault: (gameId: number, mapId: number) => void | Promise<void>
+    onUpdateRegion: (
+        gameId: number,
+        mapId: number,
+        region: string | null,
+    ) => void | Promise<void>
+    t: ReturnType<typeof useTranslation>['t']
+}) {
+    if (enabledMaps.length === 0) return null
+    const canDisable = enabledMaps.length > 1
+    return (
+        <div className="rounded border border-border/40 bg-muted/10 p-2 space-y-2">
+            <div className="flex items-baseline justify-between">
+                <h4 className="text-xs font-medium">
+                    {t('admin.geo.maps.multi.enabledTitle', 'Enabled maps')}
+                </h4>
+                <span className="text-[10px] text-muted-foreground">
+                    {t('admin.geo.maps.multi.enabledCount', {
+                        defaultValue: '{{count}} enabled',
+                        count: enabledMaps.length,
+                    })}
+                </span>
+            </div>
+            <ul className="space-y-1.5">
+                {enabledMaps.map((m) => (
+                    <EnabledMapRow
+                        key={m.id}
+                        gameId={gameId}
+                        map={m}
+                        canDisable={canDisable}
+                        busy={activatingMapId === m.id}
+                        onDisable={onDisable}
+                        onSetCaptureDefault={onSetCaptureDefault}
+                        onUpdateRegion={onUpdateRegion}
+                        t={t}
+                    />
+                ))}
+            </ul>
+        </div>
+    )
+}
+
+function EnabledMapRow({
+    gameId,
+    map,
+    canDisable,
+    busy,
+    onDisable,
+    onSetCaptureDefault,
+    onUpdateRegion,
+    t,
+}: {
+    gameId: number
+    map: ActiveMapInfo
+    canDisable: boolean
+    busy: boolean
+    onDisable: (gameId: number, mapId: number) => void | Promise<void>
+    onSetCaptureDefault: (gameId: number, mapId: number) => void | Promise<void>
+    onUpdateRegion: (
+        gameId: number,
+        mapId: number,
+        region: string | null,
+    ) => void | Promise<void>
+    t: ReturnType<typeof useTranslation>['t']
+}) {
+    const [editing, setEditing] = useState(false)
+    const [draft, setDraft] = useState(map.region ?? '')
+    const commit = async () => {
+        const next = draft.trim() || null
+        if ((map.region ?? null) === next) {
+            setEditing(false)
+            return
+        }
+        await onUpdateRegion(gameId, map.id, next)
+        setEditing(false)
+    }
+    return (
+        <li className="flex items-center gap-2 rounded border border-border/30 bg-background/40 px-2 py-1.5 text-xs">
+            <img
+                src={map.imageUrl}
+                alt=""
+                loading="lazy"
+                className="h-10 w-10 flex-none rounded object-cover bg-black/40"
+            />
+            <div className="min-w-0 flex-1 space-y-0.5">
+                <div className="flex items-center gap-1.5">
+                    {editing ? (
+                        <input
+                            autoFocus
+                            value={draft}
+                            disabled={busy}
+                            onChange={(e) => setDraft(e.target.value)}
+                            onBlur={() => void commit()}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') void commit()
+                                else if (e.key === 'Escape') {
+                                    setDraft(map.region ?? '')
+                                    setEditing(false)
+                                }
+                            }}
+                            placeholder={t(
+                                'admin.geo.maps.multi.regionEditPlaceholder',
+                                'Region — e.g. Act II',
+                            )}
+                            className="w-full rounded border border-border/60 bg-background px-1.5 py-0.5 text-[11px]"
+                        />
+                    ) : (
+                        <button
+                            type="button"
+                            className="truncate text-left font-medium hover:underline"
+                            onClick={() => setEditing(true)}
+                            title={t('admin.geo.maps.multi.regionEdit', 'Edit region')}
+                        >
+                            {map.region ??
+                                t('geo.daily.chooseMap.worldFallback', 'World map')}
+                        </button>
+                    )}
+                    {map.isCaptureDefault && (
+                        <span className="rounded-full border border-neon-pink/40 bg-neon-pink/10 px-1.5 py-px text-[9px] uppercase tracking-wide text-neon-pink">
+                            {t(
+                                'admin.geo.maps.multi.captureDefaultBadge',
+                                'Capture default',
+                            )}
+                        </span>
+                    )}
+                </div>
+                <p className="truncate text-[10px] text-muted-foreground">
+                    {t(`admin.geo.maps.tiers.${map.source}`)}
+                </p>
+            </div>
+            <div className="flex flex-none gap-1">
+                {!map.isCaptureDefault && (
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={busy}
+                        className="h-6 px-2 text-[10px]"
+                        onClick={() => void onSetCaptureDefault(gameId, map.id)}
+                        title={t(
+                            'admin.geo.maps.multi.setCaptureDefault',
+                            'Set as capture default',
+                        )}
+                    >
+                        {t('admin.geo.maps.multi.captureDefaultAction', 'Default')}
+                    </Button>
+                )}
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    disabled={busy || !canDisable}
+                    className="h-6 px-2 text-[10px] text-destructive hover:text-destructive"
+                    onClick={() => void onDisable(gameId, map.id)}
+                    title={
+                        canDisable
+                            ? t('admin.geo.maps.multi.disable', 'Disable map')
+                            : t(
+                                  'admin.geo.maps.multi.disableLastBlocked',
+                                  'Cannot disable the last enabled map for a game.',
+                              )
+                    }
+                >
+                    {t('admin.geo.maps.multi.disableAction', 'Disable')}
+                </Button>
+            </div>
+        </li>
     )
 }
 

--- a/packages/frontend/src/components/geo/GeoMapChooser.tsx
+++ b/packages/frontend/src/components/geo/GeoMapChooser.tsx
@@ -1,0 +1,152 @@
+import { useTranslation } from 'react-i18next'
+import type { GeoMap } from '@the-box/types'
+import { Check, X } from 'lucide-react'
+import { isPlaceholderImageUrl } from '@/lib/geo-image'
+import { cn } from '@/lib/utils'
+
+interface GeoMapChooserProps {
+  maps: GeoMap[]
+  selectedMapId: number | null
+  // The canonical map of the screenshot. Only set after the player has
+  // submitted; drives the green check / red X reveal.
+  correctMapId: number | null
+  // True after submit so cards become non-interactive.
+  disabled: boolean
+  onSelect: (mapId: number) => void
+}
+
+// Multi-map picker — surfaced for the daily challenge whenever a game
+// has more than one enabled map. Looks like the Map Genie wiki listing
+// (thumbnail + region label per card) and collapses to a single passive
+// label on single-map games so the existing Elden Ring flow is unchanged.
+export function GeoMapChooser({
+  maps,
+  selectedMapId,
+  correctMapId,
+  disabled,
+  onSelect,
+}: GeoMapChooserProps) {
+  const { t } = useTranslation()
+
+  if (maps.length === 0) return null
+
+  // Single-map games: a passive label keeps the layout consistent without
+  // demanding a click. The chooser still mounts so the component is the
+  // single source of truth for multi-map UX, just not interactive.
+  if (maps.length === 1) {
+    const only = maps[0]!
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-muted/30 bg-card/40 px-3 py-2 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">
+          {only.region ?? t('geo.daily.chooseMap.worldFallback', 'World map')}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-medium text-foreground">
+          {t('geo.daily.chooseMap.title', 'Which map?')}
+        </h3>
+        <p className="text-xs text-muted-foreground">
+          {t(
+            'geo.daily.chooseMap.hint',
+            'Pick the map this screenshot is on, then drop a pin.',
+          )}
+        </p>
+      </div>
+      <div
+        role="radiogroup"
+        aria-label={t('geo.daily.chooseMap.title', 'Which map?')}
+        className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4"
+      >
+        {maps.map((m) => (
+          <MapCard
+            key={m.id}
+            map={m}
+            selected={selectedMapId === m.id}
+            correct={correctMapId === m.id}
+            wrong={
+              correctMapId != null &&
+              selectedMapId === m.id &&
+              correctMapId !== m.id
+            }
+            disabled={disabled}
+            onSelect={() => onSelect(m.id)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface MapCardProps {
+  map: GeoMap
+  selected: boolean
+  correct: boolean
+  wrong: boolean
+  disabled: boolean
+  onSelect: () => void
+}
+
+function MapCard({ map, selected, correct, wrong, disabled, onSelect }: MapCardProps) {
+  const { t } = useTranslation()
+  const label = map.region ?? t('geo.daily.chooseMap.worldFallback', 'World map')
+  const placeholder = isPlaceholderImageUrl(map.imageUrl)
+
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      aria-label={label}
+      onClick={onSelect}
+      disabled={disabled}
+      className={cn(
+        'group relative aspect-square overflow-hidden rounded-lg border bg-muted/30 text-left transition',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        selected
+          ? 'border-neon-pink ring-2 ring-neon-pink/60 shadow-[0_0_12px_rgba(236,72,153,0.4)]'
+          : 'border-muted/40 hover:border-neon-pink/60',
+        disabled && !selected && 'opacity-60',
+        disabled && 'cursor-default',
+      )}
+    >
+      {!placeholder ? (
+        <img
+          src={map.imageUrl}
+          alt=""
+          className="h-full w-full object-cover transition group-hover:scale-[1.02]"
+          loading="lazy"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+          {label}
+        </div>
+      )}
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-2 py-1.5">
+        <span className="block truncate text-xs font-medium text-white">
+          {label}
+        </span>
+      </div>
+      {correct && (
+        <div
+          className="absolute right-1.5 top-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-score-high text-white shadow"
+          aria-label={t('geo.daily.chooseMap.correct', 'Correct map')}
+        >
+          <Check className="h-3.5 w-3.5" aria-hidden />
+        </div>
+      )}
+      {wrong && (
+        <div
+          className="absolute right-1.5 top-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-destructive text-destructive-foreground shadow"
+          aria-label={t('geo.daily.chooseMap.incorrect', 'Wrong map')}
+        >
+          <X className="h-3.5 w-3.5" aria-hidden />
+        </div>
+      )}
+    </button>
+  )
+}

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -53,7 +53,13 @@ export interface GeoDailyView {
     challenge: GeoChallenge
     meta: GeoScreenshotMeta
     candidate: GeoScreenshotCandidate
-    map: GeoMap
+    // Multi-map: every enabled map for the challenge's game. Always at
+    // least one entry; single-map games surface an array of length 1.
+    maps: GeoMap[]
+    // The canonical map. Server only sends this AFTER the player has
+    // guessed — the in-progress payload omits it so DevTools can't leak
+    // the answer.
+    map?: GeoMap
     hasGuessed: boolean
 }
 
@@ -85,6 +91,10 @@ export const geoApi = {
 
     submitGuess(input: {
         challengeId: number
+        // Map the player picked from the chooser. Optional for single-map
+        // games (server auto-resolves); required by validation when the
+        // game has multiple enabled maps.
+        geoMapId?: number
         guess: GeoPoint
         durationMs?: number
     }): Promise<GeoGuessResult> {

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -4,6 +4,7 @@ import { useSession } from '@/lib/auth-client'
 import { useGeoStore } from '@/stores/geoStore'
 import { connectGeoSocket } from '@/lib/geo-socket'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
+import { GeoMapChooser } from '@/components/geo/GeoMapChooser'
 import { ReportCaptureDialog } from '@/components/ReportCaptureDialog'
 import { CubeBackground } from '@/components/backgrounds/CubeBackground'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -21,7 +22,9 @@ export default function GeoDailyPage() {
         challenge,
         meta,
         candidate,
-        map,
+        maps,
+        selectedMapId,
+        correctMap,
         hasGuessed,
         pendingGuess,
         result,
@@ -29,11 +32,14 @@ export default function GeoDailyPage() {
         errorMessage,
         errorCode,
         loadCurrent,
+        selectMap,
         setPendingGuess,
         submitGuess,
         skipChallenge,
         loadNextUnplayed,
     } = useGeoStore()
+    const selectedMap = maps.find((m) => m.id === selectedMapId) ?? null
+    const isMultiMap = maps.length > 1
 
     // useRef's initial value runs on every render; lazy-via-useState keeps
     // Date.now() out of render while staying mount-stable.
@@ -47,7 +53,13 @@ export default function GeoDailyPage() {
         connectGeoSocket(session?.user?.id)
     }, [session?.user?.id])
 
-    const canSubmit = phase === 'playing' && !!pendingGuess && !hasGuessed
+    // Multi-map games gate submit on having picked a map; single-map games
+    // auto-select at load time so the gate becomes a no-op.
+    const canSubmit =
+        phase === 'playing' &&
+        !!pendingGuess &&
+        !hasGuessed &&
+        (selectedMapId != null || maps.length === 0)
     const canSkip = phase === 'playing' && !hasGuessed
 
     const handleSubmit = async () => {
@@ -114,7 +126,7 @@ export default function GeoDailyPage() {
                         </Card>
                     )}
 
-                {challenge && meta && candidate && map && (phase === 'playing' || phase === 'submitting' || phase === 'result' || phase === 'skipped') && (
+                {challenge && meta && candidate && maps.length > 0 && (phase === 'playing' || phase === 'submitting' || phase === 'result' || phase === 'skipped') && (
                     <div className="grid gap-6 lg:grid-cols-2">
                         <Card>
                             <CardHeader className="pb-2 flex-row items-center justify-between space-y-0">
@@ -139,16 +151,48 @@ export default function GeoDailyPage() {
                                 </CardTitle>
                             </CardHeader>
                             <CardContent className="space-y-4">
-                                <GeoMapCanvas
-                                    imageUrl={map.imageUrl}
-                                    widthPx={map.widthPx}
-                                    heightPx={map.heightPx}
-                                    pin={pendingGuess ?? result?.guess ?? null}
-                                    canonical={result?.canonical ?? null}
-                                    disabled={hasGuessed || phase === 'submitting' || phase === 'result' || phase === 'skipped'}
-                                    onPin={setPendingGuess}
-                                    showGuessLine={phase === 'result'}
-                                />
+                                {isMultiMap && (
+                                    <GeoMapChooser
+                                        maps={maps}
+                                        selectedMapId={selectedMapId}
+                                        correctMapId={correctMap?.id ?? null}
+                                        disabled={hasGuessed || phase !== 'playing'}
+                                        onSelect={selectMap}
+                                    />
+                                )}
+
+                                {selectedMap ? (
+                                    <GeoMapCanvas
+                                        imageUrl={selectedMap.imageUrl}
+                                        widthPx={selectedMap.widthPx}
+                                        heightPx={selectedMap.heightPx}
+                                        pin={pendingGuess ?? result?.guess ?? null}
+                                        canonical={
+                                            // Only show the canonical pin when the player picked
+                                            // the right map — otherwise the dot would land on
+                                            // a different map's coordinate space and look like
+                                            // an off-screen bug.
+                                            phase === 'result' &&
+                                            correctMap &&
+                                            selectedMap.id === correctMap.id
+                                                ? result?.canonical ?? null
+                                                : null
+                                        }
+                                        disabled={hasGuessed || phase === 'submitting' || phase === 'result' || phase === 'skipped'}
+                                        onPin={setPendingGuess}
+                                        showGuessLine={phase === 'result' && !!correctMap && selectedMap.id === correctMap.id}
+                                    />
+                                ) : (
+                                    <div
+                                        className="flex aspect-video w-full items-center justify-center rounded-lg border border-dashed bg-muted/30 px-6 text-center text-xs text-muted-foreground"
+                                        role="status"
+                                    >
+                                        {t(
+                                            'geo.daily.chooseMap.required',
+                                            'Pick a map above before dropping a pin.',
+                                        )}
+                                    </div>
+                                )}
 
                                 <div className="flex items-center justify-between gap-2">
                                     <span className="text-xs text-muted-foreground">
@@ -183,7 +227,14 @@ export default function GeoDailyPage() {
                                     </div>
                                 </div>
 
-                                {result && <ResultBlock result={result} t={t} language={i18n.language} />}
+                                {result && (
+                                    <ResultBlock
+                                        result={result}
+                                        correctMap={correctMap}
+                                        t={t}
+                                        language={i18n.language}
+                                    />
+                                )}
                                 {phase === 'skipped' && wasSkipped && <SkipResultBlock t={t} />}
                                 {(phase === 'result' || phase === 'skipped') && (
                                     <Button
@@ -230,10 +281,12 @@ function SkipResultBlock({ t }: { t: ReturnType<typeof useTranslation>['t'] }) {
 
 function ResultBlock({
     result,
+    correctMap,
     t,
     language,
 }: {
     result: NonNullable<ReturnType<typeof useGeoStore.getState>['result']>
+    correctMap: ReturnType<typeof useGeoStore.getState>['correctMap']
     t: ReturnType<typeof useTranslation>['t']
     language: string
 }) {
@@ -241,13 +294,37 @@ function ResultBlock({
         typeof result.averageScore === 'number' &&
         typeof result.playerCount === 'number' &&
         result.playerCount > 0
+    const correctRegion =
+        correctMap?.region ?? t('geo.daily.chooseMap.worldFallback', 'World map')
     return (
         <div className="rounded-lg border bg-card/50 p-4 space-y-2">
+            {result.wrongMap && (
+                <div
+                    className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+                    role="alert"
+                >
+                    <p className="font-medium text-destructive">
+                        {t('geo.daily.wrongMap.banner', 'Wrong map — score floored.')}
+                    </p>
+                    {correctMap && (
+                        <p className="mt-0.5">
+                            {t('geo.daily.reveal.correctMap', 'Correct map: {{region}}', {
+                                region: correctRegion,
+                            })}
+                        </p>
+                    )}
+                </div>
+            )}
             <div className="flex items-center gap-2 text-neon-pink font-medium">
                 <Trophy className="h-4 w-4" />
                 <span>
                     {t('geo.daily.score', 'Score')}: {result.score.toLocaleString(language)}
                 </span>
+                {result.wrongMap && (
+                    <span className="rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-destructive">
+                        {t('geo.daily.wrongMap.chip', 'Wrong map')}
+                    </span>
+                )}
             </div>
             {hasStats && (
                 <ScoreComparison

--- a/packages/frontend/src/stores/geoStore.ts
+++ b/packages/frontend/src/stores/geoStore.ts
@@ -30,7 +30,15 @@ interface GeoState {
     challenge: GeoChallenge | null
     meta: GeoScreenshotMeta | null
     candidate: GeoScreenshotCandidate | null
-    map: GeoMap | null
+    // Multi-map: every enabled map the player can pick from. The
+    // chooser renders these; the canvas renders whichever
+    // `selectedMapId` references. For single-map games this is a
+    // length-1 array and the only id is auto-selected at load time.
+    maps: GeoMap[]
+    selectedMapId: number | null
+    // The canonical map of the screenshot. Only populated after the
+    // result reveal. Reused for the "correct map" highlight + reveal banner.
+    correctMap: GeoMap | null
     hasGuessed: boolean
     pendingGuess: GeoPoint | null
     result: GeoGuessResult | null
@@ -60,6 +68,7 @@ interface GeoState {
     // Actions
     loadCurrent: () => Promise<void>
     loadDaily: (date: string) => Promise<void>
+    selectMap: (mapId: number) => void
     setPendingGuess: (p: GeoPoint | null) => void
     submitGuess: (durationMs?: number) => Promise<GeoGuessResult | null>
     skipChallenge: () => Promise<boolean>
@@ -92,7 +101,8 @@ async function loadView(
         challenge: GeoChallenge
         meta: GeoScreenshotMeta
         candidate: GeoScreenshotCandidate
-        map: GeoMap
+        maps: GeoMap[]
+        map?: GeoMap
         hasGuessed: boolean
     }>,
 ): Promise<void> {
@@ -104,12 +114,23 @@ async function loadView(
             prev.challenge !== null && prev.challenge.id === view.challenge.id
         const restoredResult = view.hasGuessed && sameChallenge && prev.result !== null
         const restoredSkip = view.hasGuessed && sameChallenge && prev.wasSkipped
+        // Single-map games auto-select so the chooser feels invisible —
+        // a reload mid-result also restores the previously selected map
+        // when the challenge is the same.
+        const autoSelect =
+            view.maps.length === 1
+                ? view.maps[0]?.id ?? null
+                : sameChallenge
+                  ? prev.selectedMapId
+                  : null
         set({
             phase: restoredResult ? 'result' : restoredSkip ? 'skipped' : 'playing',
             challenge: view.challenge,
             meta: view.meta,
             candidate: view.candidate,
-            map: view.map,
+            maps: view.maps,
+            selectedMapId: autoSelect,
+            correctMap: view.map ?? null,
             hasGuessed: view.hasGuessed,
             result: restoredResult ? prev.result : null,
             wasSkipped: restoredSkip,
@@ -131,7 +152,9 @@ export const useGeoStore = create<GeoState>()(
     challenge: null,
     meta: null,
     candidate: null,
-    map: null,
+    maps: [],
+    selectedMapId: null,
+    correctMap: null,
     hasGuessed: false,
     pendingGuess: null,
     result: null,
@@ -155,22 +178,48 @@ export const useGeoStore = create<GeoState>()(
         await loadView(get, set, () => geoApi.getDaily(date))
     },
 
+    selectMap(mapId) {
+        // Pin coordinates are normalized [0..1] per map — switching the
+        // selected map invalidates the previous pin. Clearing it forces
+        // the player to re-pin, which matches the visual: the canvas
+        // image swaps under them.
+        set({ selectedMapId: mapId, pendingGuess: null })
+    },
+
     setPendingGuess(p) {
         set({ pendingGuess: p })
     },
 
     async submitGuess(durationMs) {
-        const { challenge, pendingGuess } = get()
+        const { challenge, pendingGuess, selectedMapId, maps } = get()
         if (!challenge || !pendingGuess) return null
+        // Multi-map games require an explicit pick. Single-map games
+        // would have auto-selected at load time, so a null here is
+        // genuinely a UI bug rather than a missing pick.
+        if (selectedMapId == null && maps.length > 1) return null
 
         set({ phase: 'submitting', errorMessage: null })
         try {
             const result = await geoApi.submitGuess({
                 challengeId: challenge.id,
+                geoMapId: selectedMapId ?? undefined,
                 guess: pendingGuess,
                 durationMs,
             })
-            set({ phase: 'result', result, hasGuessed: true, wasSkipped: false })
+            // Resolve the canonical map locally for the reveal — server
+            // also sends `correctMapId` on the result, so we just look
+            // up the matching `GeoMap` from the chooser list.
+            const correctMap =
+                result.correctMapId != null
+                    ? maps.find((m) => m.id === result.correctMapId) ?? null
+                    : null
+            set({
+                phase: 'result',
+                result,
+                hasGuessed: true,
+                wasSkipped: false,
+                correctMap,
+            })
             return result
         } catch (err) {
             set({
@@ -331,7 +380,9 @@ export const useGeoStore = create<GeoState>()(
             challenge: null,
             meta: null,
             candidate: null,
-            map: null,
+            maps: [],
+            selectedMapId: null,
+            correctMap: null,
             hasGuessed: false,
             pendingGuess: null,
             result: null,
@@ -356,6 +407,10 @@ export const useGeoStore = create<GeoState>()(
                 hasGuessed: state.hasGuessed,
                 pendingGuess: state.pendingGuess,
                 wasSkipped: state.wasSkipped,
+                // Persist the selected map so a reload mid-result doesn't
+                // bounce the user back to "pick a map" before showing
+                // their score.
+                selectedMapId: state.selectedMapId,
             }),
         },
     ),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -771,6 +771,21 @@ export interface GeoMap {
   // the JSON revisionId at import time, used for change detection.
   wikiMapName?: string
   wikiRevisionId?: number
+  // True when Steam/RAWG capture providers should attach new candidates to
+  // this map. Exactly one row per game_id is the capture default; for a
+  // single-map game it's the only enabled row.
+  isCaptureDefault?: boolean
+}
+
+// Lightweight subset of GeoMap surfaced to the daily challenge chooser. The
+// player needs an image + size to render the thumbnail and (for the selected
+// map) the canvas; everything else stays server-side until reveal.
+export interface GeoMapOption {
+  id: number
+  region?: string
+  imageUrl: string
+  widthPx: number
+  heightPx: number
 }
 
 export interface GeoScreenshotCandidate {
@@ -820,6 +835,10 @@ export interface GeoChallengeWithStatus extends GeoChallenge {
 
 export interface GeoGuessInput {
   geoChallengeId: number
+  // Map the player picked from the chooser. Required when the challenge's
+  // game has > 1 enabled map; the API still accepts a missing value for
+  // single-map games and treats it as "the only one".
+  geoMapId?: number
   guess: GeoPoint
   durationMs?: number
 }
@@ -836,6 +855,11 @@ export interface GeoGuessResult {
   // Optional so older clients / older persisted store snapshots stay valid.
   averageScore?: number
   playerCount?: number
+  // Multi-map reveal: the map the screenshot actually belongs to and a
+  // flag for "the player picked the wrong map" (score floored to ~1).
+  // Optional so older persisted store snapshots stay valid.
+  correctMapId?: number
+  wrongMap?: boolean
 }
 
 export interface GeoLeaderboardEntry {


### PR DESCRIPTION
## Summary

This PR implements multi-map support for geo daily challenges, allowing games to have multiple enabled maps that players can choose from. Previously, each game could only have one active map; now admins can enable multiple maps per game and players see a map chooser when playing challenges for multi-map games.

## Key Changes

### Frontend
- **New `GeoMapChooser` component**: Displays enabled maps as selectable cards with thumbnails and region labels. Single-map games show a passive label to keep the layout consistent.
- **Admin map management UI**: Added `EnabledMapsPanel` and `EnabledMapRow` components in the admin GeoMapsTab to manage multiple maps per game with per-map controls:
  - Disable/enable maps (with validation preventing disabling the last enabled map)
  - Set capture default (which map Steam/RAWG capture providers attach to)
  - Inline region editing
- **Updated `GeoDailyPage`**: Integrated the map chooser and updated state management to track selected map and correct map separately
- **Store updates**: Modified `geoStore` to track `maps` (all enabled), `selectedMapId` (player's choice), and `correctMap` (revealed after guess)

### Backend
- **New API endpoints**:
  - `POST /api/admin/geo/games/:id/maps/enable` - Enable a map for a game
  - `POST /api/admin/geo/games/:id/maps/disable` - Disable a map (with LAST_ENABLED validation)
  - `POST /api/admin/geo/games/:id/maps/capture-default` - Set which map receives Steam/RAWG captures
  - `PATCH /api/admin/geo/maps/:mapId` - Update map region inline
  - Deprecated `/api/admin/geo/games/:id/active-map` kept as alias for backwards compatibility
- **Database schema**: Added `is_capture_default` column to `geo_map` table with partial unique index to enforce one capture default per game. Added `geo_map_id_picked` to `geo_guess` to track which map players selected.
- **Repository methods**: 
  - `enableForGame()` - Enable a map and auto-promote to capture default if game had none
  - `disableForGame()` - Disable with validation and auto-reassign capture default
  - `setCaptureDefault()` - Explicitly set capture default
  - `listEnabledByGameId()` - Get all enabled maps for a game
  - `findCaptureDefaultByGameId()` - Get the capture default map
- **Service updates**: Modified `GeoGameService.submitGuess()` to accept optional `geoMapId` parameter (required for multi-map games, auto-resolved for single-map)
- **Scoring**: Updated `GEO_SCORE_VERSION` to v2 to introduce wrong-map penalty (distance floored to 1.0 when player picks wrong map)

### Data & Types
- **Migration**: `20260428_geo_multi_map.ts` adds `is_capture_default` column, creates partial unique index, and backfills existing active maps as capture defaults
- **Type updates**: Added `isCaptureDefault` to `GeoMap` interface and new `GeoMapOption` type for lightweight map data
- **API responses**: Updated `/geo/games/:id/sources` to return `enabledMaps` array and `captureDefaultMap` alongside deprecated `activeMap` for backwards compatibility

### Localization
- Added translation keys for multi-map UI: enabled maps panel, disable/enable actions, capture default controls, region editing

## Notable Implementation Details

- **Backwards compatibility**: The deprecated `activeMap` field in API responses now carries the capture-default map (closest analog to legacy single-active row), allowing stale frontends to continue working for one release
- **Auto-selection**: Single-map games auto-select their only map at load time, making the chooser invisible and preserving existing UX
- **Capture default semantics**: When enabling the first map for a game, it's automatically promoted to capture default so ingest has a target without admin intervention
- **Validation**: Prevents disabling the last enabled map for a game with a specific `LAST_ENABLED` error code
- **

https://claude.ai/code/session_01MTmCxyGQZ6C5WDaoAizi8K