### PR TITLE
feat(admin/geo): show games list with per-game capture counts

### DIFF
--- a/packages/backend/migrations/20260505_geo_candidate_game_status_index.ts
+++ b/packages/backend/migrations/20260505_geo_candidate_game_status_index.ts
@@ -1,0 +1,21 @@
+import type { Knex } from 'knex'
+
+// Composite index supporting the per-game moderation summary
+// (`/api/admin/geo/candidates/by-game`). The summary does
+// `GROUP BY game_id` with `COUNT(*) FILTER (WHERE status = ...)`,
+// so an index leading on game_id and including status keeps the
+// aggregation index-only as the candidate table grows.
+
+const INDEX_NAME = 'geo_screenshot_candidate_game_id_status_idx'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('geo_screenshot_candidate', (table) => {
+    table.index(['game_id', 'status'], INDEX_NAME)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('geo_screenshot_candidate', (table) => {
+    table.dropIndex(['game_id', 'status'], INDEX_NAME)
+  })
+}

--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -1,7 +1,11 @@
 import type { Knex } from 'knex'
 import { db } from '../database/connection.js'
 import { repoLogger } from '../logger/logger.js'
-import type { GeoScreenshotCandidate, GeoScreenshotMeta } from '@the-box/types'
+import type {
+  GeoCandidateGameSummary,
+  GeoScreenshotCandidate,
+  GeoScreenshotMeta,
+} from '@the-box/types'
 
 const log = repoLogger.child({ repository: 'geo-screenshot' })
 
@@ -278,6 +282,96 @@ export const geoScreenshotRepository = {
       mapCount: Number(r.map_count ?? 0),
       screenshotCount: Number(r.screenshot_count ?? 0),
     }))
