### PR TITLE
fix(geo): hyphenate jobIds so BullMQ accepts them

### DIFF
--- a/packages/backend/src/infrastructure/queue/workers/maps-pipeline-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/maps-pipeline-logic.ts
@@ -89,7 +89,8 @@ export async function runMapsPipeline(input: {
   const childKind = `maps:fetch-from-${chosen.source}` as const
   // Use a deterministic-enough jobId to dedupe accidental double-enqueues
   // within the same second. Re-runs after the second elapses are intentional.
-  const jobId = `${childKind}:${gameId}:${Math.floor(Date.now() / 1000)}`
+  // BullMQ rejects custom ids containing `:`, so we hyphen-separate.
+  const jobId = `maps-fetch-from-${chosen.source}-${gameId}-${Math.floor(Date.now() / 1000)}`
   await geoQueue.add(
     childKind,
     { kind: childKind, gameId, correlationId } as GeoJobData,
@@ -122,7 +123,7 @@ export async function advancePipeline(input: {
     { kind: 'maps:pipeline', gameId: input.gameId, correlationId: input.correlationId },
     {
       delay: input.delayMs ?? 0,
-      jobId: `maps:pipeline:${input.gameId}:${Math.floor(Date.now() / 1000)}`,
+      jobId: `maps-pipeline-${input.gameId}-${Math.floor(Date.now() / 1000)}`,
     },
   )
 }

--- a/packages/backend/src/presentation/routes/geo-fetch.routes.ts
+++ b/packages/backend/src/presentation/routes/geo-fetch.routes.ts
@@ -130,7 +130,7 @@ router.post('/start', async (req, res, next) => {
       await geoQueue.add(
         'maps:pipeline',
         { kind: 'maps:pipeline', gameId } as GeoJobData,
-        { jobId: `maps:pipeline:start:${gameId}:${Date.now()}` },
+        { jobId: `maps-pipeline-start-${gameId}-${Date.now()}` },
       )
     }
     emitGeoFetchStarted({ totalGames: gameIds.length })
@@ -186,7 +186,7 @@ router.post('/:gameId/retry', async (req, res, next) => {
     await geoQueue.add(
       'maps:pipeline',
       { kind: 'maps:pipeline', gameId } as GeoJobData,
-      { jobId: `maps:pipeline:retry:${gameId}:${Date.now()}` },
+      { jobId: `maps-pipeline-retry-${gameId}-${Date.now()}` },
     )
     res.json({ success: true, data: { ok: true } })
   } catch (err) {
@@ -211,7 +211,7 @@ router.post('/:gameId/:source/retry', async (req, res, next) => {
     await geoQueue.add(
       kind,
       { kind, gameId } as GeoJobData,
-      { jobId: `${kind}:manual-retry:${gameId}:${Date.now()}` },
+      { jobId: `maps-fetch-from-${source}-manual-retry-${gameId}-${Date.now()}` },
     )
     res.json({ success: true, data: { ok: true } })
   } catch (err) {


### PR DESCRIPTION
BullMQ v5.66+ throws "Custom Id cannot contain :" for any custom job
id whose colon-split has more than 3 parts, so every maps:* enqueue
(start / retry / per-source retry, plus the orchestrator's child and
self re-enqueues) was hitting the global error handler and returning
INTERNAL_ERROR — surfaced by the new "Récupérer plus de captures"
button in the moderation queue.

Switch to hyphen-separated jobIds. Job names (queue.add's first arg)
keep the legacy maps:* shape since BullMQ doesn't restrict those.