### PR TITLE
feat(admin): notify user by email and toast on premium grant

### DIFF
--- a/packages/backend/src/infrastructure/email/premium-granted-email.ts
+++ b/packages/backend/src/infrastructure/email/premium-granted-email.ts
@@ -1,0 +1,85 @@
+import { env } from '../../config/env.js'
+import { sendEmail, type SendEmailResult } from './email-sender.js'
+import { renderEmailHtml, renderEmailText } from './template.js'
+
+export interface PremiumGrantedEmailInput {
+  userId: string
+  to: string
+  /** Display name used in the greeting; falls back to "joueur" if blank. */
+  displayName: string | null | undefined
+  /** Locale for the email copy. Currently 'fr' or 'en'; defaults to 'fr'. */
+  locale?: 'fr' | 'en'
+}
+
+interface Copy {
+  subject: string
+  eyebrow: string
+  heading: string
+  paragraphs: string[]
+  ctaLabel: string
+  tip: string
+}
+
+function copyFor(displayName: string, locale: 'fr' | 'en'): Copy {
+  if (locale === 'en') {
+    return {
+      subject: 'Premium unlocked — welcome to The Box',
+      eyebrow: 'Premium unlocked',
+      heading: `Welcome to Premium, ${displayName}!`,
+      paragraphs: [
+        'An admin just granted you <strong style="color:#f0abfc;">lifetime Premium</strong> on The Box. No charge, no expiration — it\'s yours.',
+        'You now have access to the full archive of past challenges, unlimited hints in catch-up mode, and the Premium badge on your profile.',
+      ],
+      ctaLabel: 'Open my profile',
+      tip: 'Refresh your browser if your profile still shows the free tier.',
+    }
+  }
+  return {
+    subject: 'Premium activé — bienvenue sur The Box',
+    eyebrow: 'Premium activé',
+    heading: `Bienvenue dans Premium, ${displayName} !`,
+    paragraphs: [
+      'Un administrateur vient de t\'offrir le <strong style="color:#f0abfc;">Premium à vie</strong> sur The Box. Aucun paiement, aucune expiration — c\'est pour toi.',
+      'Tu as désormais accès à toutes les archives de défis, aux indices illimités en mode rattrapage, et au badge Premium sur ton profil.',
+    ],
+    ctaLabel: 'Voir mon profil',
+    tip: 'Rafraîchis la page si ton profil affiche encore le palier gratuit.',
+  }
+}
+
+/**
+ * Notifies a user that an admin has granted them lifetime Premium.
+ * Delegates to the shared `sendEmail` chokepoint so it lands in the
+ * `email_log` audit trail like every other transactional mail.
+ */
+export async function sendPremiumGrantedEmail(
+  input: PremiumGrantedEmailInput,
+): Promise<SendEmailResult> {
+  const locale = input.locale ?? 'fr'
+  const displayName = (input.displayName ?? '').trim() || (locale === 'en' ? 'player' : 'joueur')
+  const copy = copyFor(displayName, locale)
+  const profileUrl = `${env.FRONTEND_URL}/${locale}/profile`
+
+  const html = renderEmailHtml({
+    eyebrow: copy.eyebrow,
+    heading: copy.heading,
+    paragraphs: copy.paragraphs,
+    cta: { label: copy.ctaLabel, url: profileUrl },
+    tip: copy.tip,
+  })
+  const text = renderEmailText({
+    heading: copy.heading,
+    paragraphs: copy.paragraphs,
+    cta: { label: copy.ctaLabel, url: profileUrl },
+    tip: copy.tip,
+  })
+
+  return sendEmail({
+    type: 'premium-granted',
+    userId: input.userId,
+    to: input.to,
+    subject: copy.subject,
+    html,
+    text,
+  })
+}

--- a/packages/backend/src/infrastructure/repositories/email-log.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/email-log.repository.ts
@@ -11,6 +11,7 @@ export type EmailType =
   | 'inactive-reminder'
   | 'referral-announcement'
   | 'admin-test'
+  | 'premium-granted'
 
 export type EmailStatus = 'sent' | 'failed' | 'skipped'
 

--- a/packages/backend/src/infrastructure/repositories/user.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/user.repository.ts
@@ -166,17 +166,20 @@ export const userRepository = {
     return row?.supporter_lifetime_at ?? null
   },
 