+  },
+
+  /**
+   * Per-game summary for the moderation overview. One row per game that has
+   * any candidate (active or not — we still want rejected/promoted counts so
+   * the moderator can audit). Counts are computed via conditional aggregates
+   * on a single GROUP BY so the totals are honest even when the per-candidate
+   * listing is paginated. `oldestPendingAt` drives the default sort: games
+   * with the longest-waiting captures float to the top.
+   */
+  async summarizeCandidatesByGame(args: {
+    statusFilter?: GeoScreenshotCandidateRow['status']
+    limit?: number
+  } = {}): Promise<GeoCandidateGameSummary[]> {
+    const { statusFilter, limit = 100 } = args
+    const rows = await db('geo_screenshot_candidate as gsc')
+      .leftJoin('games as g', 'g.id', 'gsc.game_id')
+      .groupBy('gsc.game_id', 'g.name')
+      .orderByRaw(
+        // Games with the oldest pending capture come first. NULLS LAST so
+        // games without any pending captures fall to the bottom regardless
+        // of their other counts. Tie-break on pending count desc, then game id
+        // for a stable ordering.
+        `MIN(CASE WHEN gsc.status = 'pending' THEN gsc.created_at END) ASC NULLS LAST,
+         COUNT(*) FILTER (WHERE gsc.status = 'pending') DESC,
+         gsc.game_id ASC`,
+      )
+      .limit(limit)
+      .select<
+        Array<{
+          game_id: number
+          game_name: string | null
+          collecting_count: string
+          pending_count: string
+          promoted_count: string
+          rejected_count: string
+          total_count: string
+          oldest_pending_at: Date | null
+        }>
+      >(
+        'gsc.game_id',
+        db.raw('g.name as game_name'),
+        db.raw(
+          `COUNT(*) FILTER (WHERE gsc.status = 'collecting') as collecting_count`,
+        ),
+        db.raw(
+          `COUNT(*) FILTER (WHERE gsc.status = 'pending') as pending_count`,
+        ),
+        db.raw(
+          `COUNT(*) FILTER (WHERE gsc.status = 'promoted') as promoted_count`,
+        ),
+        db.raw(
+          `COUNT(*) FILTER (WHERE gsc.status = 'rejected') as rejected_count`,
+        ),
+        db.raw('COUNT(*) as total_count'),
+        db.raw(
+          `MIN(CASE WHEN gsc.status = 'pending' THEN gsc.created_at END) as oldest_pending_at`,
+        ),
+      )
+
+    const summaries: GeoCandidateGameSummary[] = rows.map((r) => ({
+      gameId: r.game_id,
+      gameName: r.game_name,
+      collectingCount: Number(r.collecting_count ?? 0),
+      pendingCount: Number(r.pending_count ?? 0),
+      promotedCount: Number(r.promoted_count ?? 0),
+      rejectedCount: Number(r.rejected_count ?? 0),
+      totalCount: Number(r.total_count ?? 0),
+      oldestPendingAt: r.oldest_pending_at
+        ? new Date(r.oldest_pending_at).toISOString()
+        : null,
+    }))
+
+    // Status filter is applied AFTER aggregation so a "pending" view only
+    // surfaces games that actually have pending captures while still
+    // exposing the full counts the row needs to render context (e.g.
+    // showing how many promoted captures the same game has).
+    if (statusFilter === 'collecting') {
+      return summaries.filter((s) => s.collectingCount > 0)
+    }
+    if (statusFilter === 'pending') {
+      return summaries.filter((s) => s.pendingCount > 0)
+    }
+    if (statusFilter === 'promoted') {
+      return summaries.filter((s) => s.promotedCount > 0)
+    }
+    if (statusFilter === 'rejected') {
+      return summaries.filter((s) => s.rejectedCount > 0)
+    }
+    return summaries
   },
 
   async listCandidatesForReview(args: {

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1396,6 +1396,30 @@ router.get('/growth-stats', async (_req, res, next) => {
 
 // === Geolocation mode (admin review) ===
 
+// Per-game moderation summary. Replaces the flat "show every capture" list
+// the panel used to render: the moderator now sees one row per game with
+// the full per-status counts and the oldest pending date. Counts come from
+// a single GROUP BY in the repo so they're honest beyond the per-candidate
+// page size.
+router.get('/geo/candidates/by-game', async (req, res, next) => {
+  try {
+    const status = typeof req.query.status === 'string' ? req.query.status : undefined
+    const limit = req.query.limit ? Math.min(500, Number(req.query.limit)) : 100
+    const summaries = await geoScreenshotRepository.summarizeCandidatesByGame({
+      statusFilter: status as
+        | 'pending'
+        | 'collecting'
+        | 'promoted'
+        | 'rejected'
+        | undefined,
+      limit,
+    })
+    res.json({ success: true, data: summaries })
+  } catch (err) {
+    next(err)
+  }
+})
+
 router.get('/geo/candidates', async (req, res, next) => {
   try {
     const status = typeof req.query.status === 'string' ? req.query.status : undefined

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -731,6 +731,26 @@
         "captureCount_one": "{{count}} capture",
         "captureCount_other": "{{count}} captures"
       },
+      "gamesList": {
+        "header_one": "Games ({{count}})",
+        "header_other": "Games ({{count}})",
+        "count": {
+          "pending_one": "{{count}} awaiting review",
+          "pending_other": "{{count}} awaiting review",
+          "collecting_one": "{{count}} open",
+          "collecting_other": "{{count}} open",
+          "promoted_one": "{{count}} made official",
+          "promoted_other": "{{count}} made official",
+          "all_one": "{{count}} capture total",
+          "all_other": "{{count}} captures total"
+        },
+        "oldestPending": "oldest {{relative}}",
+        "relative": {
+          "today": "today",
+          "daysAgo_one": "{{count}} day ago",
+          "daysAgo_other": "{{count}} days ago"
+        }
+      },
       "statusFilter": {
         "label": "Filter by status",
         "collecting": "Open",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -731,6 +731,26 @@
         "captureCount_one": "{{count}} capture",
         "captureCount_other": "{{count}} captures"
       },
+      "gamesList": {
+        "header_one": "Jeux ({{count}})",
+        "header_other": "Jeux ({{count}})",
+        "count": {
+          "pending_one": "{{count}} à modérer",
+          "pending_other": "{{count}} à modérer",
+          "collecting_one": "{{count}} ouverte",
+          "collecting_other": "{{count}} ouvertes",
+          "promoted_one": "{{count}} officialisée",
+          "promoted_other": "{{count}} officialisées",
+          "all_one": "{{count}} capture au total",
+          "all_other": "{{count}} captures au total"
+        },
+        "oldestPending": "plus ancienne {{relative}}",
+        "relative": {
+          "today": "aujourd'hui",
+          "daysAgo_one": "il y a {{count}} j",
+          "daysAgo_other": "il y a {{count}} j"
+        }
+      },
       "statusFilter": {
         "label": "Filtrer par statut",
         "collecting": "Ouvert",

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -40,6 +40,7 @@ import { useGeoHealth } from '@/hooks/useGeoHealth'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type {
+    GeoCandidateGameSummary,
     GeoMap,
     GeoPinSubmission,
     GeoPoint,
@@ -100,6 +101,20 @@ async function fetchCandidates(args: {
     const qs = params.toString() ? `?${params.toString()}` : ''
     const res = await fetch(`/api/admin/geo/candidates${qs}`, { credentials: 'include' })
     if (!res.ok) throw new Error(`list failed: ${res.status}`)
+    const json = await res.json()
+    return json.data
+}
+
+async function fetchGameSummaries(args: {
+    status?: string
+}): Promise<GeoCandidateGameSummary[]> {
+    const params = new URLSearchParams()
+    if (args.status) params.set('status', args.status)
+    const qs = params.toString() ? `?${params.toString()}` : ''
+    const res = await fetch(`/api/admin/geo/candidates/by-game${qs}`, {
+        credentials: 'include',
+    })
+    if (!res.ok) throw new Error(`summary failed: ${res.status}`)
     const json = await res.json()
     return json.data
 }
@@ -169,6 +184,11 @@ export function GeoReviewPanel() {
         gameName: string
     } | null>(null)
     const [candidates, setCandidates] = useState<GeoScreenshotCandidate[]>([])
+    // Per-game summary for the overview list (one row per game, with the
+    // honest count of captures per status). Fetched whenever no `gameFilter`
+    // is active; the per-candidate list takes over once the moderator drills
+    // into a specific game.
+    const [summaries, setSummaries] = useState<GeoCandidateGameSummary[]>([])
     const [detail, setDetail] = useState<CandidateDetail | null>(null)
     const [pin, setPin] = useState<GeoPoint | null>(null)
     const [loading, setLoading] = useState(true)
@@ -188,13 +208,31 @@ export function GeoReviewPanel() {
     useEffect(() => {
         let cancelled = false
         setLoading(true)
-        fetchCandidates({
-            status: statusFilter === 'all' ? undefined : statusFilter,
-            gameId: gameFilter?.gameId,
-        })
-            .then((rows) => !cancelled && setCandidates(rows))
-            .catch((e) => !cancelled && setError(String(e)))
-            .finally(() => !cancelled && setLoading(false))
+        // Two modes:
+        //  - No game selected → fetch per-game summary (the "Propositions"
+        //    list shows one row per game with its capture counts).
+        //  - Game selected (drill-down) → fetch the candidates of that game
+        //    so the moderator can act on individual captures.
+        const status = statusFilter === 'all' ? undefined : statusFilter
+        const gameId = gameFilter?.gameId
+        if (gameId !== undefined) {
+            fetchCandidates({ status, gameId })
+                .then((rows) => !cancelled && setCandidates(rows))
+                .catch((e) => !cancelled && setError(String(e)))
+                .finally(() => !cancelled && setLoading(false))
+        } else {
+            fetchGameSummaries({ status })
+                .then((rows) => {
+                    if (cancelled) return
+                    setSummaries(rows)
+                    // Keep `candidates` empty in summary mode so the
+                    // detail/prev-next bookkeeping (which reads candidates)
+                    // doesn't carry stale rows from a previous drill-down.
+                    setCandidates([])
+                })
+                .catch((e) => !cancelled && setError(String(e)))
+                .finally(() => !cancelled && setLoading(false))
+        }
         return () => {
             cancelled = true
         }
@@ -249,6 +287,10 @@ export function GeoReviewPanel() {
                 await openDetail(next.id)
             } else {
                 setDetail(null)
+                // Game has no more captures matching the active filter —
+                // bounce back to the per-game summary so the moderator can
+                // pick the next game to triage.
+                if (rows.length === 0 && gameFilter) setGameFilter(null)
             }
         } catch (e) {
             setError(String(e))
@@ -286,6 +328,7 @@ export function GeoReviewPanel() {
                 await openDetail(next.id)
             } else {
                 setDetail(null)
+                if (rows.length === 0 && gameFilter) setGameFilter(null)
             }
         } catch (e) {
             setError(String(e))
@@ -335,6 +378,34 @@ export function GeoReviewPanel() {
         const key = `admin.geo.statusBadge.${status}`
         const translated = t(key)
         return translated === key ? status : translated
+    }
+
+    // Pick which count drives a summary row's primary number based on the
+    // active status filter. `all` shows the total so the row never hides
+    // captures when the moderator switches to the audit view.
+    const summaryCountFor = (s: GeoCandidateGameSummary): number => {
+        switch (statusFilter) {
+            case 'collecting':
+                return s.collectingCount
+            case 'pending':
+                return s.pendingCount
+            case 'promoted':
+                return s.promotedCount
+            case 'all':
+                return s.totalCount
+        }
+    }
+
+    // Days between `iso` and now, rounded down to whole days. Used to label
+    // the oldest pending capture per game so triage can prioritise stale
+    // ones. Returns null for invalid input so callers can skip the badge.
+    const daysSince = (iso: string | null): number | null => {
+        if (!iso) return null
+        const ts = Date.parse(iso)
+        if (Number.isNaN(ts)) return null
+        const ms = Date.now() - ts
+        if (ms <= 0) return 0
+        return Math.floor(ms / (1000 * 60 * 60 * 24))
     }
 
     return (
@@ -495,7 +566,11 @@ export function GeoReviewPanel() {
                         <CardHeader className="pb-2 p-4 sm:p-6">
                             <div className="flex items-center justify-between gap-2">
                                 <CardTitle className="text-sm">
-                                    {t('admin.geo.submissions')} ({candidates.length})
+                                    {gameFilter
+                                        ? `${t('admin.geo.submissions')} (${candidates.length})`
+                                        : t('admin.geo.gamesList.header', {
+                                              count: summaries.length,
+                                          })}
                                 </CardTitle>
                                 <Button
                                     type="button"
@@ -509,59 +584,131 @@ export function GeoReviewPanel() {
                                 </Button>
                             </div>
                         </CardHeader>
-                        <CardContent className="space-y-4 lg:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
-                            {groupCandidatesByGame(candidates).map((group) => (
-                                <section key={group.gameId} className="space-y-2">
-                                    <header className="flex items-baseline justify-between gap-2 border-b border-border/40 pb-1">
-                                        <h3 className="truncate text-xs font-semibold text-foreground">
-                                            {group.gameName ??
-                                                t('admin.geo.groupHeader.unknownGame', {
-                                                    id: group.gameId,
+                        <CardContent className="space-y-3 lg:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
+                            {gameFilter ? (
+                                <>
+                                    {candidates.map((c) => (
+                                        <button
+                                            key={c.id}
+                                            onClick={() => openDetail(c.id)}
+                                            className={`w-full text-left rounded border p-2 text-xs hover:bg-muted/40 active:bg-muted/60 ${
+                                                detail?.candidate.id === c.id && !isMobile
+                                                    ? 'border-neon-pink'
+                                                    : ''
+                                            }`}
+                                        >
+                                            <div className="flex justify-between items-center gap-2">
+                                                <span className="truncate font-mono font-medium">
+                                                    #{c.id}
+                                                </span>
+                                                <Badge variant="outline">
+                                                    {statusLabel(c.status)}
+                                                </Badge>
+                                            </div>
+                                            <div className="mt-1 text-muted-foreground">
+                                                {t('admin.geo.submissionRow.pinCount', {
+                                                    count: c.pinCount,
                                                 })}
-                                        </h3>
-                                        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                                            {t('admin.geo.groupHeader.captureCount', {
-                                                count: group.candidates.length,
-                                            })}
-                                        </span>
-                                    </header>
-                                    <div className="space-y-2">
-                                        {group.candidates.map((c) => (
-                                            <button
-                                                key={c.id}
-                                                onClick={() => openDetail(c.id)}
-                                                className={`w-full text-left rounded border p-2 text-xs hover:bg-muted/40 active:bg-muted/60 ${
-                                                    detail?.candidate.id === c.id && !isMobile
-                                                        ? 'border-neon-pink'
-                                                        : ''
-                                                }`}
-                                            >
-                                                <div className="flex justify-between items-center gap-2">
-                                                    <span className="truncate font-mono font-medium">
-                                                        #{c.id}
-                                                    </span>
-                                                    <Badge variant="outline">
-                                                        {statusLabel(c.status)}
-                                                    </Badge>
-                                                </div>
-                                                <div className="mt-1 text-muted-foreground">
-                                                    {t('admin.geo.submissionRow.pinCount', {
-                                                        count: c.pinCount,
-                                                    })}
-                                                    {' · '}
-                                                    {t('admin.geo.submissionRow.source', {
-                                                        source: c.source,
-                                                    })}
-                                                </div>
-                                            </button>
-                                        ))}
-                                    </div>
-                                </section>
-                            ))}
-                            {candidates.length === 0 && (
-                                <p className="text-xs text-muted-foreground">
-                                    {t('admin.geo.emptyQueue')}
-                                </p>
+                                                {' · '}
+                                                {t('admin.geo.submissionRow.source', {
+                                                    source: c.source,
+                                                })}
+                                            </div>
+                                        </button>
+                                    ))}
+                                    {candidates.length === 0 && (
+                                        <p className="text-xs text-muted-foreground">
+                                            {t('admin.geo.emptyQueue')}
+                                        </p>
+                                    )}
+                                </>
+                            ) : (
+                                <>
+                                    {summaries
+                                        .filter((s) => summaryCountFor(s) > 0)
+                                        .map((s) => {
+                                            const primary = summaryCountFor(s)
+                                            const days = daysSince(s.oldestPendingAt)
+                                            return (
+                                                <button
+                                                    key={s.gameId}
+                                                    onClick={() =>
+                                                        viewCapturesForGame(
+                                                            s.gameId,
+                                                            s.gameName ??
+                                                                t(
+                                                                    'admin.geo.groupHeader.unknownGame',
+                                                                    { id: s.gameId },
+                                                                ),
+                                                        )
+                                                    }
+                                                    className="w-full text-left rounded border p-3 text-xs hover:bg-muted/40 active:bg-muted/60 transition-colors"
+                                                >
+                                                    <div className="flex items-baseline justify-between gap-2">
+                                                        <h3 className="truncate text-sm font-semibold text-foreground">
+                                                            {s.gameName ??
+                                                                t(
+                                                                    'admin.geo.groupHeader.unknownGame',
+                                                                    { id: s.gameId },
+                                                                )}
+                                                        </h3>
+                                                        <span className="shrink-0 font-mono text-sm font-bold text-neon-pink">
+                                                            {primary}
+                                                        </span>
+                                                    </div>
+                                                    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+                                                        <span>
+                                                            {t(
+                                                                `admin.geo.gamesList.count.${statusFilter}`,
+                                                                { count: primary },
+                                                            )}
+                                                        </span>
+                                                        {statusFilter !== 'pending' &&
+                                                            s.pendingCount > 0 && (
+                                                                <Badge
+                                                                    variant="outline"
+                                                                    className="h-4 px-1 text-[10px]"
+                                                                >
+                                                                    {t(
+                                                                        'admin.geo.gamesList.count.pending',
+                                                                        {
+                                                                            count: s.pendingCount,
+                                                                        },
+                                                                    )}
+                                                                </Badge>
+                                                            )}
+                                                        {days !== null && s.pendingCount > 0 && (
+                                                            <span>
+                                                                {' · '}
+                                                                {t(
+                                                                    'admin.geo.gamesList.oldestPending',
+                                                                    {
+                                                                        relative:
+                                                                            days === 0
+                                                                                ? t(
+                                                                                      'admin.geo.gamesList.relative.today',
+                                                                                  )
+                                                                                : t(
+                                                                                      'admin.geo.gamesList.relative.daysAgo',
+                                                                                      {
+                                                                                          count: days,
+                                                                                      },
+                                                                                  ),
+                                                                    },
+                                                                )}
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                </button>
+                                            )
+                                        })}
+                                    {summaries.filter((s) => summaryCountFor(s) > 0).length ===
+                                        0 && (
+                                        <p className="text-xs text-muted-foreground">
+                                            {t('admin.geo.emptyQueue')}
+                                        </p>
+                                    )}
+                                </>
                             )}
                         </CardContent>
                     </Card>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -897,6 +897,21 @@ export interface GeoScreenshotMeta {
   promotedVia: 'consensus' | 'admin'
 }
 
+// Per-game summary surfaced by the admin moderation list. Counts come from a
+// single GROUP BY on geo_screenshot_candidate so the moderator sees the true
+// number of captures per game (the per-candidate listing is paginated and
+// would lie if we summed a capped page client-side).
+export interface GeoCandidateGameSummary {
+  gameId: number
+  gameName: string | null
+  collectingCount: number
+  pendingCount: number
+  promotedCount: number
+  rejectedCount: number
+  totalCount: number
+  oldestPendingAt: string | null
+}
+
 export interface GeoChallenge {
   id: number
   challengeDate: string


### PR DESCRIPTION
The "À modérer" view used to render every individual capture as its own
card, drowning the moderator in #ids. It now lists one row per game with
the count for the active status filter and the oldest pending date, and
drills into the per-capture view when the moderator picks a game. Counts
come from a single GROUP BY in the repo so they're honest beyond the
50/200 per-page limit.

- New endpoint GET /api/admin/geo/candidates/by-game with conditional
  aggregates (COUNT(*) FILTER) and oldest-pending sort.
- Composite index (game_id, status) on geo_screenshot_candidate.
- Drill-down reuses the existing /api/admin/geo/candidates?gameId=X path.
- After moderating the last capture in a game, the panel auto-returns
  to the games list so the moderator can pick the next one.