### PR TITLE
feat(geo): prevent replaying already-guessed free-play screenshots

### DIFF
--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -632,6 +632,7 @@ export interface GeoScreenshotRepository {
   pickRandomPromotedForGame(
     gameId: number,
     geoMapId?: number,
+    excludeMetaIds?: number[],
   ): Promise<GeoScreenshotMeta | null>
   // Free-play catalog: games with at least one promoted screenshot, plus
   // the per-game count of distinct maps and screenshots so the picker can

--- a/packages/backend/src/domain/services/geo-game.service.ts
+++ b/packages/backend/src/domain/services/geo-game.service.ts
@@ -70,6 +70,7 @@ export interface GeoGameService {
   pickFreePlayScreenshot(args: {
     gameId: number
     geoMapId?: number
+    excludeMetaIds?: number[]
   }): Promise<GeoFreePlayView | null>
 
   scoreFreePlayGuess(args: {
@@ -126,7 +127,7 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
     // (game, map) pair, surface every enabled map for the chooser, and
     // never write anything. Returns null when the game has no promoted
     // screenshots yet.
-    async pickFreePlayScreenshot({ gameId, geoMapId }) {
+    async pickFreePlayScreenshot({ gameId, geoMapId, excludeMetaIds }) {
       const enabledMaps = await geoMapRepository.listEnabledByGameId(gameId)
       if (enabledMaps.length === 0) return null
       if (geoMapId != null && !enabledMaps.some((m) => m.id === geoMapId)) {
@@ -138,6 +139,7 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
       const meta = await geoScreenshotRepository.pickRandomPromotedForGame(
         gameId,
         geoMapId,
+        excludeMetaIds,
       )
       if (!meta) return null
       const candidate = await geoScreenshotRepository.findCandidateById(

--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -212,6 +212,7 @@ export const geoScreenshotRepository = {
   async pickRandomPromotedForGame(
     gameId: number,
     geoMapId?: number,
+    excludeMetaIds?: number[],
   ): Promise<GeoScreenshotMeta | null> {
     const q = db('geo_screenshot_meta')
       .join(
@@ -225,6 +226,9 @@ export const geoScreenshotRepository = {
       .select<GeoScreenshotMetaRow>('geo_screenshot_meta.*')
     if (geoMapId !== undefined) {
       q.where('geo_screenshot_meta.geo_map_id', geoMapId)
+    }
+    if (excludeMetaIds && excludeMetaIds.length > 0) {
+      q.whereNotIn('geo_screenshot_meta.id', excludeMetaIds)
     }
     const row = await q.first()
     return row ? mapMeta(row) : null

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -47,6 +47,10 @@ const gameIdParamSchema = z.object({
 const freePlayPickBodySchema = z.object({
   gameId: z.number().int().positive(),
   geoMapId: z.number().int().positive().optional(),
+  // Client-tracked list of meta IDs the user has already played. The
+  // server filters them out so a single session never sees the same
+  // screenshot twice. Capped to keep the WHERE NOT IN payload bounded.
+  excludeMetaIds: z.array(z.number().int().positive()).max(1000).optional(),
 })
 
 const freePlayGuessBodySchema = z.object({
@@ -221,9 +225,34 @@ router.post(
   validateBody(freePlayPickBodySchema),
   async (req, res, next) => {
     try {
-      const { gameId, geoMapId } = req.body as z.infer<typeof freePlayPickBodySchema>
-      const view = await geoGameService.pickFreePlayScreenshot({ gameId, geoMapId })
+      const { gameId, geoMapId, excludeMetaIds } = req.body as z.infer<
+        typeof freePlayPickBodySchema
+      >
+      const view = await geoGameService.pickFreePlayScreenshot({
+        gameId,
+        geoMapId,
+        excludeMetaIds,
+      })
       if (!view) {
+        // If the exclusion list ate the only remaining candidates,
+        // surface a distinct code so the UI can offer "reset history"
+        // instead of the generic empty-catalog message.
+        if (excludeMetaIds && excludeMetaIds.length > 0) {
+          const fallback = await geoGameService.pickFreePlayScreenshot({
+            gameId,
+            geoMapId,
+          })
+          if (fallback) {
+            res.status(409).json({
+              success: false,
+              error: {
+                code: 'ALL_PLAYED',
+                message: 'all available screenshots have been played',
+              },
+            })
+            return
+          }
+        }
         res.status(404).json({
           success: false,
           error: {

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1627,6 +1627,11 @@
           "multi": "This game has several maps. Pick one to start guessing.",
           "none": "No playable maps for this game yet."
         }
+      },
+      "exhausted": {
+        "title": "You've seen every screenshot",
+        "body": "Nice run! You've guessed every available screenshot for this game. Reset the history to replay the ones you've already seen.",
+        "reset": "Reset history"
       }
     },
     "fullscreen": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1627,6 +1627,11 @@
           "multi": "Ce jeu a plusieurs cartes. Choisissez-en une pour commencer.",
           "none": "Aucune carte jouable pour ce jeu."
         }
+      },
+      "exhausted": {
+        "title": "Vous avez vu toutes les captures",
+        "body": "Bravo ! Vous avez deviné toutes les captures disponibles pour ce jeu. Réinitialisez l'historique pour rejouer celles déjà vues.",
+        "reset": "Réinitialiser l'historique"
       }
     },
     "fullscreen": {

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -100,6 +100,7 @@ export const geoApi = {
     pickFreePlay(input: {
         gameId: number
         geoMapId?: number
+        excludeMetaIds?: number[]
     }): Promise<GeoFreePlayView> {
         return request<GeoFreePlayView>('/api/geo/free-play/random', {
             method: 'POST',

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -6,6 +6,7 @@ import {
     Gamepad2,
     Loader2,
     Map as MapIcon,
+    RotateCcw,
     Shuffle,
     Trophy,
 } from 'lucide-react'
@@ -54,6 +55,7 @@ export default function GeoPlayPage() {
         setPendingGuess,
         submitGuess,
         nextRound,
+        resetPlayedHistory,
     } = useGeoFreePlayStore()
 
     const [gamePickerOpen, setGamePickerOpen] = useState(false)
@@ -125,8 +127,10 @@ export default function GeoPlayPage() {
                         imageUrl={view?.candidate.imageUrl ?? null}
                         loading={phase === 'loading' || (currentGameId != null && phase === 'idle')}
                         empty={currentGameId == null}
+                        exhausted={phase === 'exhausted'}
                         errorMessage={phase === 'error' ? errorMessage : null}
                         onPickGame={() => setGamePickerOpen(true)}
+                        onResetHistory={() => void resetPlayedHistory()}
                     />
                 }
                 map={
@@ -210,17 +214,52 @@ function ScreenshotPanel({
     imageUrl,
     loading,
     empty,
+    exhausted,
     errorMessage,
     onPickGame,
+    onResetHistory,
 }: {
     imageUrl: string | null
     loading: boolean
     empty: boolean
+    exhausted: boolean
     errorMessage: string | null
     onPickGame: () => void
+    onResetHistory: () => void
 }) {
     const { t } = useTranslation()
     const safeUrl = imageUrl && !isPlaceholderImageUrl(imageUrl) ? imageUrl : null
+
+    if (exhausted) {
+        return (
+            <div
+                className="flex h-full w-full flex-col items-center justify-center px-6 text-center gap-4"
+                role="status"
+            >
+                <div className="rounded-full bg-neon-pink/10 p-4">
+                    <Trophy className="h-8 w-8 text-neon-pink" aria-hidden />
+                </div>
+                <div className="space-y-1 max-w-xs">
+                    <h2 className="text-lg font-semibold">
+                        {t('geo.play.exhausted.title', "You've seen every screenshot")}
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                        {t(
+                            'geo.play.exhausted.body',
+                            "Nice run! You've guessed every available screenshot for this game. Reset the history to replay the ones you've already seen.",
+                        )}
+                    </p>
+                </div>
+                <Button
+                    onClick={onResetHistory}
+                    className="gradient-gaming hover:opacity-90"
+                >
+                    <RotateCcw className="h-4 w-4 mr-2" aria-hidden />
+                    {t('geo.play.exhausted.reset', 'Reset history')}
+                </Button>
+            </div>
+        )
+    }
 
     if (errorMessage) {
         return (
@@ -392,6 +431,7 @@ function Dock({
     const { t } = useTranslation()
     const submitting = phase === 'submitting'
     const revealed = phase === 'revealed'
+    const exhausted = phase === 'exhausted'
     return (
         <div className="flex flex-col gap-2">
             {/* Context row — game / map labels with quick-change links.
@@ -428,7 +468,7 @@ function Dock({
                     variant="ghost"
                     onClick={onReroll}
                     className="text-white/80 hover:text-white"
-                    disabled={submitting || gameLabel == null}
+                    disabled={submitting || exhausted || gameLabel == null}
                     aria-label={t('geo.play.reroll', 'New screenshot')}
                 >
                     <Shuffle className="h-4 w-4 mr-1.5" aria-hidden />

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -10,9 +10,21 @@ import type {
 import { geoApi, GeoApiError } from '../lib/api/geo'
 import { getApiErrorMessage } from '../lib/api-errors'
 
-type Phase = 'idle' | 'loading' | 'ready' | 'submitting' | 'revealed' | 'error'
+type Phase =
+    | 'idle'
+    | 'loading'
+    | 'ready'
+    | 'submitting'
+    | 'revealed'
+    | 'error'
+    | 'exhausted'
 
 const GAMES_TTL_MS = 5 * 60 * 1000
+// WHERE NOT IN payload cap on the backend. Older plays simply roll off
+// the front of the array once we hit it — re-seeing the very oldest
+// screenshot after hundreds of rounds is acceptable, while letting the
+// list grow unbounded would balloon both storage and the request body.
+const MAX_PLAYED_PER_GAME = 1000
 
 interface GeoFreePlayState {
     // Catalog
@@ -34,6 +46,12 @@ interface GeoFreePlayState {
     // Round counter so the screenshot/map components can re-key on
     // each new pick (prevents Embla / stale-pin glitches between rounds).
     round: number
+    // History of meta IDs the user has already played per game. Used as
+    // the exclusion list on each reroll so the same screenshot is never
+    // served twice in a row to the same client. Tracked per game (not
+    // per map) so changing the map filter still hides already-seen
+    // screenshots that happen to live on another map.
+    playedByGame: Record<number, number[]>
 
     // Actions
     loadGames(force?: boolean): Promise<void>
@@ -43,6 +61,7 @@ interface GeoFreePlayState {
     setPendingGuess(p: GeoPoint | null): void
     submitGuess(): Promise<GeoFreePlayResult | null>
     nextRound(): Promise<void>
+    resetPlayedHistory(): Promise<void>
     reset(): void
 }
 
@@ -62,6 +81,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             errorMessage: null,
             errorCode: null,
             round: 0,
+            playedByGame: {},
 
             async loadGames(force) {
                 const { gamesFetchedAt } = get()
@@ -122,7 +142,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             },
 
             async rerollScreenshot() {
-                const { currentGameId, currentMapId } = get()
+                const { currentGameId, currentMapId, playedByGame } = get()
                 if (currentGameId == null) return
                 set({
                     phase: 'loading',
@@ -134,9 +154,12 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                     errorCode: null,
                 })
                 try {
+                    const excludeMetaIds = playedByGame[currentGameId] ?? []
                     const view = await geoApi.pickFreePlay({
                         gameId: currentGameId,
                         geoMapId: currentMapId ?? undefined,
+                        excludeMetaIds:
+                            excludeMetaIds.length > 0 ? excludeMetaIds : undefined,
                     })
                     set({
                         view,
@@ -148,10 +171,15 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                         round: get().round + 1,
                     })
                 } catch (err) {
+                    // The server returns ALL_PLAYED when the exclusion
+                    // list ate the only remaining candidates. Surface a
+                    // dedicated phase so the UI can offer a "reset
+                    // history" affordance instead of looking broken.
+                    const code = err instanceof GeoApiError ? err.code : null
                     set({
-                        phase: 'error',
+                        phase: code === 'ALL_PLAYED' ? 'exhausted' : 'error',
                         errorMessage: getApiErrorMessage(err),
-                        errorCode: err instanceof GeoApiError ? err.code : null,
+                        errorCode: code,
                     })
                 }
             },
@@ -161,7 +189,8 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             },
 
             async submitGuess() {
-                const { view, pendingGuess, currentMapId, maps } = get()
+                const { view, pendingGuess, currentMapId, currentGameId, maps } =
+                    get()
                 if (!view || !pendingGuess) return null
                 // Multi-map games require an explicit pick. Single-map
                 // games auto-selected at load time so this is a no-op there.
@@ -176,6 +205,21 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                         guess: pendingGuess,
                     })
                     const correctMap = maps.find((m) => m.id === result.correctMapId) ?? null
+                    // Record this metaId as played so the next reroll
+                    // (and every future session — see persist config)
+                    // excludes it from the random pool.
+                    if (currentGameId != null) {
+                        const prev = get().playedByGame[currentGameId] ?? []
+                        const next = prev.includes(view.meta.id)
+                            ? prev
+                            : [...prev, view.meta.id].slice(-MAX_PLAYED_PER_GAME)
+                        set({
+                            playedByGame: {
+                                ...get().playedByGame,
+                                [currentGameId]: next,
+                            },
+                        })
+                    }
                     set({ result, correctMap, phase: 'revealed' })
                     return result
                 } catch (err) {
@@ -189,6 +233,15 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             },
 
             async nextRound() {
+                await get().rerollScreenshot()
+            },
+
+            async resetPlayedHistory() {
+                const { currentGameId } = get()
+                if (currentGameId == null) return
+                const next = { ...get().playedByGame }
+                delete next[currentGameId]
+                set({ playedByGame: next })
                 await get().rerollScreenshot()
             },
 
@@ -209,15 +262,18 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
         }),
         {
             name: 'geo-free-play-store-v1',
-            // Only persist the user's last picked game + map so a reload
-            // resumes the same context. Screenshots and results are
-            // intentionally re-fetched from the network — stale state
-            // would resurrect a round the player already finished.
+            // Persist the user's last picked game + map so a reload
+            // resumes the same context, and the played-meta history so
+            // we don't reshow the same screenshots after a refresh.
+            // Live round state (view, result, etc.) is intentionally
+            // re-fetched from the network — stale state would
+            // resurrect a round the player already finished.
             partialize: (state) => ({
                 currentGameId: state.currentGameId,
                 currentMapId: state.currentMapId,
+                playedByGame: state.playedByGame,
             }),
-            version: 1,
+            version: 2,
         },
     ),
 )


### PR DESCRIPTION
Track played meta IDs per game on the client (persisted) and forward
them as an exclusion list to /api/geo/free-play/random. When the pool
is exhausted the API returns ALL_PLAYED so the UI can surface a
"reset history" affordance instead of looping the same screenshots.