### PR TITLE
feat(geo): prevent replaying already-guessed free-play screenshots

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1633,10 +1633,12 @@
           "none": "No playable maps for this game yet."
         }
       },
+      "newBadge": "+{{count}} new",
+      "newCaptures": "{{count}} new screenshots to guess",
       "exhausted": {
         "title": "You've seen every screenshot",
-        "body": "Nice run! You've guessed every available screenshot for this game. Reset the history to replay the ones you've already seen.",
-        "reset": "Reset history"
+        "body": "Nice run! You've guessed every available screenshot for this game. We'll let you know when new ones are added.",
+        "checkForNew": "Check for new screenshots"
       }
     },
     "fullscreen": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1633,10 +1633,12 @@
           "none": "Aucune carte jouable pour ce jeu."
         }
       },
+      "newBadge": "+{{count}} nouvelles",
+      "newCaptures": "{{count}} nouvelles captures à deviner",
       "exhausted": {
         "title": "Vous avez vu toutes les captures",
-        "body": "Bravo ! Vous avez deviné toutes les captures disponibles pour ce jeu. Réinitialisez l'historique pour rejouer celles déjà vues.",
-        "reset": "Réinitialiser l'historique"
+        "body": "Bravo ! Vous avez deviné toutes les captures disponibles pour ce jeu. Nous vous préviendrons quand de nouvelles seront ajoutées.",
+        "checkForNew": "Vérifier les nouvelles captures"
       }
     },
     "fullscreen": {

--- a/packages/frontend/src/components/geo/GamePicker.tsx
+++ b/packages/frontend/src/components/geo/GamePicker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { GeoPlayableGame } from '@the-box/types'
-import { Search, MapPin, Image as ImageIcon, Loader2 } from 'lucide-react'
+import { Search, MapPin, Image as ImageIcon, Loader2, Sparkles } from 'lucide-react'
 import {
     Sheet,
     SheetContent,
@@ -20,6 +20,9 @@ interface GamePickerProps {
     games: GeoPlayableGame[]
     isLoading: boolean
     selectedGameId: number | null
+    // How many screenshots the user has already played per game id, used
+    // to flag games whose catalog has grown since their last visit.
+    playedCountByGame?: Record<string, number>
     onSelect: (gameId: number) => void
 }
 
@@ -35,6 +38,7 @@ export function GamePicker({
     games,
     isLoading,
     selectedGameId,
+    playedCountByGame,
     onSelect,
 }: GamePickerProps) {
     const { t } = useTranslation()
@@ -124,18 +128,29 @@ export function GamePicker({
                             aria-label={t('geo.play.pickGame', 'Pick a game')}
                             className="grid grid-cols-2 gap-3 pt-2 sm:grid-cols-1"
                         >
-                            {filtered.map((g) => (
-                                <li key={g.id}>
-                                    <GameCard
-                                        game={g}
-                                        selected={selectedGameId === g.id}
-                                        onSelect={() => {
-                                            onSelect(g.id)
-                                            onOpenChange(false)
-                                        }}
-                                    />
-                                </li>
-                            ))}
+                            {filtered.map((g) => {
+                                const played = playedCountByGame?.[String(g.id)] ?? 0
+                                // Clamp to ≥0 in case the catalog count
+                                // shrank (e.g. an admin demoted a meta).
+                                const newCount = Math.max(0, g.screenshotCount - played)
+                                // Only flag "new" once the player has
+                                // actually started this game — otherwise
+                                // every entry would scream "NEW".
+                                const hasNew = played > 0 && newCount > 0
+                                return (
+                                    <li key={g.id}>
+                                        <GameCard
+                                            game={g}
+                                            selected={selectedGameId === g.id}
+                                            newCount={hasNew ? newCount : 0}
+                                            onSelect={() => {
+                                                onSelect(g.id)
+                                                onOpenChange(false)
+                                            }}
+                                        />
+                                    </li>
+                                )
+                            })}
                         </ul>
                     )}
                 </div>
@@ -147,10 +162,12 @@ export function GamePicker({
 function GameCard({
     game,
     selected,
+    newCount,
     onSelect,
 }: {
     game: GeoPlayableGame
     selected: boolean
+    newCount: number
     onSelect: () => void
 }) {
     const { t } = useTranslation()
@@ -171,6 +188,17 @@ function GameCard({
                     : 'border-border hover:border-neon-pink/60',
             )}
         >
+            {newCount > 0 && (
+                <span
+                    className="absolute left-2 top-2 z-10 inline-flex items-center gap-1 rounded-full bg-neon-pink px-2 py-0.5 text-[10px] font-semibold text-white shadow-lg"
+                    aria-label={t('geo.play.newCaptures', '{{count}} new screenshots to guess', {
+                        count: newCount,
+                    })}
+                >
+                    <Sparkles className="h-3 w-3" aria-hidden />
+                    {t('geo.play.newBadge', '+{{count}} new', { count: newCount })}
+                </span>
+            )}
             <div className="aspect-video w-full bg-muted/30 sm:aspect-[16/7]">
                 {cover ? (
                     <img

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -6,7 +6,7 @@ import {
     Gamepad2,
     Loader2,
     Map as MapIcon,
-    RotateCcw,
+    RefreshCw,
     Shuffle,
     Trophy,
 } from 'lucide-react'
@@ -48,6 +48,7 @@ export default function GeoPlayPage() {
         phase,
         errorMessage,
         round,
+        playedByGame,
         loadGames,
         selectGame,
         selectMap,
@@ -55,7 +56,7 @@ export default function GeoPlayPage() {
         setPendingGuess,
         submitGuess,
         nextRound,
-        resetPlayedHistory,
+        checkForNewScreenshots,
     } = useGeoFreePlayStore()
 
     const [gamePickerOpen, setGamePickerOpen] = useState(false)
@@ -130,7 +131,7 @@ export default function GeoPlayPage() {
                         exhausted={phase === 'exhausted'}
                         errorMessage={phase === 'error' ? errorMessage : null}
                         onPickGame={() => setGamePickerOpen(true)}
-                        onResetHistory={() => void resetPlayedHistory()}
+                        onCheckForNew={() => void checkForNewScreenshots()}
                     />
                 }
                 map={
@@ -196,6 +197,9 @@ export default function GeoPlayPage() {
                 games={games}
                 isLoading={gamesFetchedAt == null && games.length === 0}
                 selectedGameId={currentGameId}
+                playedCountByGame={Object.fromEntries(
+                    Object.entries(playedByGame).map(([id, ids]) => [id, ids.length]),
+                )}
                 onSelect={(id) => void selectGame(id)}
             />
             <MapPicker
@@ -217,7 +221,7 @@ function ScreenshotPanel({
     exhausted,
     errorMessage,
     onPickGame,
-    onResetHistory,
+    onCheckForNew,
 }: {
     imageUrl: string | null
     loading: boolean
@@ -225,7 +229,7 @@ function ScreenshotPanel({
     exhausted: boolean
     errorMessage: string | null
     onPickGame: () => void
-    onResetHistory: () => void
+    onCheckForNew: () => void
 }) {
     const { t } = useTranslation()
     const safeUrl = imageUrl && !isPlaceholderImageUrl(imageUrl) ? imageUrl : null
@@ -246,16 +250,16 @@ function ScreenshotPanel({
                     <p className="text-sm text-muted-foreground">
                         {t(
                             'geo.play.exhausted.body',
-                            "Nice run! You've guessed every available screenshot for this game. Reset the history to replay the ones you've already seen.",
+                            "Nice run! You've guessed every available screenshot for this game. We'll let you know when new ones are added.",
                         )}
                     </p>
                 </div>
                 <Button
-                    onClick={onResetHistory}
-                    className="gradient-gaming hover:opacity-90"
+                    onClick={onCheckForNew}
+                    variant="outline"
                 >
-                    <RotateCcw className="h-4 w-4 mr-2" aria-hidden />
-                    {t('geo.play.exhausted.reset', 'Reset history')}
+                    <RefreshCw className="h-4 w-4 mr-2" aria-hidden />
+                    {t('geo.play.exhausted.checkForNew', 'Check for new screenshots')}
                 </Button>
             </div>
         )

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -61,7 +61,10 @@ interface GeoFreePlayState {
     setPendingGuess(p: GeoPoint | null): void
     submitGuess(): Promise<GeoFreePlayResult | null>
     nextRound(): Promise<void>
-    resetPlayedHistory(): Promise<void>
+    // Force-refresh the catalog and try to roll again. Used from the
+    // exhausted state so a player who's seen everything can pull in
+    // newly-promoted screenshots without a full page reload.
+    checkForNewScreenshots(): Promise<void>
     reset(): void
 }
 
@@ -236,12 +239,12 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                 await get().rerollScreenshot()
             },
 
-            async resetPlayedHistory() {
-                const { currentGameId } = get()
-                if (currentGameId == null) return
-                const next = { ...get().playedByGame }
-                delete next[currentGameId]
-                set({ playedByGame: next })
+            async checkForNewScreenshots() {
+                // Force-refresh the catalog so screenshotCount badges
+                // reflect newly-promoted captures, then try to roll
+                // again — succeeds iff there's now at least one
+                // unplayed meta for the current game.
+                await get().loadGames(true)
                 await get().rerollScreenshot()
             },
 


### PR DESCRIPTION
## Summary

- Track played meta IDs per game on the client (persisted) and forward them as an exclusion list to `POST /api/geo/free-play/random`. The same screenshot is never served twice to the same player.
- Backend distinguishes "all played" (`409 ALL_PLAYED`) from "no candidates at all" (`404 NO_FREE_PLAY_CANDIDATE`) so the UI can react accordingly.
- Played is permanent — no per-game reset. The exhausted panel offers **Check for new screenshots** which force-reloads the catalog and retries the roll.
- `GamePicker` shows a **+N new** badge on games whose `screenshotCount` has grown past the user's local played count, so returning players see fresh content at a glance.

## Test plan

- [ ] Play a free-play game, finish a round; reload — the same screenshot is not served again.
- [ ] Exhaust a game's pool; verify the exhausted panel renders with **Check for new screenshots**, and that pressing it after a new capture is promoted unblocks the roll.
- [ ] Open the **Pick a game** sheet for a game whose catalog has grown since last play — the **+N new** badge appears with the correct count.
- [ ] `npm run build` and `npm run lint` clean.

https://claude.ai/code/session_018D4nvdnuakxVptj1FCQWWy

---
_Generated by [Claude Code](https://claude.ai/code/session_018D4nvdnuakxVptj1FCQWWy)_