### PR TITLE
feat(geo): show photo + map together with type tags

### DIFF
--- a/packages/frontend/src/components/geo/ImmersiveLayout.tsx
+++ b/packages/frontend/src/components/geo/ImmersiveLayout.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image as ImageIcon, MapPin } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useIsMobile } from '@/hooks/useIsMobile'
-
-type Tab = 'photo' | 'map'
 
 interface ImmersiveLayoutProps {
     screenshot: ReactNode
@@ -18,20 +15,16 @@ interface ImmersiveLayoutProps {
     // True when the page should pin itself to the viewport (CSS immersive
     // fallback for browsers without native fullscreen).
     isImmersive: boolean
-    // Reset the active tab to "photo" — handy when the round changes so
-    // the player always lands on the screenshot for the new shot.
-    roundKey: number | string
+    // Kept for API compatibility with consumers that pass it; the layout
+    // no longer needs to reset any internal state per round.
+    roundKey?: number | string
 }
 
 /**
- * Mobile-first split-panel for the screenshot ↔ map flow. Defaults to a
- * **toggle** (one panel at a time, swap via tabs or horizontal swipe) on
- * mobile and a **side-by-side** view on desktop.
- *
- * The swipe gesture is enhancement-only — keyboard / SR users get the
- * tab buttons as a first-class non-gesture path. Swiping is ignored when
- * the user prefers reduced motion (handled by the consumer's transition
- * styles).
+ * Split-panel layout for the screenshot + map flow. Both panels are
+ * always visible — stacked vertically on mobile, side-by-side on desktop —
+ * and each carries a corner type-tag badge so the player can tell them
+ * apart at a glance without a Photo/Map toggle.
  */
 export function ImmersiveLayout({
     screenshot,
@@ -40,48 +33,8 @@ export function ImmersiveLayout({
     bottomDock,
     resultOverlay,
     isImmersive,
-    roundKey,
 }: ImmersiveLayoutProps) {
     const { t } = useTranslation()
-    const isMobile = useIsMobile()
-    const [tab, setTab] = useState<Tab>('photo')
-
-    // Snap back to "photo" whenever a new round starts. Players want to
-    // see the new screenshot first; if they were on the map mid-pin they
-    // can swipe back.
-    useEffect(() => {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing local tab to the parent-driven `roundKey` change; no external system to subscribe to.
-        setTab('photo')
-    }, [roundKey])
-
-    // Touch-driven swipe to toggle Photo ↔ Map on mobile only. Desktop
-    // shows both surfaces, so swipe is a no-op there.
-    const touchStartXRef = useRef<number | null>(null)
-    const touchStartYRef = useRef<number | null>(null)
-    const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
-        const touch = e.touches.item(0)
-        if (!touch) return
-        touchStartXRef.current = touch.clientX
-        touchStartYRef.current = touch.clientY
-    }
-    const onTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
-        if (!isMobile) return
-        const startX = touchStartXRef.current
-        const startY = touchStartYRef.current
-        touchStartXRef.current = null
-        touchStartYRef.current = null
-        if (startX == null || startY == null) return
-        const touch = e.changedTouches.item(0)
-        if (!touch) return
-        const dx = touch.clientX - startX
-        const dy = touch.clientY - startY
-        // Tight threshold so a casual finger drift doesn't flip the tab,
-        // and a strong vertical bias (|dy| > |dx|) cancels — players will
-        // be tapping pins, scrolling result sheets, etc.
-        if (Math.abs(dx) < 60 || Math.abs(dy) > Math.abs(dx)) return
-        if (dx < 0 && tab === 'photo') setTab('map')
-        else if (dx > 0 && tab === 'map') setTab('photo')
-    }
 
     return (
         <div
@@ -93,41 +46,6 @@ export function ImmersiveLayout({
             )}
             data-immersive={isImmersive ? 'true' : 'false'}
         >
-            {/* Tab bar — mobile only. On desktop both panels show side-by-side
-                and the tablist is a no-op (we still render it, hidden, so
-                screen-reader users on resized viewports keep the same
-                navigation contract). */}
-            <div
-                role="tablist"
-                aria-label={t('geo.play.deck.label', 'Screenshot and map')}
-                className={cn(
-                    'absolute left-1/2 top-3 -translate-x-1/2 z-30 flex gap-1 rounded-full bg-black/50 p-1 backdrop-blur md:hidden',
-                )}
-            >
-                <TabButton
-                    id="geo-tab-photo"
-                    controls="geo-panel-photo"
-                    active={tab === 'photo'}
-                    onClick={() => setTab('photo')}
-                >
-                    <ImageIcon className="h-3.5 w-3.5" aria-hidden />
-                    <span className="text-xs font-medium">
-                        {t('geo.play.tabs.screenshot', 'Photo')}
-                    </span>
-                </TabButton>
-                <TabButton
-                    id="geo-tab-map"
-                    controls="geo-panel-map"
-                    active={tab === 'map'}
-                    onClick={() => setTab('map')}
-                >
-                    <MapPin className="h-3.5 w-3.5" aria-hidden />
-                    <span className="text-xs font-medium">
-                        {t('geo.play.tabs.map', 'Map')}
-                    </span>
-                </TabButton>
-            </div>
-
             {/* Top-right overlay (fullscreen toggle, etc.) */}
             {topRight && (
                 <div
@@ -138,26 +56,32 @@ export function ImmersiveLayout({
                 </div>
             )}
 
-            {/* Deck */}
-            <div
-                className="flex-1 relative overflow-hidden"
-                onTouchStart={onTouchStart}
-                onTouchEnd={onTouchEnd}
-            >
-                <div className="absolute inset-0 grid md:grid-cols-2">
+            {/* Deck — both panels are always visible. Stacked rows on mobile,
+                two columns on desktop. */}
+            <div className="flex-1 relative overflow-hidden">
+                <div className="absolute inset-0 grid grid-rows-2 md:grid-rows-1 md:grid-cols-2">
                     <Panel
                         id="geo-panel-photo"
-                        labelledBy="geo-tab-photo"
-                        active={tab === 'photo'}
-                        className="md:!opacity-100 md:!pointer-events-auto"
+                        tag={
+                            <>
+                                <ImageIcon className="h-3.5 w-3.5" aria-hidden />
+                                <span>
+                                    {t('geo.play.tabs.screenshot', 'Photo')}
+                                </span>
+                            </>
+                        }
+                        className="border-b border-white/10 md:border-b-0 md:border-r"
                     >
                         {screenshot}
                     </Panel>
                     <Panel
                         id="geo-panel-map"
-                        labelledBy="geo-tab-map"
-                        active={tab === 'map'}
-                        className="md:!opacity-100 md:!pointer-events-auto"
+                        tag={
+                            <>
+                                <MapPin className="h-3.5 w-3.5" aria-hidden />
+                                <span>{t('geo.play.tabs.map', 'Map')}</span>
+                            </>
+                        }
                     >
                         {map}
                     </Panel>
@@ -195,67 +119,29 @@ export function ImmersiveLayout({
     )
 }
 
-function TabButton({
-    id,
-    controls,
-    active,
-    onClick,
-    children,
-}: {
-    id: string
-    controls: string
-    active: boolean
-    onClick: () => void
-    children: ReactNode
-}) {
-    return (
-        <button
-            id={id}
-            role="tab"
-            type="button"
-            aria-selected={active}
-            aria-controls={controls}
-            tabIndex={active ? 0 : -1}
-            onClick={onClick}
-            className={cn(
-                'inline-flex items-center gap-1.5 rounded-full px-3 py-1 transition',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink',
-                active
-                    ? 'bg-white text-black shadow'
-                    : 'text-white/80 hover:text-white',
-            )}
-        >
-            {children}
-        </button>
-    )
-}
-
 function Panel({
     id,
-    active,
-    labelledBy,
+    tag,
     className,
     children,
 }: {
     id: string
-    active: boolean
-    labelledBy: string
+    tag: ReactNode
     className?: string
     children: ReactNode
 }) {
     return (
         <div
             id={id}
-            role="tabpanel"
-            aria-labelledby={labelledBy}
             className={cn(
-                'relative h-full w-full overflow-hidden transition-opacity duration-200',
-                active ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none',
-                'motion-reduce:transition-none',
+                'relative h-full w-full overflow-hidden',
                 className,
             )}
         >
             {children}
+            <div className="pointer-events-none absolute left-3 top-3 z-20 inline-flex items-center gap-1.5 rounded-full bg-black/55 px-2.5 py-1 text-xs font-medium text-white shadow backdrop-blur">
+                {tag}
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
Mobile previously toggled between the screenshot and the map via a
Photo/Carte tab, leaving half the viewport empty. The deck now stacks
both panels and labels each with a corner type tag, so the player can
read the screenshot and place a pin without flipping views.