### PR TITLE
fix(admin/geo): rename Officialiser button to Valider le pin

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -772,7 +772,7 @@
         "rejected": "Declined"
       },
       "actions": {
-        "makeOfficial": "Make official",
+        "makeOfficial": "Validate pin",
         "removeOfficial": "Remove official location",
         "decline": "Decline"
       },

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -772,7 +772,7 @@
         "rejected": "Refusé"
       },
       "actions": {
-        "makeOfficial": "Officialiser",
+        "makeOfficial": "Valider le pin",
         "removeOfficial": "Retirer du lieu officiel",
         "decline": "Refuser"
       },


### PR DESCRIPTION
## Summary
- Rename the moderator action button in Modération Géo from "Officialiser" to "Valider le pin" (FR) and "Validate pin" (EN).

## Test plan
- [ ] Open Admin → Modération Géo and verify the action button reads "Valider le pin".
- [ ] Switch UI language to English; button reads "Validate pin".

https://claude.ai/code/session_01CLy5DDvB68GCgxYF8qTgJR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLy5DDvB68GCgxYF8qTgJR)_