### PR TITLE
fix(geo): shorten next round button label to "Suivant"

### DIFF
--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1636,7 +1636,7 @@
       "changeGame": "Changer de jeu",
       "changeMap": "Changer de carte",
       "submit": "Placer l'épingle",
-      "next": "Tour suivant",
+      "next": "Suivant",
       "reroll": "Nouvelle capture",
       "tabs": {
         "screenshot": "Photo",


### PR DESCRIPTION
## Summary
- Shorten the geo play "next round" button label from "Tour suivant" to "Suivant" in the French locale.

## Test plan
- [ ] Visit `/fr/geo`, complete a round, and verify the action button reads "Suivant".

https://claude.ai/code/session_0182bJ6ggyxMt78f6o5dtmcz

---
_Generated by [Claude Code](https://claude.ai/code/session_0182bJ6ggyxMt78f6o5dtmcz)_