### PR TITLE
fix(geo/free-play): auto-switch to another game when captures run out

### DIFF
--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -127,6 +127,16 @@ export default function GeoPlayPage() {
         })
     }, [games, ignoredSet, playedByGame])
 
+    // When the current game runs out of captures but the catalog still has
+    // unplayed screenshots elsewhere, silently switch to another game
+    // instead of showing a per-game "you've seen everything" notice. The
+    // exhausted UI is reserved for the all-catalog-done case.
+    useEffect(() => {
+        if (phase === 'exhausted' && !allGamesCompleted) {
+            void pickRandomAcrossGames()
+        }
+    }, [phase, allGamesCompleted, pickRandomAcrossGames])
+
     const canSubmit =
         phase === 'ready' &&
         !!pendingGuess &&

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -237,11 +237,18 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                 if (get().games.length === 0) {
                     await get().loadGames()
                 }
-                const { games, ignoredGameIds, currentGameId } = get()
+                const { games, ignoredGameIds, currentGameId, playedByGame } = get()
                 const ignored = new Set(ignoredGameIds)
-                const candidates = games.filter(
-                    (g) => !ignored.has(g.id) && g.screenshotCount > 0,
-                )
+                // Exclude games the player has already fully played — landing
+                // on one would just bounce back into the exhausted state and
+                // (with the auto-switch effect) thrash through games until
+                // every remaining candidate is also exhausted.
+                const candidates = games.filter((g) => {
+                    if (ignored.has(g.id)) return false
+                    if (g.screenshotCount <= 0) return false
+                    const played = playedByGame[g.id]?.length ?? 0
+                    return played < g.screenshotCount
+                })
                 if (candidates.length === 0) return
                 // Avoid landing back on the same game when there's an
                 // alternative — otherwise the shuffle feels broken on


### PR DESCRIPTION
When a player exhausted every screenshot for the current game, the UI
rendered the per-game "Vous avez vu toutes les captures" notice inside
the screenshot panel only — the map and dock stayed visible alongside
it, making the page look broken.

Silently shuffle to another non-completed game in that case (the
all-catalog-done overlay still fires when truly nothing is left to play)
and tighten pickRandomAcrossGames to skip games whose plays already
cover their full screenshot count so the auto-switch can't bounce back
onto an exhausted game.