### PR TITLE
fix(admin/geo): require admin pin when no submissions + reward first pin

### DIFF
--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -11,12 +11,23 @@ import {
   geoContributorRepository,
   geoScreenshotRepository,
   geoMapRepository,
+  inventoryRepository,
   sessionRepository,
 } from '../../infrastructure/repositories/index.js'
 import { authMiddleware } from '../middleware/auth.middleware.js'
 import { validateBody, validateParams } from '../middleware/validation.middleware.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
 import { geoQueue } from '../../infrastructure/queue/queues.js'
+import { emitGeoRewarded } from '../../infrastructure/socket/socket.js'
+
+// Granted to the user who places the very first pin on a candidate. Sized
+// to match the smallest accuracy reward (1σ hit) so discovery is encouraged
+// without dwarfing the consensus-based grants that follow.
+const FIRST_PIN_REWARD = {
+  itemType: 'powerup' as const,
+  itemKey: 'hint_year' as const,
+  quantity: 1,
+}
 
 const log = routeLogger.child({ route: 'geo' })
 
@@ -130,7 +141,29 @@ router.post(
       })
 
       if (submission) {
-        await geoScreenshotRepository.incrementPinCount(geoScreenshotCandidateId)
+        const newPinCount =
+          await geoScreenshotRepository.incrementPinCount(geoScreenshotCandidateId)
+
+        // First-pin reward: the increment is atomic, so exactly one
+        // submitter ever sees newPinCount === 1 per candidate.
+        if (newPinCount === 1) {
+          try {
+            await inventoryRepository.addItems(
+              userId,
+              FIRST_PIN_REWARD.itemType,
+              FIRST_PIN_REWARD.itemKey,
+              FIRST_PIN_REWARD.quantity,
+            )
+            emitGeoRewarded({
+              userId,
+              geoScreenshotCandidateId,
+              items: [FIRST_PIN_REWARD],
+            })
+          } catch (e) {
+            log.warn({ err: String(e), userId }, 'failed to grant first-pin reward')
+          }
+        }
+
         // Enqueue consensus evaluation; the worker itself decides (based on
         // threshold gates) whether this pin count warrants a full pass.
         try {

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -787,6 +787,7 @@
       "emptyQueue": "No submissions match this filter.",
       "pickSubmission": "Pick a submission",
       "pickPointForOfficial": "Click to set a location, or validate without a pin to use the average of submissions",
+      "pickPointRequired": "No submissions to average — click the map to set a location.",
       "detailHintOfficial": "Pick a submission from the list to review it and set its official location.",
       "alreadyOfficial": "Official location already set — remove it to re-pin somewhere else.",
       "submissionRow": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -787,6 +787,7 @@
       "emptyQueue": "Aucune proposition ne correspond à ce filtre.",
       "pickSubmission": "Choisir une proposition",
       "pickPointForOfficial": "Cliquez pour fixer un lieu, ou validez sans pin pour utiliser la moyenne des propositions",
+      "pickPointRequired": "Aucune proposition à moyenner — cliquez sur la carte pour fixer un lieu.",
       "detailHintOfficial": "Sélectionnez une proposition dans la liste pour la consulter et fixer son lieu officiel.",
       "alreadyOfficial": "Lieu officiel déjà fixé — retirez-le pour replacer le repère.",
       "submissionRow": {

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -1046,7 +1046,11 @@ function CandidateDetailBody({
                     <span className="text-xs text-muted-foreground">
                         {pin
                             ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
-                            : t('admin.geo.pickPointForOfficial')}
+                            : t(
+                                  detail.pins.length === 0
+                                      ? 'admin.geo.pickPointRequired'
+                                      : 'admin.geo.pickPointForOfficial',
+                              )}
                     </span>
                     <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
                         <Button
@@ -1062,7 +1066,7 @@ function CandidateDetailBody({
                         <Button
                             size="sm"
                             onClick={() => void onPromote()}
-                            disabled={saving}
+                            disabled={saving || (!pin && detail.pins.length === 0)}
                             className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
                         >
                             {saving && (


### PR DESCRIPTION
## Summary

- **Fix `NO_PINS` error in admin moderation**: when an admin tried to "validate without pin" on a candidate that had zero player submissions, the backend returned `400 NO_PINS` (nothing to average from). The validate button is now disabled in that case and the helper text reads "No submissions to average — click the map to set a location.", forcing the moderator to drop a pin.
- **Reward first pin on a capture**: when a user submits the very first pin for a geo candidate, grant `+1 hint_year` and emit the existing `geo:contribution:rewarded` socket event so the frontend's recent-rewards card surfaces it. The pin-count increment is atomic, so exactly one submitter ever wins the race per candidate. Shadow-banned users remain excluded by the existing early-return.

## Test plan

- [ ] Open `/admin` geo moderation, pick a candidate with 0 submissions → validate button disabled, hint text says "No submissions to average — click the map to set a location."
- [ ] Drop an admin pin on the same candidate → button enables, validation succeeds.
- [ ] Pick a candidate with submissions but no admin pin → button still says "Valider sans pin" and validation succeeds (averages player pins).
- [ ] As a non-shadow-banned user, submit the first pin on a fresh candidate → inventory gains 1 hint_year and the "Recent rewards" card on the contribute page shows the grant.
- [ ] Submit a second pin (from a different user) on the same candidate → no extra first-pin reward.

https://claude.ai/code/session_01RANweHZQjDZ59dkoxJSHyr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RANweHZQjDZ59dkoxJSHyr)_