### PR TITLE
chore(billing): drop supporter lifetime tier from catalog

### DIFF
--- a/packages/backend/src/config/billing.ts
+++ b/packages/backend/src/config/billing.ts
@@ -28,13 +28,6 @@ export const BILLING_CATALOG: readonly BillingCatalogEntry[] = [
     currency: 'eur',
     interval: 'year',
   },
-  {
-    tier: 'supporter_lifetime',
-    stripePriceId: env.STRIPE_PRICE_SUPPORTER_LIFETIME,
-    unitAmount: 5999,
-    currency: 'eur',
-    interval: null,
-  },
 ] as const
 
 export function getCatalogEntry(tier: BillingTier): BillingCatalogEntry | undefined {


### PR DESCRIPTION
## Summary
- Removes the `supporter_lifetime` entry from `BILLING_CATALOG`. The €59.99 one-time price was archived in Stripe (`active=false` on `price_1TREHd…`) so the public catalog must drop it too.
- Webhook handler, `getEntitlement` fallback, and the `supporter_lifetime_at` column are kept intact so any existing supporter grants continue to resolve as premium.
- `/api/billing/prices` and the `PricingTable` are data-driven from `BILLING_CATALOG` / `billingStore`, so no frontend or types changes are needed.

## Test plan
- [ ] `npm run build` (backend + frontend) passes
- [ ] `npm run stripe:check` only validates monthly + annual entries
- [ ] Manual: pricing page renders 2 cards (monthly, annual)
- [ ] No regression for users who hold a `supporter_lifetime_at` grant — entitlement still returns `isPremium: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)