### PR TITLE
fix(admin/geo): prevent next-button overlap with sheet close on mobile

### DIFF
--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -798,7 +798,7 @@ export function GeoReviewPanel() {
                     side="bottom"
                     className="lg:hidden h-[92vh] p-0 flex flex-col gap-0 rounded-t-xl"
                 >
-                    <SheetHeader className="px-4 py-3 border-b border-border/40 text-left">
+                    <SheetHeader className="px-4 py-3 pr-12 border-b border-border/40 text-left">
                         <div className="flex items-center justify-between gap-2">
                             <SheetTitle className="text-sm font-semibold">
                                 {detail


### PR DESCRIPTION
The mobile candidate detail sheet placed CandidateNavControls at the
right edge of the header, sitting underneath the absolute-positioned
SheetContent close button. Reserve right padding so the next chevron
remains tappable.