### PR TITLE
refactor(admin): merge Cartes tab into Géo hub as Acquisition sub-tab

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -538,6 +538,7 @@
       "subtitle": "Curate the Geo daily challenge: import sources, schedule challenges, and review crowdsourced submissions.",
       "tabs": {
         "queue": "Review queue",
+        "acquisition": "Acquisition",
         "reports": "Reports",
         "catalog": "Catalog"
       },
@@ -579,7 +580,7 @@
         },
         "no-maps": {
           "title": "No maps imported yet",
-          "body": "Your curated games don't have an active map yet. Click \"Run all\" on the Maps tab to start the ingestion pipeline, then schedule a challenge once at least one map is ready."
+          "body": "Your curated games don't have an active map yet. Open the \"Acquisition\" sub-tab to start the ingestion pipeline, then schedule a challenge once at least one map is ready."
         }
       },
       "games": {
@@ -628,6 +629,8 @@
         "title": "Maps per game",
         "subtitle": "Click a game to see which ingestion tiers ran or would run next.",
         "refresh": "Refresh",
+        "goToAcquisition": "Acquisition",
+        "goToAcquisitionTooltip": "Open the ingestion pipeline to start or monitor map runs.",
         "empty": "No curated games yet. Add some from the curated list in the Submissions tab.",
         "reimportQueued": "Re-run pipeline queued for \"{{name}}\".",
         "row": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -538,6 +538,7 @@
       "subtitle": "Gérez le défi Géo quotidien : importez les sources, planifiez les défis et modérez les propositions communautaires.",
       "tabs": {
         "queue": "À examiner",
+        "acquisition": "Acquisition",
         "reports": "Signalements",
         "catalog": "Catalogue"
       },
@@ -579,7 +580,7 @@
         },
         "no-maps": {
           "title": "Aucune carte importée",
-          "body": "Vos jeux activés n'ont pas encore de carte active. Cliquez sur « Tout lancer » dans l'onglet Cartes pour démarrer le pipeline d'ingestion, puis planifiez un défi quand au moins une carte est prête."
+          "body": "Vos jeux activés n'ont pas encore de carte active. Ouvrez le sous-onglet « Acquisition » pour démarrer le pipeline d'ingestion, puis planifiez un défi quand au moins une carte est prête."
         }
       },
       "games": {
@@ -628,6 +629,8 @@
         "title": "Cartes par jeu",
         "subtitle": "Cliquez sur un jeu pour voir quels niveaux d'ingestion ont été essayés ou seraient lancés ensuite.",
         "refresh": "Rafraîchir",
+        "goToAcquisition": "Acquisition",
+        "goToAcquisitionTooltip": "Ouvrir le pipeline d'ingestion pour lancer ou suivre des récupérations de cartes.",
         "empty": "Aucun jeu activé pour le moment. Ajoutez-en depuis la liste des jeux activés de l'onglet Propositions.",
         "reimportQueued": "Pipeline relancé pour « {{name}} ».",
         "row": {

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -17,12 +17,12 @@ import {
     CheckCircle2,
     XCircle,
     AlertTriangle,
+    ArrowUpRight,
     Clock,
     MinusCircle,
     Sparkles,
     Trash2,
     Play,
-    Zap,
     Search,
     RefreshCcw,
     ListChecks,
@@ -158,6 +158,13 @@ interface GeoMapsTabProps {
      * because tab state and the candidate list filter live there.
      */
     onViewCaptures?: (gameId: number, gameName: string) => void
+    /**
+     * Deep-link out of the Catalog into the Acquisition sub-tab. Replaces
+     * the bulk "Tout lancer" + per-row ▶ controls that used to live here
+     * and duplicated the Acquisition entry-point — the Catalog stays a
+     * read-and-curate surface; ingestion is run from one place.
+     */
+    onGoToAcquisition?: () => void
 }
 
 export function GeoMapsTab({
@@ -165,6 +172,7 @@ export function GeoMapsTab({
     runError,
     armRunPolling,
     onViewCaptures,
+    onGoToAcquisition,
 }: GeoMapsTabProps) {
     const { t } = useTranslation()
     const isMobile = useIsMobile()
@@ -186,8 +194,6 @@ export function GeoMapsTab({
     const [resetting, setResetting] = useState(false)
     const [uncurateFor, setUncurateFor] = useState<CuratedGame | null>(null)
     const [uncurating, setUncurating] = useState(false)
-    const [runningAll, setRunningAll] = useState(false)
-    const [runningGameId, setRunningGameId] = useState<number | null>(null)
     const [retryingTier, setRetryingTier] = useState<string | null>(null)
     const [runningTier, setRunningTier] = useState<string | null>(null)
     const [activatingMapId, setActivatingMapId] = useState<number | null>(null)
@@ -280,36 +286,6 @@ export function GeoMapsTab({
         }
         wasActiveRef.current = active
     }, [runState?.isActive, reload, reloadSources, selectedId])
-
-    const handleRunAll = async () => {
-        setRunningAll(true)
-        setMessage(null)
-        setError(null)
-        try {
-            await fetchJson('/api/admin/geo/run', { method: 'POST' })
-            setMessage(t('admin.geo.run.allQueued'))
-            armRunPolling()
-        } catch (e) {
-            setError(String(e))
-        } finally {
-            setRunningAll(false)
-        }
-    }
-
-    const handleRunGame = async (game: CuratedGame) => {
-        setRunningGameId(game.id)
-        setMessage(null)
-        setError(null)
-        try {
-            await fetchJson(`/api/admin/geo/run/${game.id}`, { method: 'POST' })
-            setMessage(t('admin.geo.run.gameQueued', { name: game.name }))
-            armRunPolling()
-        } catch (e) {
-            setError(String(e))
-        } finally {
-            setRunningGameId(null)
-        }
-    }
 
     const handleRetryTier = async (gameId: number, tier: string) => {
         setRetryingTier(tier)
@@ -506,23 +482,18 @@ export function GeoMapsTab({
                             </CardDescription>
                         </div>
                         <div className="flex items-center gap-1">
-                            <Button
-                                size="sm"
-                                variant="default"
-                                onClick={() => void handleRunAll()}
-                                disabled={runningAll || runState?.isActive}
-                                className="h-7 gap-1.5 text-xs"
-                                title={t('admin.geo.run.allTooltip')}
-                            >
-                                {runningAll || runState?.isActive ? (
-                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                                ) : (
-                                    <Zap className="h-3.5 w-3.5" />
-                                )}
-                                {runState?.isActive
-                                    ? t('admin.geo.run.running')
-                                    : t('admin.geo.run.allCta')}
-                            </Button>
+                            {onGoToAcquisition && (
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={onGoToAcquisition}
+                                    className="h-7 gap-1.5 text-xs"
+                                    title={t('admin.geo.maps.goToAcquisitionTooltip')}
+                                >
+                                    <ArrowUpRight className="h-3.5 w-3.5" />
+                                    {t('admin.geo.maps.goToAcquisition')}
+                                </Button>
+                            )}
                             <Button
                                 size="sm"
                                 variant="ghost"
@@ -571,7 +542,6 @@ export function GeoMapsTab({
                         <ul className="divide-y divide-border/40">
                             {games.map((g) => {
                                 const inflight = isGameInFlight(runState, g.id)
-                                const isThisRunning = runningGameId === g.id
                                 return (
                                 <li
                                     key={g.id}
@@ -605,26 +575,6 @@ export function GeoMapsTab({
                                                 </Badge>
                                             )}
                                             <MapStatusBadge game={g} t={t} />
-                                            <Button
-                                                size="sm"
-                                                variant="ghost"
-                                                disabled={isThisRunning || inflight}
-                                                onClick={(e) => {
-                                                    e.stopPropagation()
-                                                    void handleRunGame(g)
-                                                }}
-                                                aria-label={t('admin.geo.run.gameAria', {
-                                                    name: g.name,
-                                                })}
-                                                title={t('admin.geo.run.gameTooltip')}
-                                                className="h-6 w-6 p-0"
-                                            >
-                                                {isThisRunning ? (
-                                                    <Loader2 className="h-3 w-3 animate-spin" />
-                                                ) : (
-                                                    <Play className="h-3 w-3" />
-                                                )}
-                                            </Button>
                                         </div>
                                     </div>
                                 </li>

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -29,12 +30,14 @@ import {
     X,
     ChevronLeft,
     ChevronRight,
+    Workflow,
 } from 'lucide-react'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { GeoMapsTab } from './GeoMapsTab'
 import { GeoGamesTab } from './GeoGamesTab'
 import { ModerationStatusRail } from './ModerationStatusRail'
 import { ReportsModerationPanel } from './ReportsModerationPanel'
+import GeoFetchPanel from './geo-fetch/GeoFetchPanel'
 import { useGeoRunPolling } from '@/hooks/useGeoRunPolling'
 import { useGeoHealth } from '@/hooks/useGeoHealth'
 import { useIsMobile } from '@/hooks/useIsMobile'
@@ -146,15 +149,30 @@ async function rejectCandidate(id: number): Promise<void> {
     }
 }
 
+type GeoSubTab = 'queue' | 'acquisition' | 'reports' | 'catalog'
+const SUB_TABS: GeoSubTab[] = ['queue', 'acquisition', 'reports', 'catalog']
+
 export function GeoReviewPanel() {
     const { t } = useTranslation()
     const isMobile = useIsMobile()
-    // Two top-level destinations: the moderation queue (the daily job) and
-    // the catalog of reference data (maps + games). The previous Pins / Maps
-    // / Games triple split by entity, which is the engineer's mental model,
-    // not the moderator's. `catalogView` tracks which catalog sub-section is
-    // open so the segmented control stays in sync without a third tab.
-    const [activeTab, setActiveTab] = useState<'queue' | 'reports' | 'catalog'>('queue')
+    // Sub-tab state lives in the URL (`?sub=…`) so AdminPage's redirect
+    // map can deep-link `?tab=geoFetch` straight into Acquisition and so
+    // the moderator's tab choice survives a refresh.
+    const [searchParams, setSearchParams] = useSearchParams()
+    const subFromUrl = searchParams.get('sub')
+    const activeTab: GeoSubTab =
+        subFromUrl && (SUB_TABS as string[]).includes(subFromUrl)
+            ? (subFromUrl as GeoSubTab)
+            : 'queue'
+    const setActiveTab = useCallback(
+        (next: GeoSubTab) => {
+            const params = new URLSearchParams(searchParams)
+            if (next === 'queue') params.delete('sub')
+            else params.set('sub', next)
+            setSearchParams(params, { replace: true })
+        },
+        [searchParams, setSearchParams],
+    )
     const [catalogView, setCatalogView] = useState<'maps' | 'games'>('maps')
     // Default to the only status that needs the moderator's attention. The
     // other statuses are still reachable via the chip row, but the page
@@ -366,13 +384,17 @@ export function GeoReviewPanel() {
 
             <Tabs
                 value={activeTab}
-                onValueChange={(v) => setActiveTab(v as 'queue' | 'reports' | 'catalog')}
+                onValueChange={(v) => setActiveTab(v as GeoSubTab)}
                 className="space-y-4"
             >
                 <TabsList className="w-full overflow-x-auto justify-start scrollbar-hide">
                     <TabsTrigger value="queue" className="gap-1.5 shrink-0">
                         <ListChecks className="h-3.5 w-3.5" />
                         {t('admin.geo.tabs.queue')}
+                    </TabsTrigger>
+                    <TabsTrigger value="acquisition" className="gap-1.5 shrink-0">
+                        <Workflow className="h-3.5 w-3.5" />
+                        {t('admin.geo.tabs.acquisition')}
                     </TabsTrigger>
                     <TabsTrigger value="reports" className="gap-1.5 shrink-0">
                         <Flag className="h-3.5 w-3.5" />
@@ -383,6 +405,16 @@ export function GeoReviewPanel() {
                         {t('admin.geo.tabs.catalog')}
                     </TabsTrigger>
                 </TabsList>
+
+                <TabsContent value="acquisition" className="space-y-4">
+                    {/* Folded the standalone "Cartes" admin tab in here so
+                        ingestion controls live next door to the moderation
+                        queue and the catalog they feed. The previous tab
+                        duplicated triggers already exposed in
+                        Catalogue › Cartes; the IA now keeps a single
+                        ingestion entry-point. */}
+                    <GeoFetchPanel />
+                </TabsContent>
 
                 <TabsContent value="reports" className="space-y-4">
                     <ReportsModerationPanel />
@@ -427,6 +459,7 @@ export function GeoReviewPanel() {
                             runError={runError}
                             armRunPolling={armRunPolling}
                             onViewCaptures={viewCapturesForGame}
+                            onGoToAcquisition={() => setActiveTab('acquisition')}
                         />
                     ) : (
                         <GeoGamesTab />

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -13,16 +13,21 @@ import { GrowthStats } from '@/components/admin/GrowthStats'
 import { JobQueuePanel } from '@/components/admin/JobQueuePanel'
 import { GeoReviewPanel } from '@/components/admin/GeoReviewPanel'
 import { EmailLogPanel } from '@/components/admin/EmailLogPanel'
-import GeoFetchPanel from '@/components/admin/geo-fetch/GeoFetchPanel'
 import { AnimatedTabs } from '@/components/ui/animated-tabs'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { tabContent, pageTransition, fadeInLeft } from '@/lib/animations'
-import { Settings, ListTodo, Gamepad2, Users, Mail, MailCheck, TrendingUp, ShieldCheck, Map as MapIcon } from 'lucide-react'
+import { Settings, ListTodo, Gamepad2, Users, Mail, MailCheck, TrendingUp, Compass } from 'lucide-react'
 
-// `reports` used to be its own tab; it now lives as a sub-tab inside the
-// Moderation panel. Keep it in the redirect map so bookmarks land there.
-const VALID_TABS = ['jobs', 'games', 'users', 'email', 'emailLog', 'growth', 'geo', 'geoFetch']
-const REDIRECT_TABS: Record<string, string> = { reports: 'geo' }
+// Two old tabs were folded into the unified `geo` hub:
+//   - `reports`  → sub-tab `reports`
+//   - `geoFetch` → sub-tab `acquisition` (the standalone "Cartes" surface
+//                  duplicated triggers exposed under Géo › Catalogue)
+// Bookmarks for either land on the right sub-tab via REDIRECT_TABS.
+const VALID_TABS = ['jobs', 'games', 'users', 'email', 'emailLog', 'growth', 'geo']
+const REDIRECT_TABS: Record<string, { tab: string; sub?: string }> = {
+  reports: { tab: 'geo', sub: 'reports' },
+  geoFetch: { tab: 'geo', sub: 'acquisition' },
+}
 const DEFAULT_TAB = 'jobs'
 
 export default function AdminPage() {
@@ -49,15 +54,15 @@ export default function AdminPage() {
     { id: 'email', label: t('admin.tabs.email'), icon: <Mail className="h-4 w-4" /> },
     { id: 'emailLog', label: t('admin.tabs.emailLog'), icon: <MailCheck className="h-4 w-4" /> },
     { id: 'growth', label: t('admin.tabs.growth'), icon: <TrendingUp className="h-4 w-4" /> },
-    { id: 'geo', label: t('admin.tabs.moderation', 'Modération'), icon: <ShieldCheck className="h-4 w-4" /> },
-    { id: 'geoFetch', label: t('admin.tabs.geoFetch', 'Cartes'), icon: <MapIcon className="h-4 w-4" /> },
+    { id: 'geo', label: t('admin.tabs.geo', 'Géo'), icon: <Compass className="h-4 w-4" /> },
   ]
 
   // Get active tab from URL, default to 'jobs' if not present or invalid
   const tabFromUrl = searchParams.get('tab')
   const activeTab = tabFromUrl && VALID_TABS.includes(tabFromUrl) ? tabFromUrl : DEFAULT_TAB
 
-  // Handle tab change - update URL
+  // Handle tab change - update URL. Drop the `sub` param when switching
+  // away so a stale Géo sub-tab marker doesn't ride along into other tabs.
   const handleTabChange = (tabId: string) => {
     if (VALID_TABS.includes(tabId)) {
       const newSearchParams = new URLSearchParams(searchParams)
@@ -66,21 +71,27 @@ export default function AdminPage() {
       } else {
         newSearchParams.set('tab', tabId)
       }
+      if (tabId !== 'geo') newSearchParams.delete('sub')
       setSearchParams(newSearchParams, { replace: true })
     }
   }
 
   // Clean up invalid tab parameters from URL. Old tab ids that have been
-  // folded into another tab (e.g. `reports` → `geo` as a sub-tab) get
-  // rewritten so existing bookmarks land on the right place.
+  // folded into the Géo hub (`reports`, `geoFetch`) get rewritten so
+  // bookmarks land on the right sub-tab.
   useEffect(() => {
     const currentTab = searchParams.get('tab')
     if (!currentTab) return
     if (VALID_TABS.includes(currentTab)) return
     const newSearchParams = new URLSearchParams(searchParams)
     const redirectTo = REDIRECT_TABS[currentTab]
-    if (redirectTo && redirectTo !== DEFAULT_TAB) {
-      newSearchParams.set('tab', redirectTo)
+    if (redirectTo) {
+      if (redirectTo.tab === DEFAULT_TAB) {
+        newSearchParams.delete('tab')
+      } else {
+        newSearchParams.set('tab', redirectTo.tab)
+      }
+      if (redirectTo.sub) newSearchParams.set('sub', redirectTo.sub)
     } else {
       newSearchParams.delete('tab')
     }
@@ -166,7 +177,6 @@ export default function AdminPage() {
               {activeTab === 'emailLog' && <EmailLogPanel />}
               {activeTab === 'growth' && <GrowthStats />}
               {activeTab === 'geo' && <GeoReviewPanel />}
-              {activeTab === 'geoFetch' && <GeoFetchPanel />}
             </motion.div>
           </AnimatePresence>
         </div>


### PR DESCRIPTION
The standalone "Cartes" admin tab (geoFetch) and the "Modération" tab
both targeted the same Géo workflow. The Catalogue › Cartes view inside
Modération already exposed `Tout lancer` and per-row ▶ ingestion
triggers that duplicated the standalone tab — two doors to one room,
with two parallel state pipelines and inconsistent KPI counters.

Consolidate into a single `Géo` hub:

- Drop `geoFetch` from the admin top tab bar; rename `Modération` →
  `Géo` (the hub now covers acquisition + moderation).
- Mount `GeoFetchPanel` as a new `acquisition` sub-tab inside
  `GeoReviewPanel`, alongside `queue / reports / catalog`.
- Persist sub-tab in `?sub=` so deeplinks work; extend AdminPage's
  `REDIRECT_TABS` so old `?tab=geoFetch` bookmarks land on
  `?tab=geo&sub=acquisition`.
- Remove the duplicate `Tout lancer` and per-row ▶ controls from
  `GeoMapsTab`; replace with a deeplink CTA pointing to Acquisition so
  ingestion has a single authoritative entry-point.
- Update cold-start guidance to reference the new sub-tab.

State-pipeline unification (`useGeoFetchStore` vs `useGeoRunPolling`)
and backend route deduplication (`/geo-fetch/*` vs `/geo/run/*`) remain
as a follow-up — the IA fix here addresses the user-visible duplication
without touching the data layer.

https://claude.ai/code/session_01SH1TSvegz9BcLN7vSUT6Tq