### PR TITLE
feat: premium feature gating + supporter lifetime (PR 4/4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,29 @@ INACTIVE_USER_REMINDER_CRON=0 16 * * 1
 INACTIVE_USER_REMINDER_DAYS=14
 
 # ============================================
+# STRIPE — Premium subscription billing
+# ============================================
+# Required once premium features ship. Get keys at
+# https://dashboard.stripe.com/apikeys (use test keys for development).
+# Create one Product "The Box Premium" with three Prices:
+#   - 3,99 € / month  → STRIPE_PRICE_PREMIUM_MONTHLY
+#   - 29,99 € / year  → STRIPE_PRICE_PREMIUM_ANNUAL
+#   - 59,99 € one-time → STRIPE_PRICE_SUPPORTER_LIFETIME
+# Run `npm run stripe:check` to verify the price IDs match the
+# declared catalog in packages/backend/src/config/billing.ts.
+STRIPE_SECRET_KEY=sk_test_xxxxxxxxxxxx
+STRIPE_WEBHOOK_SECRET=whsec_xxxxxxxxxxxx
+STRIPE_PRICE_PREMIUM_MONTHLY=price_xxxxxxxxxxxx
+STRIPE_PRICE_PREMIUM_ANNUAL=price_xxxxxxxxxxxx
+STRIPE_PRICE_SUPPORTER_LIFETIME=price_xxxxxxxxxxxx
+
+# Where Stripe redirects after Checkout / Customer Portal. Override per
+# environment so local dev doesn't bounce users to production.
+STRIPE_CHECKOUT_SUCCESS_URL=http://localhost:5173/fr/premium?checkout=success
+STRIPE_CHECKOUT_CANCEL_URL=http://localhost:5173/fr/premium?checkout=cancel
+STRIPE_PORTAL_RETURN_URL=http://localhost:5173/fr/profile
+
+# ============================================
 # RAWG API (OPTIONAL - for admin game imports)
 # ============================================
 # Get API key from https://rawg.io/apidocs

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -536,12 +537,14 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+      "peer": true
     },
     "node_modules/@commitlint/cli": {
       "version": "20.3.1",
@@ -4545,6 +4548,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.6.tgz",
       "integrity": "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4580,6 +4584,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4590,6 +4595,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4723,6 +4729,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -5017,6 +5024,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5372,6 +5380,7 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.10.tgz",
       "integrity": "sha512-AThrfb6CpG80wqkanfrbN2/fGOYzhGladHFf3JhaWt/3/Vtf4h084T6PJLrDE7M/vCCGYvDI1DkvP3P1OB2HAg==",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "zod": "^4.1.12"
@@ -5402,6 +5411,7 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.7.tgz",
       "integrity": "sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.0",
         "@better-fetch/fetch": "^1.1.4",
@@ -5533,6 +5543,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6093,6 +6104,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6463,6 +6475,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -6500,7 +6513,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6731,6 +6745,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7866,6 +7881,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -8263,6 +8279,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -8505,6 +8522,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.9.tgz",
       "integrity": "sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -8513,7 +8531,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -9330,6 +9349,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -9976,6 +9996,7 @@
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -10263,6 +10284,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10293,6 +10315,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10305,6 +10328,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.0.tgz",
       "integrity": "sha512-oFDt/iIFMV9ZfV52waONXzg4xuSlbwKUPvXVH2jumL1me5qFhBMc4knZxuXiZ2+j6h546sYe3ZKJcg/900/iHw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11388,6 +11412,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
+      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11511,7 +11552,8 @@
       "version": "0.182.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
       "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -11781,6 +11823,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12005,6 +12048,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12385,6 +12429,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12459,6 +12504,7 @@
         "pino-pretty": "^13.0.0",
         "resend": "^6.7.0",
         "socket.io": "^4.8.3",
+        "stripe": "^22.1.0",
         "uuid": "^13.0.0",
         "zod": "^4.3.5"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:rollback": "npm run db:rollback -w @the-box/backend",
     "db:seed": "npm run db:seed -w @the-box/backend",
     "db:seed:geo": "npm run db:seed:geo -w @the-box/backend",
+    "stripe:check": "npm run stripe:check -w @the-box/backend",
     "clean": "npm run clean --workspaces --if-present && rm -rf node_modules",
     "version:patch": "npm version patch --workspaces --no-git-tag-version && npm version patch --no-git-tag-version",
     "version:minor": "npm version minor --workspaces --no-git-tag-version && npm version minor --no-git-tag-version",

--- a/packages/backend/migrations/20260428_billing.ts
+++ b/packages/backend/migrations/20260428_billing.ts
@@ -1,0 +1,66 @@
+import type { Knex } from 'knex'
+
+// Billing foundation for Premium subscriptions backed by Stripe.
+//
+// Schema split:
+//   - user.stripe_customer_id  → 1:1 link to a Stripe Customer, lazy-created
+//                                on first checkout. Nullable: free users
+//                                never get a Customer object until they try
+//                                to pay.
+//   - subscriptions            → mirror of Stripe Subscription state, kept
+//                                in sync via webhook. Source of truth for
+//                                "is this user premium right now" without
+//                                round-tripping to Stripe per request.
+//   - stripe_event_log         → idempotency table. Stripe retries webhooks
+//                                aggressively; the unique PK on event.id
+//                                guarantees we apply each event exactly once.
+//
+// The `entitlements` cache from the proposal is intentionally deferred:
+// `subscriptions` already gives O(1) lookup by user_id + status, and adding
+// a denormalized cache before measuring contention is premature.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.text('stripe_customer_id').nullable().unique()
+  })
+
+  await knex.schema.createTable('subscriptions', (table) => {
+    table.increments('id').primary()
+    table
+      .text('user_id')
+      .notNullable()
+      .references('id')
+      .inTable('user')
+      .onDelete('CASCADE')
+    table.text('stripe_subscription_id').notNullable().unique()
+    table.text('stripe_price_id').notNullable()
+    table
+      .string('status', 32)
+      .notNullable()
+      .comment('active | trialing | past_due | canceled | incomplete | incomplete_expired | unpaid | paused')
+    table.timestamp('current_period_end', { useTz: true }).nullable()
+    table.boolean('cancel_at_period_end').notNullable().defaultTo(false)
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+    table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+
+    table.index('user_id')
+    table.index(['user_id', 'status'])
+  })
+
+  // Webhook idempotency. We INSERT (event_id) inside the same transaction
+  // that applies the event's effect; a duplicate webhook hits the unique
+  // PK and the handler short-circuits without re-applying.
+  await knex.schema.createTable('stripe_event_log', (table) => {
+    table.text('event_id').primary()
+    table.string('type', 64).notNullable()
+    table.timestamp('received_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('stripe_event_log')
+  await knex.schema.dropTableIfExists('subscriptions')
+  await knex.schema.alterTable('user', (table) => {
+    table.dropColumn('stripe_customer_id')
+  })
+}

--- a/packages/backend/migrations/20260428_supporter_lifetime.ts
+++ b/packages/backend/migrations/20260428_supporter_lifetime.ts
@@ -1,0 +1,23 @@
+import type { Knex } from 'knex'
+
+// Single-column entitlement for the one-time Supporter tier. We could
+// model this as a separate table for cleanliness, but it's a 1:1 grant
+// keyed on user with no per-grant metadata worth keeping out-of-line —
+// timestamp on user keeps the read path single-row and lets the existing
+// findById join pick it up for free.
+//
+// `subscriptions` is the right home for recurring tiers; lifetime grants
+// don't have a stripe_subscription_id so they wouldn't fit that table
+// without making fields nullable that are otherwise notNullable.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.timestamp('supporter_lifetime_at', { useTz: true }).nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.dropColumn('supporter_lifetime_at')
+  })
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,7 +20,8 @@
     "fetch:steam": "tsx src/tools/steam-screenshot-fetcher.ts fetch --screenshots-per-game 5",
     "fetch:steam-download": "tsx src/tools/steam-screenshot-fetcher.ts download",
     "fetch:steam-all": "tsx src/tools/steam-screenshot-fetcher.ts all --screenshots-per-game 5",
-    "e2e:seed": "tsx scripts/e2e-seed.ts"
+    "e2e:seed": "tsx scripts/e2e-seed.ts",
+    "stripe:check": "tsx scripts/stripe-check.ts"
   },
   "dependencies": {
     "@the-box/types": "*",
@@ -37,6 +38,7 @@
     "pino-pretty": "^13.0.0",
     "resend": "^6.7.0",
     "socket.io": "^4.8.3",
+    "stripe": "^22.1.0",
     "uuid": "^13.0.0",
     "zod": "^4.3.5"
   },

--- a/packages/backend/scripts/stripe-check.ts
+++ b/packages/backend/scripts/stripe-check.ts
@@ -1,0 +1,131 @@
+/**
+ * Pricing sync check.
+ *
+ * Asserts that every entry in BILLING_CATALOG matches what Stripe has on
+ * record:
+ *   - the stripePriceId resolves to an existing Price
+ *   - active === true
+ *   - currency matches
+ *   - unit_amount matches (in cents)
+ *   - recurring.interval matches (or null for one-time)
+ *
+ * Exits non-zero on any mismatch so the release pipeline can gate on it.
+ *
+ * Usage:
+ *   npm run stripe:check                 # uses STRIPE_SECRET_KEY from .env
+ *   npm run stripe:check -- --live       # explicit (still reads env, just
+ *                                          a guard against running it with
+ *                                          test-mode keys when you meant prod)
+ */
+import Stripe from 'stripe'
+import { BILLING_CATALOG, type BillingCatalogEntry } from '../src/config/billing.js'
+import { env } from '../src/config/env.js'
+
+interface CheckFailure {
+  tier: string
+  reason: string
+}
+
+const RED = '\x1b[31m'
+const GREEN = '\x1b[32m'
+const YELLOW = '\x1b[33m'
+const DIM = '\x1b[2m'
+const RESET = '\x1b[0m'
+
+function fail(failures: CheckFailure[], tier: string, reason: string): void {
+  failures.push({ tier, reason })
+}
+
+async function checkEntry(stripe: Stripe, entry: BillingCatalogEntry, failures: CheckFailure[]): Promise<void> {
+  if (!entry.stripePriceId) {
+    fail(failures, entry.tier, 'no STRIPE_PRICE_* env var set (price ID is empty)')
+    return
+  }
+
+  let price: Stripe.Price
+  try {
+    price = await stripe.prices.retrieve(entry.stripePriceId, { expand: ['product'] })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    fail(failures, entry.tier, `prices.retrieve(${entry.stripePriceId}) failed: ${message}`)
+    return
+  }
+
+  if (!price.active) {
+    fail(failures, entry.tier, `price ${price.id} is not active in Stripe`)
+  }
+
+  if (price.currency !== entry.currency) {
+    fail(failures, entry.tier, `currency mismatch: expected ${entry.currency}, Stripe has ${price.currency}`)
+  }
+
+  if (price.unit_amount !== entry.unitAmount) {
+    fail(
+      failures,
+      entry.tier,
+      `unit_amount mismatch: expected ${entry.unitAmount} cents (${(entry.unitAmount / 100).toFixed(2)} ${entry.currency.toUpperCase()}), Stripe has ${price.unit_amount}`,
+    )
+  }
+
+  const stripeInterval = price.recurring?.interval ?? null
+  if (stripeInterval !== entry.interval) {
+    fail(
+      failures,
+      entry.tier,
+      `interval mismatch: expected ${entry.interval ?? 'one-time'}, Stripe has ${stripeInterval ?? 'one-time'}`,
+    )
+  }
+
+  const product = typeof price.product === 'object' && price.product !== null && !('deleted' in price.product) ? price.product : null
+  if (!product || !product.active) {
+    fail(failures, entry.tier, `parent product is missing or inactive`)
+  }
+
+  if (failures.find((f) => f.tier === entry.tier)) return
+
+  console.log(
+    `${GREEN}✓${RESET} ${entry.tier.padEnd(20)} ${DIM}${price.id}${RESET} ${(entry.unitAmount / 100).toFixed(2)} ${entry.currency.toUpperCase()} ${entry.interval ? `/ ${entry.interval}` : '(one-time)'}`,
+  )
+}
+
+async function main(): Promise<void> {
+  if (!env.STRIPE_SECRET_KEY) {
+    console.error(`${RED}STRIPE_SECRET_KEY is not set.${RESET} Add it to .env or export it before running this script.`)
+    process.exit(2)
+  }
+
+  const isLive = env.STRIPE_SECRET_KEY.startsWith('sk_live_')
+  const flagLive = process.argv.includes('--live')
+  if (isLive && !flagLive) {
+    console.error(`${RED}Refusing to run against LIVE Stripe keys without --live flag.${RESET}`)
+    process.exit(2)
+  }
+  if (flagLive && !isLive) {
+    console.error(`${YELLOW}--live flag passed but STRIPE_SECRET_KEY is a test key. Continuing in test mode.${RESET}`)
+  }
+
+  console.log(`Checking ${BILLING_CATALOG.length} prices against Stripe (${isLive ? 'LIVE' : 'test'} mode)...\n`)
+
+  const stripe = new Stripe(env.STRIPE_SECRET_KEY)
+  const failures: CheckFailure[] = []
+
+  for (const entry of BILLING_CATALOG) {
+    await checkEntry(stripe, entry, failures)
+  }
+
+  if (failures.length > 0) {
+    console.log(`\n${RED}✗ ${failures.length} mismatch${failures.length === 1 ? '' : 'es'}:${RESET}`)
+    for (const f of failures) {
+      console.log(`  ${RED}•${RESET} ${f.tier}: ${f.reason}`)
+    }
+    process.exit(1)
+  }
+
+  console.log(`\n${GREEN}All prices in sync.${RESET}`)
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(`${RED}Unexpected error:${RESET}`, err)
+  process.exit(1)
+})

