### PR TITLE
feat: premium feature gating + supporter lifetime (was #109)

### DIFF
--- a/packages/backend/migrations/20260428_supporter_lifetime.ts
+++ b/packages/backend/migrations/20260428_supporter_lifetime.ts
@@ -1,0 +1,23 @@
+import type { Knex } from 'knex'
+
+// Single-column entitlement for the one-time Supporter tier. We could
+// model this as a separate table for cleanliness, but it's a 1:1 grant
+// keyed on user with no per-grant metadata worth keeping out-of-line —
+// timestamp on user keeps the read path single-row and lets the existing
+// findById join pick it up for free.
+//
+// `subscriptions` is the right home for recurring tiers; lifetime grants
+// don't have a stripe_subscription_id so they wouldn't fit that table
+// without making fields nullable that are otherwise notNullable.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.timestamp('supporter_lifetime_at', { useTz: true }).nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.dropColumn('supporter_lifetime_at')
+  })
+}

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -153,6 +153,7 @@ export interface TierSessionWithContextRecord extends TierSessionRecord {
   game_session_started_at: Date
   game_session_id: string
   daily_challenge_id: number
+  is_catch_up: boolean
   tier_number: number
   time_limit_seconds: number
 }

--- a/packages/backend/src/domain/services/billing.service.ts
+++ b/packages/backend/src/domain/services/billing.service.ts
@@ -47,7 +47,23 @@ export const billingService = {
   // The entitlement read every gated endpoint hits. Returns the cheapest
   // safe default (no premium) when anything is missing or off, so a
   // misconfigured env never silently grants premium to free users.
+  //
+  // Resolution order: supporter lifetime wins over recurring subscription.
+  // A user who paid once for lifetime and later subscribed should still
+  // surface as 'supporter' (the more durable grant) so cancellation of
+  // the recurring sub doesn't drop their entitlement.
   async getEntitlement(userId: string): Promise<BillingEntitlement> {
+    const supporterAt = await userRepository.getSupporterLifetimeAt(userId)
+    if (supporterAt) {
+      return {
+        isPremium: true,
+        tier: 'supporter_lifetime',
+        validUntil: null,
+        cancelAtPeriodEnd: false,
+        source: 'supporter',
+      }
+    }
+
     const row = await subscriptionRepository.findActiveByUserId(userId)
     if (!row) {
       return {

--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -36,6 +36,11 @@ const BASE_SCORE = 100
 const UNFOUND_PENALTY = 0
 const WRONG_GUESS_PENALTY = 0
 const CATCH_UP_DAYS = 7
+// Premium tier extends the catch-up window. 365 days is generous enough
+// to feel like "the full archive" for end-users while still bounding the
+// challenge-list query — the recurring `create-daily-challenge` job
+// produces one row per day, so the upper bound on cardinality is small.
+export const PREMIUM_CATCH_UP_DAYS = 365
 
 /**
  * Calculate speed multiplier based on time taken to find the screenshot
@@ -75,7 +80,7 @@ export interface GameServiceDeps {
 
 export interface GameService {
   getTodayChallenge(userId?: string, date?: string): Promise<TodayChallengeResponse>
-  startChallenge(challengeId: number, userId: string): Promise<StartChallengeResponse>
+  startChallenge(challengeId: number, userId: string, isPremium?: boolean): Promise<StartChallengeResponse>
   getScreenshot(sessionId: string, position: number, userId: string): Promise<ScreenshotResponse>
   submitGuess(data: {
     tierSessionId: string
@@ -86,6 +91,7 @@ export interface GameService {
     roundTimeTakenMs: number
     userId: string
     powerUpUsed?: 'hint_year' | 'hint_publisher'
+    isPremium?: boolean
   }): Promise<GuessResponse>
   endGame(sessionId: string, userId: string): Promise<EndGameResponse>
 }
@@ -234,7 +240,11 @@ export function createGameService(deps: GameServiceDeps): GameService {
     }
   },
 
-  async startChallenge(challengeId: number, userId: string): Promise<StartChallengeResponse> {
+  async startChallenge(
+    challengeId: number,
+    userId: string,
+    isPremium: boolean = false,
+  ): Promise<StartChallengeResponse> {
     log.info({ challengeId, userId }, 'startChallenge')
 
     const tiers = await challengeRepository.findTiersByChallenge(challengeId)
@@ -253,9 +263,12 @@ export function createGameService(deps: GameServiceDeps): GameService {
     const today = new Date()
     today.setHours(0, 0, 0, 0)
 
-    // Calculate the oldest allowed date (CATCH_UP_DAYS days ago)
+    // Free tier sees the last CATCH_UP_DAYS; premium extends to
+    // PREMIUM_CATCH_UP_DAYS. Outside both windows the challenge is
+    // genuinely too old for anyone and we keep the original 400.
+    const allowedDays = isPremium ? PREMIUM_CATCH_UP_DAYS : CATCH_UP_DAYS
     const oldestAllowed = new Date(today)
-    oldestAllowed.setDate(oldestAllowed.getDate() - CATCH_UP_DAYS)
+    oldestAllowed.setDate(oldestAllowed.getDate() - allowedDays)
 
     const challengeDate = new Date(challenge.challenge_date)
     challengeDate.setHours(0, 0, 0, 0)
@@ -265,10 +278,28 @@ export function createGameService(deps: GameServiceDeps): GameService {
       ? challenge.challenge_date
       : challengeDate.toISOString().split('T')[0]
 
-    // Check if challenge is from the past (not today and older than CATCH_UP_DAYS)
     const isCatchUp = challengeDateStr !== todayStr
     if (isCatchUp && challengeDate < oldestAllowed) {
-      throw new GameError('CHALLENGE_TOO_OLD', `This challenge is no longer available. You can only play challenges from the last ${CATCH_UP_DAYS} days.`, 400)
+      // Premium would already have allowedDays === PREMIUM_CATCH_UP_DAYS,
+      // so reaching this branch as a free user with a 7..365 day-old
+      // challenge is the upgrade moment. 402 lets the frontend route to
+      // the upsell instead of rendering a generic error.
+      if (!isPremium) {
+        const freeOldest = new Date(today)
+        freeOldest.setDate(freeOldest.getDate() - CATCH_UP_DAYS)
+        if (challengeDate >= new Date(today.getTime() - PREMIUM_CATCH_UP_DAYS * 24 * 60 * 60 * 1000) && challengeDate < freeOldest) {
+          throw new GameError(
+            'PREMIUM_REQUIRED_FOR_OLD_CATCHUP',
+            `Challenges older than ${CATCH_UP_DAYS} days require Premium`,
+            402,
+          )
+        }
+      }
+      throw new GameError(
+        'CHALLENGE_TOO_OLD',
+        `This challenge is no longer available. You can only play challenges from the last ${allowedDays} days.`,
+        400,
+      )
     }
 
     let gameSession = await sessionRepository.findGameSession(userId, challengeId)
@@ -349,6 +380,7 @@ export function createGameService(deps: GameServiceDeps): GameService {
     roundTimeTakenMs: number
     userId: string
     powerUpUsed?: 'hint_year' | 'hint_publisher'
+    isPremium?: boolean
   }): Promise<GuessResponse> {
     log.debug({ tierSessionId: data.tierSessionId, position: data.position, userId: data.userId }, 'submitGuess')
 
@@ -382,23 +414,36 @@ export function createGameService(deps: GameServiceDeps): GameService {
 
       // Check if hint was used and handle penalty/inventory
       if (data.powerUpUsed === 'hint_year' || data.powerUpUsed === 'hint_publisher' || data.powerUpUsed === 'hint_developer') {
-        // Check if user has hint in inventory (use it for free)
-        const hasHintInInventory = await inventoryRepository.useItems(
-          data.userId,
-          'powerup',
-          data.powerUpUsed,
-          1
-        )
+        // Premium entitlement bypasses the hint cost ENTIRELY in catch-up
+        // sessions only — never on today's daily, since today is what
+        // feeds the leaderboard and ranked integrity is non-negotiable.
+        const premiumFreeHint = !!data.isPremium && !!tierSession.is_catch_up
 
-        if (hasHintInInventory) {
-          // Hint from inventory - no penalty
-          hintFromInventory = true
-          log.info({ userId: data.userId, hintType: data.powerUpUsed }, 'hint used from inventory (no penalty)')
+        if (premiumFreeHint) {
+          hintFromInventory = true // accounting bucket: "no penalty"
+          log.info(
+            { userId: data.userId, hintType: data.powerUpUsed },
+            'hint free for premium in catch-up',
+          )
         } else {
-          // No inventory - apply 20% penalty
-          hintPenalty = Math.round(scoreEarned * 0.20)
-          scoreEarned -= hintPenalty
-          log.info({ userId: data.userId, hintType: data.powerUpUsed, penalty: hintPenalty }, 'hint used with penalty (no inventory)')
+          // Check if user has hint in inventory (use it for free)
+          const hasHintInInventory = await inventoryRepository.useItems(
+            data.userId,
+            'powerup',
+            data.powerUpUsed,
+            1
+          )
+
+          if (hasHintInInventory) {
+            // Hint from inventory - no penalty
+            hintFromInventory = true
+            log.info({ userId: data.userId, hintType: data.powerUpUsed }, 'hint used from inventory (no penalty)')
+          } else {
+            // No inventory - apply 20% penalty
+            hintPenalty = Math.round(scoreEarned * 0.20)
+            scoreEarned -= hintPenalty
+            log.info({ userId: data.userId, hintType: data.powerUpUsed, penalty: hintPenalty }, 'hint used with penalty (no inventory)')
+          }
         }
       }
     }

--- a/packages/backend/src/domain/services/user.service.ts
+++ b/packages/backend/src/domain/services/user.service.ts
@@ -15,9 +15,12 @@ import type {
 const TOTAL_SCREENSHOTS = 10
 const WRONG_GUESS_PENALTY = 0
 const CATCH_UP_DAYS = 7
+// Mirror of game.service.ts. Kept duplicated rather than cross-imported
+// to avoid pulling game.service into user.service's dependency graph.
+const PREMIUM_CATCH_UP_DAYS = 365
 
 export interface UserService {
-  getGameHistory(userId: string): Promise<GameHistoryResponse>
+  getGameHistory(userId: string, isPremium?: boolean): Promise<GameHistoryResponse>
   getPublicGameSessionDetails(sessionId: string): Promise<GameSessionDetailsResponse>
   getGameSessionDetails(
     sessionId: string,
@@ -179,11 +182,13 @@ export function createUserService(deps: UserServiceDeps): UserService {
   }
 
   return {
-    async getGameHistory(userId: string): Promise<GameHistoryResponse> {
+    async getGameHistory(userId: string, isPremium: boolean = false): Promise<GameHistoryResponse> {
       const entries = await sessionRepository.findUserGameHistory(userId)
 
-      // Get recent challenges (last CATCH_UP_DAYS days)
-      const recentChallenges = await challengeRepository.findRecentChallenges(CATCH_UP_DAYS)
+      // Premium users see the extended archive so they have something to
+      // play beyond the 7-day window. Free users keep the existing list.
+      const lookbackDays = isPremium ? PREMIUM_CATCH_UP_DAYS : CATCH_UP_DAYS
+      const recentChallenges = await challengeRepository.findRecentChallenges(lookbackDays)
 
       // Get today's date to exclude it from missed challenges
       const today = new Date().toISOString().split('T')[0]

--- a/packages/backend/src/infrastructure/repositories/session.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/session.repository.ts
@@ -42,6 +42,7 @@ export interface TierSessionWithContext extends TierSessionRow {
   game_session_started_at: Date
   game_session_id: string
   daily_challenge_id: number
+  is_catch_up: boolean
   tier_number: number
   time_limit_seconds: number
 }
@@ -133,6 +134,7 @@ export const sessionRepository = {
         'game_sessions.started_at as game_session_started_at',
         'game_sessions.id as game_session_id',
         'game_sessions.daily_challenge_id',
+        'game_sessions.is_catch_up',
         'tiers.tier_number',
         'tiers.time_limit_seconds'
       )

--- a/packages/backend/src/infrastructure/repositories/user.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/user.repository.ts
@@ -159,6 +159,26 @@ export const userRepository = {
     return row ?? null
   },
 
+  async getSupporterLifetimeAt(userId: string): Promise<Date | null> {
+    const row = await db('user')
+      .where('id', userId)
+      .first<{ supporter_lifetime_at: Date | null }>('supporter_lifetime_at')
+    return row?.supporter_lifetime_at ?? null
+  },
+
+  async grantSupporterLifetime(userId: string, grantedAt: Date = new Date()): Promise<void> {
+    log.info({ userId, grantedAt }, 'grantSupporterLifetime')
+    // Idempotent: keep the earliest grant timestamp so a duplicate webhook
+    // doesn't overwrite the original supporter date.
+    await db('user')
+      .where('id', userId)
+      .whereNull('supporter_lifetime_at')
+      .update({
+        supporter_lifetime_at: grantedAt,
+        updatedAt: new Date(),
+      })
+  },
+
   async updateEmailMarketingConsent(userId: string, consent: boolean): Promise<User | null> {
     log.info({ userId, consent }, 'updateEmailMarketingConsent')
     await db('user')

--- a/packages/backend/src/presentation/routes/billing-webhook.routes.ts
+++ b/packages/backend/src/presentation/routes/billing-webhook.routes.ts
@@ -6,6 +6,7 @@ import {
   subscriptionRepository,
   stripeEventLogRepository,
 } from '../../infrastructure/repositories/subscription.repository.js'
+import { userRepository } from '../../infrastructure/repositories/user.repository.js'
 import { billingService } from '../../domain/services/billing.service.js'
 import { logger } from '../../infrastructure/logger/logger.js'
 
@@ -70,10 +71,6 @@ async function dispatch(event: Stripe.Event): Promise<void> {
   switch (event.type) {
     case 'checkout.session.completed': {
       const session = event.data.object as Stripe.Checkout.Session
-      // For one-time supporter purchases there is no Subscription created;
-      // we still log the event so future PRs can grant a lifetime flag.
-      // Subscription mode hands off to customer.subscription.created which
-      // Stripe fires alongside this event.
       log.info(
         {
           mode: session.mode,
@@ -83,6 +80,28 @@ async function dispatch(event: Stripe.Event): Promise<void> {
         },
         'checkout completed',
       )
+
+      // One-time supporter purchases never create a Subscription, so the
+      // sibling customer.subscription.created handler doesn't fire. Persist
+      // the grant directly here when the Checkout Session was created for
+      // the supporter SKU; recurring-tier sessions fall through.
+      if (session.mode !== 'payment') return
+      if (session.metadata?.['tier'] !== 'supporter_lifetime') {
+        log.debug({ sessionId: session.id }, 'one-time checkout ignored — not the supporter SKU')
+        return
+      }
+
+      const userId =
+        (session.metadata?.['userId'] as string | undefined) ??
+        session.client_reference_id ??
+        null
+      if (!userId) {
+        log.warn({ sessionId: session.id }, 'supporter checkout missing userId metadata')
+        return
+      }
+
+      await userRepository.grantSupporterLifetime(userId)
+      log.info({ userId, sessionId: session.id }, 'supporter lifetime granted')
       return
     }
 

--- a/packages/backend/src/presentation/routes/game.routes.ts
+++ b/packages/backend/src/presentation/routes/game.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { gameService, GameError } from '../../domain/services/index.js'
+import { billingService } from '../../domain/services/billing.service.js'
 import { challengeRepository, gameRepository, screenshotRepository } from '../../infrastructure/repositories/index.js'
 import { authMiddleware, optionalAuthMiddleware } from '../middleware/auth.middleware.js'
 import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
@@ -161,7 +162,12 @@ router.get('/today', optionalAuthMiddleware, async (req, res, next) => {
 router.post('/start/:challengeId', authMiddleware, async (req, res, next) => {
   try {
     const challengeId = parseInt(req.params['challengeId'] as string, 10)
-    const data = await gameService.startChallenge(challengeId, req.userId!)
+    // Premium status flips two things in startChallenge: the catch-up
+    // window expands to PREMIUM_CATCH_UP_DAYS, and an old free attempt
+    // returns 402 PREMIUM_REQUIRED_FOR_OLD_CATCHUP instead of a generic
+    // 400 so the frontend can surface the upsell instead of a dead end.
+    const isPremium = await billingService.isPremium(req.userId!)
+    const data = await gameService.startChallenge(challengeId, req.userId!, isPremium)
 
     res.json({
       success: true,
@@ -219,6 +225,11 @@ router.post('/guess', authMiddleware, async (req, res, next) => {
   try {
     const { tierSessionId, screenshotId, position, gameId, guessText, roundTimeTakenMs, powerUpUsed } = req.body
 
+    // Premium status only changes hint accounting in catch-up sessions
+    // (see game.service: premium + is_catch_up → free hint, no penalty).
+    // The flag is checked once here so the service stays sync-friendly.
+    const isPremium = await billingService.isPremium(req.userId!)
+
     const data = await gameService.submitGuess({
       tierSessionId,
       screenshotId,
@@ -228,6 +239,7 @@ router.post('/guess', authMiddleware, async (req, res, next) => {
       roundTimeTakenMs: roundTimeTakenMs || 0, // Fallback for backward compatibility
       userId: req.userId!,
       powerUpUsed,
+      isPremium,
     })
 
     res.json({

--- a/packages/backend/src/presentation/routes/user.routes.ts
+++ b/packages/backend/src/presentation/routes/user.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { userService } from '../../domain/services/index.js'
+import { billingService } from '../../domain/services/billing.service.js'
 import { authMiddleware } from '../middleware/auth.middleware.js'
 import { userRepository } from '../../infrastructure/repositories/user.repository.js'
 import { avatarUpload, getAvatarUrl, deleteAvatarFile } from '../middleware/upload.middleware.js'
@@ -114,7 +115,11 @@ router.get('/me', authMiddleware, async (req, res, next) => {
 // Get user's daily game history
 router.get('/history', authMiddleware, async (req, res, next) => {
   try {
-    const data = await userService.getGameHistory(req.userId!)
+    // Premium users get the extended catch-up window in their missed
+    // challenges list, so the UI surfaces playable archive entries
+    // without the user having to know a deep-link challenge ID.
+    const isPremium = await billingService.isPremium(req.userId!)
+    const data = await userService.getGameHistory(req.userId!, isPremium)
 
     res.json({
       success: true,

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -149,6 +149,7 @@
     "errorLoadingScreenshot": "Failed to load image",
     "errorStarting": "Failed to start game",
     "alreadyCompleted": "You have already completed today's challenge! Come back tomorrow for a new one.",
+    "premiumRequiredForOldCatchup": "This challenge is more than 7 days old — available with Premium.",
     "catchUpNotice": "This is a catch-up session. Your score won't appear on the leaderboard.",
     "noChallenge": "No challenge available",
     "noChallengeAvailable": "No challenge available for {{date}}. Please check back later!",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -149,6 +149,7 @@
     "errorLoadingScreenshot": "Impossible de charger l'image",
     "errorStarting": "Impossible de démarrer la partie",
     "alreadyCompleted": "Vous avez déjà terminé le défi d'aujourd'hui ! Revenez demain pour un nouveau.",
+    "premiumRequiredForOldCatchup": "Ce défi a plus de 7 jours — accessible avec Premium.",
     "catchUpNotice": "Ceci est une session de rattrapage. Votre score n'apparaîtra pas au classement.",
     "noChallenge": "Aucun défi disponible",
     "noChallengeAvailable": "Aucun défi disponible pour le {{date}}. Revenez plus tard !",

--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useMemo } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { motion, AnimatePresence } from 'framer-motion'
+import { toast } from 'sonner'
 import { useGameStore } from '@/stores/gameStore'
 import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
 import { DailyIntro } from '@/components/game/TierIntro'
@@ -380,12 +381,20 @@ export default function GamePage() {
       const code = err && typeof err === 'object' && 'code' in err ? (err as { code?: string }).code : undefined
       if (code === 'CHALLENGE_ALREADY_COMPLETED' || code === 'SESSION_ALREADY_COMPLETED') {
         setError(t('game.alreadyCompleted'))
+      } else if (code === 'PREMIUM_REQUIRED_FOR_OLD_CATCHUP') {
+        // Free user clicked an archived challenge they can't access. Send
+        // them straight to the upsell instead of a dead-end error so the
+        // upgrade path is one click away. Toast surfaces context briefly
+        // before the navigation lands them on /premium.
+        toast.info(t('game.premiumRequiredForOldCatchup'))
+        setError(t('game.premiumRequiredForOldCatchup'))
+        navigate(localizedPath('/premium'))
       } else {
         setError(t('game.errorStarting'))
       }
       setLoading(false)
     }
-  }, [challengeId, session, isSessionPending, setSessionId, initializePositionStates, fetchScreenshot, setGamePhase, setLoading, prefetchAllScreenshots, t])
+  }, [challengeId, session, isSessionPending, setSessionId, initializePositionStates, fetchScreenshot, setGamePhase, setLoading, prefetchAllScreenshots, t, navigate, localizedPath])
 
   // Fetch screenshot when position changes (after navigation)
   useEffect(() => {


### PR DESCRIPTION
Replaces #109 (auto-closed when its base \`feat/premium-ui\` was deleted on merge of #113). Rebased onto \`main\`.

See #109 for full description. Summary: catch-up archive expanded to 365d for premium users (free stays at 7d), 402 PREMIUM_REQUIRED_FOR_OLD_CATCHUP for free users on archived challenges, premium gets free hints in catch-up sessions only (today's daily unchanged for leaderboard integrity), supporter_lifetime_at column + grant on supporter checkout, getEntitlement resolves supporter before subscription, frontend handles 402 with toast + redirect to /premium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)