### PR TITLE
feat(game): show end-game button once all positions are visited

### DIFF
--- a/packages/frontend/src/components/game/EndGameButton.tsx
+++ b/packages/frontend/src/components/game/EndGameButton.tsx
@@ -22,7 +22,6 @@ export function EndGameButton() {
 
   const gamePhase = useGameStore((s) => s.gamePhase)
   const hasVisitedAllPositions = useGameStore((s) => s.hasVisitedAllPositions)
-  const hasSkippedPositions = useGameStore((s) => s.hasSkippedPositions)
   const endGameAction = useGameStore((s) => s.endGameAction)
   const isSessionCompleted = useGameStore((s) => s.isSessionCompleted)
 
@@ -32,9 +31,7 @@ export function EndGameButton() {
     return sentences[Math.floor(Math.random() * sentences.length)]
   }, [showConfirm, t]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Show if playing, all positions visited, session not completed, and no skipped positions
-  // When there are skipped positions, the completion choice modal handles ending the game
-  const canShowButton = gamePhase === 'playing' && hasVisitedAllPositions() && !isSessionCompleted && !hasSkippedPositions()
+  const canShowButton = gamePhase === 'playing' && hasVisitedAllPositions() && !isSessionCompleted
 
   const handleEndGame = async () => {
     setIsEnding(true)


### PR DESCRIPTION
Drop the !hasSkippedPositions() gate so the End Game button appears as
soon as the player has visited all 10 positions, regardless of whether
some were skipped. Previously the button was hidden whenever any
position was skipped, leaving players with no visible way to end the
session from the main UI.

https://claude.ai/code/session_012ATyqQgQTVs16mAN68pYDh