-  async grantSupporterLifetime(userId: string, grantedAt: Date = new Date()): Promise<void> {
+  async grantSupporterLifetime(userId: string, grantedAt: Date = new Date()): Promise<boolean> {
     log.info({ userId, grantedAt }, 'grantSupporterLifetime')
     // Idempotent: keep the earliest grant timestamp so a duplicate webhook
-    // doesn't overwrite the original supporter date.
-    await db('user')
+    // doesn't overwrite the original supporter date. Returns true only when
+    // a row was actually flipped, so callers can fire one-shot side effects
+    // (notifications, emails) without re-firing on a duplicate webhook.
+    const updated = await db('user')
       .where('id', userId)
       .whereNull('supporter_lifetime_at')
       .update({
         supporter_lifetime_at: grantedAt,
         updatedAt: new Date(),
       })
+    return updated > 0
   },
 
   async revokeSupporterLifetime(userId: string, reason: string): Promise<boolean> {

--- a/packages/backend/src/infrastructure/socket/socket.ts
+++ b/packages/backend/src/infrastructure/socket/socket.ts
@@ -3,7 +3,11 @@ import { Server as SocketIOServer } from 'socket.io'
 import { env } from '../../config/env.js'
 import { logger } from '../logger/logger.js'
 import { importQueueEvents } from '../queue/queues.js'
-import type { GeoRewardedEvent, GeoTierUpEvent } from '@the-box/types'
+import type {
+    GeoRewardedEvent,
+    GeoTierUpEvent,
+    UserPremiumGrantedEvent,
+} from '@the-box/types'
 
 let io: SocketIOServer | null = null
 
@@ -46,6 +50,7 @@ export function initializeSocketIO(httpServer: HTTPServer): SocketIOServer {
     setupQueueEventListeners(adminNamespace)
 
     ensureGeoNamespace()
+    ensureUserNotificationsNamespace()
 
     logger.info('Socket.IO server initialized')
     return io
@@ -245,6 +250,37 @@ export function emitGeoLeaderboardUpdate(payload: {
     const ns = geoNamespace()
     if (!ns) return
     ns.emit('geo:leaderboard:update', payload)
+}
+
+// ---------- User-targeted notifications ----------
+//
+// Generic per-user notification channel (Premium grants, future account-level
+// alerts). Lives under `/notifications` so it stays mounted regardless of which
+// page the user is on, unlike `/geo` which only connects on Geo screens.
+
+function userNotificationsNamespace(): ReturnType<SocketIOServer['of']> | null {
+    return io ? io.of('/notifications') : null
+}
+
+export function ensureUserNotificationsNamespace(): void {
+    const ns = userNotificationsNamespace()
+    if (!ns) return
+    if ((ns as unknown as { _the_box_user_wired?: boolean })._the_box_user_wired) return
+    ns.on('connection', (socket) => {
+        logger.debug({ socketId: socket.id }, 'user-notifications client connected')
+        socket.on('join_user', (userId: unknown) => {
+            if (typeof userId === 'string' && userId.length > 0) {
+                socket.join(`user:${userId}`)
+            }
+        })
+    })
+    ;(ns as unknown as { _the_box_user_wired?: boolean })._the_box_user_wired = true
+}
+
+export function emitUserPremiumGranted(event: UserPremiumGrantedEvent): void {
+    const ns = userNotificationsNamespace()
+    if (!ns) return
+    ns.to(`user:${event.userId}`).emit('user:premium-granted', event)
 }
 
 // ---------- Geo-fetch pipeline (admin-only) ----------

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -31,6 +31,8 @@ import { env } from '../../config/env.js'
 import { db } from '../../infrastructure/database/connection.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
 import { renderEmailHtml, renderEmailText } from '../../infrastructure/email/template.js'
+import { sendPremiumGrantedEmail } from '../../infrastructure/email/premium-granted-email.js'
+import { emitUserPremiumGranted } from '../../infrastructure/socket/socket.js'
 import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
 import {
   geoScreenshotRepository,
@@ -3003,12 +3005,40 @@ router.post('/users/:userId/grant-supporter', async (req, res, next) => {
       })
       return
     }
-    await userRepository.grantSupporterLifetime(userId)
+    const grantedAt = new Date()
+    const newlyGranted = await userRepository.grantSupporterLifetime(userId, grantedAt)
     const entitlement = await billingService.getEntitlement(userId)
     routeLogger.warn(
-      { adminId: req.userId, targetUserId: userId },
+      { adminId: req.userId, targetUserId: userId, newlyGranted },
       'admin granted supporter lifetime',
     )
+
+    // Fire one-shot notifications only on the transition from non-premium →
+    // premium so a duplicate grant click doesn't re-spam the user.
+    if (newlyGranted) {
+      emitUserPremiumGranted({
+        userId,
+        tier: 'supporter_lifetime',
+        grantedAt: grantedAt.toISOString(),
+      })
+
+      const target = await userRepository.findById(userId)
+      if (target?.email && !target.isGuest) {
+        // Don't block the admin response on the mail provider; failures are
+        // already captured in `email_log` by the sendEmail chokepoint.
+        void sendPremiumGrantedEmail({
+          userId,
+          to: target.email,
+          displayName: target.displayName ?? target.username,
+        }).catch((err) => {
+          routeLogger.warn(
+            { err, targetUserId: userId },
+            'premium-granted email send failed',
+          )
+        })
+      }
+    }
+
     res.json({ success: true, data: { entitlement } })
   } catch (err) {
     next(err)

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1766,5 +1766,11 @@
       "too_easy": "Too easy",
       "other": "Other"
     }
+  },
+  "notifications": {
+    "premiumGranted": {
+      "title": "Premium unlocked!",
+      "body": "An admin just granted you lifetime Premium. Enjoy the archive, unlimited hints and the Premium badge."
+    }
   }
 }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1766,5 +1766,11 @@
       "too_easy": "Trop facile",
       "other": "Autre"
     }
