### PR TITLE
feat: premium pricing page + header upsell (was #108)

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -15,6 +15,7 @@
     "leaderboard": "Leaderboard",
     "geoDaily": "Geo",
     "alpha": "Alpha",
+    "premium": "Premium",
     "settings": "Settings",
     "login": "Login",
     "register": "Register",
@@ -1156,6 +1157,64 @@
       "emailRequired": "Please enter a recipient email address",
       "invalidEmail": "Please enter a valid email address"
     }
+  },
+  "pricing": {
+    "title": "The Box Premium",
+    "subtitle": "Support the game, unlock the full archive, and customize your profile.",
+    "billingMonthly": "/month",
+    "billingAnnual": "/year",
+    "billingLifetime": "lifetime",
+    "savingsAnnual": "~37% savings vs monthly",
+    "ctaSubscribe": "Subscribe",
+    "ctaLifetime": "Become a Supporter",
+    "ctaManage": "Manage subscription",
+    "ctaLogin": "Sign in to subscribe",
+    "ctaCurrent": "Current plan",
+    "loading": "Loading…",
+    "redirecting": "Redirecting to checkout…",
+    "errorCheckout": "Couldn't start checkout. Please try again shortly.",
+    "errorPortal": "Couldn't open the management portal.",
+    "checkoutSuccess": "Payment successful — welcome to Premium!",
+    "checkoutCancel": "Checkout canceled. You were not charged.",
+    "alreadyPremium": "You already have Premium access",
+    "premiumUntil": "Premium active until {{date}}",
+    "cancelScheduled": "Renewal canceled for {{date}}",
+    "tiers": {
+      "premium_monthly": {
+        "name": "Premium Monthly",
+        "description": "Try it without commitment"
+      },
+      "premium_annual": {
+        "name": "Premium Annual",
+        "description": "Best value per month",
+        "highlight": "Most popular"
+      },
+      "supporter_lifetime": {
+        "name": "Lifetime Supporter",
+        "description": "One-time support — Premium access and Founding Player badge"
+      }
+    },
+    "features": {
+      "title": "What's included",
+      "free": "Free",
+      "premium": "Premium",
+      "items": {
+        "dailyChallenge": "Daily challenge",
+        "leaderboards": "Live leaderboards",
+        "achievements": "Achievements and progression",
+        "catchUp7d": "Catch up on the last 7 days",
+        "catchUpFull": "Full archive of past challenges",
+        "hintsBaseline": "Base hints",
+        "hintsUnlimitedCatchUp": "Unlimited hints in catch-up",
+        "advancedStats": "Advanced profile statistics",
+        "cosmetics": "Premium badge and animated frames",
+        "themes": "Extra themes",
+        "earlyAccess": "Early access to new game packs"
+      },
+      "yes": "Yes",
+      "no": "No"
+    },
+    "footnote": "Secure payment via Stripe. VAT applied based on your country. Cancel anytime from your profile."
   },
   "footer": {
     "allRightsReserved": "All rights reserved.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -15,6 +15,7 @@
     "leaderboard": "Classement",
     "geoDaily": "Geo",
     "alpha": "Alpha",
+    "premium": "Premium",
     "settings": "Paramètres",
     "login": "Connexion",
     "register": "Inscription",
@@ -1156,6 +1157,64 @@
       "emailRequired": "Veuillez entrer une adresse email destinataire",
       "invalidEmail": "Veuillez entrer une adresse email valide"
     }