--- a/packages/backend/src/config/billing.ts
+++ b/packages/backend/src/config/billing.ts
@@ -1,0 +1,46 @@
+import type { BillingTier } from '@the-box/types'
+import { env } from './env.js'
+
+// Source of truth for what a tier should look like in Stripe. The
+// `npm run stripe:check` script retrieves each `stripePriceId` from
+// Stripe and asserts amount/currency/interval match these declarations,
+// so a renamed price in the dashboard fails CI before reaching prod.
+export interface BillingCatalogEntry {
+  tier: BillingTier
+  stripePriceId: string
+  unitAmount: number // cents (EUR)
+  currency: 'eur'
+  interval: 'month' | 'year' | null // null = one-time
+}
+
+export const BILLING_CATALOG: readonly BillingCatalogEntry[] = [
+  {
+    tier: 'premium_monthly',
+    stripePriceId: env.STRIPE_PRICE_PREMIUM_MONTHLY,
+    unitAmount: 399,
+    currency: 'eur',
+    interval: 'month',
+  },
+  {
+    tier: 'premium_annual',
+    stripePriceId: env.STRIPE_PRICE_PREMIUM_ANNUAL,
+    unitAmount: 2999,
+    currency: 'eur',
+    interval: 'year',
+  },
+  {
+    tier: 'supporter_lifetime',
+    stripePriceId: env.STRIPE_PRICE_SUPPORTER_LIFETIME,
+    unitAmount: 5999,
+    currency: 'eur',
+    interval: null,
+  },
+] as const
+
+export function getCatalogEntry(tier: BillingTier): BillingCatalogEntry | undefined {
+  return BILLING_CATALOG.find((entry) => entry.tier === tier)
+}
+
+export function getCatalogEntryByPriceId(priceId: string): BillingCatalogEntry | undefined {
+  return BILLING_CATALOG.find((entry) => entry.stripePriceId === priceId)
+}

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -37,6 +37,18 @@ export const env = {
 
   // Redis (for BullMQ job queue)
   REDIS_URL: process.env['REDIS_URL'] || 'redis://localhost:6379',
+
+  // Stripe — Premium subscription billing. Empty defaults keep dev boot
+  // working without a Stripe account; production validation in
+  // validateEnv() enforces presence once any premium feature ships.
+  STRIPE_SECRET_KEY: process.env['STRIPE_SECRET_KEY'] || '',
+  STRIPE_WEBHOOK_SECRET: process.env['STRIPE_WEBHOOK_SECRET'] || '',
+  STRIPE_PRICE_PREMIUM_MONTHLY: process.env['STRIPE_PRICE_PREMIUM_MONTHLY'] || '',
+  STRIPE_PRICE_PREMIUM_ANNUAL: process.env['STRIPE_PRICE_PREMIUM_ANNUAL'] || '',
+  STRIPE_PRICE_SUPPORTER_LIFETIME: process.env['STRIPE_PRICE_SUPPORTER_LIFETIME'] || '',
+  STRIPE_CHECKOUT_SUCCESS_URL: process.env['STRIPE_CHECKOUT_SUCCESS_URL'] || 'http://localhost:5173/fr/premium?checkout=success',
+  STRIPE_CHECKOUT_CANCEL_URL: process.env['STRIPE_CHECKOUT_CANCEL_URL'] || 'http://localhost:5173/fr/premium?checkout=cancel',
+  STRIPE_PORTAL_RETURN_URL: process.env['STRIPE_PORTAL_RETURN_URL'] || 'http://localhost:5173/fr/profile',
 }
 
 export function validateEnv(): void {

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -153,6 +153,7 @@ export interface TierSessionWithContextRecord extends TierSessionRecord {
   game_session_started_at: Date
   game_session_id: string
   daily_challenge_id: number
+  is_catch_up: boolean
   tier_number: number
   time_limit_seconds: number
 }

--- a/packages/backend/src/domain/services/billing.service.ts
+++ b/packages/backend/src/domain/services/billing.service.ts
@@ -1,0 +1,172 @@
+import type {
+  BillingEntitlement,
+  BillingTier,
+  SubscriptionStatus,
+} from '@the-box/types'
+import { BILLING_CATALOG, getCatalogEntryByPriceId } from '../../config/billing.js'
+import {
+  subscriptionRepository,
+  ENTITLED_STATUSES,
+  type SubscriptionRow,
+} from '../../infrastructure/repositories/subscription.repository.js'
+import { userRepository } from '../../infrastructure/repositories/user.repository.js'
+import { getStripe } from '../../infrastructure/stripe/stripe.client.js'
+import { repoLogger } from '../../infrastructure/logger/logger.js'
+import type Stripe from 'stripe'
+
+const log = repoLogger.child({ service: 'billing' })
+
+// Stripe Subscription.status values map 1:1 to our SubscriptionStatus union;
+// this guard keeps the type system honest when reading from the SDK.
+const KNOWN_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
+  'active',
+  'trialing',
+  'past_due',
+  'canceled',
+  'incomplete',
+  'incomplete_expired',
+  'unpaid',
+  'paused',
+])
+
+export function toSubscriptionStatus(raw: string): SubscriptionStatus {
+  return (KNOWN_STATUSES as Set<string>).has(raw)
+    ? (raw as SubscriptionStatus)
+    : 'incomplete'
+}
+
+// Lookup the BillingTier for a Stripe price ID. Returns null if the price
+// isn't one we recognize (e.g. an old/archived price that survived in
+// Stripe history but has been removed from our catalog). The caller treats
+// that as "no entitlement" rather than crashing.
+export function tierFromPriceId(stripePriceId: string): BillingTier | null {
+  return getCatalogEntryByPriceId(stripePriceId)?.tier ?? null
+}
+
+export const billingService = {
+  // The entitlement read every gated endpoint hits. Returns the cheapest
+  // safe default (no premium) when anything is missing or off, so a
+  // misconfigured env never silently grants premium to free users.
+  async getEntitlement(userId: string): Promise<BillingEntitlement> {
+    const row = await subscriptionRepository.findActiveByUserId(userId)
+    if (!row) {
+      return {
+        isPremium: false,
+        tier: null,
+        validUntil: null,
+        cancelAtPeriodEnd: false,
+        source: null,
+      }
+    }
+    const tier = tierFromPriceId(row.stripe_price_id)
+    const isPremium = ENTITLED_STATUSES.has(row.status)
+    return {
+      isPremium,
+      tier,
+      validUntil: row.current_period_end?.toISOString() ?? null,
+      cancelAtPeriodEnd: row.cancel_at_period_end,
+      source: 'subscription',
+    }
+  },
+
+  async isPremium(userId: string): Promise<boolean> {
+    const entitlement = await this.getEntitlement(userId)
+    return entitlement.isPremium
+  },
+
+  // Lazy customer creation. Free users never get a Stripe Customer; the
+  // first time they hit checkout we create one with metadata.userId so
+  // webhooks can resolve back even if our DB row is missing.
+  async ensureStripeCustomer(args: {
+    userId: string
+    email: string
+    name?: string
+  }): Promise<string> {
+    const existing = await userRepository.getStripeCustomerId(args.userId)
+    if (existing) return existing
+
+    const stripe = getStripe()
+    const customer = await stripe.customers.create({
+      email: args.email,
+      name: args.name,
+      metadata: { userId: args.userId },
+    })
+    await userRepository.setStripeCustomerId(args.userId, customer.id)
+    log.info({ userId: args.userId, customerId: customer.id }, 'stripe customer created')
+    return customer.id
+  },
+
+  // Build the catalog payload for GET /api/billing/prices. Source of truth
+  // is BILLING_CATALOG; the boolean `active` matches what stripe-check
+  // would assert, so the UI only has to render strings.
+  listPublicPrices(): Array<{
+    tier: BillingTier
+    stripePriceId: string
+    unitAmount: number
+    currency: string
+    interval: 'month' | 'year' | null
+    active: boolean
+  }> {
+    return BILLING_CATALOG.map((entry) => ({
+      tier: entry.tier,
+      stripePriceId: entry.stripePriceId,
+      unitAmount: entry.unitAmount,
+      currency: entry.currency,
+      interval: entry.interval,
+      active: !!entry.stripePriceId,
+    }))
+  },
+
+  // Pull the relevant fields out of a Stripe subscription so the repo can
+  // upsert without leaking SDK types into the data layer. Period end on a
+  // canceled subscription is the cancellation timestamp, which we keep
+  // around so the UI can show "premium ended on …".
+  fromStripeSubscription(sub: Stripe.Subscription): {
+    stripeSubscriptionId: string
+    stripePriceId: string
+    status: SubscriptionStatus
+    currentPeriodEnd: Date | null
+    cancelAtPeriodEnd: boolean
+  } {
+    const item = sub.items.data[0]
+    if (!item) {
+      throw new Error(`stripe subscription ${sub.id} has no items`)
+    }
+    const periodEnd = (item as Stripe.SubscriptionItem & { current_period_end?: number })
+      .current_period_end
+    return {
+      stripeSubscriptionId: sub.id,
+      stripePriceId: item.price.id,
+      status: toSubscriptionStatus(sub.status),
+      currentPeriodEnd: periodEnd ? new Date(periodEnd * 1000) : null,
+      cancelAtPeriodEnd: sub.cancel_at_period_end,
+    }
+  },
+
+  // Resolve a Stripe customer ID to our internal user. Webhooks key on
+  // customer.id (not user.id), so this is the bridge.
+  async resolveUserIdFromCustomer(customerId: string): Promise<string | null> {
+    const row = await userRepository.findByStripeCustomerId(customerId)
+    if (row) return row.id
+
+    // Fallback: customer might exist in Stripe with a userId in metadata
+    // even if our DB linking row is missing (e.g. migration race). Read
+    // metadata from Stripe and re-link rather than dropping the event.
+    try {
+      const stripe = getStripe()
+      const customer = await stripe.customers.retrieve(customerId)
+      if (customer.deleted) return null
+      const userId = customer.metadata?.['userId']
+      if (userId) {
+        await userRepository.setStripeCustomerId(userId, customerId)
+        log.warn({ userId, customerId }, 'relinked stripe_customer_id from metadata')
+        return userId
+      }
+    } catch (err) {
+      log.error({ err: String(err), customerId }, 'failed to retrieve customer for fallback')
+    }
+    return null
+  },
+
+  rowToSubscription: (row: SubscriptionRow) => row,
+}

