### PR TITLE
feat(admin/geo): make admin pin optional, fall back to player centroid

### DIFF
--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -43,6 +43,7 @@ import {
   emailLogRepository,
 } from '../../infrastructure/repositories/index.js'
 import { GEO_CONSENSUS_VERSION } from '../../domain/services/index.js'
+import { evaluateConsensus } from '../../domain/services/geo-consensus.service.js'
 import { isMapEligibleByGenre } from '../../domain/services/geo-metadata.service.js'
 import { geoQueue, type GeoJobData } from '../../infrastructure/queue/queues.js'
 import { findRegistryEntryBySlug } from '../../infrastructure/queue/workers/geo-registry-import-logic.js'
@@ -1468,10 +1469,18 @@ router.get('/geo/candidates/:id', async (req, res, next) => {
   }
 })
 
-const overrideBodySchema = z.object({
-  canonicalX: z.number().min(0).max(1),
-  canonicalY: z.number().min(0).max(1),
-})
+// Admin can either pin the canonical location themselves, or omit both
+// coordinates to let the centroid of player submissions stand in. The
+// "approach the right answer through participation" path: more pins
+// pull the centroid toward the true location.
+const overrideBodySchema = z
+  .object({
+    canonicalX: z.number().min(0).max(1).optional(),
+    canonicalY: z.number().min(0).max(1).optional(),
+  })
+  .refine((v) => (v.canonicalX === undefined) === (v.canonicalY === undefined), {
+    message: 'canonicalX and canonicalY must both be provided or both omitted',
+  })
 
 router.post('/geo/candidates/:id/override', async (req, res, next) => {
   try {
@@ -1507,14 +1516,51 @@ router.post('/geo/candidates/:id/override', async (req, res, next) => {
       return
     }
 
+    let canonicalX: number
+    let canonicalY: number
+    let confidence: number
+    let promotedVia: 'consensus' | 'admin'
+
+    if (parse.data.canonicalX !== undefined && parse.data.canonicalY !== undefined) {
+      canonicalX = parse.data.canonicalX
+      canonicalY = parse.data.canonicalY
+      confidence = 1.0
+      promotedVia = 'admin'
+    } else {
+      const pins = await geoPinRepository.listByCandidate(id)
+      if (pins.length === 0) {
+        res.status(400).json({
+          success: false,
+          error: {
+            code: 'NO_PINS',
+            message: 'no submissions to compute average from',
+          },
+        })
+        return
+      }
+      const map = await geoMapRepository.findById(candidate.geoMapId)
+      if (!map) {
+        res.status(404).json({ success: false, error: { code: 'MAP_NOT_FOUND' } })
+        return
+      }
+      const consensus = evaluateConsensus(
+        pins.map((p) => ({ id: p.id, pin: p.pin })),
+        map.consensusRadius,
+      )
+      canonicalX = consensus.centroid.x
+      canonicalY = consensus.centroid.y
+      confidence = consensus.confidence
+      promotedVia = 'consensus'
+    }
+
     const meta = await geoScreenshotRepository.promoteCandidateToMeta({
       candidateId: id,
       geoMapId: candidate.geoMapId,
-      canonicalX: parse.data.canonicalX,
-      canonicalY: parse.data.canonicalY,
-      confidence: 1.0,
+      canonicalX,
+      canonicalY,
+      confidence,
       consensusVersion: GEO_CONSENSUS_VERSION,
-      promotedVia: 'admin',
+      promotedVia,
       promotedBy: req.userId,
     })
 

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -785,7 +785,7 @@
       "submissionsLoading": "Loading submissions…",
       "emptyQueue": "No submissions match this filter.",
       "pickSubmission": "Pick a submission",
-      "pickPointForOfficial": "Click the map to set the official location",
+      "pickPointForOfficial": "Click to set a location, or validate without a pin to use the average of submissions",
       "detailHintOfficial": "Pick a submission from the list to review it and set its official location.",
       "alreadyOfficial": "Official location already set — remove it to re-pin somewhere else.",
       "submissionRow": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -785,7 +785,7 @@
       "submissionsLoading": "Chargement des propositions…",
       "emptyQueue": "Aucune proposition ne correspond à ce filtre.",
       "pickSubmission": "Choisir une proposition",
-      "pickPointForOfficial": "Cliquez sur la carte pour fixer le lieu officiel",
+      "pickPointForOfficial": "Cliquez pour fixer un lieu, ou validez sans pin pour utiliser la moyenne des propositions",
       "detailHintOfficial": "Sélectionnez une proposition dans la liste pour la consulter et fixer son lieu officiel.",
       "alreadyOfficial": "Lieu officiel déjà fixé — retirez-le pour replacer le repère.",
       "submissionRow": {

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -129,12 +129,14 @@ async function fetchCandidateDetail(id: number): Promise<CandidateDetail> {
     return json.data
 }
 
-async function overrideCandidate(id: number, pin: GeoPoint): Promise<void> {
+async function overrideCandidate(id: number, pin: GeoPoint | null): Promise<void> {
     const res = await fetch(`/api/admin/geo/candidates/${id}/override`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ canonicalX: pin.x, canonicalY: pin.y }),
+        body: JSON.stringify(
+            pin ? { canonicalX: pin.x, canonicalY: pin.y } : {},
+        ),
     })
     if (!res.ok) {
         const json = await res.json().catch(() => ({}))
@@ -286,7 +288,7 @@ export function GeoReviewPanel() {
     }
 
     const applyOverride = async () => {
-        if (!detail || !pin) return
+        if (!detail) return
         setSaving(true)
         try {
             const previousFlat = groupCandidatesByGame(candidates).flatMap(
@@ -1071,7 +1073,7 @@ function CandidateDetailBody({
                         <Button
                             size="sm"
                             onClick={() => void onPromote()}
-                            disabled={!pin || saving}
+                            disabled={saving}
                             className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
                         >
                             {saving && (


### PR DESCRIPTION
When officialising a capture without placing a pin, the canonical
location is now computed as the centroid of player submissions, with
the consensus confidence and 'consensus' promotion source. Players
approach the right answer through participation. Empty submissions
still return NO_PINS so admins know to pin manually.