### PR TITLE
fix(ci): retry release push when main moves during Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,8 +332,53 @@ jobs:
 
       - name: Push changes to repository
         run: |
-          git push origin HEAD:main
-          git push origin "v${{ needs.decide.outputs.new_version }}"
+          set -euo pipefail
+          NEW_VERSION="${{ needs.decide.outputs.new_version }}"
+
+          # Multi-arch Docker builds take ~5 minutes; if another PR merges
+          # to main during that window, a sibling Release run will have
+          # bumped main to the same target version (or beyond) by the time
+          # we try to push. The concurrency group on this workflow does not
+          # actually serialize the build matrix in practice, so handle the
+          # race here:
+          #   1. Try push.
+          #   2. On reject, fetch main. If our target tag already exists,
+          #      a sibling run won and the Docker manifest we already
+          #      published is co-tagged correctly — exit clean.
+          #   3. Otherwise rebase. If the rebase conflicts (typical: both
+          #      runs touched package.json version field), the sibling
+          #      released a different version that effectively supersedes
+          #      ours; exit clean rather than try to recover.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main 2>&1; then
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "::error::push to main failed after 3 attempts"
+              exit 1
+            fi
+
+            echo "Push rejected (attempt $attempt) — fetching origin/main…"
+            git fetch origin main
+
+            if git ls-remote --tags origin "v${NEW_VERSION}" | grep -q .; then
+              echo "v${NEW_VERSION} already exists on origin — sibling release won the race. Exiting clean."
+              exit 0
+            fi
+
+            if ! git rebase origin/main; then
+              git rebase --abort
+              echo "Rebase conflicted — sibling release bumped to a different version. Exiting clean."
+              exit 0
+            fi
+          done
+
+          # Tag push uses --force-with-lease=v…:''  semantics implicitly:
+          # the tag is local-only until this point, so a successful main
+          # push above means no other run holds the tag. If a sibling
+          # tagged the same v$NEW_VERSION between the two pushes, the
+          # second push will fail and we surface that as a real error.
+          git push origin "v${NEW_VERSION}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

The 4 premium PRs (#106, #112, #113, #114) merged in quick succession exposed a race in the Release workflow. Three of four release runs **failed** with \`non-fast-forward\`; only #114's release succeeded — by happenstance of being the last merged with no further merges behind it. Production luckily reached v2.37.0, but the next time several PRs land within ~5 min of each other the pipeline will get stuck again.

## What was happening

Each push to \`main\` triggers a Release run that:

1. Decides bump type from conventional commits → e.g. \`minor\` (\`feat:\` present)
2. Runs lint/build/test in parallel with a multi-arch Docker build (~5 min on QEMU-free arm64 runner)
3. Publishes the manifest, bumps version files, commits + tags, **pushes to main and the tag**

The workflow has \`concurrency: { group: release-main, cancel-in-progress: false }\`, which should serialize runs — but in practice the multi-job structure (separate runners per matrix entry) escapes the lock and the runs proceed in parallel. Each one ends up at step 3 holding a \`chore: bump version to v2.37.0\` commit on top of \`main\` at SHA X1, while remote main has already advanced to X4. The push is rejected.

## What this PR changes

A retry-with-rebase loop on the \`Push changes to repository\` step:

1. **Try push.** If it succeeds we're done.
2. **On reject:** fetch main. If our target tag already exists on origin, a sibling release pushed the same version — the Docker manifest we built is co-tagged correctly under that version, so exit clean (no error, no double-bump).
3. **Otherwise:** rebase on \`origin/main\` and retry. If the rebase conflicts (typical: both runs touched \`package.json\`'s \`version\` field), a sibling won with a different version that effectively supersedes ours — exit clean rather than try to recover with a re-bump that could double-increment.

Up to 3 attempts; final failure surfaces as a real error.

## What this does NOT fix

- The underlying concurrency-not-serializing behavior. Could investigate later if releases stall. The retry-with-rebase is robust against parallelism either way, so this is fine for now.
- The Docker manifest waste: when a sibling wins, our build still pushed digests to Docker Hub. They're tagged with the same version under a different digest. Harmless but slightly wasteful.

## Test plan

- [x] YAML syntax: workflow loads (verified by gh API on the new PR)
- [x] Logical: covers all four observed paths (push wins / sibling already tagged / rebase conflict / rebase clean retry)
- [ ] Live test: requires merging two PRs in quick succession to verify, which is exactly the situation we're trying to fix. Will verify next time multiple PRs land naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)