--- a/packages/backend/src/domain/services/billing.service.ts
+++ b/packages/backend/src/domain/services/billing.service.ts
@@ -47,7 +47,23 @@ export const billingService = {
   // The entitlement read every gated endpoint hits. Returns the cheapest
   // safe default (no premium) when anything is missing or off, so a
   // misconfigured env never silently grants premium to free users.
+  //
+  // Resolution order: supporter lifetime wins over recurring subscription.
+  // A user who paid once for lifetime and later subscribed should still
+  // surface as 'supporter' (the more durable grant) so cancellation of
+  // the recurring sub doesn't drop their entitlement.
   async getEntitlement(userId: string): Promise<BillingEntitlement> {
+    const supporterAt = await userRepository.getSupporterLifetimeAt(userId)
+    if (supporterAt) {
+      return {
+        isPremium: true,
+        tier: 'supporter_lifetime',
+        validUntil: null,
+        cancelAtPeriodEnd: false,
+        source: 'supporter',
+      }
+    }
+
     const row = await subscriptionRepository.findActiveByUserId(userId)
     if (!row) {
       return {

--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -36,6 +36,11 @@ const BASE_SCORE = 100
 const UNFOUND_PENALTY = 0
 const WRONG_GUESS_PENALTY = 0
 const CATCH_UP_DAYS = 7
+// Premium tier extends the catch-up window. 365 days is generous enough
+// to feel like "the full archive" for end-users while still bounding the
+// challenge-list query — the recurring `create-daily-challenge` job
+// produces one row per day, so the upper bound on cardinality is small.
+export const PREMIUM_CATCH_UP_DAYS = 365
 
 /**
  * Calculate speed multiplier based on time taken to find the screenshot
@@ -75,7 +80,7 @@ export interface GameServiceDeps {
 
 export interface GameService {
   getTodayChallenge(userId?: string, date?: string): Promise<TodayChallengeResponse>
-  startChallenge(challengeId: number, userId: string): Promise<StartChallengeResponse>
+  startChallenge(challengeId: number, userId: string, isPremium?: boolean): Promise<StartChallengeResponse>
   getScreenshot(sessionId: string, position: number, userId: string): Promise<ScreenshotResponse>
   submitGuess(data: {
     tierSessionId: string
@@ -86,6 +91,7 @@ export interface GameService {
     roundTimeTakenMs: number
     userId: string
     powerUpUsed?: 'hint_year' | 'hint_publisher'
+    isPremium?: boolean
   }): Promise<GuessResponse>
   endGame(sessionId: string, userId: string): Promise<EndGameResponse>
 }
@@ -234,7 +240,11 @@ export function createGameService(deps: GameServiceDeps): GameService {
     }
   },
 
-  async startChallenge(challengeId: number, userId: string): Promise<StartChallengeResponse> {
+  async startChallenge(
+    challengeId: number,
+    userId: string,
+    isPremium: boolean = false,
+  ): Promise<StartChallengeResponse> {
     log.info({ challengeId, userId }, 'startChallenge')
 
     const tiers = await challengeRepository.findTiersByChallenge(challengeId)
@@ -253,9 +263,12 @@ export function createGameService(deps: GameServiceDeps): GameService {
     const today = new Date()
     today.setHours(0, 0, 0, 0)
 
-    // Calculate the oldest allowed date (CATCH_UP_DAYS days ago)
+    // Free tier sees the last CATCH_UP_DAYS; premium extends to
+    // PREMIUM_CATCH_UP_DAYS. Outside both windows the challenge is
+    // genuinely too old for anyone and we keep the original 400.
+    const allowedDays = isPremium ? PREMIUM_CATCH_UP_DAYS : CATCH_UP_DAYS
     const oldestAllowed = new Date(today)
-    oldestAllowed.setDate(oldestAllowed.getDate() - CATCH_UP_DAYS)
+    oldestAllowed.setDate(oldestAllowed.getDate() - allowedDays)
 
     const challengeDate = new Date(challenge.challenge_date)
     challengeDate.setHours(0, 0, 0, 0)
@@ -265,10 +278,28 @@ export function createGameService(deps: GameServiceDeps): GameService {
       ? challenge.challenge_date
       : challengeDate.toISOString().split('T')[0]
 
-    // Check if challenge is from the past (not today and older than CATCH_UP_DAYS)
     const isCatchUp = challengeDateStr !== todayStr
     if (isCatchUp && challengeDate < oldestAllowed) {
-      throw new GameError('CHALLENGE_TOO_OLD', `This challenge is no longer available. You can only play challenges from the last ${CATCH_UP_DAYS} days.`, 400)
+      // Premium would already have allowedDays === PREMIUM_CATCH_UP_DAYS,
+      // so reaching this branch as a free user with a 7..365 day-old
+      // challenge is the upgrade moment. 402 lets the frontend route to
+      // the upsell instead of rendering a generic error.
+      if (!isPremium) {
+        const freeOldest = new Date(today)
+        freeOldest.setDate(freeOldest.getDate() - CATCH_UP_DAYS)
+        if (challengeDate >= new Date(today.getTime() - PREMIUM_CATCH_UP_DAYS * 24 * 60 * 60 * 1000) && challengeDate < freeOldest) {
+          throw new GameError(
+            'PREMIUM_REQUIRED_FOR_OLD_CATCHUP',
+            `Challenges older than ${CATCH_UP_DAYS} days require Premium`,
+            402,
+          )
+        }
+      }
+      throw new GameError(
+        'CHALLENGE_TOO_OLD',
+        `This challenge is no longer available. You can only play challenges from the last ${allowedDays} days.`,
+        400,
+      )
     }
 
     let gameSession = await sessionRepository.findGameSession(userId, challengeId)
@@ -349,6 +380,7 @@ export function createGameService(deps: GameServiceDeps): GameService {
     roundTimeTakenMs: number
     userId: string
     powerUpUsed?: 'hint_year' | 'hint_publisher'
+    isPremium?: boolean
   }): Promise<GuessResponse> {
     log.debug({ tierSessionId: data.tierSessionId, position: data.position, userId: data.userId }, 'submitGuess')
 
@@ -382,23 +414,36 @@ export function createGameService(deps: GameServiceDeps): GameService {
 
       // Check if hint was used and handle penalty/inventory
       if (data.powerUpUsed === 'hint_year' || data.powerUpUsed === 'hint_publisher' || data.powerUpUsed === 'hint_developer') {
-        // Check if user has hint in inventory (use it for free)
-        const hasHintInInventory = await inventoryRepository.useItems(
-          data.userId,
-          'powerup',
-          data.powerUpUsed,
-          1
-        )
+        // Premium entitlement bypasses the hint cost ENTIRELY in catch-up
+        // sessions only — never on today's daily, since today is what
+        // feeds the leaderboard and ranked integrity is non-negotiable.
+        const premiumFreeHint = !!data.isPremium && !!tierSession.is_catch_up
 
-        if (hasHintInInventory) {
-          // Hint from inventory - no penalty
-          hintFromInventory = true
-          log.info({ userId: data.userId, hintType: data.powerUpUsed }, 'hint used from inventory (no penalty)')
+        if (premiumFreeHint) {
+          hintFromInventory = true // accounting bucket: "no penalty"
+          log.info(
+            { userId: data.userId, hintType: data.powerUpUsed },
+            'hint free for premium in catch-up',
+          )
         } else {
-          // No inventory - apply 20% penalty
-          hintPenalty = Math.round(scoreEarned * 0.20)
-          scoreEarned -= hintPenalty
-          log.info({ userId: data.userId, hintType: data.powerUpUsed, penalty: hintPenalty }, 'hint used with penalty (no inventory)')
+          // Check if user has hint in inventory (use it for free)
+          const hasHintInInventory = await inventoryRepository.useItems(
+            data.userId,
+            'powerup',
+            data.powerUpUsed,
+            1
+          )
+
+          if (hasHintInInventory) {
+            // Hint from inventory - no penalty
+            hintFromInventory = true
+            log.info({ userId: data.userId, hintType: data.powerUpUsed }, 'hint used from inventory (no penalty)')
+          } else {
+            // No inventory - apply 20% penalty
+            hintPenalty = Math.round(scoreEarned * 0.20)
+            scoreEarned -= hintPenalty
+            log.info({ userId: data.userId, hintType: data.powerUpUsed, penalty: hintPenalty }, 'hint used with penalty (no inventory)')
+          }
         }
       }
     }

--- a/packages/backend/src/domain/services/user.service.ts
+++ b/packages/backend/src/domain/services/user.service.ts
@@ -15,9 +15,12 @@ import type {
 const TOTAL_SCREENSHOTS = 10
 const WRONG_GUESS_PENALTY = 0
 const CATCH_UP_DAYS = 7
+// Mirror of game.service.ts. Kept duplicated rather than cross-imported
+// to avoid pulling game.service into user.service's dependency graph.
+const PREMIUM_CATCH_UP_DAYS = 365
 
 export interface UserService {
-  getGameHistory(userId: string): Promise<GameHistoryResponse>
+  getGameHistory(userId: string, isPremium?: boolean): Promise<GameHistoryResponse>
   getPublicGameSessionDetails(sessionId: string): Promise<GameSessionDetailsResponse>
   getGameSessionDetails(
     sessionId: string,
@@ -179,11 +182,13 @@ export function createUserService(deps: UserServiceDeps): UserService {
   }
 
   return {
-    async getGameHistory(userId: string): Promise<GameHistoryResponse> {
+    async getGameHistory(userId: string, isPremium: boolean = false): Promise<GameHistoryResponse> {
       const entries = await sessionRepository.findUserGameHistory(userId)
 
-      // Get recent challenges (last CATCH_UP_DAYS days)
-      const recentChallenges = await challengeRepository.findRecentChallenges(CATCH_UP_DAYS)
+      // Premium users see the extended archive so they have something to
+      // play beyond the 7-day window. Free users keep the existing list.
+      const lookbackDays = isPremium ? PREMIUM_CATCH_UP_DAYS : CATCH_UP_DAYS
+      const recentChallenges = await challengeRepository.findRecentChallenges(lookbackDays)
 
       // Get today's date to exclude it from missed challenges
       const today = new Date().toISOString().split('T')[0]

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -22,6 +22,8 @@ import referralRoutes from './presentation/routes/referral.routes.js'
 import ogRoutes from './presentation/routes/og.routes.js'
 import geoRoutes from './presentation/routes/geo.routes.js'
 import screenshotReportRoutes from './presentation/routes/screenshot-report.routes.js'
+import billingRoutes from './presentation/routes/billing.routes.js'
+import billingWebhookRoutes from './presentation/routes/billing-webhook.routes.js'
 import { testRedisConnection } from './infrastructure/queue/connection.js'
 import { importQueue, geoQueue } from './infrastructure/queue/queues.js'
 import './infrastructure/queue/workers/import.worker.js'
@@ -60,6 +62,11 @@ app.use(cors({
   origin: env.CORS_ORIGIN,
   credentials: true,
 }))
+
+// Stripe webhooks must mount BEFORE the global JSON parser — signature
+// verification needs the exact raw bytes Stripe sent. The route applies
+// its own express.raw() so only this path skips JSON parsing.
+app.use('/api/billing/webhook', billingWebhookRoutes)
 
 // JSON parsing middleware
 app.use(express.json())
@@ -183,6 +190,7 @@ app.use('/api/referral', referralRoutes)
 app.use('/api/og', ogRoutes)
 app.use('/api/geo', geoRoutes)
 app.use('/api/screenshot-reports', screenshotReportRoutes)
+app.use('/api/billing', billingRoutes)
 
 // Serve frontend static files (after API routes)
 const frontendPath = path.resolve(__dirname, '..', '..', '..', 'packages', 'frontend', 'dist')

--- a/packages/backend/src/infrastructure/repositories/index.ts
+++ b/packages/backend/src/infrastructure/repositories/index.ts
@@ -32,3 +32,10 @@ export {
   type GeoIngestFailureRow,
   type GeoIngestSource,
 } from './geo-ingest-failure.repository.js'
+export {
+  subscriptionRepository,
+  stripeEventLogRepository,
+  ENTITLED_STATUSES,
+  type SubscriptionRow,
+  type UpsertSubscriptionInput,
+} from './subscription.repository.js'

--- a/packages/backend/src/infrastructure/repositories/session.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/session.repository.ts
@@ -42,6 +42,7 @@ export interface TierSessionWithContext extends TierSessionRow {
   game_session_started_at: Date
   game_session_id: string
   daily_challenge_id: number
+  is_catch_up: boolean
   tier_number: number
   time_limit_seconds: number
 }
@@ -133,6 +134,7 @@ export const sessionRepository = {
         'game_sessions.started_at as game_session_started_at',
         'game_sessions.id as game_session_id',
         'game_sessions.daily_challenge_id',
+        'game_sessions.is_catch_up',
         'tiers.tier_number',
         'tiers.time_limit_seconds'
       )

--- a/packages/backend/src/infrastructure/repositories/subscription.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/subscription.repository.ts
@@ -1,0 +1,131 @@
+import { db } from '../database/connection.js'
+import { repoLogger } from '../logger/logger.js'
+import type { SubscriptionStatus } from '@the-box/types'
+
+const log = repoLogger.child({ repository: 'subscription' })
+
+export interface SubscriptionRow {
+  id: number
+  user_id: string
+  stripe_subscription_id: string
+  stripe_price_id: string
+  status: SubscriptionStatus
+  current_period_end: Date | null
+  cancel_at_period_end: boolean
+  created_at: Date
+  updated_at: Date
+}
+
+export interface UpsertSubscriptionInput {
+  userId: string
+  stripeSubscriptionId: string
+  stripePriceId: string
+  status: SubscriptionStatus
+  currentPeriodEnd: Date | null
+  cancelAtPeriodEnd: boolean
+}
+
+// Statuses that grant premium entitlement. `trialing` is included so a Stripe
+// trial without payment still unlocks features; everything else (past_due,
+// canceled, incomplete, ...) treats the user as free.
+export const ENTITLED_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
+  'active',
+  'trialing',
+])
+
+export const subscriptionRepository = {
+  async upsert(input: UpsertSubscriptionInput): Promise<SubscriptionRow> {
+    log.info(
+      {
+        userId: input.userId,
+        stripeSubscriptionId: input.stripeSubscriptionId,
+        status: input.status,
+      },
+      'upsert',
+    )
+
+    const [row] = await db('subscriptions')
+      .insert({
+        user_id: input.userId,
+        stripe_subscription_id: input.stripeSubscriptionId,
+        stripe_price_id: input.stripePriceId,
+        status: input.status,
+        current_period_end: input.currentPeriodEnd,
+        cancel_at_period_end: input.cancelAtPeriodEnd,
+        updated_at: new Date(),
+      })
+      .onConflict('stripe_subscription_id')
+      .merge({
+        stripe_price_id: input.stripePriceId,
+        status: input.status,
+        current_period_end: input.currentPeriodEnd,
+        cancel_at_period_end: input.cancelAtPeriodEnd,
+        updated_at: new Date(),
+      })
+      .returning<SubscriptionRow[]>('*')
+
+    return row!
+  },
+
+  async findActiveByUserId(userId: string): Promise<SubscriptionRow | null> {
+    // Most recent entitled-status subscription wins. A user shouldn't have
+    // multiple active subs at once, but checkout idempotency in the wild
+    // means we sometimes see two — pick the one with the latest period end
+    // so the UI's "Premium until …" reflects the actual grant.
+    const row = await db('subscriptions')
+      .where({ user_id: userId })
+      .whereIn('status', Array.from(ENTITLED_STATUSES))
+      .orderBy('current_period_end', 'desc')
+      .first<SubscriptionRow>()
+    return row ?? null
+  },
+
+  async findByStripeId(stripeSubscriptionId: string): Promise<SubscriptionRow | null> {
+    const row = await db('subscriptions')
+      .where({ stripe_subscription_id: stripeSubscriptionId })
+      .first<SubscriptionRow>()
+    return row ?? null
+  },
+
+  async updateStatus(
+    stripeSubscriptionId: string,
+    status: SubscriptionStatus,
+    currentPeriodEnd: Date | null,
+    cancelAtPeriodEnd: boolean,
+  ): Promise<void> {
+    await db('subscriptions')
+      .where({ stripe_subscription_id: stripeSubscriptionId })
+      .update({
+        status,
+        current_period_end: currentPeriodEnd,
+        cancel_at_period_end: cancelAtPeriodEnd,
+        updated_at: new Date(),
+      })
+  },
+}
+
+// Webhook idempotency: every event we accept is logged here in the same
+// transaction as its side effect. A duplicate event hits the unique PK and
+// the handler short-circuits without re-applying.
+export const stripeEventLogRepository = {
+  async record(eventId: string, type: string): Promise<{ alreadyApplied: boolean }> {
+    try {
+      await db('stripe_event_log').insert({
+        event_id: eventId,
+        type,
+      })
+      return { alreadyApplied: false }
+    } catch (err) {
+      // Postgres unique violation → duplicate event, safe to ignore.
+      if (
+        err instanceof Error &&
+        'code' in err &&
+        (err as { code?: string }).code === '23505'
+      ) {
+        log.info({ eventId, type }, 'duplicate webhook event ignored')
+        return { alreadyApplied: true }
+      }
+      throw err
+    }
+  },
+}

--- a/packages/backend/src/infrastructure/repositories/user.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/user.repository.ts
@@ -135,6 +135,30 @@ export const userRepository = {
     return this.findById(userId)
   },
 
+  async getStripeCustomerId(userId: string): Promise<string | null> {
+    const row = await db('user')
+      .where('id', userId)
+      .first<{ stripe_customer_id: string | null }>('stripe_customer_id')
+    return row?.stripe_customer_id ?? null
+  },
+
+  async setStripeCustomerId(userId: string, customerId: string): Promise<void> {
+    log.info({ userId, customerId }, 'setStripeCustomerId')
+    await db('user')
+      .where('id', userId)
+      .update({
+        stripe_customer_id: customerId,
+        updatedAt: new Date(),
+      })
+  },
+
+  async findByStripeCustomerId(customerId: string): Promise<{ id: string; email: string } | null> {
+    const row = await db('user')
+      .where('stripe_customer_id', customerId)
+      .first<{ id: string; email: string }>('id', 'email')
+    return row ?? null
+  },
+
   async updateEmailMarketingConsent(userId: string, consent: boolean): Promise<User | null> {
     log.info({ userId, consent }, 'updateEmailMarketingConsent')
     await db('user')

--- a/packages/backend/src/infrastructure/repositories/user.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/user.repository.ts
@@ -159,6 +159,26 @@ export const userRepository = {
     return row ?? null
   },
 
+  async getSupporterLifetimeAt(userId: string): Promise<Date | null> {
+    const row = await db('user')
+      .where('id', userId)
+      .first<{ supporter_lifetime_at: Date | null }>('supporter_lifetime_at')
+    return row?.supporter_lifetime_at ?? null
+  },
+
+  async grantSupporterLifetime(userId: string, grantedAt: Date = new Date()): Promise<void> {
+    log.info({ userId, grantedAt }, 'grantSupporterLifetime')
+    // Idempotent: keep the earliest grant timestamp so a duplicate webhook
+    // doesn't overwrite the original supporter date.
+    await db('user')
+      .where('id', userId)
+      .whereNull('supporter_lifetime_at')
+      .update({
+        supporter_lifetime_at: grantedAt,
+        updatedAt: new Date(),
+      })
+  },
+
   async updateEmailMarketingConsent(userId: string, consent: boolean): Promise<User | null> {
     log.info({ userId, consent }, 'updateEmailMarketingConsent')
     await db('user')

--- a/packages/backend/src/infrastructure/stripe/stripe.client.ts
+++ b/packages/backend/src/infrastructure/stripe/stripe.client.ts
@@ -1,0 +1,28 @@
+import Stripe from 'stripe'
+import { env } from '../../config/env.js'
+import { logger } from '../logger/logger.js'
+
+// Lazy singleton: don't crash boot if STRIPE_SECRET_KEY is missing in dev,
+// but every billing code path that actually needs Stripe must call
+// getStripe() rather than importing a top-level instance. That way unit
+// tests can boot the app without touching Stripe and prod still gets a
+// loud failure the moment a billing route is hit without configuration.
+
+let client: Stripe | null = null
+
+export function getStripe(): Stripe {
+  if (client) return client
+  if (!env.STRIPE_SECRET_KEY) {
+    throw new Error('STRIPE_SECRET_KEY is not configured — billing endpoints will not work')
+  }
+  client = new Stripe(env.STRIPE_SECRET_KEY)
+  logger.info(
+    { mode: env.STRIPE_SECRET_KEY.startsWith('sk_live_') ? 'live' : 'test' },
+    'stripe client initialized',
+  )
+  return client
+}
+
+export function isStripeConfigured(): boolean {
+  return !!env.STRIPE_SECRET_KEY
+}

--- a/packages/backend/src/presentation/middleware/require-premium.middleware.ts
+++ b/packages/backend/src/presentation/middleware/require-premium.middleware.ts
@@ -1,0 +1,34 @@
+import type { NextFunction, Request, Response } from 'express'
+import { billingService } from '../../domain/services/billing.service.js'
+
+// Gate a route on the caller having an active premium entitlement. Always
+// chain after authMiddleware — it relies on req.userId being populated.
+//
+// Failure mode: 402 Payment Required with a code the frontend can detect
+// to surface the upsell modal. Don't use 403 (forbidden) since the user
+// can resolve this by paying, not by getting permission.
+export async function requirePremium(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  if (!req.userId) {
+    res.status(401).json({
+      success: false,
+      error: { code: 'UNAUTHORIZED' },
+    })
+    return
+  }
+  const entitlement = await billingService.getEntitlement(req.userId)
+  if (!entitlement.isPremium) {
+    res.status(402).json({
+      success: false,
+      error: {
+        code: 'PREMIUM_REQUIRED',
+        message: 'This feature requires The Box Premium',
+      },
+    })
+    return
+  }
+  next()
+}

--- a/packages/backend/src/presentation/routes/billing-webhook.routes.ts
+++ b/packages/backend/src/presentation/routes/billing-webhook.routes.ts
@@ -1,0 +1,141 @@
+import express, { Router } from 'express'
+import type Stripe from 'stripe'
+import { getStripe } from '../../infrastructure/stripe/stripe.client.js'
+import { env } from '../../config/env.js'
+import {
+  subscriptionRepository,
+  stripeEventLogRepository,
+} from '../../infrastructure/repositories/subscription.repository.js'
+import { billingService } from '../../domain/services/billing.service.js'
+import { logger } from '../../infrastructure/logger/logger.js'
+
+const log = logger.child({ route: 'billing-webhook' })
+
+// Mounted at the very top of index.ts BEFORE express.json(), because Stripe
+// signature verification requires the raw request bytes. Using a path-scoped
+// raw parser keeps every other route on the existing JSON pipeline.
+
+const router = Router()
+
+router.post(
+  '/',
+  express.raw({ type: 'application/json' }),
+  async (req, res) => {
+    const signature = req.headers['stripe-signature']
+    if (!signature || typeof signature !== 'string') {
+      res.status(400).send('missing stripe-signature header')
+      return
+    }
+    if (!env.STRIPE_WEBHOOK_SECRET) {
+      log.error('STRIPE_WEBHOOK_SECRET is not configured — refusing webhook')
+      res.status(503).send('webhook not configured')
+      return
+    }
+
+    let event: Stripe.Event
+    try {
+      const stripe = getStripe()
+      event = stripe.webhooks.constructEvent(
+        req.body as Buffer,
+        signature,
+        env.STRIPE_WEBHOOK_SECRET,
+      )
+    } catch (err) {
+      log.warn({ err: String(err) }, 'webhook signature verification failed')
+      res.status(400).send(`signature verification failed: ${err instanceof Error ? err.message : 'unknown'}`)
+      return
+    }
+
+    // Always 200 after we successfully apply (or detect duplicate); Stripe
+    // retries 5xx aggressively. Errors past this point return 500 so we get
+    // retried — but the idempotency check inside ensures we never apply
+    // twice even if our handler crashes after a partial DB write.
+    try {
+      const { alreadyApplied } = await stripeEventLogRepository.record(event.id, event.type)
+      if (alreadyApplied) {
+        res.json({ received: true, duplicate: true })
+        return
+      }
+
+      await dispatch(event)
+      res.json({ received: true })
+    } catch (err) {
+      log.error({ err: String(err), eventId: event.id, type: event.type }, 'webhook handler failed')
+      res.status(500).send('webhook handler error')
+    }
+  },
+)
+
+async function dispatch(event: Stripe.Event): Promise<void> {
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const session = event.data.object as Stripe.Checkout.Session
+      // For one-time supporter purchases there is no Subscription created;
+      // we still log the event so future PRs can grant a lifetime flag.
+      // Subscription mode hands off to customer.subscription.created which
+      // Stripe fires alongside this event.
+      log.info(
+        {
+          mode: session.mode,
+          customerId: session.customer,
+          userId: session.metadata?.['userId'] ?? session.client_reference_id,
+          tier: session.metadata?.['tier'],
+        },
+        'checkout completed',
+      )
+      return
+    }
+
+    case 'customer.subscription.created':
+    case 'customer.subscription.updated':
+    case 'customer.subscription.deleted': {
+      const sub = event.data.object as Stripe.Subscription
+      const customerId = typeof sub.customer === 'string' ? sub.customer : sub.customer.id
+      const userId = await billingService.resolveUserIdFromCustomer(customerId)
+      if (!userId) {
+        log.warn(
+          { eventType: event.type, customerId, subscriptionId: sub.id },
+          'subscription event for unknown customer',
+        )
+        return
+      }
+      const fields = billingService.fromStripeSubscription(sub)
+      await subscriptionRepository.upsert({
+        userId,
+        ...fields,
+      })
+      log.info(
+        { userId, subscriptionId: sub.id, status: fields.status, eventType: event.type },
+        'subscription synced',
+      )
+      return
+    }
+
+    case 'invoice.payment_failed': {
+      const invoice = event.data.object as Stripe.Invoice
+      // Just log for now — the subsequent customer.subscription.updated
+      // event from Stripe carries the new status (past_due/unpaid), and
+      // that's where we adjust entitlement. Email notifications belong in
+      // a later iteration.
+      log.warn(
+        {
+          invoiceId: invoice.id,
+          customerId: invoice.customer,
+          // Stripe's typing exposes `subscription` only on the subscription
+          // shape; cast through unknown to read it without depending on the
+          // SDK's discriminated union.
+          subscriptionId: (invoice as unknown as { subscription?: string }).subscription,
+        },
+        'invoice payment failed',
+      )
+      return
+    }
+
+    default:
+      // Stripe sends a lot of event types we don't care about; logging at
+      // debug keeps prod logs clean while preserving traceability.
+      log.debug({ eventType: event.type }, 'webhook event ignored')
+  }
+}
+
+export default router

--- a/packages/backend/src/presentation/routes/billing-webhook.routes.ts
+++ b/packages/backend/src/presentation/routes/billing-webhook.routes.ts
@@ -6,6 +6,7 @@ import {
   subscriptionRepository,
   stripeEventLogRepository,
 } from '../../infrastructure/repositories/subscription.repository.js'
+import { userRepository } from '../../infrastructure/repositories/user.repository.js'
 import { billingService } from '../../domain/services/billing.service.js'
 import { logger } from '../../infrastructure/logger/logger.js'
 
@@ -70,10 +71,6 @@ async function dispatch(event: Stripe.Event): Promise<void> {
   switch (event.type) {
     case 'checkout.session.completed': {
       const session = event.data.object as Stripe.Checkout.Session
-      // For one-time supporter purchases there is no Subscription created;
-      // we still log the event so future PRs can grant a lifetime flag.
-      // Subscription mode hands off to customer.subscription.created which
-      // Stripe fires alongside this event.
       log.info(
         {
           mode: session.mode,
@@ -83,6 +80,28 @@ async function dispatch(event: Stripe.Event): Promise<void> {
         },
         'checkout completed',
       )
+
+      // One-time supporter purchases never create a Subscription, so the
+      // sibling customer.subscription.created handler doesn't fire. Persist
+      // the grant directly here when the Checkout Session was created for
+      // the supporter SKU; recurring-tier sessions fall through.
+      if (session.mode !== 'payment') return
+      if (session.metadata?.['tier'] !== 'supporter_lifetime') {
+        log.debug({ sessionId: session.id }, 'one-time checkout ignored — not the supporter SKU')
+        return
+      }
+
+      const userId =
+        (session.metadata?.['userId'] as string | undefined) ??
+        session.client_reference_id ??
+        null
+      if (!userId) {
+        log.warn({ sessionId: session.id }, 'supporter checkout missing userId metadata')
+        return
+      }
+
+      await userRepository.grantSupporterLifetime(userId)
+      log.info({ userId, sessionId: session.id }, 'supporter lifetime granted')
       return
     }
 

--- a/packages/backend/src/presentation/routes/billing.routes.ts
+++ b/packages/backend/src/presentation/routes/billing.routes.ts
@@ -1,0 +1,138 @@
+import { Router } from 'express'
+import { z } from 'zod'
+import type { BillingTier } from '@the-box/types'
+import { authMiddleware } from '../middleware/auth.middleware.js'
+import { validateBody } from '../middleware/validation.middleware.js'
+import { billingService } from '../../domain/services/billing.service.js'
+import { getCatalogEntry } from '../../config/billing.js'
+import { getStripe, isStripeConfigured } from '../../infrastructure/stripe/stripe.client.js'
+import { env } from '../../config/env.js'
+import { logger } from '../../infrastructure/logger/logger.js'
+
+const log = logger.child({ route: 'billing' })
+
+const router = Router()
+
+const TIERS = ['premium_monthly', 'premium_annual', 'supporter_lifetime'] as const satisfies readonly BillingTier[]
+
+// Public catalog. Used by the marketing page so the displayed amount is
+// always the same string the rest of the system asserts against. Cached
+// via Cache-Control to keep the page snappy without round-tripping Stripe
+// on every visitor — sync-check guarantees we'd never serve stale numbers
+// against a renamed price (CI fails first).
+router.get('/prices', (_req, res) => {
+  res.set('Cache-Control', 'public, max-age=300')
+  res.json({ success: true, data: { prices: billingService.listPublicPrices() } })
+})
+
+router.get('/me', authMiddleware, async (req, res, next) => {
+  try {
+    const entitlement = await billingService.getEntitlement(req.userId!)
+    res.json({ success: true, data: entitlement })
+  } catch (err) {
+    next(err)
+  }
+})
+
+const checkoutBodySchema = z.object({
+  tier: z.enum(TIERS),
+})
+
+router.post('/checkout', authMiddleware, validateBody(checkoutBodySchema), async (req, res, next) => {
+  try {
+    if (!isStripeConfigured()) {
+      res.status(503).json({
+        success: false,
+        error: { code: 'BILLING_NOT_CONFIGURED', message: 'Billing is not enabled on this server' },
+      })
+      return
+    }
+
+    const { tier } = req.body as z.infer<typeof checkoutBodySchema>
+    const entry = getCatalogEntry(tier)
+    if (!entry || !entry.stripePriceId) {
+      res.status(500).json({
+        success: false,
+        error: { code: 'PRICE_NOT_CONFIGURED', message: `No Stripe price ID for ${tier}` },
+      })
+      return
+    }
+
+    const user = req.user!
+    if (!user.email) {
+      // Anonymous Better Auth users have no real email; refuse so they
+      // can't end up with a paid subscription nobody can recover.
+      res.status(400).json({
+        success: false,
+        error: { code: 'EMAIL_REQUIRED', message: 'Sign up with a real email before subscribing' },
+      })
+      return
+    }
+
+    const customerId = await billingService.ensureStripeCustomer({
+      userId: user.id,
+      email: user.email,
+      name: user.name ?? undefined,
+    })
+
+    const stripe = getStripe()
+    const session = await stripe.checkout.sessions.create({
+      mode: entry.interval === null ? 'payment' : 'subscription',
+      customer: customerId,
+      line_items: [{ price: entry.stripePriceId, quantity: 1 }],
+      success_url: env.STRIPE_CHECKOUT_SUCCESS_URL,
+      cancel_url: env.STRIPE_CHECKOUT_CANCEL_URL,
+      // Lock the line items so a tampered redirect can't trick Stripe into
+      // charging for a different price than the user clicked.
+      allow_promotion_codes: true,
+      automatic_tax: { enabled: true },
+      // Carry the user back through the webhook even if the customer
+      // metadata round-trip is somehow missed.
+      client_reference_id: user.id,
+      metadata: { userId: user.id, tier },
+    })
+
+    if (!session.url) {
+      res.status(500).json({
+        success: false,
+        error: { code: 'CHECKOUT_SESSION_NO_URL', message: 'Stripe did not return a redirect URL' },
+      })
+      return
+    }
+
+    log.info({ userId: user.id, tier, sessionId: session.id }, 'checkout session created')
+    res.json({ success: true, data: { url: session.url } })
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.post('/portal', authMiddleware, async (req, res, next) => {
+  try {
+    if (!isStripeConfigured()) {
+      res.status(503).json({
+        success: false,
+        error: { code: 'BILLING_NOT_CONFIGURED', message: 'Billing is not enabled on this server' },
+      })
+      return
+    }
+
+    const customerId = await billingService.ensureStripeCustomer({
+      userId: req.user!.id,
+      email: req.user!.email,
+      name: req.user!.name ?? undefined,
+    })
+
+    const stripe = getStripe()
+    const session = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: env.STRIPE_PORTAL_RETURN_URL,
+    })
+
+    res.json({ success: true, data: { url: session.url } })
+  } catch (err) {
+    next(err)
+  }
+})
+
+export default router

--- a/packages/backend/src/presentation/routes/game.routes.ts
+++ b/packages/backend/src/presentation/routes/game.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { gameService, GameError } from '../../domain/services/index.js'
+import { billingService } from '../../domain/services/billing.service.js'
 import { challengeRepository, gameRepository, screenshotRepository } from '../../infrastructure/repositories/index.js'
 import { authMiddleware, optionalAuthMiddleware } from '../middleware/auth.middleware.js'
 import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
@@ -161,7 +162,12 @@ router.get('/today', optionalAuthMiddleware, async (req, res, next) => {
 router.post('/start/:challengeId', authMiddleware, async (req, res, next) => {
   try {
     const challengeId = parseInt(req.params['challengeId'] as string, 10)
-    const data = await gameService.startChallenge(challengeId, req.userId!)
+    // Premium status flips two things in startChallenge: the catch-up
+    // window expands to PREMIUM_CATCH_UP_DAYS, and an old free attempt
+    // returns 402 PREMIUM_REQUIRED_FOR_OLD_CATCHUP instead of a generic
+    // 400 so the frontend can surface the upsell instead of a dead end.
+    const isPremium = await billingService.isPremium(req.userId!)
+    const data = await gameService.startChallenge(challengeId, req.userId!, isPremium)
 
     res.json({
       success: true,
@@ -219,6 +225,11 @@ router.post('/guess', authMiddleware, async (req, res, next) => {
   try {
     const { tierSessionId, screenshotId, position, gameId, guessText, roundTimeTakenMs, powerUpUsed } = req.body
 
+    // Premium status only changes hint accounting in catch-up sessions
+    // (see game.service: premium + is_catch_up → free hint, no penalty).
+    // The flag is checked once here so the service stays sync-friendly.
+    const isPremium = await billingService.isPremium(req.userId!)
+
     const data = await gameService.submitGuess({
       tierSessionId,
       screenshotId,
@@ -228,6 +239,7 @@ router.post('/guess', authMiddleware, async (req, res, next) => {
       roundTimeTakenMs: roundTimeTakenMs || 0, // Fallback for backward compatibility
       userId: req.userId!,
       powerUpUsed,
+      isPremium,
     })
 
     res.json({

--- a/packages/backend/src/presentation/routes/user.routes.ts
+++ b/packages/backend/src/presentation/routes/user.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { userService } from '../../domain/services/index.js'
+import { billingService } from '../../domain/services/billing.service.js'
 import { authMiddleware } from '../middleware/auth.middleware.js'
 import { userRepository } from '../../infrastructure/repositories/user.repository.js'
 import { avatarUpload, getAvatarUrl, deleteAvatarFile } from '../middleware/upload.middleware.js'
@@ -114,7 +115,11 @@ router.get('/me', authMiddleware, async (req, res, next) => {
 // Get user's daily game history
 router.get('/history', authMiddleware, async (req, res, next) => {
   try {
-    const data = await userService.getGameHistory(req.userId!)
+    // Premium users get the extended catch-up window in their missed
+    // challenges list, so the UI surfaces playable archive entries
+    // without the user having to know a deep-link challenge ID.
+    const isPremium = await billingService.isPremium(req.userId!)
+    const data = await userService.getGameHistory(req.userId!, isPremium)
 
     res.json({
       success: true,

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -149,6 +149,7 @@
     "errorLoadingScreenshot": "Failed to load image",
     "errorStarting": "Failed to start game",
     "alreadyCompleted": "You have already completed today's challenge! Come back tomorrow for a new one.",
+    "premiumRequiredForOldCatchup": "This challenge is more than 7 days old — available with Premium.",
     "catchUpNotice": "This is a catch-up session. Your score won't appear on the leaderboard.",
     "noChallenge": "No challenge available",
     "noChallengeAvailable": "No challenge available for {{date}}. Please check back later!",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -15,6 +15,7 @@
     "leaderboard": "Leaderboard",
     "geoDaily": "Geo",
     "alpha": "Alpha",
+    "premium": "Premium",
     "settings": "Settings",
     "login": "Login",
     "register": "Register",
@@ -1156,6 +1157,64 @@
       "emailRequired": "Please enter a recipient email address",
       "invalidEmail": "Please enter a valid email address"
     }
+  },
+  "pricing": {
+    "title": "The Box Premium",
+    "subtitle": "Support the game, unlock the full archive, and customize your profile.",
+    "billingMonthly": "/month",
+    "billingAnnual": "/year",
+    "billingLifetime": "lifetime",
+    "savingsAnnual": "~37% savings vs monthly",
+    "ctaSubscribe": "Subscribe",
+    "ctaLifetime": "Become a Supporter",
+    "ctaManage": "Manage subscription",
+    "ctaLogin": "Sign in to subscribe",
+    "ctaCurrent": "Current plan",
+    "loading": "Loading…",
+    "redirecting": "Redirecting to checkout…",
+    "errorCheckout": "Couldn't start checkout. Please try again shortly.",
+    "errorPortal": "Couldn't open the management portal.",
+    "checkoutSuccess": "Payment successful — welcome to Premium!",
+    "checkoutCancel": "Checkout canceled. You were not charged.",
+    "alreadyPremium": "You already have Premium access",
+    "premiumUntil": "Premium active until {{date}}",
+    "cancelScheduled": "Renewal canceled for {{date}}",
+    "tiers": {
+      "premium_monthly": {
+        "name": "Premium Monthly",
+        "description": "Try it without commitment"
+      },
+      "premium_annual": {
+        "name": "Premium Annual",
+        "description": "Best value per month",
+        "highlight": "Most popular"
+      },
+      "supporter_lifetime": {
+        "name": "Lifetime Supporter",
+        "description": "One-time support — Premium access and Founding Player badge"
+      }
+    },
+    "features": {
+      "title": "What's included",
+      "free": "Free",
+      "premium": "Premium",
+      "items": {
+        "dailyChallenge": "Daily challenge",
+        "leaderboards": "Live leaderboards",
+        "achievements": "Achievements and progression",
+        "catchUp7d": "Catch up on the last 7 days",
+        "catchUpFull": "Full archive of past challenges",
+        "hintsBaseline": "Base hints",
+        "hintsUnlimitedCatchUp": "Unlimited hints in catch-up",
+        "advancedStats": "Advanced profile statistics",
+        "cosmetics": "Premium badge and animated frames",
+        "themes": "Extra themes",
+        "earlyAccess": "Early access to new game packs"
+      },
+      "yes": "Yes",
+      "no": "No"
+    },
+    "footnote": "Secure payment via Stripe. VAT applied based on your country. Cancel anytime from your profile."
   },
   "footer": {
     "allRightsReserved": "All rights reserved.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -15,6 +15,7 @@
     "leaderboard": "Classement",
     "geoDaily": "Geo",
     "alpha": "Alpha",
+    "premium": "Premium",
     "settings": "Paramètres",
     "login": "Connexion",
     "register": "Inscription",
@@ -1156,6 +1157,64 @@
       "emailRequired": "Veuillez entrer une adresse email destinataire",
       "invalidEmail": "Veuillez entrer une adresse email valide"
     }
+  },
+  "pricing": {
+    "title": "The Box Premium",
+    "subtitle": "Soutenez le jeu, débloquez l'archive complète et personnalisez votre profil.",
+    "billingMonthly": "/mois",
+    "billingAnnual": "/an",
+    "billingLifetime": "à vie",
+    "savingsAnnual": "Soit ~37 % d'économies",
+    "ctaSubscribe": "S'abonner",
+    "ctaLifetime": "Devenir Supporter",
+    "ctaManage": "Gérer mon abonnement",
+    "ctaLogin": "Se connecter pour s'abonner",
+    "ctaCurrent": "Plan actuel",
+    "loading": "Chargement…",
+    "redirecting": "Redirection vers le paiement…",
+    "errorCheckout": "Impossible de démarrer le paiement. Réessayez dans un instant.",
+    "errorPortal": "Impossible d'ouvrir le portail de gestion.",
+    "checkoutSuccess": "Paiement réussi — bienvenue parmi les Premium !",
+    "checkoutCancel": "Paiement annulé. Aucun montant n'a été débité.",
+    "alreadyPremium": "Vous avez déjà accès à Premium",
+    "premiumUntil": "Premium actif jusqu'au {{date}}",
+    "cancelScheduled": "Renouvellement annulé pour le {{date}}",
+    "tiers": {
+      "premium_monthly": {
+        "name": "Premium Mensuel",
+        "description": "Pour essayer sans engagement"
+      },
+      "premium_annual": {
+        "name": "Premium Annuel",
+        "description": "Le meilleur rapport qualité-prix",
+        "highlight": "Le plus populaire"
+      },
+      "supporter_lifetime": {
+        "name": "Supporter à vie",
+        "description": "Un soutien ponctuel — accès Premium et badge Founding Player"
+      }
+    },
+    "features": {
+      "title": "Ce qui est inclus",
+      "free": "Gratuit",
+      "premium": "Premium",
+      "items": {
+        "dailyChallenge": "Défi quotidien",
+        "leaderboards": "Classements en temps réel",
+        "achievements": "Succès et progression",
+        "catchUp7d": "Rattrapage des 7 derniers jours",
+        "catchUpFull": "Archive complète des défis passés",
+        "hintsBaseline": "Indices de base",
+        "hintsUnlimitedCatchUp": "Indices illimités en rattrapage",
+        "advancedStats": "Statistiques avancées du profil",
+        "cosmetics": "Badge et cadres animés",
+        "themes": "Thèmes supplémentaires",
+        "earlyAccess": "Accès anticipé aux nouveaux packs"
+      },
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "footnote": "Paiement sécurisé via Stripe. TVA appliquée selon votre pays. Annulation possible à tout moment depuis votre profil."
   },
   "footer": {
     "allRightsReserved": "Tous droits réservés.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -149,6 +149,7 @@
     "errorLoadingScreenshot": "Impossible de charger l'image",
     "errorStarting": "Impossible de démarrer la partie",
     "alreadyCompleted": "Vous avez déjà terminé le défi d'aujourd'hui ! Revenez demain pour un nouveau.",
+    "premiumRequiredForOldCatchup": "Ce défi a plus de 7 jours — accessible avec Premium.",
     "catchUpNotice": "Ceci est une session de rattrapage. Votre score n'apparaîtra pas au classement.",
     "noChallenge": "Aucun défi disponible",
     "noChallengeAvailable": "Aucun défi disponible pour le {{date}}. Revenez plus tard !",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -37,6 +37,7 @@ const PublicProfilePage = lazy(() => import('@/pages/PublicProfilePage'))
 const GeoDailyPage = lazy(() => import('@/pages/GeoDailyPage'))
 const GeoContributePage = lazy(() => import('@/pages/GeoContributePage'))
 const GeoLeaderboardPage = lazy(() => import('@/pages/GeoLeaderboardPage'))
+const PricingPage = lazy(() => import('@/pages/PricingPage'))
 
 function LoadingSpinner() {
   return (
@@ -142,6 +143,12 @@ function App() {
           <Route path="geo/daily" element={<GeoDailyPage />} />
           <Route path="geo/leaderboard" element={<GeoLeaderboardPage />} />
           <Route path="geo/contribute" element={<GeoContributePage />} />
+
+          <Route path="premium" element={<PricingPage />} />
+          {/* French-friendly alias resolves to the same component so links from
+              older marketing copy still land. The page itself renders identically; SEO
+              gets a single canonical via the language-prefixed /premium URL. */}
+          <Route path="abonnement" element={<PricingPage />} />
         </Route>
 
         {/* Catch-all redirect to browser language */}

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -17,11 +17,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin } from 'lucide-react'
+import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin, Sparkles } from 'lucide-react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
 import { DailyRewardBadge } from '@/components/daily-login'
 import { useDailyLoginStore } from '@/stores/dailyLoginStore'
+import { useBillingStore } from '@/stores/billingStore'
 import { KoeSupportWidget } from '@/components/layout/KoeSupportWidget'
 import { cn } from '@/lib/utils'
 
@@ -30,9 +31,10 @@ interface NavigationLinksProps {
   t: (key: string) => string
   localizedPath: (path: string) => string
   onMobileClick?: () => void
+  showPremiumUpsell: boolean
 }
 
-function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick }: NavigationLinksProps) {
+function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick, showPremiumUpsell }: NavigationLinksProps) {
   const mobileClasses = isMobile ? "w-full justify-start" : ""
   const iconClass = isMobile ? "mr-2" : "mr-1"
   const handleClick = isMobile ? onMobileClick : undefined
@@ -62,6 +64,17 @@ function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick }: 
           </Badge>
         </Link>
       </Button>
