### PR TITLE
feat: premium billing foundation (PR 1/4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,29 @@ INACTIVE_USER_REMINDER_CRON=0 16 * * 1
 INACTIVE_USER_REMINDER_DAYS=14
 
 # ============================================
+# STRIPE — Premium subscription billing
+# ============================================
+# Required once premium features ship. Get keys at
+# https://dashboard.stripe.com/apikeys (use test keys for development).
+# Create one Product "The Box Premium" with three Prices:
+#   - 3,99 € / month  → STRIPE_PRICE_PREMIUM_MONTHLY
+#   - 29,99 € / year  → STRIPE_PRICE_PREMIUM_ANNUAL
+#   - 59,99 € one-time → STRIPE_PRICE_SUPPORTER_LIFETIME
+# Run `npm run stripe:check` to verify the price IDs match the
+# declared catalog in packages/backend/src/config/billing.ts.
+STRIPE_SECRET_KEY=sk_test_xxxxxxxxxxxx
+STRIPE_WEBHOOK_SECRET=whsec_xxxxxxxxxxxx
+STRIPE_PRICE_PREMIUM_MONTHLY=price_xxxxxxxxxxxx
+STRIPE_PRICE_PREMIUM_ANNUAL=price_xxxxxxxxxxxx
+STRIPE_PRICE_SUPPORTER_LIFETIME=price_xxxxxxxxxxxx
+
+# Where Stripe redirects after Checkout / Customer Portal. Override per
+# environment so local dev doesn't bounce users to production.
+STRIPE_CHECKOUT_SUCCESS_URL=http://localhost:5173/fr/premium?checkout=success
+STRIPE_CHECKOUT_CANCEL_URL=http://localhost:5173/fr/premium?checkout=cancel
+STRIPE_PORTAL_RETURN_URL=http://localhost:5173/fr/profile
+
+# ============================================
 # RAWG API (OPTIONAL - for admin game imports)
 # ============================================
 # Get API key from https://rawg.io/apidocs

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -536,12 +537,14 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+      "peer": true
     },
     "node_modules/@commitlint/cli": {
       "version": "20.3.1",
@@ -4545,6 +4548,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.6.tgz",
       "integrity": "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4580,6 +4584,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4590,6 +4595,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4723,6 +4729,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -5017,6 +5024,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5372,6 +5380,7 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.10.tgz",
       "integrity": "sha512-AThrfb6CpG80wqkanfrbN2/fGOYzhGladHFf3JhaWt/3/Vtf4h084T6PJLrDE7M/vCCGYvDI1DkvP3P1OB2HAg==",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "zod": "^4.1.12"
@@ -5402,6 +5411,7 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.7.tgz",
       "integrity": "sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.0",
         "@better-fetch/fetch": "^1.1.4",
@@ -5533,6 +5543,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6093,6 +6104,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6463,6 +6475,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -6500,7 +6513,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6731,6 +6745,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7866,6 +7881,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -8263,6 +8279,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -8505,6 +8522,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.9.tgz",
       "integrity": "sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -8513,7 +8531,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -9330,6 +9349,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -9976,6 +9996,7 @@
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -10263,6 +10284,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10293,6 +10315,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10305,6 +10328,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.0.tgz",
       "integrity": "sha512-oFDt/iIFMV9ZfV52waONXzg4xuSlbwKUPvXVH2jumL1me5qFhBMc4knZxuXiZ2+j6h546sYe3ZKJcg/900/iHw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11388,6 +11412,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
+      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11511,7 +11552,8 @@
       "version": "0.182.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
       "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -11781,6 +11823,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12005,6 +12048,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12385,6 +12429,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12459,6 +12504,7 @@
         "pino-pretty": "^13.0.0",
         "resend": "^6.7.0",
         "socket.io": "^4.8.3",
+        "stripe": "^22.1.0",
         "uuid": "^13.0.0",
         "zod": "^4.3.5"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:rollback": "npm run db:rollback -w @the-box/backend",
     "db:seed": "npm run db:seed -w @the-box/backend",
     "db:seed:geo": "npm run db:seed:geo -w @the-box/backend",
+    "stripe:check": "npm run stripe:check -w @the-box/backend",
     "clean": "npm run clean --workspaces --if-present && rm -rf node_modules",
     "version:patch": "npm version patch --workspaces --no-git-tag-version && npm version patch --no-git-tag-version",
     "version:minor": "npm version minor --workspaces --no-git-tag-version && npm version minor --no-git-tag-version",

--- a/packages/backend/migrations/20260428_billing.ts
+++ b/packages/backend/migrations/20260428_billing.ts
@@ -1,0 +1,66 @@
+import type { Knex } from 'knex'
+
+// Billing foundation for Premium subscriptions backed by Stripe.
+//
+// Schema split:
+//   - user.stripe_customer_id  → 1:1 link to a Stripe Customer, lazy-created
+//                                on first checkout. Nullable: free users
+//                                never get a Customer object until they try
+//                                to pay.
+//   - subscriptions            → mirror of Stripe Subscription state, kept
+//                                in sync via webhook. Source of truth for
+//                                "is this user premium right now" without
+//                                round-tripping to Stripe per request.
+//   - stripe_event_log         → idempotency table. Stripe retries webhooks
+//                                aggressively; the unique PK on event.id
+//                                guarantees we apply each event exactly once.
+//
+// The `entitlements` cache from the proposal is intentionally deferred:
+// `subscriptions` already gives O(1) lookup by user_id + status, and adding
+// a denormalized cache before measuring contention is premature.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.text('stripe_customer_id').nullable().unique()
+  })
+
+  await knex.schema.createTable('subscriptions', (table) => {
+    table.increments('id').primary()
+    table
+      .text('user_id')
+      .notNullable()
+      .references('id')
+      .inTable('user')
+      .onDelete('CASCADE')
+    table.text('stripe_subscription_id').notNullable().unique()
+    table.text('stripe_price_id').notNullable()
+    table
+      .string('status', 32)
+      .notNullable()
+      .comment('active | trialing | past_due | canceled | incomplete | incomplete_expired | unpaid | paused')
+    table.timestamp('current_period_end', { useTz: true }).nullable()
+    table.boolean('cancel_at_period_end').notNullable().defaultTo(false)
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+    table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+
+    table.index('user_id')
+    table.index(['user_id', 'status'])
+  })
+
+  // Webhook idempotency. We INSERT (event_id) inside the same transaction
+  // that applies the event's effect; a duplicate webhook hits the unique
+  // PK and the handler short-circuits without re-applying.
+  await knex.schema.createTable('stripe_event_log', (table) => {
+    table.text('event_id').primary()
+    table.string('type', 64).notNullable()
+    table.timestamp('received_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('stripe_event_log')
+  await knex.schema.dropTableIfExists('subscriptions')
+  await knex.schema.alterTable('user', (table) => {
+    table.dropColumn('stripe_customer_id')
+  })
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,7 +20,8 @@
     "fetch:steam": "tsx src/tools/steam-screenshot-fetcher.ts fetch --screenshots-per-game 5",
     "fetch:steam-download": "tsx src/tools/steam-screenshot-fetcher.ts download",
     "fetch:steam-all": "tsx src/tools/steam-screenshot-fetcher.ts all --screenshots-per-game 5",
-    "e2e:seed": "tsx scripts/e2e-seed.ts"
+    "e2e:seed": "tsx scripts/e2e-seed.ts",
+    "stripe:check": "tsx scripts/stripe-check.ts"
   },
   "dependencies": {
     "@the-box/types": "*",
@@ -37,6 +38,7 @@
     "pino-pretty": "^13.0.0",
     "resend": "^6.7.0",
     "socket.io": "^4.8.3",
+    "stripe": "^22.1.0",
     "uuid": "^13.0.0",
     "zod": "^4.3.5"
   },

--- a/packages/backend/scripts/stripe-check.ts
+++ b/packages/backend/scripts/stripe-check.ts
@@ -1,0 +1,131 @@
+/**
+ * Pricing sync check.
+ *
+ * Asserts that every entry in BILLING_CATALOG matches what Stripe has on
+ * record:
+ *   - the stripePriceId resolves to an existing Price
+ *   - active === true
+ *   - currency matches
+ *   - unit_amount matches (in cents)
+ *   - recurring.interval matches (or null for one-time)
+ *
+ * Exits non-zero on any mismatch so the release pipeline can gate on it.
+ *
+ * Usage:
+ *   npm run stripe:check                 # uses STRIPE_SECRET_KEY from .env
+ *   npm run stripe:check -- --live       # explicit (still reads env, just
+ *                                          a guard against running it with
+ *                                          test-mode keys when you meant prod)
+ */
+import Stripe from 'stripe'
+import { BILLING_CATALOG, type BillingCatalogEntry } from '../src/config/billing.js'
+import { env } from '../src/config/env.js'
+
+interface CheckFailure {
+  tier: string
+  reason: string
+}
+
+const RED = '\x1b[31m'
+const GREEN = '\x1b[32m'
+const YELLOW = '\x1b[33m'
+const DIM = '\x1b[2m'
+const RESET = '\x1b[0m'
+
+function fail(failures: CheckFailure[], tier: string, reason: string): void {
+  failures.push({ tier, reason })
+}
+
+async function checkEntry(stripe: Stripe, entry: BillingCatalogEntry, failures: CheckFailure[]): Promise<void> {
+  if (!entry.stripePriceId) {
+    fail(failures, entry.tier, 'no STRIPE_PRICE_* env var set (price ID is empty)')
+    return
+  }
+
+  let price: Stripe.Price
+  try {
+    price = await stripe.prices.retrieve(entry.stripePriceId, { expand: ['product'] })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    fail(failures, entry.tier, `prices.retrieve(${entry.stripePriceId}) failed: ${message}`)
+    return
+  }
+
+  if (!price.active) {
+    fail(failures, entry.tier, `price ${price.id} is not active in Stripe`)
+  }
+
+  if (price.currency !== entry.currency) {
+    fail(failures, entry.tier, `currency mismatch: expected ${entry.currency}, Stripe has ${price.currency}`)
+  }
+
+  if (price.unit_amount !== entry.unitAmount) {
+    fail(
+      failures,
+      entry.tier,
+      `unit_amount mismatch: expected ${entry.unitAmount} cents (${(entry.unitAmount / 100).toFixed(2)} ${entry.currency.toUpperCase()}), Stripe has ${price.unit_amount}`,
+    )
+  }
+
+  const stripeInterval = price.recurring?.interval ?? null
+  if (stripeInterval !== entry.interval) {
+    fail(
+      failures,
+      entry.tier,
+      `interval mismatch: expected ${entry.interval ?? 'one-time'}, Stripe has ${stripeInterval ?? 'one-time'}`,
+    )
+  }
+
+  const product = typeof price.product === 'object' && price.product !== null && !('deleted' in price.product) ? price.product : null
+  if (!product || !product.active) {
+    fail(failures, entry.tier, `parent product is missing or inactive`)
+  }
+
+  if (failures.find((f) => f.tier === entry.tier)) return
+
+  console.log(
+    `${GREEN}✓${RESET} ${entry.tier.padEnd(20)} ${DIM}${price.id}${RESET} ${(entry.unitAmount / 100).toFixed(2)} ${entry.currency.toUpperCase()} ${entry.interval ? `/ ${entry.interval}` : '(one-time)'}`,
+  )
+}
+
+async function main(): Promise<void> {
+  if (!env.STRIPE_SECRET_KEY) {
+    console.error(`${RED}STRIPE_SECRET_KEY is not set.${RESET} Add it to .env or export it before running this script.`)
+    process.exit(2)
+  }
+
+  const isLive = env.STRIPE_SECRET_KEY.startsWith('sk_live_')
+  const flagLive = process.argv.includes('--live')
+  if (isLive && !flagLive) {
+    console.error(`${RED}Refusing to run against LIVE Stripe keys without --live flag.${RESET}`)
+    process.exit(2)
+  }
+  if (flagLive && !isLive) {
+    console.error(`${YELLOW}--live flag passed but STRIPE_SECRET_KEY is a test key. Continuing in test mode.${RESET}`)
+  }
+
+  console.log(`Checking ${BILLING_CATALOG.length} prices against Stripe (${isLive ? 'LIVE' : 'test'} mode)...\n`)
+
+  const stripe = new Stripe(env.STRIPE_SECRET_KEY)
+  const failures: CheckFailure[] = []
+
+  for (const entry of BILLING_CATALOG) {
+    await checkEntry(stripe, entry, failures)
+  }
+
+  if (failures.length > 0) {
+    console.log(`\n${RED}✗ ${failures.length} mismatch${failures.length === 1 ? '' : 'es'}:${RESET}`)
+    for (const f of failures) {
+      console.log(`  ${RED}•${RESET} ${f.tier}: ${f.reason}`)
+    }
+    process.exit(1)
+  }
+
+  console.log(`\n${GREEN}All prices in sync.${RESET}`)
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(`${RED}Unexpected error:${RESET}`, err)
+  process.exit(1)
+})

--- a/packages/backend/src/config/billing.ts
+++ b/packages/backend/src/config/billing.ts
@@ -1,0 +1,46 @@
+import type { BillingTier } from '@the-box/types'
+import { env } from './env.js'
+
+// Source of truth for what a tier should look like in Stripe. The
+// `npm run stripe:check` script retrieves each `stripePriceId` from
+// Stripe and asserts amount/currency/interval match these declarations,
+// so a renamed price in the dashboard fails CI before reaching prod.
+export interface BillingCatalogEntry {
+  tier: BillingTier
+  stripePriceId: string
+  unitAmount: number // cents (EUR)
+  currency: 'eur'
+  interval: 'month' | 'year' | null // null = one-time
+}
+
+export const BILLING_CATALOG: readonly BillingCatalogEntry[] = [
+  {
+    tier: 'premium_monthly',
+    stripePriceId: env.STRIPE_PRICE_PREMIUM_MONTHLY,
+    unitAmount: 399,
+    currency: 'eur',
+    interval: 'month',
+  },
+  {
+    tier: 'premium_annual',
+    stripePriceId: env.STRIPE_PRICE_PREMIUM_ANNUAL,
+    unitAmount: 2999,
+    currency: 'eur',
+    interval: 'year',
+  },
+  {
+    tier: 'supporter_lifetime',
+    stripePriceId: env.STRIPE_PRICE_SUPPORTER_LIFETIME,
+    unitAmount: 5999,
+    currency: 'eur',
+    interval: null,
+  },
+] as const
+
+export function getCatalogEntry(tier: BillingTier): BillingCatalogEntry | undefined {
+  return BILLING_CATALOG.find((entry) => entry.tier === tier)
+}
+
+export function getCatalogEntryByPriceId(priceId: string): BillingCatalogEntry | undefined {
+  return BILLING_CATALOG.find((entry) => entry.stripePriceId === priceId)
+}

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -37,6 +37,18 @@ export const env = {
 
   // Redis (for BullMQ job queue)
   REDIS_URL: process.env['REDIS_URL'] || 'redis://localhost:6379',
+
+  // Stripe — Premium subscription billing. Empty defaults keep dev boot
+  // working without a Stripe account; production validation in
+  // validateEnv() enforces presence once any premium feature ships.
+  STRIPE_SECRET_KEY: process.env['STRIPE_SECRET_KEY'] || '',
+  STRIPE_WEBHOOK_SECRET: process.env['STRIPE_WEBHOOK_SECRET'] || '',
+  STRIPE_PRICE_PREMIUM_MONTHLY: process.env['STRIPE_PRICE_PREMIUM_MONTHLY'] || '',
+  STRIPE_PRICE_PREMIUM_ANNUAL: process.env['STRIPE_PRICE_PREMIUM_ANNUAL'] || '',
+  STRIPE_PRICE_SUPPORTER_LIFETIME: process.env['STRIPE_PRICE_SUPPORTER_LIFETIME'] || '',
+  STRIPE_CHECKOUT_SUCCESS_URL: process.env['STRIPE_CHECKOUT_SUCCESS_URL'] || 'http://localhost:5173/fr/premium?checkout=success',
+  STRIPE_CHECKOUT_CANCEL_URL: process.env['STRIPE_CHECKOUT_CANCEL_URL'] || 'http://localhost:5173/fr/premium?checkout=cancel',
+  STRIPE_PORTAL_RETURN_URL: process.env['STRIPE_PORTAL_RETURN_URL'] || 'http://localhost:5173/fr/profile',
 }
 
 export function validateEnv(): void {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -936,3 +936,47 @@ export type ScreenshotReportReason =
   | 'inappropriate'
   | 'too_easy'
   | 'other'
+
+// ============================================
+// Billing — Stripe-backed Premium subscription
+// ============================================
+// Wire shape only. The runtime price catalog (display amounts paired with
+// env-driven Stripe price IDs) lives server-side in the backend config so
+// this package stays types-only.
+
+export type BillingTier = 'premium_monthly' | 'premium_annual' | 'supporter_lifetime'
+
+// Mirrors a Stripe Subscription status. Internal billing status is derived
+// from this; treat 'active' and 'trialing' as the only entitlement-granting
+// states for recurring tiers.
+export type SubscriptionStatus =
+  | 'active'
+  | 'trialing'
+  | 'past_due'
+  | 'canceled'
+  | 'incomplete'
+  | 'incomplete_expired'
+  | 'unpaid'
+  | 'paused'
+
+// Public-facing price metadata returned by GET /api/billing/prices. Amount
+// is in the smallest currency unit (cents) so the frontend formats once.
+export interface BillingPrice {
+  tier: BillingTier
+  stripePriceId: string
+  unitAmount: number
+  currency: string
+  interval: 'month' | 'year' | null
+  active: boolean
+}
+
+// Server-derived view of the caller's entitlement, returned by
+// GET /api/billing/me. `validUntil` is the period end for recurring tiers
+// (so the UI can show "Premium until ...") and null for lifetime grants.
+export interface BillingEntitlement {
+  isPremium: boolean
+  tier: BillingTier | null
+  validUntil: string | null
+  cancelAtPeriodEnd: boolean
+  source: 'subscription' | 'supporter' | null
+}


### PR DESCRIPTION
## Summary

First of four PRs introducing a Stripe-backed Premium subscription. This one is **foundation only** — no business logic, no routes, no UI. Everything here is reversible (migration round-trips clean) and dry-runnable (no Stripe account required to land it).

- **Migration** `20260428_billing.ts` — adds `user.stripe_customer_id`, plus `subscriptions` and `stripe_event_log` tables. The event log gives us webhook idempotency before any webhook handler ships.
- **Types** in `@the-box/types` — `BillingTier`, `SubscriptionStatus`, `BillingPrice`, `BillingEntitlement`. Wire shapes only; runtime catalog stays server-side because the package is types-only (CJS, consumed types-only).
- **Config** — `STRIPE_*` env vars in `packages/backend/src/config/env.ts` and `.env.example`, plus `packages/backend/src/config/billing.ts` declaring the price catalog (3,99 €/mo, 29,99 €/yr, 59,99 € one-time supporter).
- **Sync script** `npm run stripe:check` — `tsx packages/backend/scripts/stripe-check.ts` retrieves each declared `stripePriceId` from Stripe and asserts `active`, `currency`, `unit_amount`, `recurring.interval`, and parent product all match the local catalog. Refuses live keys without `--live`. Designed to gate the release pipeline so a renamed Stripe price breaks CI, not checkout.
- Stripe SDK installed (`stripe@^22.1.0`).

## What's intentionally NOT here

- No `billing.service`, no routes (`/api/billing/*`), no webhook handler — that's PR 2.
- No `/premium` page or any UI — that's PR 3.
- No feature gating (catch-up archive, hint refills, profile stats, cosmetics, themes) — that's PR 4.
- No `entitlements` denormalized cache — `subscriptions(user_id, status)` index is enough until we measure contention.

## Scope correction noticed

The `tournaments` migration (`20260115_add_tournaments.ts`) is a removal stub — the feature was ripped out. "Private tournaments" should be dropped from the PR 4 premium scope unless we want to rebuild it as premium-only.

## What you need before PR 2

1. Stripe account (test mode is fine to start)
2. One Product "The Box Premium" with three Prices in EUR: `3,99 €/month`, `29,99 €/year`, `59,99 € one-time`
3. Put `sk_test_…`, `whsec_…`, and the three `price_…` IDs in `.env`
4. `npm run stripe:check` should print three green checks — that's the green light for PR 2

## Test plan

- [x] `npm run build:types` clean
- [x] `npm run build:backend` clean (typecheck passes)
- [x] `npm run db:migrate` applies (batch 1, 30 migrations)
- [x] `npm run db:rollback` rolls back cleanly, then re-migrate works
- [x] Verified schema in Postgres: `subscriptions` columns + indexes + FK CASCADE, `stripe_event_log` PK on `event_id`, `user.stripe_customer_id` nullable + unique
- [x] `npm run stripe:check` with empty IDs prints 3 clear errors and exits non-zero
- [ ] `npm run stripe:check` against real Stripe test prices — pending Stripe account setup
- [x] Frontend lint: 0 errors (5 pre-existing warnings, none in touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)