### PR TITLE
fix(admin/geo): sync map crosshair to placed pin

### DIFF
--- a/packages/frontend/src/components/geo/MapCanvas.tsx
+++ b/packages/frontend/src/components/geo/MapCanvas.tsx
@@ -58,12 +58,15 @@ export function MapCanvas({
         if (disabled || errored || !onPin) return
         const rect = containerRef.current?.getBoundingClientRect()
         if (!rect) return
-        const x = (e.clientX - rect.left) / rect.width
-        const y = (e.clientY - rect.top) / rect.height
-        onPin({
-            x: clamp01(x),
-            y: clamp01(y),
-        })
+        const x = clamp01((e.clientX - rect.left) / rect.width)
+        const y = clamp01((e.clientY - rect.top) / rect.height)
+        // Anchor the keyboard cursor to the click. Tapping focuses the canvas
+        // (role=button, tabIndex=0), which fires handleFocus before the new
+        // pin prop has propagated — without this sync the focus-seeded cursor
+        // would land on the stale pin or the center default, leaving the
+        // crosshair pinned to (0.5, 0.5) while the marker sits elsewhere.
+        setKbCursor({ x, y })
+        onPin({ x, y })
     }
 
     const handleMove = (e: MouseEvent<HTMLDivElement>) => {
@@ -168,6 +171,14 @@ export function MapCanvas({
             {/* Keyboard cursor — solid (not faint) so it's distinguishable
                 from the mouse-hover crosshair. */}
             {kbCursor && <Crosshair x={kbCursor.x} y={kbCursor.y} />}
+
+            {/* Pin axis guide — when no hover/keyboard crosshair is active,
+                draw faint X/Y lines through the placed pin so the operator
+                can read its coordinates at a glance instead of seeing the
+                axis stuck at the canvas center. */}
+            {pin && !hover && !kbCursor && (
+                <Crosshair x={pin.x} y={pin.y} faint />
+            )}
 
             {/* Guess → canonical line */}
             {showGuessLine && pin && canonical && (


### PR DESCRIPTION
## Summary
- Anchor `kbCursor` to the click point in `handleClick` so the focus-seeded crosshair lands on the marker (previously stuck at canvas center because `handleFocus` read a stale `pin` prop after tap-focus).
- Render a faint X/Y crosshair through the placed pin when no hover/keyboard guide is active, so the axis always follows the pin.

## Test plan
- [ ] On mobile, tap the admin moderation map to place a pin — crosshair now passes through the pin instead of staying at center.
- [ ] On desktop, hover still shows the faint hover crosshair; keyboard arrows still drive the solid keyboard crosshair.
- [ ] After placing a pin and moving the mouse out of the canvas, faint axis lines remain through the pin.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ztyfHsQJkKMmL9s1ASXSP)_