+
+      {/* Premium upsell — hidden once the user already has it, so the header stops
+          nagging paying users. The link itself stays available via /premium. */}
+      {showPremiumUpsell && (
+        <Button variant="ghost" size="sm" asChild className={cn(mobileClasses, 'text-neon-pink hover:text-neon-pink/80')}>
+          <Link to={localizedPath('/premium')} onClick={handleClick}>
+            <Sparkles className={`w-4 h-4 ${iconClass}`} />
+            {t('common.premium')}
+          </Link>
+        </Button>
+      )}
     </>
   )
 }
@@ -82,6 +95,15 @@ export function Header() {
   const [isScrolled, setIsScrolled] = useState(false)
   const isRewardModalOpen = useDailyLoginStore((state) => state.isModalOpen)
   const closeRewardModal = useDailyLoginStore((state) => state.closeModal)
+  const billingEntitlement = useBillingStore((state) => state.entitlement)
+  const fetchBillingEntitlement = useBillingStore((state) => state.fetchEntitlement)
+  const showPremiumUpsell = !billingEntitlement?.isPremium
+
+  // Hydrate billing entitlement once we know who the user is. Anonymous
+  // visitors get a 401 → store falls back to FREE_ENTITLEMENT silently.
+  useEffect(() => {
+    void fetchBillingEntitlement()
+  }, [fetchBillingEntitlement, session?.user?.id])
 
   // Keep the mobile menu and the daily reward modal mutually exclusive so the
   // modal can't render underneath the Sheet on small screens.
@@ -130,7 +152,7 @@ export function Header() {
                 <SheetTitle className="text-left">{t('common.menu')}</SheetTitle>
               </SheetHeader>
               <div className="flex flex-col gap-2 mt-6">
-                <NavigationLinks isMobile={true} t={t} localizedPath={localizedPath} onMobileClick={() => setMobileMenuOpen(false)} />
+                <NavigationLinks isMobile={true} t={t} localizedPath={localizedPath} onMobileClick={() => setMobileMenuOpen(false)} showPremiumUpsell={showPremiumUpsell} />
 
                 {/* Mobile Auth Section */}
                 <div className="border-t border-border pt-4 mt-4">
@@ -218,7 +240,7 @@ export function Header() {
 
         {/* Desktop Navigation - hidden on mobile, shown on md and up */}
         <nav className="hidden md:flex items-center gap-1 lg:gap-2">
-          <NavigationLinks isMobile={false} t={t} localizedPath={localizedPath} />
+          <NavigationLinks isMobile={false} t={t} localizedPath={localizedPath} showPremiumUpsell={showPremiumUpsell} />
         </nav>
 
         {/* Auth Buttons - Desktop - hidden on mobile, shown on md and up */}

--- a/packages/frontend/src/components/pricing/FeatureMatrix.tsx
+++ b/packages/frontend/src/components/pricing/FeatureMatrix.tsx
@@ -24,7 +24,7 @@ const ROWS: FeatureRow[] = [
 
 function FeatureCell({ on, label }: { on: boolean; label: string }) {
   return (
-    <span className={cn('inline-flex items-center justify-center', on ? 'text-emerald-400' : 'text-muted-foreground/50')}>
+    <span className={cn('inline-flex items-center justify-center', on ? 'text-success' : 'text-muted-foreground/50')}>
       {on ? <Check className="w-5 h-5" aria-label={label} /> : <X className="w-5 h-5" aria-label={label} />}
     </span>
   )

--- a/packages/frontend/src/components/pricing/FeatureMatrix.tsx
+++ b/packages/frontend/src/components/pricing/FeatureMatrix.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from 'react-i18next'
+import { Check, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface FeatureRow {
+  key: string
+  free: boolean
+  premium: boolean
+}
+
+const ROWS: FeatureRow[] = [
+  { key: 'dailyChallenge', free: true, premium: true },
+  { key: 'leaderboards', free: true, premium: true },
+  { key: 'achievements', free: true, premium: true },
+  { key: 'hintsBaseline', free: true, premium: true },
+  { key: 'catchUp7d', free: true, premium: true },
+  { key: 'catchUpFull', free: false, premium: true },
+  { key: 'hintsUnlimitedCatchUp', free: false, premium: true },
+  { key: 'advancedStats', free: false, premium: true },
+  { key: 'cosmetics', free: false, premium: true },
+  { key: 'themes', free: false, premium: true },
+  { key: 'earlyAccess', free: false, premium: true },
+]
+
+function FeatureCell({ on, label }: { on: boolean; label: string }) {
+  return (
+    <span className={cn('inline-flex items-center justify-center', on ? 'text-emerald-400' : 'text-muted-foreground/50')}>
+      {on ? <Check className="w-5 h-5" aria-label={label} /> : <X className="w-5 h-5" aria-label={label} />}
+    </span>
+  )
+}
+
+export function FeatureMatrix() {
+  const { t } = useTranslation()
+  return (
+    <div className="rounded-lg border border-border/60 overflow-hidden">
+      <h2 className="text-lg font-semibold px-4 sm:px-6 py-3 border-b border-border/60">
+        {t('pricing.features.title')}
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border/60 bg-muted/30">
+              <th className="text-left px-4 sm:px-6 py-2 font-medium text-muted-foreground"></th>
+              <th className="px-3 py-2 font-medium text-muted-foreground w-24 text-center">
+                {t('pricing.features.free')}
+              </th>
+              <th className="px-3 py-2 font-medium text-neon-pink w-24 text-center">
+                {t('pricing.features.premium')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map((row) => (
+              <tr key={row.key} className="border-b border-border/40 last:border-b-0">
+                <td className="px-4 sm:px-6 py-3 text-foreground/90">{t(`pricing.features.items.${row.key}`)}</td>
+                <td className="text-center py-3">
+                  <FeatureCell on={row.free} label={row.free ? t('pricing.features.yes') : t('pricing.features.no')} />
+                </td>
+                <td className="text-center py-3">
+                  <FeatureCell on={row.premium} label={row.premium ? t('pricing.features.yes') : t('pricing.features.no')} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/packages/frontend/src/components/pricing/PricingCard.tsx
+++ b/packages/frontend/src/components/pricing/PricingCard.tsx
@@ -1,0 +1,107 @@
+import { useTranslation } from 'react-i18next'
+import { motion } from 'framer-motion'
+import { Check, Sparkles } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import type { BillingPrice, BillingTier } from '@the-box/types'
+
+interface PricingCardProps {
+  price: BillingPrice
+  isCurrentPlan: boolean
+  isLoggedIn: boolean
+  isWorking: boolean
+  highlight?: boolean
+  onSelect: (tier: BillingTier) => void
+}
+
+function formatAmount(unitAmountCents: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(unitAmountCents / 100)
+}
+
+export function PricingCard({
+  price,
+  isCurrentPlan,
+  isLoggedIn,
+  isWorking,
+  highlight,
+  onSelect,
+}: PricingCardProps) {
+  const { t, i18n } = useTranslation()
+  const tierKey = `pricing.tiers.${price.tier}`
+  const isLifetime = price.interval === null
+  const ctaKey = isCurrentPlan
+    ? 'pricing.ctaCurrent'
+    : !isLoggedIn
+      ? 'pricing.ctaLogin'
+      : isLifetime
+        ? 'pricing.ctaLifetime'
+        : 'pricing.ctaSubscribe'
+
+  const intervalKey =
+    price.interval === 'month'
+      ? 'pricing.billingMonthly'
+      : price.interval === 'year'
+        ? 'pricing.billingAnnual'
+        : 'pricing.billingLifetime'
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+      className="h-full"
+    >
+      <Card
+        className={cn(
+          'h-full flex flex-col relative overflow-hidden',
+          highlight && 'border-neon-pink/60 shadow-[0_0_40px_-12px_rgba(244,114,182,0.45)]',
+        )}
+      >
+        {highlight && (
+          <Badge
+            variant="outline"
+            className="absolute top-4 right-4 border-neon-pink/60 text-neon-pink uppercase tracking-wide text-[10px] px-2 py-0.5"
+          >
+            <Sparkles className="w-3 h-3 mr-1" />
+            {t(`${tierKey}.highlight`, '')}
+          </Badge>
+        )}
+        <CardHeader>
+          <CardTitle className="text-xl">{t(`${tierKey}.name`)}</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">{t(`${tierKey}.description`)}</p>
+        </CardHeader>
+
+        <CardContent className="flex-1 space-y-4">
+          <div className="flex items-baseline gap-1">
+            <span className="text-4xl font-bold">{formatAmount(price.unitAmount, i18n.language)}</span>
+            <span className="text-muted-foreground text-sm">
+              {isLifetime ? ` ${t(intervalKey)}` : t(intervalKey)}
+            </span>
+          </div>
+          {price.tier === 'premium_annual' && (
+            <p className="text-xs text-neon-pink/80 font-medium">{t('pricing.savingsAnnual')}</p>
+          )}
+        </CardContent>
+
+        <CardFooter>
+          <Button
+            className="w-full"
+            disabled={isCurrentPlan || isWorking}
+            onClick={() => onSelect(price.tier)}
+            variant={highlight ? 'default' : 'outline'}
+          >
+            {isCurrentPlan && <Check className="w-4 h-4 mr-2" />}
+            {t(ctaKey)}
+          </Button>
+        </CardFooter>
+      </Card>
+    </motion.div>
+  )
+}

--- a/packages/frontend/src/components/pricing/PricingTable.tsx
+++ b/packages/frontend/src/components/pricing/PricingTable.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+import type { BillingTier } from '@the-box/types'
+import { useAuth } from '@/hooks/useAuth'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { useBillingStore } from '@/stores/billingStore'
+import { PricingCard } from './PricingCard'
+
+export function PricingTable() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { localizedPath } = useLocalizedPath()
+  const { isAuthenticated } = useAuth()
+  const {
+    prices,
+    pricesLoaded,
+    entitlement,
+    isStartingCheckout,
+    fetchPrices,
+    fetchEntitlement,
+    startCheckout,
+  } = useBillingStore()
+
+  useEffect(() => {
+    void fetchPrices()
+  }, [fetchPrices])
+
+  useEffect(() => {
+    void fetchEntitlement()
+  }, [fetchEntitlement, isAuthenticated])
+
+  const handleSelect = async (tier: BillingTier) => {
+    if (!isAuthenticated) {
+      navigate(localizedPath('/login'), {
+        state: { redirectTo: localizedPath('/premium') },
+      })
+      return
+    }
+    const result = await startCheckout(tier)
+    if ('url' in result) {
+      window.location.href = result.url
+    } else {
+      toast.error(t('pricing.errorCheckout'))
+    }
+  }
+
+  if (!pricesLoaded) {
+    return <p className="text-center text-muted-foreground">{t('pricing.loading')}</p>
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-3">
+      {prices.map((price) => (
+        <PricingCard
+          key={price.tier}
+          price={price}
+          isCurrentPlan={entitlement?.tier === price.tier && entitlement.isPremium}
+          isLoggedIn={isAuthenticated}
+          isWorking={isStartingCheckout}
+          highlight={price.tier === 'premium_annual'}
+          onSelect={handleSelect}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useMemo } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { motion, AnimatePresence } from 'framer-motion'
+import { toast } from 'sonner'
 import { useGameStore } from '@/stores/gameStore'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 import { DailyIntro } from '@/components/game/TierIntro'
@@ -380,12 +381,20 @@ export default function GamePage() {
       const code = err && typeof err === 'object' && 'code' in err ? (err as { code?: string }).code : undefined
       if (code === 'CHALLENGE_ALREADY_COMPLETED' || code === 'SESSION_ALREADY_COMPLETED') {
         setError(t('game.alreadyCompleted'))
+      } else if (code === 'PREMIUM_REQUIRED_FOR_OLD_CATCHUP') {
+        // Free user clicked an archived challenge they can't access. Send
+        // them straight to the upsell instead of a dead-end error so the
+        // upgrade path is one click away. Toast surfaces context briefly
+        // before the navigation lands them on /premium.
+        toast.info(t('game.premiumRequiredForOldCatchup'))
+        setError(t('game.premiumRequiredForOldCatchup'))
+        navigate(localizedPath('/premium'))
       } else {
         setError(t('game.errorStarting'))
       }
       setLoading(false)
     }
-  }, [challengeId, session, isSessionPending, setSessionId, initializePositionStates, fetchScreenshot, setGamePhase, setLoading, prefetchAllScreenshots, t])
+  }, [challengeId, session, isSessionPending, setSessionId, initializePositionStates, fetchScreenshot, setGamePhase, setLoading, prefetchAllScreenshots, t, navigate, localizedPath])
 
   // Fetch screenshot when position changes (after navigation)
   useEffect(() => {

--- a/packages/frontend/src/pages/PricingPage.tsx
+++ b/packages/frontend/src/pages/PricingPage.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
+import { Sparkles } from 'lucide-react'
+import { toast } from 'sonner'
+import { PageHero } from '@/components/layout/PageHero'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { useAuth } from '@/hooks/useAuth'
+import { useBillingStore } from '@/stores/billingStore'
+import { PricingTable } from '@/components/pricing/PricingTable'
+import { FeatureMatrix } from '@/components/pricing/FeatureMatrix'
+
+export default function PricingPage() {
+  const { t, i18n } = useTranslation()
+  const { isAuthenticated } = useAuth()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { entitlement, fetchEntitlement, openPortal, isOpeningPortal } = useBillingStore()
+
+  // Surface the result of a Stripe-hosted checkout redirect, then strip the
+  // query param so a refresh doesn't re-toast.
+  useEffect(() => {
+    const checkout = searchParams.get('checkout')
+    if (!checkout) return
+    if (checkout === 'success') {
+      toast.success(t('pricing.checkoutSuccess'))
+      // Refetch entitlement; the webhook may have already arrived.
+      void fetchEntitlement()
+    } else if (checkout === 'cancel') {
+      toast.info(t('pricing.checkoutCancel'))
+    }
+    const next = new URLSearchParams(searchParams)
+    next.delete('checkout')
+    setSearchParams(next, { replace: true })
+  }, [searchParams, setSearchParams, t, fetchEntitlement])
+
+  const handlePortal = async () => {
+    const result = await openPortal()
+    if ('url' in result) {
+      window.location.href = result.url
+    } else {
+      toast.error(t('pricing.errorPortal'))
+    }
+  }
+
+  const isPremium = !!entitlement?.isPremium
+  const validUntil = entitlement?.validUntil
+    ? new Date(entitlement.validUntil).toLocaleDateString(i18n.language === 'fr' ? 'fr-FR' : 'en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null
+
+  return (
+    <PageHero icon={Sparkles} title={t('pricing.title')} subtitle={t('pricing.subtitle')}>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-10">
+        {isAuthenticated && isPremium && (
+          <Card className="border-emerald-500/40 bg-emerald-500/5">
+            <CardContent className="py-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div>
+                <p className="font-medium">{t('pricing.alreadyPremium')}</p>
+                {validUntil && (
+                  <p className="text-sm text-muted-foreground">
+                    {entitlement?.cancelAtPeriodEnd
+                      ? t('pricing.cancelScheduled', { date: validUntil })
+                      : t('pricing.premiumUntil', { date: validUntil })}
+                  </p>
+                )}
+              </div>
+              <Button onClick={handlePortal} disabled={isOpeningPortal} variant="secondary">
+                {t('pricing.ctaManage')}
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        <PricingTable />
+
+        <FeatureMatrix />
+
+        <p className="text-center text-xs text-muted-foreground max-w-2xl mx-auto">
+          {t('pricing.footnote')}
+        </p>
+      </div>
+    </PageHero>
+  )
+}

--- a/packages/frontend/src/pages/PricingPage.tsx
+++ b/packages/frontend/src/pages/PricingPage.tsx
@@ -56,7 +56,7 @@ export default function PricingPage() {
     <PageHero icon={Sparkles} title={t('pricing.title')} subtitle={t('pricing.subtitle')}>
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-10">
         {isAuthenticated && isPremium && (
-          <Card className="border-emerald-500/40 bg-emerald-500/5">
+          <Card className="border-success/40 bg-success/5">
             <CardContent className="py-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <div>
                 <p className="font-medium">{t('pricing.alreadyPremium')}</p>

--- a/packages/frontend/src/stores/billingStore.ts
+++ b/packages/frontend/src/stores/billingStore.ts
@@ -1,0 +1,120 @@
+import { create } from 'zustand'
+import type { BillingEntitlement, BillingPrice, BillingTier } from '@the-box/types'
+
+interface BillingState {
+  prices: BillingPrice[]
+  pricesLoaded: boolean
+  entitlement: BillingEntitlement | null
+  isLoadingEntitlement: boolean
+  isStartingCheckout: boolean
+  isOpeningPortal: boolean
+
+  fetchPrices: () => Promise<void>
+  fetchEntitlement: () => Promise<void>
+  startCheckout: (tier: BillingTier) => Promise<{ url: string } | { error: string }>
+  openPortal: () => Promise<{ url: string } | { error: string }>
+  reset: () => void
+}
+
+const FREE_ENTITLEMENT: BillingEntitlement = {
+  isPremium: false,
+  tier: null,
+  validUntil: null,
+  cancelAtPeriodEnd: false,
+  source: null,
+}
+
+export const useBillingStore = create<BillingState>((set) => ({
+  prices: [],
+  pricesLoaded: false,
+  entitlement: null,
+  isLoadingEntitlement: false,
+  isStartingCheckout: false,
+  isOpeningPortal: false,
+
+  fetchPrices: async () => {
+    try {
+      const response = await fetch('/api/billing/prices', {
+        credentials: 'include',
+      })
+      if (!response.ok) throw new Error('Failed to load prices')
+      const json = await response.json()
+      set({ prices: json.data?.prices ?? [], pricesLoaded: true })
+    } catch (error) {
+      console.error('Failed to load billing prices:', error)
+      set({ pricesLoaded: true })
+    }
+  },
+
+  fetchEntitlement: async () => {
+    set({ isLoadingEntitlement: true })
+    try {
+      const response = await fetch('/api/billing/me', {
+        credentials: 'include',
+      })
+      if (response.status === 401) {
+        // Anonymous visitors are simply free; not an error worth surfacing.
+        set({ entitlement: FREE_ENTITLEMENT, isLoadingEntitlement: false })
+        return
+      }
+      if (!response.ok) throw new Error('Failed to load entitlement')
+      const json = await response.json()
+      set({ entitlement: json.data as BillingEntitlement, isLoadingEntitlement: false })
+    } catch (error) {
+      console.error('Failed to load billing entitlement:', error)
+      set({ entitlement: FREE_ENTITLEMENT, isLoadingEntitlement: false })
+    }
+  },
+
+  startCheckout: async (tier: BillingTier) => {
+    set({ isStartingCheckout: true })
+    try {
+      const response = await fetch('/api/billing/checkout', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tier }),
+      })
+      const json = await response.json()
+      if (!response.ok || !json.success) {
+        const code = json?.error?.code ?? 'CHECKOUT_FAILED'
+        return { error: code }
+      }
+      return { url: json.data.url as string }
+    } catch (error) {
+      console.error('Checkout request failed:', error)
+      return { error: 'NETWORK_ERROR' }
+    } finally {
+      set({ isStartingCheckout: false })
+    }
+  },
+
+  openPortal: async () => {
+    set({ isOpeningPortal: true })
+    try {
+      const response = await fetch('/api/billing/portal', {
+        method: 'POST',
+        credentials: 'include',
+      })
+      const json = await response.json()
+      if (!response.ok || !json.success) {
+        const code = json?.error?.code ?? 'PORTAL_FAILED'
+        return { error: code }
+      }
+      return { url: json.data.url as string }
+    } catch (error) {
+      console.error('Portal request failed:', error)
+      return { error: 'NETWORK_ERROR' }
+    } finally {
+      set({ isOpeningPortal: false })
+    }
+  },
+
+  reset: () =>
+    set({
+      entitlement: null,
+      isLoadingEntitlement: false,
+      isStartingCheckout: false,
+      isOpeningPortal: false,
+    }),
+}))

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -936,3 +936,47 @@ export type ScreenshotReportReason =
   | 'inappropriate'
   | 'too_easy'
   | 'other'
+
+// ============================================
+// Billing — Stripe-backed Premium subscription
+// ============================================
+// Wire shape only. The runtime price catalog (display amounts paired with
+// env-driven Stripe price IDs) lives server-side in the backend config so
+// this package stays types-only.
+
+export type BillingTier = 'premium_monthly' | 'premium_annual' | 'supporter_lifetime'
+
+// Mirrors a Stripe Subscription status. Internal billing status is derived
+// from this; treat 'active' and 'trialing' as the only entitlement-granting
+// states for recurring tiers.
+export type SubscriptionStatus =
+  | 'active'
+  | 'trialing'
+  | 'past_due'
+  | 'canceled'
+  | 'incomplete'
+  | 'incomplete_expired'
+  | 'unpaid'
+  | 'paused'
+
+// Public-facing price metadata returned by GET /api/billing/prices. Amount
+// is in the smallest currency unit (cents) so the frontend formats once.
+export interface BillingPrice {
+  tier: BillingTier
+  stripePriceId: string
+  unitAmount: number
+  currency: string
+  interval: 'month' | 'year' | null
+  active: boolean
+}
+
+// Server-derived view of the caller's entitlement, returned by
+// GET /api/billing/me. `validUntil` is the period end for recurring tiers
+// (so the UI can show "Premium until ...") and null for lifetime grants.
+export interface BillingEntitlement {
+  isPremium: boolean
+  tier: BillingTier | null
+  validUntil: string | null
+  cancelAtPeriodEnd: boolean
+  source: 'subscription' | 'supporter' | null
+}


### PR DESCRIPTION
**Final PR in the stack** — \`main ← #106 (foundation) ← #107 (backend) ← #108 (UI) ← this\`. Each merge retargets the next.

## Summary

Closes the loop on Premium. Catch-up archive extends to 365 days for paying users, hints in catch-up are free, and the supporter lifetime SKU finally grants entitlement.

## What changed

### Migration
- \`20260428_supporter_lifetime.ts\` — adds \`user.supporter_lifetime_at\` (nullable timestamp). Single column instead of a sibling table because the lookup is single-row and the existing user join picks it up for free.

### Entitlement resolution (\`billing.service.ts\`)
- \`getEntitlement\` resolves **lifetime supporter before recurring subscription**. A user who paid lifetime once and later subscribed surfaces as \`'supporter'\`, so canceling the recurring sub doesn't drop their access.

### Supporter webhook (\`billing-webhook.routes.ts\`)
- \`checkout.session.completed\` with \`mode=payment\` AND \`metadata.tier === 'supporter_lifetime'\` → \`userRepository.grantSupporterLifetime\`. Idempotent via \`whereNull\` guard so a duplicate webhook can't overwrite the original grant timestamp. Other one-time SKUs fall through; recurring tiers continue handled by \`customer.subscription.created\`.

### Catch-up gating (\`game.service.ts\` + \`game.routes.ts\` + \`user.service.ts\`)
- Free: 7-day window (unchanged). Premium: \`PREMIUM_CATCH_UP_DAYS = 365\`.
- Free attempts on challenges 7..365 days old return **402 \`PREMIUM_REQUIRED_FOR_OLD_CATCHUP\`** instead of the original 400. Older than 365 days still returns 400.
- \`userService.getGameHistory\` takes \`isPremium\` and bumps the missed-challenges window so the UI surfaces playable archive entries without deep-linking.

### Hint gating (\`game.service.ts\`)
- \`TierSessionWithContext\` + ports record now carry \`is_catch_up\`.
- \`submitGuess\` checks: **premium + catch-up = free hint**, no penalty, no inventory decrement.
- **Premium on today's daily** intentionally goes through the existing inventory/penalty path. Leaderboard integrity is non-negotiable.

### Frontend 402 handling (\`GamePage.tsx\` + locales)
- 402 \`PREMIUM_REQUIRED_FOR_OLD_CATCHUP\` triggers a toast and navigates to \`/premium\`. Other error codes unchanged.
- \`game.premiumRequiredForOldCatchup\` key added in \`fr\` and \`en\`.

## Test plan

- [x] \`npm run build:backend\` clean (threaded \`isPremium\` through GameService interface + ports type cleanly)
- [x] \`npm run build:frontend\` clean
- [x] Migration applies; \`user.supporter_lifetime_at\` present, nullable, timestamp with timezone
- [x] Existing endpoints (\`/billing/me\`, \`/billing/prices\`, \`/game/start/:id\`) unaffected for unauthenticated callers
- [ ] End-to-end with a real Stripe Checkout + \`stripe listen\` — pending. Need to (a) sign up a test user, (b) checkout the \`supporter_lifetime\` price, (c) verify the webhook lands and \`/api/billing/me\` returns \`{ tier: 'supporter_lifetime', source: 'supporter' }\`, (d) hit a 30-day-old challenge and confirm 200 instead of 402.
- [ ] Manually verify a free user hitting an old challenge → 402 → toast + redirect to \`/premium\`. (Requires seeding an old daily challenge; the e2e seed script could be extended.)

## What's intentionally NOT in this PR

- **Theme switcher** — too big for this PR; would need a Zustand theme store + Tailwind v4 CSS-vars wiring + theme picker UI. Standalone follow-up.
- **Animated cosmetic frames / leaderboard highlight** — design work; standalone PR.
- **Advanced profile stats endpoint + UI** — new \`stats.service\` + \`stats.routes\` + \`ProfilePage\` extension; standalone PR.
- **Day-zero pack early access** — needs a \`release_at\` column on \`games\` + selection-query change; standalone PR.

These were called out in the original proposal as Premium features but landed as out-of-scope for this PR's "wire the gating" milestone.

## Stripe live-mode

Account is currently in test mode (\`acct_1SFA9V…\`). Before any of this is real money:
1. Activate live mode in the Stripe dashboard
2. Recreate the Product + 3 Prices in live mode
3. Set live keys + price IDs in production env
4. Run \`npm run stripe:check -- --live\` from the deploy host
5. Configure live webhook endpoint to \`https://the-box.battistella.ovh/api/billing/webhook\` with the relevant events checked
6. Enable Stripe Tax for EU VAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)