### PR TITLE
feat(geo): add unrestricted free-play mode with fullscreen and mobile-first UI

### DIFF
--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -629,7 +629,22 @@ export interface GeoScreenshotRepository {
     promotedBy?: string
   }): Promise<GeoScreenshotMeta>
   countPromotedForGame(gameId: number): Promise<number>
-  pickRandomPromotedForGame(gameId: number): Promise<GeoScreenshotMeta | null>
+  pickRandomPromotedForGame(
+    gameId: number,
+    geoMapId?: number,
+  ): Promise<GeoScreenshotMeta | null>
+  // Free-play catalog: games with at least one promoted screenshot, plus
+  // the per-game count of distinct maps and screenshots so the picker can
+  // render badges without an N+1 lookup.
+  listPlayableGames(): Promise<
+    Array<{
+      id: number
+      name: string
+      coverImageUrl: string | null
+      mapCount: number
+      screenshotCount: number
+    }>
+  >
 }
 
 export interface GeoChallengeRepository {

--- a/packages/backend/src/domain/services/geo-game.service.ts
+++ b/packages/backend/src/domain/services/geo-game.service.ts
@@ -59,6 +59,35 @@ export interface GeoDailyChallengeView {
   hasGuessed: boolean
 }
 
+// Free-play view: any game, any enabled map, no daily-challenge gating, no
+// leaderboard side effects. The chooser surface gets the full list of enabled
+// maps for the game; the canonical map id is held back until after the guess
+// (same DevTools-cheat protection as the daily flow).
+export interface GeoFreePlayView {
+  game: { id: number; name: string }
+  meta: GeoScreenshotMeta
+  candidate: GeoScreenshotCandidate
+  maps: GeoMap[]
+  // The map the screenshot canonically belongs to. Only populated AFTER the
+  // player has submitted a free-play guess (i.e. it's never returned by the
+  // pick endpoint). Reuses the same shape as `GeoDailyChallengeView.map`.
+  map?: GeoMap
+}
+
+// Pure-scoring result for free-play. Same shape as `GeoGuessResult` minus the
+// fields that only make sense in a leaderboard context (averageScore /
+// playerCount). Free-play never writes to daily/monthly aggregates, so those
+// stats would always be empty — we omit them rather than ship zeros.
+export interface GeoFreePlayResult {
+  guess: GeoPoint
+  canonical: GeoPoint
+  distance: number
+  score: number
+  scoreVersion: number
+  correctMapId: number
+  wrongMap: boolean
+}
+
 export interface GeoGameService {
   getDailyChallenge(args: {
     date: string
@@ -90,6 +119,19 @@ export interface GeoGameService {
     gameId: number
     userId: string
   }): Promise<GeoScreenshotCandidate>
+
+  // ---- Free-play (unranked, all-games-all-maps browser) ----
+
+  pickFreePlayScreenshot(args: {
+    gameId: number
+    geoMapId?: number
+  }): Promise<GeoFreePlayView | null>
+
+  scoreFreePlayGuess(args: {
+    metaId: number
+    geoMapId: number
+    guess: GeoPoint
+  }): Promise<GeoFreePlayResult>
 }
 
 export interface GeoGameServiceDeps {
@@ -355,6 +397,97 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
 
     getLeaderboardMonthly(period, limit) {
       return geoChallengeRepository.topMonthly(period, limit)
+    },
+
+    // Free-play view hydration: pick a random promoted screenshot for the
+    // (game, map) pair, surface every enabled map for the chooser, and
+    // never write anything. Returns null when the game has no promoted
+    // screenshots yet (the UI should show an empty state).
+    async pickFreePlayScreenshot({ gameId, geoMapId }) {
+      const enabledMaps = await geoMapRepository.listEnabledByGameId(gameId)
+      if (enabledMaps.length === 0) return null
+      // Validate the optional geoMapId belongs to the game's enabled set —
+      // otherwise an attacker could probe arbitrary map ids by way of a
+      // foreign-game request.
+      if (geoMapId != null && !enabledMaps.some((m) => m.id === geoMapId)) {
+        throw new GeoGameError(
+          'geoMapId does not belong to the requested game',
+          'INVALID_MAP',
+        )
+      }
+      const meta = await geoScreenshotRepository.pickRandomPromotedForGame(
+        gameId,
+        geoMapId,
+      )
+      if (!meta) return null
+      const candidate = await geoScreenshotRepository.findCandidateById(
+        meta.geoScreenshotCandidateId,
+      )
+      if (!candidate) return null
+      // Refuse to serve placeholder seed data — same guard as the daily flow.
+      if (
+        isPlaceholderImageUrl(candidate.imageUrl) ||
+        enabledMaps.every((m) => isPlaceholderImageUrl(m.imageUrl))
+      ) {
+        return null
+      }
+      // Look up the game's display name from the existing maps query
+      // result chain — we already know the game id; a lightweight join
+      // would need a port. Keep it simple: callers that want the name
+      // can join client-side with the games list.
+      return {
+        game: { id: gameId, name: '' },
+        meta,
+        candidate,
+        maps: enabledMaps,
+        // map: omitted — only the score endpoint reveals the canonical.
+      }
+    },
+
+    // Pure scoring + canonical reveal for free-play. No leaderboard writes,
+    // no socket emits, no upserts. Reuses `geoScoringService.score()` so the
+    // formula stays in lockstep with daily.
+    async scoreFreePlayGuess({ metaId, geoMapId, guess }) {
+      if (!validPoint(guess)) {
+        throw new GeoGameError('guess must have x and y in [0..1]', 'INVALID_POINT')
+      }
+      const meta = await geoScreenshotRepository.findMetaById(metaId)
+      if (!meta) {
+        throw new GeoGameError('meta not found', 'CHALLENGE_NOT_FOUND')
+      }
+      const candidate = await geoScreenshotRepository.findCandidateById(
+        meta.geoScreenshotCandidateId,
+      )
+      if (!candidate) {
+        throw new GeoGameError('candidate not found', 'CHALLENGE_NOT_FOUND')
+      }
+      // The picked map must be one of the game's currently-enabled maps —
+      // OR the canonical map (which may have been disabled mid-session,
+      // same fallback as the daily flow so the player isn't punished by
+      // an admin's flip).
+      const enabledMaps = await geoMapRepository.listEnabledByGameId(candidate.gameId)
+      const isEnabled = enabledMaps.some((m) => m.id === geoMapId)
+      if (!isEnabled && geoMapId !== meta.geoMapId) {
+        throw new GeoGameError(
+          'geoMapId does not belong to the screenshot game',
+          'INVALID_MAP',
+        )
+      }
+      const wrongMap = geoMapId !== meta.geoMapId
+      const { distance, score, scoreVersion } = geoScoringService.score(
+        guess,
+        meta.canonical,
+        { wrongMap },
+      )
+      return {
+        guess,
+        canonical: meta.canonical,
+        distance,
+        score,
+        scoreVersion,
+        correctMapId: meta.geoMapId,
+        wrongMap,
+      }
     },
 
     async pickContributionTarget({ gameId, userId }) {

--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -197,8 +197,11 @@ export const geoScreenshotRepository = {
     return Number(result?.count ?? 0)
   },
 
-  async pickRandomPromotedForGame(gameId: number): Promise<GeoScreenshotMeta | null> {
-    const row = await db('geo_screenshot_meta')
+  async pickRandomPromotedForGame(
+    gameId: number,
+    geoMapId?: number,
+  ): Promise<GeoScreenshotMeta | null> {
+    const q = db('geo_screenshot_meta')
       .join(
         'geo_screenshot_candidate',
         'geo_screenshot_meta.geo_screenshot_candidate_id',
@@ -208,8 +211,57 @@ export const geoScreenshotRepository = {
       .where('geo_screenshot_candidate.is_active', true)
       .orderByRaw('RANDOM()')
       .select<GeoScreenshotMetaRow>('geo_screenshot_meta.*')
-      .first()
+    if (geoMapId !== undefined) {
+      q.where('geo_screenshot_meta.geo_map_id', geoMapId)
+    }
+    const row = await q.first()
     return row ? mapMeta(row) : null
+  },
+
+  // Catalog of games that the free-play browser can offer: any game whose
+  // catalogue contains at least one promoted (consensus-confirmed) screenshot
+  // on an active candidate. Returned with the count of enabled maps and the
+  // count of playable screenshots so the picker can render badges without an
+  // N+1. Ordered by recent activity (most promoted-screenshots first) so the
+  // list feels alive.
+  async listPlayableGames(): Promise<
+    Array<{
+      id: number
+      name: string
+      coverImageUrl: string | null
+      mapCount: number
+      screenshotCount: number
+    }>
+  > {
+    const rows = await db('games as g')
+      .join('geo_screenshot_candidate as gsc', 'gsc.game_id', 'g.id')
+      .join('geo_screenshot_meta as gsm', 'gsm.geo_screenshot_candidate_id', 'gsc.id')
+      .where('gsc.is_active', true)
+      .groupBy('g.id', 'g.name', 'g.cover_image_url')
+      .orderByRaw('COUNT(DISTINCT gsm.id) DESC')
+      .orderBy('g.name', 'asc')
+      .select<
+        Array<{
+          id: number
+          name: string
+          cover_image_url: string | null
+          screenshot_count: string
+          map_count: string
+        }>
+      >(
+        'g.id',
+        'g.name',
+        'g.cover_image_url',
+        db.raw('COUNT(DISTINCT gsm.id) as screenshot_count'),
+        db.raw('COUNT(DISTINCT gsm.geo_map_id) as map_count'),
+      )
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      coverImageUrl: r.cover_image_url,
+      mapCount: Number(r.map_count ?? 0),
+      screenshotCount: Number(r.screenshot_count ?? 0),
+    }))
   },
 
   async listCandidatesForReview(args: {

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -66,6 +66,23 @@ const historyQuerySchema = z.object({
   days: z.coerce.number().int().positive().max(30).optional(),
 })
 
+// ---- Free-play schemas (unranked, all-games-all-maps browser) ----
+
+const gameIdParamSchema = z.object({
+  gameId: z.coerce.number().int().positive(),
+})
+
+const freePlayPickBodySchema = z.object({
+  gameId: z.number().int().positive(),
+  geoMapId: z.number().int().positive().optional(),
+})
+
+const freePlayGuessBodySchema = z.object({
+  metaId: z.number().int().positive(),
+  geoMapId: z.number().int().positive(),
+  guess: pointSchema,
+})
+
 // ---------- Current / daily challenge ----------
 
 // Slow-rollout entrypoint: returns whichever challenge is currently flagged
@@ -329,5 +346,107 @@ router.get('/contributor/me', authMiddleware, async (req, res, next) => {
     next(err)
   }
 })
+
+// ---------- Free-play (unranked, all-games-all-maps browser) ----------
+
+// Public catalog: every game with at least one promoted screenshot, plus
+// per-game map and screenshot counts so the picker can render badges
+// without an N+1. Aggressively cacheable — content rotates only when an
+// admin promotes a new screenshot or enables a map.
+router.get('/games', async (_req, res, next) => {
+  try {
+    const games = await geoScreenshotRepository.listPlayableGames()
+    res.set('Cache-Control', 'public, max-age=300')
+    res.json({ success: true, data: games })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Public per-game map list: enabled (playable) maps only. Deliberately
+// reuses `listEnabledByGameId` so any admin enable/disable flips
+// propagate immediately to the free-play picker.
+router.get(
+  '/games/:gameId/maps',
+  validateParams(gameIdParamSchema),
+  async (req, res, next) => {
+    try {
+      const { gameId } = req.params as unknown as { gameId: number }
+      const maps = await geoMapRepository.listEnabledByGameId(gameId)
+      res.set('Cache-Control', 'public, max-age=60')
+      res.json({ success: true, data: maps })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// Pick a random playable screenshot for a (game, optional map) pair.
+// Public — auth not required for browsing/practicing. Returns 404 when
+// the game has no promoted screenshots (or none for the chosen map) so
+// the UI can render an empty state instead of a generic error.
+router.post(
+  '/free-play/random',
+  validateBody(freePlayPickBodySchema),
+  async (req, res, next) => {
+    try {
+      const { gameId, geoMapId } = req.body as z.infer<typeof freePlayPickBodySchema>
+      const view = await geoGameService.pickFreePlayScreenshot({ gameId, geoMapId })
+      if (!view) {
+        res.status(404).json({
+          success: false,
+          error: {
+            code: 'NO_FREE_PLAY_CANDIDATE',
+            message: 'no playable screenshot for this game/map',
+          },
+        })
+        return
+      }
+      res.json({ success: true, data: view })
+    } catch (err) {
+      if (err instanceof GeoGameError) {
+        const status = err.code === 'INVALID_MAP' ? 400 : 404
+        res.status(status).json({
+          success: false,
+          error: { code: err.code, message: err.message },
+        })
+        return
+      }
+      next(err)
+    }
+  },
+)
+
+// Score a free-play guess. Public — anonymous players get the score reveal
+// without leaderboard credit. No daily/monthly upserts, no socket emit:
+// free-play is strictly practice.
+router.post(
+  '/free-play/guess',
+  validateBody(freePlayGuessBodySchema),
+  async (req, res, next) => {
+    try {
+      const { metaId, geoMapId, guess } = req.body as z.infer<
+        typeof freePlayGuessBodySchema
+      >
+      const result = await geoGameService.scoreFreePlayGuess({
+        metaId,
+        geoMapId,
+        guess,
+      })
+      res.json({ success: true, data: result })
+    } catch (err) {
+      if (err instanceof GeoGameError) {
+        const status =
+          err.code === 'INVALID_POINT' || err.code === 'INVALID_MAP' ? 400 : 404
+        res.status(status).json({
+          success: false,
+          error: { code: err.code, message: err.message },
+        })
+        return
+      }
+      next(err)
+    }
+  },
+)
 
 export default router

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1589,7 +1589,57 @@
       },
       "reveal": {
         "correctMap": "Correct map: {{region}}"
-      }
+      },
+      "freePlayCta": "Free play any game"
+    },
+    "play": {
+      "title": "Free play",
+      "pickGame": "Pick a game",
+      "pickGameHint": "All games with at least one playable screenshot.",
+      "pickMap": "Pick a map",
+      "pickMapHint": "Pick the in-game map you want to guess on.",
+      "searchGames": "Search games",
+      "searchGamesPlaceholder": "Search games…",
+      "noGamesFound": "No games match your search.",
+      "noGamesYet": "No games are available for free play yet.",
+      "noMapsYet": "No maps are available for this game yet.",
+      "mapCount": "{{count}} maps",
+      "screenshotCount": "{{count}} shots",
+      "anyMap": "Surprise me",
+      "changeGame": "Choose game",
+      "changeMap": "Choose map",
+      "submit": "Drop pin",
+      "next": "Next round",
+      "reroll": "New screenshot",
+      "tabs": {
+        "screenshot": "Photo",
+        "map": "Map"
+      },
+      "deck": {
+        "label": "Screenshot and map"
+      },
+      "empty": {
+        "title": "Pick a game to start",
+        "body": "Free play covers every game and every map in the catalog. No daily limits.",
+        "cta": "Browse games"
+      },
+      "map": {
+        "empty": {
+          "noGame": "Pick a game first — the map list shows up here once you have one.",
+          "multi": "This game has several maps. Pick one to start guessing.",
+          "none": "No playable maps for this game yet."
+        }
+      },
+      "practiceNote": "Practice mode — your score does not affect the leaderboard.",
+      "backToDaily": "Play the ranked daily challenge"
+    },
+    "fullscreen": {
+      "enter": "Enter fullscreen",
+      "enterImmersive": "Enter immersive view",
+      "exit": "Exit immersive view",
+      "entered": "Fullscreen activated",
+      "exited": "Fullscreen exited",
+      "unsupported": "Fullscreen isn't supported on this device — using immersive view instead."
     },
     "contribute": {
       "title": "Tag a screenshot",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1589,7 +1589,57 @@
       },
       "reveal": {
         "correctMap": "Bonne carte : {{region}}"
-      }
+      },
+      "freePlayCta": "Jouer librement"
+    },
+    "play": {
+      "title": "Mode libre",
+      "pickGame": "Choisir un jeu",
+      "pickGameHint": "Tous les jeux avec au moins une capture jouable.",
+      "pickMap": "Choisir une carte",
+      "pickMapHint": "Choisissez la carte du jeu sur laquelle vous voulez deviner.",
+      "searchGames": "Rechercher un jeu",
+      "searchGamesPlaceholder": "Rechercher un jeu…",
+      "noGamesFound": "Aucun jeu ne correspond à votre recherche.",
+      "noGamesYet": "Aucun jeu n'est disponible en mode libre pour l'instant.",
+      "noMapsYet": "Aucune carte n'est encore disponible pour ce jeu.",
+      "mapCount": "{{count}} cartes",
+      "screenshotCount": "{{count}} captures",
+      "anyMap": "Au hasard",
+      "changeGame": "Changer de jeu",
+      "changeMap": "Changer de carte",
+      "submit": "Placer l'épingle",
+      "next": "Tour suivant",
+      "reroll": "Nouvelle capture",
+      "tabs": {
+        "screenshot": "Photo",
+        "map": "Carte"
+      },
+      "deck": {
+        "label": "Capture et carte"
+      },
+      "empty": {
+        "title": "Choisissez un jeu pour commencer",
+        "body": "Le mode libre couvre tous les jeux et toutes les cartes du catalogue. Sans limite quotidienne.",
+        "cta": "Parcourir les jeux"
+      },
+      "map": {
+        "empty": {
+          "noGame": "Choisissez d'abord un jeu — la liste des cartes apparaîtra ici.",
+          "multi": "Ce jeu a plusieurs cartes. Choisissez-en une pour commencer.",
+          "none": "Aucune carte jouable pour ce jeu."
+        }
+      },
+      "practiceNote": "Mode entraînement — votre score n'affecte pas le classement.",
+      "backToDaily": "Jouer le défi quotidien classé"
+    },
+    "fullscreen": {
+      "enter": "Passer en plein écran",
+      "enterImmersive": "Vue immersive",
+      "exit": "Quitter le mode immersif",
+      "entered": "Plein écran activé",
+      "exited": "Plein écran désactivé",
+      "unsupported": "Le plein écran n'est pas pris en charge sur cet appareil — vue immersive utilisée à la place."
     },
     "contribute": {
       "title": "Étiqueter une capture",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -35,6 +35,7 @@ const GameHistoryDetailsPage = lazy(() => import('@/pages/GameHistoryDetailsPage
 const ProfilePage = lazy(() => import('@/pages/ProfilePage'))
 const PublicProfilePage = lazy(() => import('@/pages/PublicProfilePage'))
 const GeoDailyPage = lazy(() => import('@/pages/GeoDailyPage'))
+const GeoPlayPage = lazy(() => import('@/pages/GeoPlayPage'))
 const GeoContributePage = lazy(() => import('@/pages/GeoContributePage'))
 const GeoLeaderboardPage = lazy(() => import('@/pages/GeoLeaderboardPage'))
 const PricingPage = lazy(() => import('@/pages/PricingPage'))
@@ -141,6 +142,7 @@ function App() {
 
           <Route path="geo" element={<GeoDailyPage />} />
           <Route path="geo/daily" element={<GeoDailyPage />} />
+          <Route path="geo/play" element={<GeoPlayPage />} />
           <Route path="geo/leaderboard" element={<GeoLeaderboardPage />} />
           <Route path="geo/contribute" element={<GeoContributePage />} />
 

--- a/packages/frontend/src/components/geo/FullscreenToggle.tsx
+++ b/packages/frontend/src/components/geo/FullscreenToggle.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next'
+import { Maximize2, Minimize2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface FullscreenToggleProps {
+  isImmersive: boolean
+  onToggle: () => void
+  // Native fullscreen support. When false the button still works (CSS
+  // fallback) but we badge it differently so users on iOS know they're
+  // getting an "immersive" view rather than the OS-level chrome-hiding.
+  isNativeSupported: boolean
+  className?: string
+}
+
+/**
+ * Glass FAB-style toggle for entering/leaving the immersive view. Sits in
+ * the top-right of the active surface; auto-sizes to a 44 × 44 hit area
+ * (matches Apple HIG so a fingertip can land cleanly even on a 6.7" phone
+ * held one-handed).
+ */
+export function FullscreenToggle({
+  isImmersive,
+  onToggle,
+  isNativeSupported,
+  className,
+}: FullscreenToggleProps) {
+  const { t } = useTranslation()
+  const label = isImmersive
+    ? t('geo.fullscreen.exit', 'Exit immersive view')
+    : isNativeSupported
+      ? t('geo.fullscreen.enter', 'Enter fullscreen')
+      : t('geo.fullscreen.enterImmersive', 'Enter immersive view')
+  const Icon = isImmersive ? Minimize2 : Maximize2
+  return (
+    <Button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={isImmersive}
+      aria-label={label}
+      title={label}
+      // Glassy chip on top of the screenshot/map. `backdrop-blur` keeps it
+      // legible across busy backgrounds without a hard scrim.
+      className={cn(
+        'h-11 w-11 p-0 rounded-full bg-black/40 hover:bg-black/60 backdrop-blur',
+        'border border-white/10 text-white shadow-lg',
+        'focus-visible:ring-2 focus-visible:ring-neon-pink focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        className,
+      )}
+    >
+      <Icon className="h-5 w-5" aria-hidden />
+    </Button>
+  )
+}

--- a/packages/frontend/src/components/geo/GamePicker.tsx
+++ b/packages/frontend/src/components/geo/GamePicker.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { GeoPlayableGame } from '@the-box/types'
+import { Search, MapPin, Image as ImageIcon, Loader2 } from 'lucide-react'
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetDescription,
+} from '@/components/ui/sheet'
+import { Input } from '@/components/ui/input'
+import { useIsMobile } from '@/hooks/useIsMobile'
+import { cn } from '@/lib/utils'
+import { isPlaceholderImageUrl } from '@/lib/geo-image'
+
+interface GamePickerProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    games: GeoPlayableGame[]
+    isLoading: boolean
+    selectedGameId: number | null
+    onSelect: (gameId: number) => void
+}
+
+/**
+ * Bottom-drawer picker on mobile, right-side sheet on desktop. Searchable,
+ * keyboard-navigable (radiogroup pattern, see Geo a11y notes), and renders
+ * cover art with map / screenshot count badges so the player can scan the
+ * catalog at a glance.
+ */
+export function GamePicker({
+    open,
+    onOpenChange,
+    games,
+    isLoading,
+    selectedGameId,
+    onSelect,
+}: GamePickerProps) {
+    const { t } = useTranslation()
+    const isMobile = useIsMobile()
+    const [query, setQuery] = useState('')
+
+    // Reset the search field every time the sheet re-opens — keeping a
+    // stale query across opens reads as a bug ("why am I still seeing my
+    // last search?") more often than as a convenience.
+    useEffect(() => {
+        if (open) setQuery('')
+    }, [open])
+
+    const filtered = useMemo(() => {
+        const q = query.trim().toLowerCase()
+        if (!q) return games
+        return games.filter((g) => g.name.toLowerCase().includes(q))
+    }, [games, query])
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent
+                side={isMobile ? 'bottom' : 'right'}
+                className={cn(
+                    'p-0 flex flex-col gap-0',
+                    isMobile
+                        ? 'h-[85dvh] rounded-t-2xl'
+                        : 'sm:max-w-md w-full h-full',
+                )}
+            >
+                <SheetHeader className="p-4 pb-2 text-left space-y-2">
+                    <SheetTitle>{t('geo.play.pickGame', 'Pick a game')}</SheetTitle>
+                    <SheetDescription>
+                        {t(
+                            'geo.play.pickGameHint',
+                            'All games with at least one playable screenshot.',
+                        )}
+                    </SheetDescription>
+                    <div className="relative">
+                        <Search
+                            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+                            aria-hidden
+                        />
+                        <Input
+                            type="search"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            placeholder={t(
+                                'geo.play.searchGamesPlaceholder',
+                                'Search games…',
+                            )}
+                            aria-label={t('geo.play.searchGames', 'Search games')}
+                            className="pl-9"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            autoCapitalize="off"
+                            spellCheck={false}
+                        />
+                    </div>
+                </SheetHeader>
+
+                <div className="flex-1 overflow-y-auto px-4 pb-[max(env(safe-area-inset-bottom),16px)]">
+                    {isLoading ? (
+                        <div
+                            className="flex justify-center py-16"
+                            role="status"
+                            aria-live="polite"
+                        >
+                            <Loader2 className="h-6 w-6 animate-spin text-neon-pink" aria-hidden />
+                            <span className="sr-only">
+                                {t('common.loading', 'Loading…')}
+                            </span>
+                        </div>
+                    ) : filtered.length === 0 ? (
+                        <p className="py-12 text-center text-sm text-muted-foreground">
+                            {games.length === 0
+                                ? t(
+                                      'geo.play.noGamesYet',
+                                      'No games are available for free play yet.',
+                                  )
+                                : t('geo.play.noGamesFound', 'No games match your search.')}
+                        </p>
+                    ) : (
+                        <ul
+                            role="radiogroup"
+                            aria-label={t('geo.play.pickGame', 'Pick a game')}
+                            className="grid grid-cols-2 gap-3 pt-2 sm:grid-cols-1"
+                        >
+                            {filtered.map((g) => (
+                                <li key={g.id}>
+                                    <GameCard
+                                        game={g}
+                                        selected={selectedGameId === g.id}
+                                        onSelect={() => {
+                                            onSelect(g.id)
+                                            onOpenChange(false)
+                                        }}
+                                    />
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            </SheetContent>
+        </Sheet>
+    )
+}
+
+function GameCard({
+    game,
+    selected,
+    onSelect,
+}: {
+    game: GeoPlayableGame
+    selected: boolean
+    onSelect: () => void
+}) {
+    const { t } = useTranslation()
+    const cover = game.coverImageUrl && !isPlaceholderImageUrl(game.coverImageUrl)
+        ? game.coverImageUrl
+        : null
+    return (
+        <button
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={onSelect}
+            className={cn(
+                'group relative w-full overflow-hidden rounded-lg border bg-card text-left transition',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink',
+                selected
+                    ? 'border-neon-pink ring-2 ring-neon-pink/60'
+                    : 'border-border hover:border-neon-pink/60',
+            )}
+        >
+            <div className="aspect-video w-full bg-muted/30 sm:aspect-[16/7]">
+                {cover ? (
+                    <img
+                        src={cover}
+                        alt=""
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                        decoding="async"
+                    />
+                ) : (
+                    <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                        {game.name}
+                    </div>
+                )}
+            </div>
+            <div className="p-3 space-y-1">
+                <p className="font-medium text-sm leading-tight line-clamp-2">{game.name}</p>
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                    <span className="inline-flex items-center gap-1">
+                        <MapPin className="h-3 w-3" aria-hidden />
+                        {t('geo.play.mapCount', '{{count}} maps', { count: game.mapCount })}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                        <ImageIcon className="h-3 w-3" aria-hidden />
+                        {t('geo.play.screenshotCount', '{{count}} shots', {
+                            count: game.screenshotCount,
+                        })}
+                    </span>
+                </div>
+            </div>
+        </button>
+    )
+}

--- a/packages/frontend/src/components/geo/GamePicker.tsx
+++ b/packages/frontend/src/components/geo/GamePicker.tsx
@@ -45,6 +45,7 @@ export function GamePicker({
     // stale query across opens reads as a bug ("why am I still seeing my
     // last search?") more often than as a convenience.
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing local state to the parent-controlled `open` transition; no external system to subscribe to.
         if (open) setQuery('')
     }, [open])
 

--- a/packages/frontend/src/components/geo/ImmersiveLayout.tsx
+++ b/packages/frontend/src/components/geo/ImmersiveLayout.tsx
@@ -50,6 +50,7 @@ export function ImmersiveLayout({
     // see the new screenshot first; if they were on the map mid-pin they
     // can swipe back.
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing local tab to the parent-driven `roundKey` change; no external system to subscribe to.
         setTab('photo')
     }, [roundKey])
 

--- a/packages/frontend/src/components/geo/ImmersiveLayout.tsx
+++ b/packages/frontend/src/components/geo/ImmersiveLayout.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Image as ImageIcon, MapPin } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useIsMobile } from '@/hooks/useIsMobile'
+
+type Tab = 'photo' | 'map'
+
+interface ImmersiveLayoutProps {
+    screenshot: ReactNode
+    map: ReactNode
+    // Top-right overlay (the fullscreen toggle, plus optional report button).
+    topRight?: ReactNode
+    // Sticky bottom dock (skip / submit / next).
+    bottomDock?: ReactNode
+    // Result panel rendered as a non-blocking overlay above the dock.
+    resultOverlay?: ReactNode
+    // True when the page should pin itself to the viewport (CSS immersive
+    // fallback for browsers without native fullscreen).
+    isImmersive: boolean
+    // Reset the active tab to "photo" — handy when the round changes so
+    // the player always lands on the screenshot for the new shot.
+    roundKey: number | string
+}
+
+/**
+ * Mobile-first split-panel for the screenshot ↔ map flow. Defaults to a
+ * **toggle** (one panel at a time, swap via tabs or horizontal swipe) on
+ * mobile and a **side-by-side** view on desktop.
+ *
+ * The swipe gesture is enhancement-only — keyboard / SR users get the
+ * tab buttons as a first-class non-gesture path. Swiping is ignored when
+ * the user prefers reduced motion (handled by the consumer's transition
+ * styles).
+ */
+export function ImmersiveLayout({
+    screenshot,
+    map,
+    topRight,
+    bottomDock,
+    resultOverlay,
+    isImmersive,
+    roundKey,
+}: ImmersiveLayoutProps) {
+    const { t } = useTranslation()
+    const isMobile = useIsMobile()
+    const [tab, setTab] = useState<Tab>('photo')
+
+    // Snap back to "photo" whenever a new round starts. Players want to
+    // see the new screenshot first; if they were on the map mid-pin they
+    // can swipe back.
+    useEffect(() => {
+        setTab('photo')
+    }, [roundKey])
+
+    // Touch-driven swipe to toggle Photo ↔ Map on mobile only. Desktop
+    // shows both surfaces, so swipe is a no-op there.
+    const touchStartXRef = useRef<number | null>(null)
+    const touchStartYRef = useRef<number | null>(null)
+    const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+        const touch = e.touches.item(0)
+        if (!touch) return
+        touchStartXRef.current = touch.clientX
+        touchStartYRef.current = touch.clientY
+    }
+    const onTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+        if (!isMobile) return
+        const startX = touchStartXRef.current
+        const startY = touchStartYRef.current
+        touchStartXRef.current = null
+        touchStartYRef.current = null
+        if (startX == null || startY == null) return
+        const touch = e.changedTouches.item(0)
+        if (!touch) return
+        const dx = touch.clientX - startX
+        const dy = touch.clientY - startY
+        // Tight threshold so a casual finger drift doesn't flip the tab,
+        // and a strong vertical bias (|dy| > |dx|) cancels — players will
+        // be tapping pins, scrolling result sheets, etc.
+        if (Math.abs(dx) < 60 || Math.abs(dy) > Math.abs(dx)) return
+        if (dx < 0 && tab === 'photo') setTab('map')
+        else if (dx > 0 && tab === 'map') setTab('photo')
+    }
+
+    return (
+        <div
+            className={cn(
+                'relative flex flex-col bg-black text-foreground',
+                isImmersive
+                    ? 'fixed inset-0 z-50 h-[100dvh]'
+                    : 'h-[calc(100dvh-3.5rem)] md:h-[calc(100dvh-4rem)]',
+            )}
+            data-immersive={isImmersive ? 'true' : 'false'}
+        >
+            {/* Tab bar — mobile only. On desktop both panels show side-by-side
+                and the tablist is a no-op (we still render it, hidden, so
+                screen-reader users on resized viewports keep the same
+                navigation contract). */}
+            <div
+                role="tablist"
+                aria-label={t('geo.play.deck.label', 'Screenshot and map')}
+                className={cn(
+                    'absolute left-1/2 top-3 -translate-x-1/2 z-30 flex gap-1 rounded-full bg-black/50 p-1 backdrop-blur md:hidden',
+                )}
+            >
+                <TabButton
+                    id="geo-tab-photo"
+                    controls="geo-panel-photo"
+                    active={tab === 'photo'}
+                    onClick={() => setTab('photo')}
+                >
+                    <ImageIcon className="h-3.5 w-3.5" aria-hidden />
+                    <span className="text-xs font-medium">
+                        {t('geo.play.tabs.screenshot', 'Photo')}
+                    </span>
+                </TabButton>
+                <TabButton
+                    id="geo-tab-map"
+                    controls="geo-panel-map"
+                    active={tab === 'map'}
+                    onClick={() => setTab('map')}
+                >
+                    <MapPin className="h-3.5 w-3.5" aria-hidden />
+                    <span className="text-xs font-medium">
+                        {t('geo.play.tabs.map', 'Map')}
+                    </span>
+                </TabButton>
+            </div>
+
+            {/* Top-right overlay (fullscreen toggle, etc.) */}
+            {topRight && (
+                <div
+                    className="absolute right-3 top-3 z-30 flex items-center gap-2"
+                    style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
+                >
+                    {topRight}
+                </div>
+            )}
+
+            {/* Deck */}
+            <div
+                className="flex-1 relative overflow-hidden"
+                onTouchStart={onTouchStart}
+                onTouchEnd={onTouchEnd}
+            >
+                <div className="absolute inset-0 grid md:grid-cols-2">
+                    <Panel
+                        id="geo-panel-photo"
+                        labelledBy="geo-tab-photo"
+                        active={tab === 'photo'}
+                        className="md:!opacity-100 md:!pointer-events-auto"
+                    >
+                        {screenshot}
+                    </Panel>
+                    <Panel
+                        id="geo-panel-map"
+                        labelledBy="geo-tab-map"
+                        active={tab === 'map'}
+                        className="md:!opacity-100 md:!pointer-events-auto"
+                    >
+                        {map}
+                    </Panel>
+                </div>
+            </div>
+
+            {/* Result overlay — sits above the deck but below the dock so
+                the dock's Next button is always reachable. */}
+            {resultOverlay && (
+                <div
+                    className="absolute left-0 right-0 z-30 px-3"
+                    style={{
+                        bottom:
+                            'calc(env(safe-area-inset-bottom, 0px) + 5.5rem)',
+                    }}
+                >
+                    {resultOverlay}
+                </div>
+            )}
+
+            {/* Bottom dock — always reachable by the right thumb. Adds the
+                iOS safe-area inset so the home indicator doesn't collide
+                with the primary action. */}
+            {bottomDock && (
+                <div
+                    className="z-40 border-t border-white/10 bg-black/70 backdrop-blur"
+                    style={{
+                        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+                    }}
+                >
+                    <div className="px-3 py-3">{bottomDock}</div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+function TabButton({
+    id,
+    controls,
+    active,
+    onClick,
+    children,
+}: {
+    id: string
+    controls: string
+    active: boolean
+    onClick: () => void
+    children: ReactNode
+}) {
+    return (
+        <button
+            id={id}
+            role="tab"
+            type="button"
+            aria-selected={active}
+            aria-controls={controls}
+            tabIndex={active ? 0 : -1}
+            onClick={onClick}
+            className={cn(
+                'inline-flex items-center gap-1.5 rounded-full px-3 py-1 transition',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink',
+                active
+                    ? 'bg-white text-black shadow'
+                    : 'text-white/80 hover:text-white',
+            )}
+        >
+            {children}
+        </button>
+    )
+}
+
+function Panel({
+    id,
+    active,
+    labelledBy,
+    className,
+    children,
+}: {
+    id: string
+    active: boolean
+    labelledBy: string
+    className?: string
+    children: ReactNode
+}) {
+    return (
+        <div
+            id={id}
+            role="tabpanel"
+            aria-labelledby={labelledBy}
+            className={cn(
+                'relative h-full w-full overflow-hidden transition-opacity duration-200',
+                active ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none',
+                'motion-reduce:transition-none',
+                className,
+            )}
+        >
+            {children}
+        </div>
+    )
+}

--- a/packages/frontend/src/components/geo/MapPicker.tsx
+++ b/packages/frontend/src/components/geo/MapPicker.tsx
@@ -1,0 +1,178 @@
+import { useTranslation } from 'react-i18next'
+import type { GeoMap } from '@the-box/types'
+import { Shuffle } from 'lucide-react'
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetDescription,
+} from '@/components/ui/sheet'
+import { useIsMobile } from '@/hooks/useIsMobile'
+import { isPlaceholderImageUrl } from '@/lib/geo-image'
+import { cn } from '@/lib/utils'
+
+interface MapPickerProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    maps: GeoMap[]
+    selectedMapId: number | null
+    onSelect: (mapId: number | null) => void
+    // Extra "any map" pseudo-option at the top of the list for games with
+    // multiple maps; selecting it tells the picker to let the server
+    // randomize the map for the next round.
+    showAnyMapOption?: boolean
+}
+
+/**
+ * Free-play map chooser. Reuses the daily `GeoMapChooser` aesthetic
+ * (thumbnail + region label) but lives inside a sheet/drawer instead of
+ * inline so it doesn't compete with the immersive screenshot/map view.
+ */
+export function MapPicker({
+    open,
+    onOpenChange,
+    maps,
+    selectedMapId,
+    onSelect,
+    showAnyMapOption,
+}: MapPickerProps) {
+    const { t } = useTranslation()
+    const isMobile = useIsMobile()
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent
+                side={isMobile ? 'bottom' : 'right'}
+                className={cn(
+                    'p-0 flex flex-col gap-0',
+                    isMobile ? 'h-[80dvh] rounded-t-2xl' : 'sm:max-w-md w-full h-full',
+                )}
+            >
+                <SheetHeader className="p-4 pb-2 text-left space-y-1">
+                    <SheetTitle>{t('geo.play.pickMap', 'Pick a map')}</SheetTitle>
+                    <SheetDescription>
+                        {t(
+                            'geo.play.pickMapHint',
+                            'Pick the in-game map you want to guess on.',
+                        )}
+                    </SheetDescription>
+                </SheetHeader>
+                <div className="flex-1 overflow-y-auto px-4 pb-[max(env(safe-area-inset-bottom),16px)]">
+                    {maps.length === 0 ? (
+                        <p className="py-12 text-center text-sm text-muted-foreground">
+                            {t(
+                                'geo.play.noMapsYet',
+                                'No maps are available for this game yet.',
+                            )}
+                        </p>
+                    ) : (
+                        <ul
+                            role="radiogroup"
+                            aria-label={t('geo.play.pickMap', 'Pick a map')}
+                            className="grid grid-cols-2 gap-3 pt-2 sm:grid-cols-3"
+                        >
+                            {showAnyMapOption && (
+                                <li>
+                                    <AnyMapCard
+                                        selected={selectedMapId == null}
+                                        onSelect={() => {
+                                            onSelect(null)
+                                            onOpenChange(false)
+                                        }}
+                                    />
+                                </li>
+                            )}
+                            {maps.map((m) => (
+                                <li key={m.id}>
+                                    <MapCard
+                                        map={m}
+                                        selected={selectedMapId === m.id}
+                                        onSelect={() => {
+                                            onSelect(m.id)
+                                            onOpenChange(false)
+                                        }}
+                                    />
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            </SheetContent>
+        </Sheet>
+    )
+}
+
+function AnyMapCard({ selected, onSelect }: { selected: boolean; onSelect: () => void }) {
+    const { t } = useTranslation()
+    return (
+        <button
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={onSelect}
+            className={cn(
+                'group relative aspect-square w-full overflow-hidden rounded-lg border text-left transition',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink',
+                selected
+                    ? 'border-neon-pink ring-2 ring-neon-pink/60'
+                    : 'border-dashed border-muted-foreground/40 hover:border-neon-pink/60',
+            )}
+        >
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 text-center px-2">
+                <Shuffle className="h-5 w-5 text-neon-pink" aria-hidden />
+                <span className="text-xs font-medium">
+                    {t('geo.play.anyMap', 'Surprise me')}
+                </span>
+            </div>
+        </button>
+    )
+}
+
+function MapCard({
+    map,
+    selected,
+    onSelect,
+}: {
+    map: GeoMap
+    selected: boolean
+    onSelect: () => void
+}) {
+    const { t } = useTranslation()
+    const label = map.region ?? t('geo.daily.chooseMap.worldFallback', 'World map')
+    const placeholder = isPlaceholderImageUrl(map.imageUrl)
+    return (
+        <button
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={label}
+            onClick={onSelect}
+            className={cn(
+                'group relative aspect-square w-full overflow-hidden rounded-lg border bg-muted/30 text-left transition',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink',
+                selected
+                    ? 'border-neon-pink ring-2 ring-neon-pink/60 shadow-[0_0_12px_rgba(236,72,153,0.4)]'
+                    : 'border-muted/40 hover:border-neon-pink/60',
+            )}
+        >
+            {!placeholder ? (
+                <img
+                    src={map.imageUrl}
+                    alt=""
+                    className="h-full w-full object-cover transition group-hover:scale-[1.02]"
+                    loading="lazy"
+                    decoding="async"
+                />
+            ) : (
+                <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                    {label}
+                </div>
+            )}
+            <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-2 py-1.5">
+                <span className="block truncate text-xs font-medium text-white">
+                    {label}
+                </span>
+            </div>
+        </button>
+    )
+}

--- a/packages/frontend/src/hooks/useFullscreen.ts
+++ b/packages/frontend/src/hooks/useFullscreen.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// Webkit-prefixed surface kept around for older Safari/iOS — typed loosely
+// so we don't pull in lib.dom.d.ts overrides just for this fallback path.
+interface PrefixedFullscreenElement extends HTMLElement {
+  webkitRequestFullscreen?: () => Promise<void> | void
+}
+
+interface PrefixedDocument extends Document {
+  webkitFullscreenElement?: Element | null
+  webkitExitFullscreen?: () => Promise<void> | void
+  webkitFullscreenEnabled?: boolean
+}
+
+export interface UseFullscreenResult {
+  // Native browser fullscreen state. Always false in the CSS fallback path.
+  isFullscreen: boolean
+  // True when the browser exposes a working Element.requestFullscreen on
+  // arbitrary elements. iOS Safari (≤16, and ≤17 on iPhone for non-video
+  // elements) reports false; the consumer should mount a CSS-only
+  // immersive fallback in that case.
+  isSupported: boolean
+  // Combined state: native fullscreen OR CSS-immersive on unsupported
+  // devices. Components should bind their "immersive UI" styling to this.
+  isImmersive: boolean
+  // CSS-only immersive flag. Consumers wire this to a `data-immersive`
+  // attribute or `fixed inset-0` Tailwind variant.
+  isCssImmersive: boolean
+  enter: () => Promise<void>
+  exit: () => Promise<void>
+  toggle: () => Promise<void>
+}
+
+/**
+ * Wraps the Fullscreen API with a CSS-only fallback for browsers that
+ * refuse to put an arbitrary `<div>` into native fullscreen (iOS Safari,
+ * historically). When native isn't available the hook still flips
+ * `isImmersive`/`isCssImmersive` so the layout can pin itself to the
+ * viewport via `position: fixed; inset: 0` instead.
+ *
+ * Focus return: callers should restore focus to the toggle button on
+ * exit. We don't manage focus here because the toggle's lifecycle isn't
+ * known to the hook (it can unmount on layout changes).
+ */
+export function useFullscreen(targetRef: React.RefObject<HTMLElement | null>): UseFullscreenResult {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [isCssImmersive, setIsCssImmersive] = useState(false)
+
+  // SSR-safe support detection. `document.fullscreenEnabled` reflects
+  // both the API presence and any `<iframe allow="fullscreen">` policy.
+  const isSupported =
+    typeof document !== 'undefined' &&
+    (document.fullscreenEnabled === true ||
+      (document as PrefixedDocument).webkitFullscreenEnabled === true)
+
+  // Track the previously focused element so the consumer can restore it
+  // after exit. Stored in a ref to avoid re-renders.
+  const prevFocusRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    const onChange = () => {
+      const native =
+        document.fullscreenElement ??
+        (document as PrefixedDocument).webkitFullscreenElement ??
+        null
+      setIsFullscreen(!!native)
+    }
+    document.addEventListener('fullscreenchange', onChange)
+    document.addEventListener('webkitfullscreenchange', onChange)
+    return () => {
+      document.removeEventListener('fullscreenchange', onChange)
+      document.removeEventListener('webkitfullscreenchange', onChange)
+    }
+  }, [])
+
+  // While in CSS-immersive mode, lock body scroll so a stray two-finger
+  // pan can't drag the page underneath the immersive layer.
+  useEffect(() => {
+    if (!isCssImmersive) return
+    const html = document.documentElement
+    const prev = html.style.overflow
+    html.style.overflow = 'hidden'
+    return () => {
+      html.style.overflow = prev
+    }
+  }, [isCssImmersive])
+
+  const enter = useCallback(async () => {
+    prevFocusRef.current =
+      typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
+    const el = targetRef.current as PrefixedFullscreenElement | null
+    if (el && isSupported) {
+      try {
+        if (el.requestFullscreen) {
+          await el.requestFullscreen()
+        } else if (el.webkitRequestFullscreen) {
+          await el.webkitRequestFullscreen()
+        }
+        return
+      } catch {
+        // Native call rejected (user gesture missing, iframe policy, etc.).
+        // Fall through to CSS immersive so the user still gets the wide view.
+      }
+    }
+    setIsCssImmersive(true)
+  }, [isSupported, targetRef])
+
+  const exit = useCallback(async () => {
+    if (isFullscreen) {
+      try {
+        if (document.exitFullscreen) {
+          await document.exitFullscreen()
+        } else {
+          const d = document as PrefixedDocument
+          if (d.webkitExitFullscreen) {
+            await d.webkitExitFullscreen()
+          }
+        }
+      } catch {
+        // Ignore — `fullscreenchange` will reconcile state if it fires,
+        // and the CSS fallback below covers the user-visible case.
+      }
+    }
+    setIsCssImmersive(false)
+    // Restore focus best-effort: the toggle that opened immersive mode
+    // is the most likely active element to want focus back.
+    const prev = prevFocusRef.current
+    if (prev && document.contains(prev)) {
+      prev.focus({ preventScroll: true })
+    }
+  }, [isFullscreen])
+
+  const toggle = useCallback(async () => {
+    if (isFullscreen || isCssImmersive) await exit()
+    else await enter()
+  }, [enter, exit, isFullscreen, isCssImmersive])
+
+  return {
+    isFullscreen,
+    isSupported,
+    isImmersive: isFullscreen || isCssImmersive,
+    isCssImmersive,
+    enter,
+    exit,
+    toggle,
+  }
+}

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -4,9 +4,12 @@ import type {
     GeoContributorStats,
     GeoContributorTier,
     GeoContributorTierThreshold,
+    GeoFreePlayResult,
+    GeoFreePlayView,
     GeoGuessResult,
     GeoLeaderboardEntry,
     GeoMap,
+    GeoPlayableGame,
     GeoPoint,
     GeoScreenshotCandidate,
     GeoScreenshotMeta,
@@ -143,5 +146,36 @@ export const geoApi = {
 
     getContributorMe(): Promise<GeoContributorMe> {
         return request<GeoContributorMe>('/api/geo/contributor/me')
+    },
+
+    // ---- Free-play (unranked, all-games-all-maps browser) ----
+
+    listPlayableGames(): Promise<GeoPlayableGame[]> {
+        return request<GeoPlayableGame[]>('/api/geo/games')
+    },
+
+    listGameMaps(gameId: number): Promise<GeoMap[]> {
+        return request<GeoMap[]>(`/api/geo/games/${gameId}/maps`)
+    },
+
+    pickFreePlay(input: {
+        gameId: number
+        geoMapId?: number
+    }): Promise<GeoFreePlayView> {
+        return request<GeoFreePlayView>('/api/geo/free-play/random', {
+            method: 'POST',
+            body: JSON.stringify(input),
+        })
+    },
+
+    submitFreePlayGuess(input: {
+        metaId: number
+        geoMapId: number
+        guess: GeoPoint
+    }): Promise<GeoFreePlayResult> {
+        return request<GeoFreePlayResult>('/api/geo/free-play/guess', {
+            method: 'POST',
+            body: JSON.stringify(input),
+        })
     },
 }

--- a/packages/frontend/src/pages/GeoDailyPage.tsx
+++ b/packages/frontend/src/pages/GeoDailyPage.tsx
@@ -9,7 +9,7 @@ import { ReportCaptureDialog } from '@/components/ReportCaptureDialog'
 import { CubeBackground } from '@/components/backgrounds/CubeBackground'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { ImageOff, Loader2, MapPin, Trophy, Hourglass, History, SkipForward, ArrowRight } from 'lucide-react'
+import { ImageOff, Loader2, MapPin, Trophy, Hourglass, History, SkipForward, ArrowRight, Compass } from 'lucide-react'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
 import { Link } from 'react-router-dom'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
@@ -17,6 +17,7 @@ import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 export default function GeoDailyPage() {
     const { t, i18n } = useTranslation()
     const { data: session } = useSession()
+    const { localizedPath } = useLocalizedPath()
     const {
         phase,
         challenge,
@@ -79,10 +80,23 @@ export default function GeoDailyPage() {
         <>
             <CubeBackground />
             <div className="container mx-auto max-w-5xl px-4 py-8 space-y-6 relative z-10">
-                <header className="space-y-1">
-                    <h1 className="text-3xl font-bold tracking-tight gradient-gaming bg-clip-text text-transparent">
-                        {t('geo.daily.title', 'Geo Challenge')}
-                    </h1>
+                <header className="space-y-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                        <h1 className="text-3xl font-bold tracking-tight gradient-gaming bg-clip-text text-transparent">
+                            {t('geo.daily.title', 'Geo Challenge')}
+                        </h1>
+                        <Button
+                            asChild
+                            variant="outline"
+                            size="sm"
+                            className="border-neon-pink/40 hover:border-neon-pink"
+                        >
+                            <Link to={localizedPath('/geo/play')}>
+                                <Compass className="h-3.5 w-3.5 mr-1.5" aria-hidden />
+                                {t('geo.daily.freePlayCta', 'Free play any game')}
+                            </Link>
+                        </Button>
+                    </div>
                     <p className="text-sm text-muted-foreground">
                         {t(
                             'geo.daily.subtitle',

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -1,0 +1,493 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import {
+    ArrowLeft,
+    ArrowRight,
+    Gamepad2,
+    Loader2,
+    Map as MapIcon,
+    Shuffle,
+    Trophy,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
+import { useFullscreen } from '@/hooks/useFullscreen'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { GamePicker } from '@/components/geo/GamePicker'
+import { MapPicker } from '@/components/geo/MapPicker'
+import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
+import { ImmersiveLayout } from '@/components/geo/ImmersiveLayout'
+import { FullscreenToggle } from '@/components/geo/FullscreenToggle'
+import { isPlaceholderImageUrl } from '@/lib/geo-image'
+import { cn } from '@/lib/utils'
+
+/**
+ * Free-play geo browser. Pick any game, any map, any time — unranked. The
+ * page is mobile-first: a single screenshot↔map deck (swipe / tab to
+ * toggle) and a sticky bottom dock for actions. Native fullscreen is the
+ * primary feature; on browsers that block it on `<div>` (iOS Safari) we
+ * fall back to a CSS-immersive layout that still hides app chrome.
+ *
+ * Free-play state is held in `useGeoFreePlayStore` and is independent of
+ * the daily-challenge store, so a free-play round can never write to the
+ * leaderboard or pollute the daily resume.
+ */
+export default function GeoPlayPage() {
+    const { t, i18n } = useTranslation()
+    const { localizedPath } = useLocalizedPath()
+
+    const {
+        games,
+        gamesFetchedAt,
+        currentGameId,
+        currentMapId,
+        maps,
+        view,
+        pendingGuess,
+        result,
+        correctMap,
+        phase,
+        errorMessage,
+        round,
+        loadGames,
+        selectGame,
+        selectMap,
+        rerollScreenshot,
+        setPendingGuess,
+        submitGuess,
+        nextRound,
+    } = useGeoFreePlayStore()
+
+    const [gamePickerOpen, setGamePickerOpen] = useState(false)
+    const [mapPickerOpen, setMapPickerOpen] = useState(false)
+
+    // Fullscreen target: the entire immersive deck. Putting the wrapper
+    // ref on the outer container means the screenshot, map, dock and
+    // overlays all enter fullscreen together.
+    const rootRef = useRef<HTMLDivElement>(null)
+    const fullscreen = useFullscreen(rootRef)
+
+    // Boot: hydrate the games list (cached for 5 min) and, if the user
+    // had a game selected last session, auto-load a screenshot for it.
+    useEffect(() => {
+        loadGames()
+    }, [loadGames])
+
+    useEffect(() => {
+        if (currentGameId != null && !view && phase === 'idle') {
+            void rerollScreenshot()
+        }
+    }, [currentGameId, view, phase, rerollScreenshot])
+
+    // Open the game picker for a fresh visitor with no selection — gives
+    // them an obvious "what do I do here" cue instead of a blank canvas.
+    useEffect(() => {
+        if (currentGameId == null && games.length > 0 && !gamePickerOpen) {
+            setGamePickerOpen(true)
+        }
+        // We deliberately depend on `games.length` going from 0 → N once;
+        // re-opening on every change would fight the player.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [games.length])
+
+    const isMultiMap = maps.length > 1
+    const selectedMap = useMemo(
+        () => maps.find((m) => m.id === currentMapId) ?? null,
+        [maps, currentMapId],
+    )
+    const currentGame = useMemo(
+        () => games.find((g) => g.id === currentGameId) ?? null,
+        [games, currentGameId],
+    )
+
+    const canSubmit =
+        phase === 'ready' &&
+        !!pendingGuess &&
+        !!view &&
+        (selectedMap != null || maps.length === 1)
+
+    const handleSubmit = async () => {
+        await submitGuess()
+    }
+
+    return (
+        <div ref={rootRef} className="bg-black">
+            <ImmersiveLayout
+                isImmersive={fullscreen.isImmersive}
+                roundKey={`${currentGameId ?? 'none'}-${round}`}
+                topRight={
+                    <FullscreenToggle
+                        isImmersive={fullscreen.isImmersive}
+                        onToggle={() => void fullscreen.toggle()}
+                        isNativeSupported={fullscreen.isSupported}
+                    />
+                }
+                screenshot={
+                    <ScreenshotPanel
+                        imageUrl={view?.candidate.imageUrl ?? null}
+                        loading={phase === 'loading' || (currentGameId != null && phase === 'idle')}
+                        empty={currentGameId == null}
+                        errorMessage={phase === 'error' ? errorMessage : null}
+                        onPickGame={() => setGamePickerOpen(true)}
+                    />
+                }
+                map={
+                    selectedMap ? (
+                        <GeoMapCanvas
+                            imageUrl={selectedMap.imageUrl}
+                            widthPx={selectedMap.widthPx}
+                            heightPx={selectedMap.heightPx}
+                            pin={pendingGuess ?? result?.guess ?? null}
+                            canonical={
+                                phase === 'revealed' &&
+                                correctMap &&
+                                selectedMap.id === correctMap.id
+                                    ? result?.canonical ?? null
+                                    : null
+                            }
+                            disabled={phase !== 'ready'}
+                            onPin={setPendingGuess}
+                            showGuessLine={
+                                phase === 'revealed' &&
+                                !!correctMap &&
+                                selectedMap.id === correctMap.id
+                            }
+                            className="!rounded-none h-full"
+                        />
+                    ) : (
+                        <MapPlaceholder
+                            hasGame={currentGameId != null}
+                            multiMap={isMultiMap}
+                            onPickMap={() => setMapPickerOpen(true)}
+                        />
+                    )
+                }
+                resultOverlay={
+                    phase === 'revealed' && result ? (
+                        <ResultOverlay
+                            score={result.score}
+                            distance={result.distance}
+                            wrongMap={!!result.wrongMap}
+                            language={i18n.language}
+                        />
+                    ) : null
+                }
+                bottomDock={
+                    <Dock
+                        gameLabel={currentGame?.name ?? null}
+                        mapLabel={selectedMap?.region ?? null}
+                        showMapButton={isMultiMap || currentGameId == null}
+                        onChangeGame={() => setGamePickerOpen(true)}
+                        onChangeMap={() => setMapPickerOpen(true)}
+                        onReroll={() => void rerollScreenshot()}
+                        onSubmit={handleSubmit}
+                        onNext={() => void nextRound()}
+                        canSubmit={canSubmit}
+                        phase={phase}
+                    />
+                }
+            />
+
+            <GamePicker
+                open={gamePickerOpen}
+                onOpenChange={setGamePickerOpen}
+                games={games}
+                isLoading={gamesFetchedAt == null && games.length === 0}
+                selectedGameId={currentGameId}
+                onSelect={(id) => void selectGame(id)}
+            />
+            <MapPicker
+                open={mapPickerOpen}
+                onOpenChange={setMapPickerOpen}
+                maps={maps}
+                selectedMapId={currentMapId}
+                onSelect={(id) => void selectMap(id)}
+                showAnyMapOption={isMultiMap}
+            />
+
+            {/* Practice-mode disclaimer + back-to-daily link. Hidden when
+                immersive so it doesn't break the cinematic feel. */}
+            {!fullscreen.isImmersive && (
+                <div className="container mx-auto max-w-5xl px-4 py-4 text-center text-xs text-muted-foreground space-y-1">
+                    <p>
+                        {t(
+                            'geo.play.practiceNote',
+                            'Practice mode — your score does not affect the leaderboard.',
+                        )}
+                    </p>
+                    <p className="flex items-center justify-center gap-3">
+                        <Button asChild variant="link" size="sm" className="h-auto p-0 text-xs">
+                            <Link to={localizedPath('/geo')}>
+                                <Trophy className="h-3 w-3 mr-1" aria-hidden />
+                                {t('geo.play.backToDaily', 'Play the ranked daily challenge')}
+                            </Link>
+                        </Button>
+                    </p>
+                </div>
+            )}
+        </div>
+    )
+}
+
+function ScreenshotPanel({
+    imageUrl,
+    loading,
+    empty,
+    errorMessage,
+    onPickGame,
+}: {
+    imageUrl: string | null
+    loading: boolean
+    empty: boolean
+    errorMessage: string | null
+    onPickGame: () => void
+}) {
+    const { t } = useTranslation()
+    const safeUrl = imageUrl && !isPlaceholderImageUrl(imageUrl) ? imageUrl : null
+
+    if (errorMessage) {
+        return (
+            <div
+                className="flex h-full w-full items-center justify-center px-6 text-center"
+                role="alert"
+            >
+                <p className="text-sm text-destructive">{errorMessage}</p>
+            </div>
+        )
+    }
+
+    if (empty) {
+        return (
+            <div className="flex h-full w-full flex-col items-center justify-center px-6 text-center gap-4">
+                <div className="rounded-full bg-neon-pink/10 p-4">
+                    <Gamepad2 className="h-8 w-8 text-neon-pink" aria-hidden />
+                </div>
+                <div className="space-y-1 max-w-xs">
+                    <h2 className="text-lg font-semibold">
+                        {t('geo.play.empty.title', 'Pick a game to start')}
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                        {t(
+                            'geo.play.empty.body',
+                            'Free play covers every game and every map in the catalog. No daily limits.',
+                        )}
+                    </p>
+                </div>
+                <Button onClick={onPickGame} className="gradient-gaming hover:opacity-90">
+                    <Gamepad2 className="h-4 w-4 mr-2" aria-hidden />
+                    {t('geo.play.empty.cta', 'Browse games')}
+                </Button>
+            </div>
+        )
+    }
+
+    if (loading || !safeUrl) {
+        return (
+            <div
+                className="flex h-full w-full items-center justify-center"
+                role="status"
+                aria-busy="true"
+            >
+                <Loader2 className="h-8 w-8 animate-spin text-neon-pink" aria-hidden />
+                <span className="sr-only">{t('common.loading', 'Loading…')}</span>
+            </div>
+        )
+    }
+
+    return (
+        <img
+            src={safeUrl}
+            alt={t('geo.daily.screenshot', 'Screenshot')}
+            className="h-full w-full object-contain"
+            loading="eager"
+            decoding="async"
+        />
+    )
+}
+
+function MapPlaceholder({
+    hasGame,
+    multiMap,
+    onPickMap,
+}: {
+    hasGame: boolean
+    multiMap: boolean
+    onPickMap: () => void
+}) {
+    const { t } = useTranslation()
+    return (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center">
+            <MapIcon className="h-8 w-8 text-muted-foreground" aria-hidden />
+            <p className="text-sm text-muted-foreground max-w-xs">
+                {!hasGame
+                    ? t(
+                          'geo.play.map.empty.noGame',
+                          'Pick a game first — the map list shows up here once you have one.',
+                      )
+                    : multiMap
+                      ? t(
+                            'geo.play.map.empty.multi',
+                            'This game has several maps. Pick one to start guessing.',
+                        )
+                      : t(
+                            'geo.play.map.empty.none',
+                            'No playable maps for this game yet.',
+                        )}
+            </p>
+            {hasGame && multiMap && (
+                <Button onClick={onPickMap} variant="outline">
+                    <MapIcon className="h-4 w-4 mr-2" aria-hidden />
+                    {t('geo.play.pickMap', 'Pick a map')}
+                </Button>
+            )}
+        </div>
+    )
+}
+
+function ResultOverlay({
+    score,
+    distance,
+    wrongMap,
+    language,
+}: {
+    score: number
+    distance: number
+    wrongMap: boolean
+    language: string
+}) {
+    const { t } = useTranslation()
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className={cn(
+                'mx-auto max-w-md rounded-2xl border bg-black/70 px-4 py-3 backdrop-blur',
+                wrongMap ? 'border-destructive/50' : 'border-neon-pink/50',
+            )}
+        >
+            <div className="flex items-center justify-between gap-3 text-white">
+                <div className="flex items-center gap-2">
+                    <Trophy className="h-4 w-4 text-neon-pink" aria-hidden />
+                    <span className="font-semibold text-lg">
+                        {score.toLocaleString(language)}
+                    </span>
+                    <span className="text-xs text-white/70">
+                        {t('geo.daily.score', 'Score')}
+                    </span>
+                </div>
+                <span className="text-xs text-white/70">
+                    {t('geo.daily.distance', 'Distance')}: {(distance * 100).toFixed(1)}%
+                </span>
+            </div>
+            {wrongMap && (
+                <p className="mt-1 text-xs text-destructive">
+                    {t('geo.daily.wrongMap.banner', 'Wrong map — score floored.')}
+                </p>
+            )}
+        </div>
+    )
+}
+
+function Dock({
+    gameLabel,
+    mapLabel,
+    showMapButton,
+    onChangeGame,
+    onChangeMap,
+    onReroll,
+    onSubmit,
+    onNext,
+    canSubmit,
+    phase,
+}: {
+    gameLabel: string | null
+    mapLabel: string | null
+    showMapButton: boolean
+    onChangeGame: () => void
+    onChangeMap: () => void
+    onReroll: () => void
+    onSubmit: () => void
+    onNext: () => void
+    canSubmit: boolean
+    phase: ReturnType<typeof useGeoFreePlayStore.getState>['phase']
+}) {
+    const { t } = useTranslation()
+    const submitting = phase === 'submitting'
+    const revealed = phase === 'revealed'
+    return (
+        <div className="flex flex-col gap-2">
+            {/* Context row — game / map labels with quick-change links.
+                Tappable, so the player never has to leave the immersive
+                view to switch context. */}
+            <div className="flex items-center gap-2 text-xs text-white/80 min-h-[1.5rem]">
+                <button
+                    type="button"
+                    onClick={onChangeGame}
+                    className="inline-flex items-center gap-1 rounded-full border border-white/20 px-2.5 py-0.5 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                >
+                    <Gamepad2 className="h-3 w-3" aria-hidden />
+                    <span className="max-w-[10rem] truncate">
+                        {gameLabel ?? t('geo.play.changeGame', 'Choose game')}
+                    </span>
+                </button>
+                {showMapButton && (
+                    <button
+                        type="button"
+                        onClick={onChangeMap}
+                        className="inline-flex items-center gap-1 rounded-full border border-white/20 px-2.5 py-0.5 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                    >
+                        <MapIcon className="h-3 w-3" aria-hidden />
+                        <span className="max-w-[10rem] truncate">
+                            {mapLabel ?? t('geo.play.changeMap', 'Choose map')}
+                        </span>
+                    </button>
+                )}
+            </div>
+
+            <div className="flex items-center gap-2">
+                <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={onReroll}
+                    className="text-white/80 hover:text-white"
+                    disabled={submitting || gameLabel == null}
+                    aria-label={t('geo.play.reroll', 'New screenshot')}
+                >
+                    <Shuffle className="h-4 w-4 mr-1.5" aria-hidden />
+                    <span className="hidden sm:inline">
+                        {t('geo.play.reroll', 'New screenshot')}
+                    </span>
+                </Button>
+
+                <div className="flex-1" />
+
+                {revealed ? (
+                    <Button
+                        type="button"
+                        onClick={onNext}
+                        className="gradient-gaming hover:opacity-90 min-h-11 min-w-32"
+                    >
+                        {t('geo.play.next', 'Next round')}
+                        <ArrowRight className="h-4 w-4 ml-2" aria-hidden />
+                    </Button>
+                ) : (
+                    <Button
+                        type="button"
+                        onClick={onSubmit}
+                        disabled={!canSubmit || submitting}
+                        className="gradient-gaming hover:opacity-90 min-h-11 min-w-32"
+                    >
+                        {submitting ? (
+                            <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden />
+                        ) : (
+                            <ArrowLeft className="h-4 w-4 mr-2 rotate-180" aria-hidden />
+                        )}
+                        {t('geo.play.submit', 'Drop pin')}
+                    </Button>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -1,0 +1,223 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type {
+    GeoFreePlayResult,
+    GeoFreePlayView,
+    GeoMap,
+    GeoPlayableGame,
+    GeoPoint,
+} from '@the-box/types'
+import { geoApi, GeoApiError } from '../lib/api/geo'
+import { getApiErrorMessage } from '../lib/api-errors'
+
+type Phase = 'idle' | 'loading' | 'ready' | 'submitting' | 'revealed' | 'error'
+
+const GAMES_TTL_MS = 5 * 60 * 1000
+
+interface GeoFreePlayState {
+    // Catalog
+    games: GeoPlayableGame[]
+    gamesFetchedAt: number | null
+    // Selection
+    currentGameId: number | null
+    currentMapId: number | null
+    maps: GeoMap[]
+    // Round
+    view: GeoFreePlayView | null
+    pendingGuess: GeoPoint | null
+    result: GeoFreePlayResult | null
+    correctMap: GeoMap | null
+    // Status
+    phase: Phase
+    errorMessage: string | null
+    errorCode: string | null
+    // Round counter so the screenshot/map components can re-key on
+    // each new pick (prevents Embla / stale-pin glitches between rounds).
+    round: number
+
+    // Actions
+    loadGames(force?: boolean): Promise<void>
+    selectGame(gameId: number): Promise<void>
+    selectMap(mapId: number | null): Promise<void>
+    rerollScreenshot(): Promise<void>
+    setPendingGuess(p: GeoPoint | null): void
+    submitGuess(): Promise<GeoFreePlayResult | null>
+    nextRound(): Promise<void>
+    reset(): void
+}
+
+export const useGeoFreePlayStore = create<GeoFreePlayState>()(
+    persist(
+        (set, get) => ({
+            games: [],
+            gamesFetchedAt: null,
+            currentGameId: null,
+            currentMapId: null,
+            maps: [],
+            view: null,
+            pendingGuess: null,
+            result: null,
+            correctMap: null,
+            phase: 'idle',
+            errorMessage: null,
+            errorCode: null,
+            round: 0,
+
+            async loadGames(force) {
+                const { gamesFetchedAt } = get()
+                const fresh =
+                    !force &&
+                    gamesFetchedAt != null &&
+                    Date.now() - gamesFetchedAt < GAMES_TTL_MS
+                if (fresh && get().games.length > 0) return
+                try {
+                    const games = await geoApi.listPlayableGames()
+                    set({ games, gamesFetchedAt: Date.now() })
+                } catch (err) {
+                    set({
+                        phase: 'error',
+                        errorMessage: getApiErrorMessage(err),
+                        errorCode: err instanceof GeoApiError ? err.code : null,
+                    })
+                }
+            },
+
+            async selectGame(gameId) {
+                set({
+                    phase: 'loading',
+                    currentGameId: gameId,
+                    currentMapId: null,
+                    maps: [],
+                    view: null,
+                    pendingGuess: null,
+                    result: null,
+                    correctMap: null,
+                    errorMessage: null,
+                    errorCode: null,
+                })
+                try {
+                    const maps = await geoApi.listGameMaps(gameId)
+                    // Auto-select when the game is single-map so the player
+                    // doesn't have to tap a chooser that has only one option.
+                    const autoMapId = maps.length === 1 ? (maps[0]?.id ?? null) : null
+                    set({ maps, currentMapId: autoMapId })
+                    await get().rerollScreenshot()
+                } catch (err) {
+                    set({
+                        phase: 'error',
+                        errorMessage: getApiErrorMessage(err),
+                        errorCode: err instanceof GeoApiError ? err.code : null,
+                    })
+                }
+            },
+
+            async selectMap(mapId) {
+                // Pin coordinates are normalized [0..1] per map — switching
+                // maps invalidates the previous pin. Clear it so the player
+                // re-pins on the new image instead of seeing a stale dot.
+                set({ currentMapId: mapId, pendingGuess: null, result: null, correctMap: null })
+                if (mapId != null) {
+                    await get().rerollScreenshot()
+                }
+            },
+
+            async rerollScreenshot() {
+                const { currentGameId, currentMapId } = get()
+                if (currentGameId == null) return
+                set({
+                    phase: 'loading',
+                    view: null,
+                    pendingGuess: null,
+                    result: null,
+                    correctMap: null,
+                    errorMessage: null,
+                    errorCode: null,
+                })
+                try {
+                    const view = await geoApi.pickFreePlay({
+                        gameId: currentGameId,
+                        geoMapId: currentMapId ?? undefined,
+                    })
+                    set({
+                        view,
+                        maps: view.maps,
+                        // If we landed without a map preference, leave it
+                        // null — the player picks before guessing. If a
+                        // preference was set, keep it.
+                        phase: 'ready',
+                        round: get().round + 1,
+                    })
+                } catch (err) {
+                    set({
+                        phase: 'error',
+                        errorMessage: getApiErrorMessage(err),
+                        errorCode: err instanceof GeoApiError ? err.code : null,
+                    })
+                }
+            },
+
+            setPendingGuess(p) {
+                set({ pendingGuess: p })
+            },
+
+            async submitGuess() {
+                const { view, pendingGuess, currentMapId, maps } = get()
+                if (!view || !pendingGuess) return null
+                // Multi-map games require an explicit pick. Single-map
+                // games auto-selected at load time so this is a no-op there.
+                const pickedMapId =
+                    currentMapId ?? (maps.length === 1 ? (maps[0]?.id ?? null) : null)
+                if (pickedMapId == null) return null
+                set({ phase: 'submitting', errorMessage: null })
+                try {
+                    const result = await geoApi.submitFreePlayGuess({
+                        metaId: view.meta.id,
+                        geoMapId: pickedMapId,
+                        guess: pendingGuess,
+                    })
+                    const correctMap = maps.find((m) => m.id === result.correctMapId) ?? null
+                    set({ result, correctMap, phase: 'revealed' })
+                    return result
+                } catch (err) {
+                    set({
+                        phase: 'error',
+                        errorMessage: getApiErrorMessage(err),
+                        errorCode: err instanceof GeoApiError ? err.code : null,
+                    })
+                    return null
+                }
+            },
+
+            async nextRound() {
+                await get().rerollScreenshot()
+            },
+
+            reset() {
+                set({
+                    currentGameId: null,
+                    currentMapId: null,
+                    maps: [],
+                    view: null,
+                    pendingGuess: null,
+                    result: null,
+                    correctMap: null,
+                    phase: 'idle',
+                    errorMessage: null,
+                    errorCode: null,
+                })
+            },
+        }),
+        {
+            name: 'geo-free-play-store-v1',
+            // Only persist the user's last picked game + map so a reload
+            // resumes the same context. Screenshots and results are
+            // intentionally re-fetched from the network — stale state
+            // would resurrect a round the player already finished.
+            partialize: (state) => ({
+                currentGameId: state.currentGameId,
+                currentMapId: state.currentMapId,
+            }),
+            version: 1,
+        },
+    ),
+)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -862,6 +862,49 @@ export interface GeoGuessResult {
   wrongMap?: boolean
 }
 
+// ---- Free-play (unranked, all-games-all-maps browser) ----
+
+// Catalog row: a game that the free-play picker can offer. mapCount and
+// screenshotCount let the UI render badges without an N+1 lookup; the cover
+// art is reused from the games table when available.
+export interface GeoPlayableGame {
+  id: number
+  name: string
+  coverImageUrl: string | null
+  mapCount: number
+  screenshotCount: number
+}
+
+// View returned by `POST /api/geo/free-play/random`. Mirrors the daily
+// challenge view minus the challenge wrapper — there is no challenge id
+// because nothing is persisted server-side.
+export interface GeoFreePlayView {
+  // Echoed back so the client doesn't have to hold onto its own request
+  // copy; `name` may be empty when the service couldn't cheaply look it
+  // up (the free-play picker fills it from its games-list cache anyway).
+  game: { id: number; name: string }
+  meta: GeoScreenshotMeta
+  candidate: GeoScreenshotCandidate
+  maps: GeoMap[]
+  // The map the screenshot canonically belongs to. Only populated AFTER
+  // a guess is scored (the pick endpoint never includes it).
+  map?: GeoMap
+}
+
+// Result of `POST /api/geo/free-play/guess`. Same shape as the daily
+// `GeoGuessResult` minus the leaderboard-only `averageScore` /
+// `playerCount` fields — free-play is unranked, so those would always
+// be empty.
+export interface GeoFreePlayResult {
+  guess: GeoPoint
+  canonical: GeoPoint
+  distance: number
+  score: number
+  scoreVersion: number
+  correctMapId: number
+  wrongMap: boolean
+}
+
 export interface GeoLeaderboardEntry {
   userId: string
   username: string


### PR DESCRIPTION
Revamps the geo guesser interface for customers so every game and every
enabled map is playable any time, not just the daily challenge. Free-play
is unranked practice — daily stays the only ranked mode, so leaderboard
integrity is unaffected.

Backend:
- listPlayableGames repo query (games × promoted screenshots × enabled
  maps, with per-game counts, ordered by activity).
- pickRandomPromotedForGame now accepts an optional geoMapId filter.
- New service methods pickFreePlayScreenshot and scoreFreePlayGuess.
  Reuse the existing geoScoringService formula; never write to
  daily/monthly aggregates and never emit leaderboard sockets.
- Four new public routes: GET /api/geo/games, GET /api/geo/games/:id/maps,
  POST /api/geo/free-play/random, POST /api/geo/free-play/guess.

Frontend:
- New /geo/play route with a separate Zustand store (geoFreePlayStore)
  to keep daily-challenge state isolated.
- Mobile-first ImmersiveLayout: single screenshot↔map deck, swipe to
  toggle on mobile (with a tablist as a non-gesture fallback for
  keyboard / SR users), side-by-side on desktop, sticky bottom dock with
  iOS safe-area inset.
- useFullscreen hook + FullscreenToggle: native Fullscreen API where
  supported, CSS-immersive (fixed inset-0, lock body scroll) fallback
  for iOS Safari. Restores focus to the toggle on exit.
- GamePicker (search + cover-art grid) and MapPicker as drawers/sheets.
- Daily page header gains a "Free play any game" CTA.
- Full i18n in en + fr.