+  },
+  "pricing": {
+    "title": "The Box Premium",
+    "subtitle": "Soutenez le jeu, débloquez l'archive complète et personnalisez votre profil.",
+    "billingMonthly": "/mois",
+    "billingAnnual": "/an",
+    "billingLifetime": "à vie",
+    "savingsAnnual": "Soit ~37 % d'économies",
+    "ctaSubscribe": "S'abonner",
+    "ctaLifetime": "Devenir Supporter",
+    "ctaManage": "Gérer mon abonnement",
+    "ctaLogin": "Se connecter pour s'abonner",
+    "ctaCurrent": "Plan actuel",
+    "loading": "Chargement…",
+    "redirecting": "Redirection vers le paiement…",
+    "errorCheckout": "Impossible de démarrer le paiement. Réessayez dans un instant.",
+    "errorPortal": "Impossible d'ouvrir le portail de gestion.",
+    "checkoutSuccess": "Paiement réussi — bienvenue parmi les Premium !",
+    "checkoutCancel": "Paiement annulé. Aucun montant n'a été débité.",
+    "alreadyPremium": "Vous avez déjà accès à Premium",
+    "premiumUntil": "Premium actif jusqu'au {{date}}",
+    "cancelScheduled": "Renouvellement annulé pour le {{date}}",
+    "tiers": {
+      "premium_monthly": {
+        "name": "Premium Mensuel",
+        "description": "Pour essayer sans engagement"
+      },
+      "premium_annual": {
+        "name": "Premium Annuel",
+        "description": "Le meilleur rapport qualité-prix",
+        "highlight": "Le plus populaire"
+      },
+      "supporter_lifetime": {
+        "name": "Supporter à vie",
+        "description": "Un soutien ponctuel — accès Premium et badge Founding Player"
+      }
+    },
+    "features": {
+      "title": "Ce qui est inclus",
+      "free": "Gratuit",
+      "premium": "Premium",
+      "items": {
+        "dailyChallenge": "Défi quotidien",
+        "leaderboards": "Classements en temps réel",
+        "achievements": "Succès et progression",
+        "catchUp7d": "Rattrapage des 7 derniers jours",
+        "catchUpFull": "Archive complète des défis passés",
+        "hintsBaseline": "Indices de base",
+        "hintsUnlimitedCatchUp": "Indices illimités en rattrapage",
+        "advancedStats": "Statistiques avancées du profil",
+        "cosmetics": "Badge et cadres animés",
+        "themes": "Thèmes supplémentaires",
+        "earlyAccess": "Accès anticipé aux nouveaux packs"
+      },
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "footnote": "Paiement sécurisé via Stripe. TVA appliquée selon votre pays. Annulation possible à tout moment depuis votre profil."
   },
   "footer": {
     "allRightsReserved": "Tous droits réservés.",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -37,6 +37,7 @@ const PublicProfilePage = lazy(() => import('@/pages/PublicProfilePage'))
 const GeoDailyPage = lazy(() => import('@/pages/GeoDailyPage'))
 const GeoContributePage = lazy(() => import('@/pages/GeoContributePage'))
 const GeoLeaderboardPage = lazy(() => import('@/pages/GeoLeaderboardPage'))
+const PricingPage = lazy(() => import('@/pages/PricingPage'))
 
 function LoadingSpinner() {
   return (
@@ -142,6 +143,12 @@ function App() {
           <Route path="geo/daily" element={<GeoDailyPage />} />
           <Route path="geo/leaderboard" element={<GeoLeaderboardPage />} />
           <Route path="geo/contribute" element={<GeoContributePage />} />
+
+          <Route path="premium" element={<PricingPage />} />
+          {/* French-friendly alias resolves to the same component so links from
+              older marketing copy still land. The page itself renders identically; SEO
+              gets a single canonical via the language-prefixed /premium URL. */}
+          <Route path="abonnement" element={<PricingPage />} />
         </Route>
 
         {/* Catch-all redirect to browser language */}

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -17,11 +17,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin } from 'lucide-react'
+import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin, Sparkles } from 'lucide-react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
 import { DailyRewardBadge } from '@/components/daily-login'
 import { useDailyLoginStore } from '@/stores/dailyLoginStore'
+import { useBillingStore } from '@/stores/billingStore'
 import { KoeSupportWidget } from '@/components/layout/KoeSupportWidget'
 import { cn } from '@/lib/utils'
 
@@ -30,9 +31,10 @@ interface NavigationLinksProps {
   t: (key: string) => string
   localizedPath: (path: string) => string
   onMobileClick?: () => void
+  showPremiumUpsell: boolean
 }
 
-function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick }: NavigationLinksProps) {
+function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick, showPremiumUpsell }: NavigationLinksProps) {
   const mobileClasses = isMobile ? "w-full justify-start" : ""
   const iconClass = isMobile ? "mr-2" : "mr-1"
   const handleClick = isMobile ? onMobileClick : undefined
@@ -62,6 +64,17 @@ function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick }: 
           </Badge>
         </Link>
       </Button>
