### PR TITLE
fix(admin/geo): keep header reachable during mobile candidate review

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -796,7 +796,8 @@
       "nav": {
         "previous": "Previous capture",
         "next": "Next capture",
-        "position": "{{current}} / {{total}}"
+        "position": "{{current}} / {{total}}",
+        "backToList": "Back to list"
       },
       "guide": {
         "title": "Moderation guide",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -796,7 +796,8 @@
       "nav": {
         "previous": "Capture précédente",
         "next": "Capture suivante",
-        "position": "{{current}} / {{total}}"
+        "position": "{{current}} / {{total}}",
+        "backToList": "Retour à la liste"
       },
       "guide": {
         "title": "Guide de modération",

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -13,12 +13,6 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog'
 import {
-    Sheet,
-    SheetContent,
-    SheetHeader,
-    SheetTitle,
-} from '@/components/ui/sheet'
-import {
     Loader2,
     Trash2,
     HelpCircle,
@@ -30,8 +24,10 @@ import {
     X,
     ChevronLeft,
     ChevronRight,
+    ArrowLeft,
     Workflow,
 } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { GeoMapsTab } from './GeoMapsTab'
 import { GeoGamesTab } from './GeoGamesTab'
@@ -597,7 +593,16 @@ export function GeoReviewPanel() {
                 </div>
             ) : (
                 <div className="grid gap-3 sm:gap-4 grid-cols-1 lg:grid-cols-3">
-                    <Card className="lg:col-span-1">
+                    {/* List card — hidden on mobile while a candidate is open
+                        so the page reverts to a single column and the sticky
+                        Header stays reachable. On lg+, both cards sit
+                        side-by-side as before. */}
+                    <Card
+                        className={cn(
+                            'lg:col-span-1',
+                            detail && 'hidden lg:block',
+                        )}
+                    >
                         <CardHeader className="pb-2 p-4 sm:p-6">
                             <div className="flex items-center justify-between gap-2">
                                 <CardTitle className="text-sm">
@@ -748,15 +753,48 @@ export function GeoReviewPanel() {
                         </CardContent>
                     </Card>
 
-                    {/* Desktop: side-by-side detail card */}
-                    <Card className="hidden lg:block lg:col-span-2">
+                    {/* Detail card — on mobile, only renders when a
+                        candidate is selected (replacing the list). On lg+,
+                        always visible alongside the list. The Header stays
+                        sticky throughout because nothing is rendered as a
+                        modal/portal anymore. */}
+                    <Card
+                        className={cn(
+                            'lg:col-span-2',
+                            !detail && 'hidden lg:block',
+                        )}
+                    >
                         <CardHeader className="pb-2 p-4 sm:p-6">
                             <div className="flex items-center justify-between gap-2">
-                                <CardTitle className="text-sm">
-                                    {detail
-                                        ? `#${detail.candidate.id} · ${t('admin.geo.submissionRow.pinCount', { count: detail.pins.length })}`
-                                        : t('admin.geo.pickSubmission')}
-                                </CardTitle>
+                                <div className="flex items-center gap-2 min-w-0">
+                                    {/* Mobile back button — pops the detail
+                                        view so the user is returned to the
+                                        list. Hidden on lg+ where both cards
+                                        are visible side-by-side. */}
+                                    {detail && (
+                                        <Button
+                                            type="button"
+                                            size="icon"
+                                            variant="ghost"
+                                            className="h-8 w-8 shrink-0 lg:hidden"
+                                            onClick={() => {
+                                                setDetail(null)
+                                                setPin(null)
+                                            }}
+                                            aria-label={t(
+                                                'admin.geo.nav.backToList',
+                                                'Retour à la liste',
+                                            )}
+                                        >
+                                            <ArrowLeft className="h-4 w-4" />
+                                        </Button>
+                                    )}
+                                    <CardTitle className="text-sm truncate">
+                                        {detail
+                                            ? `#${detail.candidate.id} · ${t('admin.geo.submissionRow.pinCount', { count: detail.pins.length })}`
+                                            : t('admin.geo.pickSubmission')}
+                                    </CardTitle>
+                                </div>
                                 {detail && (
                                     <CandidateNavControls
                                         prev={prevCandidate}
@@ -785,55 +823,6 @@ export function GeoReviewPanel() {
                     </Card>
                 </div>
             )}
-
-            {/* Mobile: bottom drawer for candidate detail */}
-            <Sheet
-                open={isMobile && detail !== null}
-                onOpenChange={(open) => {
-                    if (!open) {
-                        setDetail(null)
-                        setPin(null)
-                    }
-                }}
-            >
-                <SheetContent
-                    side="bottom"
-                    className="lg:hidden h-[92vh] p-0 flex flex-col gap-0 rounded-t-xl"
-                >
-                    <SheetHeader className="px-4 py-3 pr-12 border-b border-border/40 text-left">
-                        <div className="flex items-center justify-between gap-2">
-                            <SheetTitle className="text-sm font-semibold">
-                                {detail
-                                    ? `#${detail.candidate.id} · ${t('admin.geo.submissionRow.pinCount', { count: detail.pins.length })}`
-                                    : t('admin.geo.pickSubmission')}
-                            </SheetTitle>
-                            {detail && (
-                                <CandidateNavControls
-                                    prev={prevCandidate}
-                                    next={nextCandidate}
-                                    currentIndex={currentIndex}
-                                    total={flatCandidates.length}
-                                    disabled={saving}
-                                    onNavigate={openDetail}
-                                    t={t}
-                                />
-                            )}
-                        </div>
-                    </SheetHeader>
-                    <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 pb-[max(env(safe-area-inset-bottom),1rem)]">
-                        <CandidateDetailBody
-                            detail={detail}
-                            pin={pin}
-                            setPin={setPin}
-                            saving={saving}
-                            onPromote={applyOverride}
-                            onReject={() => setRejectOpen(true)}
-                            onDemote={() => setDemoteOpen(true)}
-                            t={t}
-                        />
-                    </div>
-                </SheetContent>
-            </Sheet>
 
             <Dialog open={introOpen} onOpenChange={setIntroOpen}>
                 <DialogContent className="max-w-lg">


### PR DESCRIPTION
The mobile candidate review used a bottom Sheet at h-[92vh] with a
full-viewport Radix Dialog overlay at z-50. That overlay covered the
sticky Header (also z-50), so the hamburger/sidebar menu became
unreachable as soon as a moderator tapped a candidate.

Drop the modal Sheet and use an in-place list <-> detail navigation
(standard mobile push pattern) with the existing shadcn Card/Button
primitives:

- On mobile, the list card hides while a candidate is open and the
  detail card takes its place with an ArrowLeft back button.
- On lg+, both cards keep their original side-by-side layout.

No portal, no overlay, no focus trap -> the sticky Header stays
visible and interactive at all times, and the moderator can open the
sidebar menu without dismissing the review first.

https://claude.ai/code/session_013HQze2hxmjUa27WukwFCdJ