### PR TITLE
feat(header): add Daily Guess link to desktop and mobile nav

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -12,6 +12,7 @@
     "confirm": "Confirm",
     "back": "Back",
     "home": "Home",
+    "dailyGuess": "Daily Guess",
     "leaderboard": "Leaderboard",
     "geo": "Geo",
     "alpha": "Alpha",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -12,6 +12,7 @@
     "confirm": "Confirmer",
     "back": "Retour",
     "home": "Accueil",
+    "dailyGuess": "Défi Quotidien",
     "leaderboard": "Classement",
     "geo": "Géo",
     "alpha": "Alpha",

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin, Sparkles } from 'lucide-react'
+import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin, Sparkles, Play } from 'lucide-react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
 import { DailyRewardBadge } from '@/components/daily-login'
@@ -45,6 +45,13 @@ function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick, sh
         <Link to={localizedPath('/')} onClick={handleClick}>
           <Home className={`w-4 h-4 ${iconClass}`} />
           {t('common.home')}
+        </Link>
+      </Button>
+
+      <Button variant="ghost" size="sm" asChild className={mobileClasses}>
+        <Link to={localizedPath('/play')} onClick={handleClick}>
+          <Play className={`w-4 h-4 ${iconClass}`} />
+          {t('common.dailyGuess')}
         </Link>
       </Button>
 


### PR DESCRIPTION
Daily Guess was previously only reachable from the home page CTA, so
users (especially on mobile) had no way to jump back into /play from
deep pages. Add it as the second item in the shared NavigationLinks so
it shows up in both the desktop nav bar and the mobile hamburger menu.