### PR TITLE
feat(geo): add all-time completion message and per-game ignore

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1636,10 +1636,22 @@
       },
       "newBadge": "+{{count}} new",
       "newCaptures": "{{count}} new screenshots to guess",
+      "completedBadge": "All seen",
+      "ignoredBadge": "Ignored",
+      "markIgnored": "I don't know this game",
+      "markIgnoredShort": "Don't know",
+      "unmarkIgnored": "Restore this game",
+      "unmarkIgnoredShort": "Restore",
       "exhausted": {
         "title": "You've seen every screenshot",
         "body": "Nice run! You've guessed every available screenshot for this game. We'll let you know when new ones are added.",
-        "checkForNew": "Check for new screenshots"
+        "checkForNew": "Check for new screenshots",
+        "pickAnother": "Pick another game",
+        "markIgnored": "I don't want to see this game again"
+      },
+      "allDone": {
+        "title": "You've completed The Box!",
+        "body": "Bravo! You've guessed every screenshot in every game in your catalog. We'll ping you when new ones are added."
       }
     },
     "fullscreen": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1636,10 +1636,22 @@
       },
       "newBadge": "+{{count}} nouvelles",
       "newCaptures": "{{count}} nouvelles captures à deviner",
+      "completedBadge": "Tout vu",
+      "ignoredBadge": "Ignoré",
+      "markIgnored": "Je ne connais pas ce jeu",
+      "markIgnoredShort": "Inconnu",
+      "unmarkIgnored": "Restaurer ce jeu",
+      "unmarkIgnoredShort": "Restaurer",
       "exhausted": {
         "title": "Vous avez vu toutes les captures",
         "body": "Bravo ! Vous avez deviné toutes les captures disponibles pour ce jeu. Nous vous préviendrons quand de nouvelles seront ajoutées.",
-        "checkForNew": "Vérifier les nouvelles captures"
+        "checkForNew": "Vérifier les nouvelles captures",
+        "pickAnother": "Choisir un autre jeu",
+        "markIgnored": "Je ne veux plus voir ce jeu"
+      },
+      "allDone": {
+        "title": "Vous avez terminé The Box !",
+        "body": "Bravo ! Vous avez deviné toutes les captures de tous les jeux de votre catalogue. Nous vous préviendrons quand de nouvelles seront ajoutées."
       }
     },
     "fullscreen": {

--- a/packages/frontend/src/components/geo/GamePicker.tsx
+++ b/packages/frontend/src/components/geo/GamePicker.tsx
@@ -1,7 +1,16 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { GeoPlayableGame } from '@the-box/types'
-import { Search, MapPin, Image as ImageIcon, Loader2, Sparkles } from 'lucide-react'
+import {
+    CheckCircle2,
+    Eye,
+    EyeOff,
+    Image as ImageIcon,
+    Loader2,
+    MapPin,
+    Search,
+    Sparkles,
+} from 'lucide-react'
 import {
     Sheet,
     SheetContent,
@@ -23,7 +32,11 @@ interface GamePickerProps {
     // How many screenshots the user has already played per game id, used
     // to flag games whose catalog has grown since their last visit.
     playedCountByGame?: Record<string, number>
+    // Game ids the player has opted out of — kept visible (so they can
+    // un-ignore) but visually de-emphasized and excluded from completion.
+    ignoredGameIds?: number[]
     onSelect: (gameId: number) => void
+    onToggleIgnore?: (gameId: number) => void
 }
 
 /**
@@ -39,11 +52,17 @@ export function GamePicker({
     isLoading,
     selectedGameId,
     playedCountByGame,
+    ignoredGameIds,
     onSelect,
+    onToggleIgnore,
 }: GamePickerProps) {
     const { t } = useTranslation()
     const isMobile = useIsMobile()
     const [query, setQuery] = useState('')
+    const ignoredSet = useMemo(
+        () => new Set(ignoredGameIds ?? []),
+        [ignoredGameIds],
+    )
 
     // Reset the search field every time the sheet re-opens — keeping a
     // stale query across opens reads as a bug ("why am I still seeing my
@@ -137,16 +156,26 @@ export function GamePicker({
                                 // actually started this game — otherwise
                                 // every entry would scream "NEW".
                                 const hasNew = played > 0 && newCount > 0
+                                const completed =
+                                    g.screenshotCount > 0 && played >= g.screenshotCount
+                                const ignored = ignoredSet.has(g.id)
                                 return (
                                     <li key={g.id}>
                                         <GameCard
                                             game={g}
                                             selected={selectedGameId === g.id}
                                             newCount={hasNew ? newCount : 0}
+                                            completed={completed}
+                                            ignored={ignored}
                                             onSelect={() => {
                                                 onSelect(g.id)
                                                 onOpenChange(false)
                                             }}
+                                            onToggleIgnore={
+                                                onToggleIgnore
+                                                    ? () => onToggleIgnore(g.id)
+                                                    : undefined
+                                            }
                                         />
                                     </li>
                                 )
@@ -163,72 +192,127 @@ function GameCard({
     game,
     selected,
     newCount,
+    completed,
+    ignored,
     onSelect,
+    onToggleIgnore,
 }: {
     game: GeoPlayableGame
     selected: boolean
     newCount: number
+    completed: boolean
+    ignored: boolean
     onSelect: () => void
+    onToggleIgnore?: () => void
 }) {
     const { t } = useTranslation()
     const cover = game.coverImageUrl && !isPlaceholderImageUrl(game.coverImageUrl)
         ? game.coverImageUrl
         : null
     return (
-        <button
-            type="button"
-            role="radio"
-            aria-checked={selected}
-            onClick={onSelect}
+        <div
             className={cn(
                 'group relative w-full overflow-hidden rounded-lg border bg-card text-left transition',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink',
                 selected
                     ? 'border-neon-pink ring-2 ring-neon-pink/60'
                     : 'border-border hover:border-neon-pink/60',
+                ignored && 'opacity-60',
             )}
         >
-            {newCount > 0 && (
-                <span
-                    className="absolute left-2 top-2 z-10 inline-flex items-center gap-1 rounded-full bg-neon-pink px-2 py-0.5 text-[10px] font-semibold text-white shadow-lg"
-                    aria-label={t('geo.play.newCaptures', '{{count}} new screenshots to guess', {
-                        count: newCount,
-                    })}
-                >
-                    <Sparkles className="h-3 w-3" aria-hidden />
-                    {t('geo.play.newBadge', '+{{count}} new', { count: newCount })}
-                </span>
-            )}
-            <div className="aspect-video w-full bg-muted/30 sm:aspect-[16/7]">
-                {cover ? (
-                    <img
-                        src={cover}
-                        alt=""
-                        className="h-full w-full object-cover"
-                        loading="lazy"
-                        decoding="async"
-                    />
-                ) : (
-                    <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
-                        {game.name}
-                    </div>
-                )}
-            </div>
-            <div className="p-3 space-y-1">
-                <p className="font-medium text-sm leading-tight line-clamp-2">{game.name}</p>
-                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                    <span className="inline-flex items-center gap-1">
-                        <MapPin className="h-3 w-3" aria-hidden />
-                        {t('geo.play.mapCount', '{{count}} maps', { count: game.mapCount })}
-                    </span>
-                    <span className="inline-flex items-center gap-1">
-                        <ImageIcon className="h-3 w-3" aria-hidden />
-                        {t('geo.play.screenshotCount', '{{count}} shots', {
-                            count: game.screenshotCount,
+            <button
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                onClick={onSelect}
+                className="block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+            >
+                {newCount > 0 && !completed && !ignored && (
+                    <span
+                        className="absolute left-2 top-2 z-10 inline-flex items-center gap-1 rounded-full bg-neon-pink px-2 py-0.5 text-[10px] font-semibold text-white shadow-lg"
+                        aria-label={t('geo.play.newCaptures', '{{count}} new screenshots to guess', {
+                            count: newCount,
                         })}
+                    >
+                        <Sparkles className="h-3 w-3" aria-hidden />
+                        {t('geo.play.newBadge', '+{{count}} new', { count: newCount })}
                     </span>
+                )}
+                {completed && !ignored && (
+                    <span
+                        className="absolute left-2 top-2 z-10 inline-flex items-center gap-1 rounded-full bg-success px-2 py-0.5 text-[10px] font-semibold text-white shadow-lg"
+                    >
+                        <CheckCircle2 className="h-3 w-3" aria-hidden />
+                        {t('geo.play.completedBadge', 'All seen')}
+                    </span>
+                )}
+                {ignored && (
+                    <span
+                        className="absolute left-2 top-2 z-10 inline-flex items-center gap-1 rounded-full bg-muted-foreground/80 px-2 py-0.5 text-[10px] font-semibold text-white shadow-lg"
+                    >
+                        <EyeOff className="h-3 w-3" aria-hidden />
+                        {t('geo.play.ignoredBadge', 'Ignored')}
+                    </span>
+                )}
+                <div className="aspect-video w-full bg-muted/30 sm:aspect-[16/7]">
+                    {cover ? (
+                        <img
+                            src={cover}
+                            alt=""
+                            className={cn(
+                                'h-full w-full object-cover',
+                                ignored && 'grayscale',
+                            )}
+                            loading="lazy"
+                            decoding="async"
+                        />
+                    ) : (
+                        <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                            {game.name}
+                        </div>
+                    )}
                 </div>
-            </div>
-        </button>
+                <div className="p-3 space-y-1">
+                    <p className="font-medium text-sm leading-tight line-clamp-2">{game.name}</p>
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                        <span className="inline-flex items-center gap-1">
+                            <MapPin className="h-3 w-3" aria-hidden />
+                            {t('geo.play.mapCount', '{{count}} maps', { count: game.mapCount })}
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                            <ImageIcon className="h-3 w-3" aria-hidden />
+                            {t('geo.play.screenshotCount', '{{count}} shots', {
+                                count: game.screenshotCount,
+                            })}
+                        </span>
+                    </div>
+                </div>
+            </button>
+            {onToggleIgnore && (
+                <button
+                    type="button"
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        onToggleIgnore()
+                    }}
+                    className="absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded-full border border-white/20 bg-black/60 px-2 py-0.5 text-[10px] text-white/90 backdrop-blur hover:border-neon-pink/60 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                    aria-label={
+                        ignored
+                            ? t('geo.play.unmarkIgnored', 'Restore this game')
+                            : t('geo.play.markIgnored', "I don't know this game")
+                    }
+                >
+                    {ignored ? (
+                        <Eye className="h-3 w-3" aria-hidden />
+                    ) : (
+                        <EyeOff className="h-3 w-3" aria-hidden />
+                    )}
+                    <span className="hidden sm:inline">
+                        {ignored
+                            ? t('geo.play.unmarkIgnoredShort', 'Restore')
+                            : t('geo.play.markIgnoredShort', "Don't know")}
+                    </span>
+                </button>
+            )}
+        </div>
     )
 }

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -3,11 +3,13 @@ import { useTranslation } from 'react-i18next'
 import {
     ArrowLeft,
     ArrowRight,
+    EyeOff,
     Gamepad2,
     Loader2,
     Map as MapIcon,
     RefreshCw,
     Shuffle,
+    Sparkles,
     Trophy,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -49,6 +51,7 @@ export default function GeoPlayPage() {
         errorMessage,
         round,
         playedByGame,
+        ignoredGameIds,
         loadGames,
         selectGame,
         selectMap,
@@ -57,6 +60,7 @@ export default function GeoPlayPage() {
         submitGuess,
         nextRound,
         checkForNewScreenshots,
+        toggleIgnoreGame,
     } = useGeoFreePlayStore()
 
     const [gamePickerOpen, setGamePickerOpen] = useState(false)
@@ -101,6 +105,21 @@ export default function GeoPlayPage() {
         [games, currentGameId],
     )
 
+    const ignoredSet = useMemo(() => new Set(ignoredGameIds), [ignoredGameIds])
+
+    // "All-time done" — true when every catalog game the player hasn't
+    // ignored has its full set of screenshots already played. Computed
+    // from local state (playedByGame) plus the catalog `screenshotCount`,
+    // so it stays accurate as the catalog grows.
+    const allGamesCompleted = useMemo(() => {
+        const considered = games.filter((g) => !ignoredSet.has(g.id))
+        if (considered.length === 0) return false
+        return considered.every((g) => {
+            const played = playedByGame[g.id]?.length ?? 0
+            return g.screenshotCount > 0 && played >= g.screenshotCount
+        })
+    }, [games, ignoredSet, playedByGame])
+
     const canSubmit =
         phase === 'ready' &&
         !!pendingGuess &&
@@ -129,9 +148,21 @@ export default function GeoPlayPage() {
                         loading={phase === 'loading' || (currentGameId != null && phase === 'idle')}
                         empty={currentGameId == null}
                         exhausted={phase === 'exhausted'}
+                        allCompleted={allGamesCompleted}
+                        canIgnoreCurrent={
+                            phase === 'exhausted' &&
+                            currentGameId != null &&
+                            !ignoredSet.has(currentGameId)
+                        }
                         errorMessage={phase === 'error' ? errorMessage : null}
                         onPickGame={() => setGamePickerOpen(true)}
                         onCheckForNew={() => void checkForNewScreenshots()}
+                        onIgnoreCurrent={() => {
+                            if (currentGameId != null) {
+                                toggleIgnoreGame(currentGameId)
+                                setGamePickerOpen(true)
+                            }
+                        }}
                     />
                 }
                 map={
@@ -200,7 +231,9 @@ export default function GeoPlayPage() {
                 playedCountByGame={Object.fromEntries(
                     Object.entries(playedByGame).map(([id, ids]) => [id, ids.length]),
                 )}
+                ignoredGameIds={ignoredGameIds}
                 onSelect={(id) => void selectGame(id)}
+                onToggleIgnore={toggleIgnoreGame}
             />
             <MapPicker
                 open={mapPickerOpen}
@@ -219,20 +252,54 @@ function ScreenshotPanel({
     loading,
     empty,
     exhausted,
+    allCompleted,
+    canIgnoreCurrent,
     errorMessage,
     onPickGame,
     onCheckForNew,
+    onIgnoreCurrent,
 }: {
     imageUrl: string | null
     loading: boolean
     empty: boolean
     exhausted: boolean
+    allCompleted: boolean
+    canIgnoreCurrent: boolean
     errorMessage: string | null
     onPickGame: () => void
     onCheckForNew: () => void
+    onIgnoreCurrent: () => void
 }) {
     const { t } = useTranslation()
     const safeUrl = imageUrl && !isPlaceholderImageUrl(imageUrl) ? imageUrl : null
+
+    if (exhausted && allCompleted) {
+        return (
+            <div
+                className="flex h-full w-full flex-col items-center justify-center px-6 text-center gap-4"
+                role="status"
+            >
+                <div className="rounded-full bg-neon-pink/10 p-4">
+                    <Sparkles className="h-8 w-8 text-neon-pink" aria-hidden />
+                </div>
+                <div className="space-y-1 max-w-sm">
+                    <h2 className="text-lg font-semibold">
+                        {t('geo.play.allDone.title', "You've completed The Box!")}
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                        {t(
+                            'geo.play.allDone.body',
+                            "Bravo! You've guessed every screenshot in every game in your catalog. We'll ping you when new ones are added.",
+                        )}
+                    </p>
+                </div>
+                <Button onClick={onCheckForNew} variant="outline">
+                    <RefreshCw className="h-4 w-4 mr-2" aria-hidden />
+                    {t('geo.play.exhausted.checkForNew', 'Check for new screenshots')}
+                </Button>
+            </div>
+        )
+    }
 
     if (exhausted) {
         return (
@@ -254,13 +321,29 @@ function ScreenshotPanel({
                         )}
                     </p>
                 </div>
-                <Button
-                    onClick={onCheckForNew}
-                    variant="outline"
-                >
-                    <RefreshCw className="h-4 w-4 mr-2" aria-hidden />
-                    {t('geo.play.exhausted.checkForNew', 'Check for new screenshots')}
-                </Button>
+                <div className="flex flex-wrap items-center justify-center gap-2">
+                    <Button onClick={onPickGame} className="gradient-gaming hover:opacity-90">
+                        <Gamepad2 className="h-4 w-4 mr-2" aria-hidden />
+                        {t('geo.play.exhausted.pickAnother', 'Pick another game')}
+                    </Button>
+                    <Button onClick={onCheckForNew} variant="outline">
+                        <RefreshCw className="h-4 w-4 mr-2" aria-hidden />
+                        {t('geo.play.exhausted.checkForNew', 'Check for new screenshots')}
+                    </Button>
+                </div>
+                {canIgnoreCurrent && (
+                    <button
+                        type="button"
+                        onClick={onIgnoreCurrent}
+                        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground underline-offset-4 hover:underline"
+                    >
+                        <EyeOff className="h-3.5 w-3.5" aria-hidden />
+                        {t(
+                            'geo.play.exhausted.markIgnored',
+                            "I don't want to see this game again",
+                        )}
+                    </button>
+                )}
             </div>
         )
     }

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -52,6 +52,10 @@ interface GeoFreePlayState {
     // per map) so changing the map filter still hides already-seen
     // screenshots that happen to live on another map.
     playedByGame: Record<number, number[]>
+    // Games the player explicitly opted out of ("don't know this one").
+    // They're hidden from completion math so the all-time "done" message
+    // can fire even if the catalog has games the player will never touch.
+    ignoredGameIds: number[]
 
     // Actions
     loadGames(force?: boolean): Promise<void>
@@ -65,6 +69,7 @@ interface GeoFreePlayState {
     // exhausted state so a player who's seen everything can pull in
     // newly-promoted screenshots without a full page reload.
     checkForNewScreenshots(): Promise<void>
+    toggleIgnoreGame(gameId: number): void
     reset(): void
 }
 
@@ -85,6 +90,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             errorCode: null,
             round: 0,
             playedByGame: {},
+            ignoredGameIds: [],
 
             async loadGames(force) {
                 const { gamesFetchedAt } = get()
@@ -248,6 +254,14 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                 await get().rerollScreenshot()
             },
 
+            toggleIgnoreGame(gameId) {
+                const current = get().ignoredGameIds
+                const next = current.includes(gameId)
+                    ? current.filter((id) => id !== gameId)
+                    : [...current, gameId]
+                set({ ignoredGameIds: next })
+            },
+
             reset() {
                 set({
                     currentGameId: null,
@@ -275,8 +289,9 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                 currentGameId: state.currentGameId,
                 currentMapId: state.currentMapId,
                 playedByGame: state.playedByGame,
+                ignoredGameIds: state.ignoredGameIds,
             }),
-            version: 2,
+            version: 3,
         },
     ),
 )


### PR DESCRIPTION
Free play now tracks an all-time "you've finished everything" state
across the whole catalog instead of just the current game. Players can
mark games they don't know with a per-card "Don't know" toggle in the
game picker; ignored games are excluded from completion math so the
celebration message can fire without forcing the player through a game
they'll never play.

The exhausted state for a single game also gains a "Pick another game"
shortcut and an inline "I don't want to see this game again" link, so
finishing one game no longer leaves the player on a dead-end screen.

https://claude.ai/code/session_01Up2fEWshTa7cP38JxgYg2v