### PR TITLE
fix(admin/geo): switch button label to "Valider sans pin" when no pin set

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -773,6 +773,7 @@
       },
       "actions": {
         "makeOfficial": "Validate pin",
+        "makeOfficialNoPin": "Validate without pin",
         "removeOfficial": "Remove official location",
         "decline": "Decline"
       },

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -773,6 +773,7 @@
       },
       "actions": {
         "makeOfficial": "Valider le pin",
+        "makeOfficialNoPin": "Valider sans pin",
         "removeOfficial": "Retirer du lieu officiel",
         "decline": "Refuser"
       },

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -1079,7 +1079,11 @@ function CandidateDetailBody({
                             {saving && (
                                 <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
                             )}
-                            {t('admin.geo.actions.makeOfficial')}
+                            {t(
+                                pin
+                                    ? 'admin.geo.actions.makeOfficial'
+                                    : 'admin.geo.actions.makeOfficialNoPin',
+                            )}
                         </Button>
                     </div>
                 </div>


### PR DESCRIPTION
The action accepted submissions without a pin (centroid fallback) since
e8d2c2f, but the button still read "Valider le pin", which suggested a
pin was required. Switch the label dynamically so admins can tell at a
glance which path they're about to take.

https://claude.ai/code/session_01BeX4AwWinDbFRY7kx1fRN9