+
+      {/* Premium upsell — hidden once the user already has it, so the header stops
+          nagging paying users. The link itself stays available via /premium. */}
+      {showPremiumUpsell && (
+        <Button variant="ghost" size="sm" asChild className={cn(mobileClasses, 'text-neon-pink hover:text-neon-pink/80')}>
+          <Link to={localizedPath('/premium')} onClick={handleClick}>
+            <Sparkles className={`w-4 h-4 ${iconClass}`} />
+            {t('common.premium')}
+          </Link>
+        </Button>
+      )}
     </>
   )
 }
@@ -82,6 +95,15 @@ export function Header() {
   const [isScrolled, setIsScrolled] = useState(false)
   const isRewardModalOpen = useDailyLoginStore((state) => state.isModalOpen)
   const closeRewardModal = useDailyLoginStore((state) => state.closeModal)
+  const billingEntitlement = useBillingStore((state) => state.entitlement)
+  const fetchBillingEntitlement = useBillingStore((state) => state.fetchEntitlement)
+  const showPremiumUpsell = !billingEntitlement?.isPremium
+
+  // Hydrate billing entitlement once we know who the user is. Anonymous
+  // visitors get a 401 → store falls back to FREE_ENTITLEMENT silently.
+  useEffect(() => {
+    void fetchBillingEntitlement()
+  }, [fetchBillingEntitlement, session?.user?.id])
 
   // Keep the mobile menu and the daily reward modal mutually exclusive so the
   // modal can't render underneath the Sheet on small screens.
@@ -130,7 +152,7 @@ export function Header() {
                 <SheetTitle className="text-left">{t('common.menu')}</SheetTitle>
               </SheetHeader>
               <div className="flex flex-col gap-2 mt-6">
-                <NavigationLinks isMobile={true} t={t} localizedPath={localizedPath} onMobileClick={() => setMobileMenuOpen(false)} />
+                <NavigationLinks isMobile={true} t={t} localizedPath={localizedPath} onMobileClick={() => setMobileMenuOpen(false)} showPremiumUpsell={showPremiumUpsell} />
 
                 {/* Mobile Auth Section */}
                 <div className="border-t border-border pt-4 mt-4">
@@ -218,7 +240,7 @@ export function Header() {
 
         {/* Desktop Navigation - hidden on mobile, shown on md and up */}
         <nav className="hidden md:flex items-center gap-1 lg:gap-2">
-          <NavigationLinks isMobile={false} t={t} localizedPath={localizedPath} />
+          <NavigationLinks isMobile={false} t={t} localizedPath={localizedPath} showPremiumUpsell={showPremiumUpsell} />
         </nav>
 
         {/* Auth Buttons - Desktop - hidden on mobile, shown on md and up */}

--- a/packages/frontend/src/components/pricing/FeatureMatrix.tsx
+++ b/packages/frontend/src/components/pricing/FeatureMatrix.tsx
@@ -24,7 +24,7 @@ const ROWS: FeatureRow[] = [
 
 function FeatureCell({ on, label }: { on: boolean; label: string }) {
   return (
-    <span className={cn('inline-flex items-center justify-center', on ? 'text-emerald-400' : 'text-muted-foreground/50')}>
+    <span className={cn('inline-flex items-center justify-center', on ? 'text-success' : 'text-muted-foreground/50')}>
       {on ? <Check className="w-5 h-5" aria-label={label} /> : <X className="w-5 h-5" aria-label={label} />}
     </span>
   )

--- a/packages/frontend/src/components/pricing/FeatureMatrix.tsx
+++ b/packages/frontend/src/components/pricing/FeatureMatrix.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from 'react-i18next'
+import { Check, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface FeatureRow {
+  key: string
+  free: boolean
+  premium: boolean
+}
+
+const ROWS: FeatureRow[] = [
+  { key: 'dailyChallenge', free: true, premium: true },
+  { key: 'leaderboards', free: true, premium: true },
+  { key: 'achievements', free: true, premium: true },
+  { key: 'hintsBaseline', free: true, premium: true },
+  { key: 'catchUp7d', free: true, premium: true },
+  { key: 'catchUpFull', free: false, premium: true },
+  { key: 'hintsUnlimitedCatchUp', free: false, premium: true },
+  { key: 'advancedStats', free: false, premium: true },
+  { key: 'cosmetics', free: false, premium: true },
+  { key: 'themes', free: false, premium: true },
+  { key: 'earlyAccess', free: false, premium: true },
+]
+
+function FeatureCell({ on, label }: { on: boolean; label: string }) {
+  return (
+    <span className={cn('inline-flex items-center justify-center', on ? 'text-emerald-400' : 'text-muted-foreground/50')}>
+      {on ? <Check className="w-5 h-5" aria-label={label} /> : <X className="w-5 h-5" aria-label={label} />}
+    </span>
+  )
+}
+
+export function FeatureMatrix() {
+  const { t } = useTranslation()
+  return (
+    <div className="rounded-lg border border-border/60 overflow-hidden">
+      <h2 className="text-lg font-semibold px-4 sm:px-6 py-3 border-b border-border/60">
+        {t('pricing.features.title')}
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border/60 bg-muted/30">
+              <th className="text-left px-4 sm:px-6 py-2 font-medium text-muted-foreground"></th>
+              <th className="px-3 py-2 font-medium text-muted-foreground w-24 text-center">
+                {t('pricing.features.free')}
+              </th>
+              <th className="px-3 py-2 font-medium text-neon-pink w-24 text-center">
+                {t('pricing.features.premium')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map((row) => (
+              <tr key={row.key} className="border-b border-border/40 last:border-b-0">
+                <td className="px-4 sm:px-6 py-3 text-foreground/90">{t(`pricing.features.items.${row.key}`)}</td>
+                <td className="text-center py-3">
+                  <FeatureCell on={row.free} label={row.free ? t('pricing.features.yes') : t('pricing.features.no')} />
+                </td>
+                <td className="text-center py-3">
+                  <FeatureCell on={row.premium} label={row.premium ? t('pricing.features.yes') : t('pricing.features.no')} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/packages/frontend/src/components/pricing/PricingCard.tsx
+++ b/packages/frontend/src/components/pricing/PricingCard.tsx
@@ -1,0 +1,107 @@
+import { useTranslation } from 'react-i18next'
+import { motion } from 'framer-motion'
+import { Check, Sparkles } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import type { BillingPrice, BillingTier } from '@the-box/types'
+
+interface PricingCardProps {
+  price: BillingPrice
+  isCurrentPlan: boolean
+  isLoggedIn: boolean
+  isWorking: boolean
+  highlight?: boolean
+  onSelect: (tier: BillingTier) => void
+}
+
+function formatAmount(unitAmountCents: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(unitAmountCents / 100)
+}
+
+export function PricingCard({
+  price,
+  isCurrentPlan,
+  isLoggedIn,
+  isWorking,
+  highlight,
+  onSelect,
+}: PricingCardProps) {
+  const { t, i18n } = useTranslation()
+  const tierKey = `pricing.tiers.${price.tier}`
+  const isLifetime = price.interval === null
+  const ctaKey = isCurrentPlan
+    ? 'pricing.ctaCurrent'
+    : !isLoggedIn
+      ? 'pricing.ctaLogin'
+      : isLifetime
+        ? 'pricing.ctaLifetime'
+        : 'pricing.ctaSubscribe'
+
+  const intervalKey =
+    price.interval === 'month'
+      ? 'pricing.billingMonthly'
+      : price.interval === 'year'
+        ? 'pricing.billingAnnual'
+        : 'pricing.billingLifetime'
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+      className="h-full"
+    >
+      <Card
+        className={cn(
+          'h-full flex flex-col relative overflow-hidden',
+          highlight && 'border-neon-pink/60 shadow-[0_0_40px_-12px_rgba(244,114,182,0.45)]',
+        )}
+      >
+        {highlight && (
+          <Badge
+            variant="outline"
+            className="absolute top-4 right-4 border-neon-pink/60 text-neon-pink uppercase tracking-wide text-[10px] px-2 py-0.5"
+          >
+            <Sparkles className="w-3 h-3 mr-1" />
+            {t(`${tierKey}.highlight`, '')}
+          </Badge>
+        )}
+        <CardHeader>
+          <CardTitle className="text-xl">{t(`${tierKey}.name`)}</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">{t(`${tierKey}.description`)}</p>
+        </CardHeader>
+
+        <CardContent className="flex-1 space-y-4">
+          <div className="flex items-baseline gap-1">
+            <span className="text-4xl font-bold">{formatAmount(price.unitAmount, i18n.language)}</span>
+            <span className="text-muted-foreground text-sm">
+              {isLifetime ? ` ${t(intervalKey)}` : t(intervalKey)}
+            </span>
+          </div>
+          {price.tier === 'premium_annual' && (
+            <p className="text-xs text-neon-pink/80 font-medium">{t('pricing.savingsAnnual')}</p>
+          )}
+        </CardContent>
+
+        <CardFooter>
+          <Button
+            className="w-full"
+            disabled={isCurrentPlan || isWorking}
+            onClick={() => onSelect(price.tier)}
+            variant={highlight ? 'default' : 'outline'}
+          >
+            {isCurrentPlan && <Check className="w-4 h-4 mr-2" />}
+            {t(ctaKey)}
+          </Button>
+        </CardFooter>
+      </Card>
+    </motion.div>
+  )
+}

--- a/packages/frontend/src/components/pricing/PricingTable.tsx
+++ b/packages/frontend/src/components/pricing/PricingTable.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+import type { BillingTier } from '@the-box/types'
+import { useAuth } from '@/hooks/useAuth'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { useBillingStore } from '@/stores/billingStore'
+import { PricingCard } from './PricingCard'
+
+export function PricingTable() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { localizedPath } = useLocalizedPath()
+  const { isAuthenticated } = useAuth()
+  const {
+    prices,
+    pricesLoaded,
+    entitlement,
+    isStartingCheckout,
+    fetchPrices,
+    fetchEntitlement,
+    startCheckout,
+  } = useBillingStore()
+
+  useEffect(() => {
+    void fetchPrices()
+  }, [fetchPrices])
+
+  useEffect(() => {
+    void fetchEntitlement()
+  }, [fetchEntitlement, isAuthenticated])
+
+  const handleSelect = async (tier: BillingTier) => {
+    if (!isAuthenticated) {
+      navigate(localizedPath('/login'), {
+        state: { redirectTo: localizedPath('/premium') },
+      })
+      return
+    }
+    const result = await startCheckout(tier)
+    if ('url' in result) {
+      window.location.href = result.url
+    } else {
+      toast.error(t('pricing.errorCheckout'))
+    }
+  }
+
+  if (!pricesLoaded) {
+    return <p className="text-center text-muted-foreground">{t('pricing.loading')}</p>
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-3">
+      {prices.map((price) => (
+        <PricingCard
+          key={price.tier}
+          price={price}
+          isCurrentPlan={entitlement?.tier === price.tier && entitlement.isPremium}
+          isLoggedIn={isAuthenticated}
+          isWorking={isStartingCheckout}
+          highlight={price.tier === 'premium_annual'}
+          onSelect={handleSelect}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/frontend/src/pages/PricingPage.tsx
+++ b/packages/frontend/src/pages/PricingPage.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
+import { Sparkles } from 'lucide-react'
+import { toast } from 'sonner'
+import { PageHero } from '@/components/layout/PageHero'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { useAuth } from '@/hooks/useAuth'
+import { useBillingStore } from '@/stores/billingStore'
+import { PricingTable } from '@/components/pricing/PricingTable'
+import { FeatureMatrix } from '@/components/pricing/FeatureMatrix'
+
+export default function PricingPage() {
+  const { t, i18n } = useTranslation()
+  const { isAuthenticated } = useAuth()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { entitlement, fetchEntitlement, openPortal, isOpeningPortal } = useBillingStore()
+
+  // Surface the result of a Stripe-hosted checkout redirect, then strip the
+  // query param so a refresh doesn't re-toast.
+  useEffect(() => {
+    const checkout = searchParams.get('checkout')
+    if (!checkout) return
+    if (checkout === 'success') {
+      toast.success(t('pricing.checkoutSuccess'))
+      // Refetch entitlement; the webhook may have already arrived.
+      void fetchEntitlement()
+    } else if (checkout === 'cancel') {
+      toast.info(t('pricing.checkoutCancel'))
+    }
+    const next = new URLSearchParams(searchParams)
+    next.delete('checkout')
+    setSearchParams(next, { replace: true })
+  }, [searchParams, setSearchParams, t, fetchEntitlement])
+
+  const handlePortal = async () => {
+    const result = await openPortal()
+    if ('url' in result) {
+      window.location.href = result.url
+    } else {
+      toast.error(t('pricing.errorPortal'))
+    }
+  }
+
+  const isPremium = !!entitlement?.isPremium
+  const validUntil = entitlement?.validUntil
+    ? new Date(entitlement.validUntil).toLocaleDateString(i18n.language === 'fr' ? 'fr-FR' : 'en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null
+
+  return (
+    <PageHero icon={Sparkles} title={t('pricing.title')} subtitle={t('pricing.subtitle')}>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-10">
+        {isAuthenticated && isPremium && (
+          <Card className="border-emerald-500/40 bg-emerald-500/5">
+            <CardContent className="py-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div>
+                <p className="font-medium">{t('pricing.alreadyPremium')}</p>
+                {validUntil && (
+                  <p className="text-sm text-muted-foreground">
+                    {entitlement?.cancelAtPeriodEnd
+                      ? t('pricing.cancelScheduled', { date: validUntil })
+                      : t('pricing.premiumUntil', { date: validUntil })}
+                  </p>
+                )}
+              </div>
+              <Button onClick={handlePortal} disabled={isOpeningPortal} variant="secondary">
+                {t('pricing.ctaManage')}
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        <PricingTable />
+
+        <FeatureMatrix />
+
+        <p className="text-center text-xs text-muted-foreground max-w-2xl mx-auto">
+          {t('pricing.footnote')}
+        </p>
+      </div>
+    </PageHero>
+  )
+}

--- a/packages/frontend/src/pages/PricingPage.tsx
+++ b/packages/frontend/src/pages/PricingPage.tsx
@@ -56,7 +56,7 @@ export default function PricingPage() {
     <PageHero icon={Sparkles} title={t('pricing.title')} subtitle={t('pricing.subtitle')}>
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-10">
         {isAuthenticated && isPremium && (
-          <Card className="border-emerald-500/40 bg-emerald-500/5">
+          <Card className="border-success/40 bg-success/5">
             <CardContent className="py-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <div>
                 <p className="font-medium">{t('pricing.alreadyPremium')}</p>

--- a/packages/frontend/src/stores/billingStore.ts
+++ b/packages/frontend/src/stores/billingStore.ts
@@ -1,0 +1,120 @@
+import { create } from 'zustand'
+import type { BillingEntitlement, BillingPrice, BillingTier } from '@the-box/types'
+
+interface BillingState {
+  prices: BillingPrice[]
+  pricesLoaded: boolean
+  entitlement: BillingEntitlement | null
+  isLoadingEntitlement: boolean
+  isStartingCheckout: boolean
+  isOpeningPortal: boolean
+
+  fetchPrices: () => Promise<void>
+  fetchEntitlement: () => Promise<void>
+  startCheckout: (tier: BillingTier) => Promise<{ url: string } | { error: string }>
+  openPortal: () => Promise<{ url: string } | { error: string }>
+  reset: () => void
+}
+
+const FREE_ENTITLEMENT: BillingEntitlement = {
+  isPremium: false,
+  tier: null,
+  validUntil: null,
+  cancelAtPeriodEnd: false,
+  source: null,
+}
+
+export const useBillingStore = create<BillingState>((set) => ({
+  prices: [],
+  pricesLoaded: false,
+  entitlement: null,
+  isLoadingEntitlement: false,
+  isStartingCheckout: false,
+  isOpeningPortal: false,
+
+  fetchPrices: async () => {
+    try {
+      const response = await fetch('/api/billing/prices', {
+        credentials: 'include',
+      })
+      if (!response.ok) throw new Error('Failed to load prices')
+      const json = await response.json()
+      set({ prices: json.data?.prices ?? [], pricesLoaded: true })
+    } catch (error) {
+      console.error('Failed to load billing prices:', error)
+      set({ pricesLoaded: true })
+    }
+  },
+
+  fetchEntitlement: async () => {
+    set({ isLoadingEntitlement: true })
+    try {
+      const response = await fetch('/api/billing/me', {
+        credentials: 'include',
+      })
+      if (response.status === 401) {
+        // Anonymous visitors are simply free; not an error worth surfacing.
+        set({ entitlement: FREE_ENTITLEMENT, isLoadingEntitlement: false })
+        return
+      }
+      if (!response.ok) throw new Error('Failed to load entitlement')
+      const json = await response.json()
+      set({ entitlement: json.data as BillingEntitlement, isLoadingEntitlement: false })
+    } catch (error) {
+      console.error('Failed to load billing entitlement:', error)
+      set({ entitlement: FREE_ENTITLEMENT, isLoadingEntitlement: false })
+    }
+  },
+
+  startCheckout: async (tier: BillingTier) => {
+    set({ isStartingCheckout: true })
+    try {
+      const response = await fetch('/api/billing/checkout', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tier }),
+      })
+      const json = await response.json()
+      if (!response.ok || !json.success) {
+        const code = json?.error?.code ?? 'CHECKOUT_FAILED'
+        return { error: code }
+      }
+      return { url: json.data.url as string }
+    } catch (error) {
+      console.error('Checkout request failed:', error)
+      return { error: 'NETWORK_ERROR' }
+    } finally {
+      set({ isStartingCheckout: false })
+    }
+  },
+
+  openPortal: async () => {
+    set({ isOpeningPortal: true })
+    try {
+      const response = await fetch('/api/billing/portal', {
+        method: 'POST',
+        credentials: 'include',
+      })
+      const json = await response.json()
+      if (!response.ok || !json.success) {
+        const code = json?.error?.code ?? 'PORTAL_FAILED'
+        return { error: code }
+      }
+      return { url: json.data.url as string }
+    } catch (error) {
+      console.error('Portal request failed:', error)
+      return { error: 'NETWORK_ERROR' }
+    } finally {
+      set({ isOpeningPortal: false })
+    }
+  },
+
+  reset: () =>
+    set({
+      entitlement: null,
+      isLoadingEntitlement: false,
+      isStartingCheckout: false,
+      isOpeningPortal: false,
+    }),
+}))


### PR DESCRIPTION
Replaces #108 (auto-closed when its base \`feat/premium-backend\` was deleted on merge of #112). Rebased onto \`main\`.

See #108 for full description. Summary: PricingPage at /:lang/premium (+ /abonnement alias), PricingTable + FeatureMatrix components, billingStore (Zustand), Header upsell link hidden for paying users, fr/en i18n keys. Includes follow-up commit fixing design-tokens lint (use text-success / bg-success instead of raw emerald palette).

🤖 Generated with [Claude Code](https://claude.com/claude-code)