+  },
+  "notifications": {
+    "premiumGranted": {
+      "title": "Premium activé !",
+      "body": "Un administrateur vient de t'offrir le Premium à vie. Profite des archives, des indices illimités et du badge Premium."
+    }
   }
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -10,6 +10,10 @@ import { useDailyLoginStore } from '@/stores/dailyLoginStore'
 import { useSession } from '@/lib/auth-client'
 import { useReferralCapture } from '@/hooks/useReferralCapture'
 import {
+  connectNotificationsSocket,
+  disconnectNotificationsSocket,
+} from '@/lib/notifications-socket'
+import {
   SUPPORTED_LANGUAGES,
   getBrowserLanguage,
   type SupportedLanguage,
@@ -82,6 +86,17 @@ function LanguageLayout() {
       reset()
     }
   }, [session?.user?.id, session?.user?.role, fetchStatus, reset])
+
+  // Subscribe the authenticated user to the `/notifications` socket so account
+  // events (Premium grants, future alerts) reach them on any page.
+  useEffect(() => {
+    const userId = session?.user?.id
+    if (!userId) {
+      disconnectNotificationsSocket()
+      return
+    }
+    connectNotificationsSocket(userId)
+  }, [session?.user?.id])
 
   // Validate language parameter
   if (!lang || !SUPPORTED_LANGUAGES.includes(lang as SupportedLanguage)) {

--- a/packages/frontend/src/lib/notifications-socket.ts
+++ b/packages/frontend/src/lib/notifications-socket.ts
@@ -1,0 +1,72 @@
+import { io, Socket } from 'socket.io-client'
+import type { UserPremiumGrantedEvent } from '@the-box/types'
+import { toast as sonner } from 'sonner'
+import i18n from '@/lib/i18n'
+
+const SOCKET_URL = import.meta.env.VITE_API_URL || undefined
+
+let socket: Socket | null = null
+
+function createSocket(): Socket {
+    const path = SOCKET_URL ? `${SOCKET_URL}/notifications` : '/notifications'
+    return io(path, {
+        autoConnect: false,
+        path: '/socket.io',
+        transports: ['websocket', 'polling'],
+        reconnection: true,
+        reconnectionDelay: 1000,
+        reconnectionDelayMax: 5000,
+        reconnectionAttempts: Infinity,
+        randomizationFactor: 0.5,
+    })
+}
+
+function getNotificationsSocket(): Socket {
+    if (!socket) socket = createSocket()
+    return socket
+}
+
+function showPremiumGrantedToast(event: UserPremiumGrantedEvent): void {
+    const t = i18n.getFixedT(null, 'translation')
+    sonner.success(t('notifications.premiumGranted.title'), {
+        description: t('notifications.premiumGranted.body'),
+        duration: 8000,
+    })
+    // Side-channel for stores/components that need to react beyond the toast
+    // (e.g., refreshing cached entitlement). Kept loose to avoid coupling.
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('user:premium-granted', { detail: event }))
+    }
+}
+
+/**
+ * Open the `/notifications` socket and join the per-user room. Idempotent —
+ * re-calling with the same userId just re-joins; calling with a different
+ * userId re-joins the new room (sign-in/sign-out boundaries).
+ */
+export function connectNotificationsSocket(userId: string | null | undefined): void {
+    if (!userId) return
+    const s = getNotificationsSocket()
+
+    const join = (): void => {
+        s.emit('join_user', userId)
+    }
+
+    if (!(s as unknown as { _wired?: boolean })._wired) {
+        s.on('connect', join)
+        s.on('user:premium-granted', (e: UserPremiumGrantedEvent) => {
+            showPremiumGrantedToast(e)
+        })
+        ;(s as unknown as { _wired?: boolean })._wired = true
+    }
+
+    if (s.connected) {
+        join()
+        return
+    }
+    s.connect()
+}
+
+export function disconnectNotificationsSocket(): void {
+    if (socket?.connected) socket.disconnect()
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1045,6 +1045,15 @@ export interface GeoTierUpEvent {
   newTier: GeoContributorTier
 }
 
+// Realtime payload for the `/notifications` namespace, fired when an admin
+// grants a user lifetime Premium. The frontend listens for this event and
+// surfaces it as a toast — the user is also notified by email.
+export interface UserPremiumGrantedEvent {
+  userId: string
+  tier: 'supporter_lifetime'
+  grantedAt: string
+}
+
 // Capture eligibility reporting. A user can flag a screenshot they believe
 // shouldn't be playable (wrong game, unreadable, inappropriate, etc.). After
 // enough distinct users report the same target it is auto-deactivated for


### PR DESCRIPTION
When an admin grants lifetime Premium to a user, the user now receives
a real-time toast (via a dedicated /notifications Socket.IO namespace)
and a transactional email rendered with the standard email template.
Notifications fire only on the actual non-premium → premium transition,
so duplicate grant clicks (or stripe webhook replays) don't re-spam.

https://claude.ai/code/session_01MFNCYGMykz949MEL2WEqPr