### PR TITLE
feat(home): show entry price on premium hero teaser

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -283,6 +283,7 @@
       "perkArchive": "Full archive of past challenges",
       "perkHints": "Unlimited hints in catch-up",
       "perkCosmetics": "Premium badge and cosmetics",
+      "priceFrom": "From {{price}} / month",
       "cta": "See plans"
     },
     "achievements": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -283,6 +283,7 @@
       "perkArchive": "Archive complète des défis passés",
       "perkHints": "Indices illimités en rattrapage",
       "perkCosmetics": "Badge Premium et cosmétiques",
+      "priceFrom": "À partir de {{price}} / mois",
       "cta": "Voir les offres"
     },
     "achievements": {

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -24,7 +24,7 @@ const CubeBackground = lazy(() =>
 )
 
 export default function HomePage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const navigate = useNavigate()
   const { localizedPath } = useLocalizedPath()
   const { data: session } = useSession()
@@ -41,9 +41,29 @@ export default function HomePage() {
   const [previewAvailable, setPreviewAvailable] = useState(false)
   const timeRemaining = useNextDailyCountdown()
   const billingEntitlement = useBillingStore((state) => state.entitlement)
+  const billingPrices = useBillingStore((state) => state.prices)
+  const fetchBillingPrices = useBillingStore((state) => state.fetchPrices)
   // Header hydrates the entitlement on mount; treat unknown as "not premium"
   // so the teaser shows for anonymous visitors and free users alike.
   const showPremiumTeaser = !billingEntitlement?.isPremium
+
+  useEffect(() => {
+    if (!showPremiumTeaser) return
+    void fetchBillingPrices()
+  }, [showPremiumTeaser, fetchBillingPrices])
+
+  // Cheapest entry price for the teaser hook. Hidden until prices arrive so
+  // we never flash a "From €0.00" placeholder.
+  const monthlyPriceLabel = useMemo(() => {
+    const monthly = billingPrices.find((p) => p.tier === 'premium_monthly' && p.active)
+    if (!monthly) return null
+    return new Intl.NumberFormat(i18n.language, {
+      style: 'currency',
+      currency: monthly.currency.toUpperCase(),
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(monthly.unitAmount / 100)
+  }, [billingPrices, i18n.language])
 
   // Read once; entrance animations don't need to react mid-session.
   const reducedMotion = useMemo(() => prefersReducedMotion(), [])
@@ -357,6 +377,11 @@ export default function HomePage() {
                   <p className="mt-1.5 text-xs sm:text-sm text-muted-foreground max-w-xl">
                     {t('home.premium.subtitle')}
                   </p>
+                  {monthlyPriceLabel && (
+                    <p className="mt-2 text-sm sm:text-base font-semibold text-neon-pink">
+                      {t('home.premium.priceFrom', { price: monthlyPriceLabel })}
+                    </p>
+                  )}
                   <ul className="mt-3 grid gap-1.5 text-xs sm:text-sm text-foreground/90">
                     {[
                       t('home.premium.perkArchive'),


### PR DESCRIPTION
## Summary
- The hero subscription teaser was selling perks without surfacing a price. Now it pulls the monthly tier from \`/api/billing/prices\` (via \`billingStore\`) and renders **À partir de 3,99 € / mois** between the subtitle and the perks list.
- Driven by the same catalog the pricing page uses, so any catalog edit flows through automatically — no hard-coded amount in the hero.
- Hidden until prices load to avoid a "From €0.00" flash; hidden entirely if the visitor already has Premium (existing \`showPremiumTeaser\` gate).

## Test plan
- [ ] \`npm run build\` passes (typecheck + Vite)
- [ ] Anonymous visitor on \`/\`: sees the price line within the hero card
- [ ] Authenticated free user: same as above
- [ ] Authenticated Premium user: teaser (and price) hidden
- [ ] FR locale: \`À partir de 3,99 € / mois\`; EN locale: \`From €3.99 / month\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)