### PR TITLE
feat(geo): show total pins on capture after free-play submit

### DIFF
--- a/packages/backend/src/domain/services/geo-game.service.ts
+++ b/packages/backend/src/domain/services/geo-game.service.ts
@@ -59,6 +59,7 @@ export interface GeoFreePlayResult {
   scoreVersion: number
   correctMapId: number
   wrongMap: boolean
+  pinCount: number
 }
 
 export interface GeoGameService {
@@ -196,6 +197,7 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
         scoreVersion,
         correctMapId: meta.geoMapId,
         wrongMap,
+        pinCount: candidate.pinCount,
       }
     },
 

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1610,6 +1610,8 @@
       "screenshot": "Screenshot",
       "score": "Score",
       "distance": "Distance",
+      "pinCount_one": "{{count}} pin on this capture",
+      "pinCount_other": "{{count}} pins on this capture",
       "mapUnavailable": "Map unavailable.",
       "chooseMap": {
         "title": "Which map?",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1610,6 +1610,8 @@
       "screenshot": "Capture d'écran",
       "score": "Score",
       "distance": "Distance",
+      "pinCount_one": "{{count}} épingle sur cette capture",
+      "pinCount_other": "{{count}} épingles sur cette capture",
       "mapUnavailable": "Carte indisponible.",
       "chooseMap": {
         "title": "Quelle carte ?",

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -9,6 +9,7 @@ import {
     Gamepad2,
     Loader2,
     Map as MapIcon,
+    MapPin,
     RefreshCw,
     Shuffle,
     Sparkles,
@@ -219,6 +220,7 @@ export default function GeoPlayPage() {
                             score={result.score}
                             distance={result.distance}
                             wrongMap={!!result.wrongMap}
+                            pinCount={result.pinCount}
                             language={i18n.language}
                         />
                     ) : null
@@ -474,11 +476,13 @@ function ResultOverlay({
     score,
     distance,
     wrongMap,
+    pinCount,
     language,
 }: {
     score: number
     distance: number
     wrongMap: boolean
+    pinCount: number
     language: string
 }) {
     const { t } = useTranslation()
@@ -505,6 +509,10 @@ function ResultOverlay({
                 <span className="text-xs text-white/70">
                     {t('geo.daily.distance', 'Distance')}: {(distance * 100).toFixed(1)}%
                 </span>
+            </div>
+            <div className="mt-1 flex items-center gap-1 text-xs text-white/70">
+                <MapPin className="h-3 w-3 text-neon-pink" aria-hidden />
+                <span>{t('geo.daily.pinCount', { count: pinCount })}</span>
             </div>
             {wrongMap && (
                 <p className="mt-1 text-xs text-destructive">

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -998,6 +998,11 @@ export interface GeoFreePlayResult {
   scoreVersion: number
   correctMapId: number
   wrongMap: boolean
+  // Total contribution pins recorded against this capture so far. Surfaced
+  // on submit so the player can see how many people have pinned the same
+  // screenshot. Free-play guesses don't bump this — only crowdsourced
+  // contributions do.
+  pinCount: number
 }
 
 export interface GeoLeaderboardEntry {


### PR DESCRIPTION
Surface the candidate's pin count in the free-play guess response and
render it in the result overlay alongside score and distance, so the
player sees how many people have already pinned the same screenshot.