### PR TITLE
fix(admin/geo): security, race-condition, audit and UX hardening

### DIFF
--- a/packages/backend/migrations/20260506_admin_audit_log.ts
+++ b/packages/backend/migrations/20260506_admin_audit_log.ts
@@ -1,0 +1,41 @@
+import type { Knex } from 'knex'
+
+// Persistent audit trail for admin write actions. Every destructive or
+// state-changing admin geo route appends one row here so we can answer
+// "who did what, and when" without having to grep Pino logs. JSON columns
+// hold the action's before/after payload — kept tiny by callers (only
+// the ids and the changed fields, never blobs).
+//
+// Indexed on (admin_id, created_at) and (target_kind, target_id) so we
+// can render a user-facing "what did this admin touch in the last hour"
+// view AND a "history of this game" view at near-zero cost. created_at
+// drives the default sort and is on its own index for the global view.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('admin_audit_log', (table) => {
+    table.bigIncrements('id').primary()
+    table.string('admin_id', 64).notNullable()
+    table.string('action', 100).notNullable()
+    table.string('target_kind', 64).notNullable()
+    table.string('target_id', 100).nullable()
+    // Optional structured before/after snapshots. Callers keep these tiny:
+    // ids + flipped flags only, never full rows. JSONB so we can grep them
+    // with pg operators when investigating a specific incident.
+    table.jsonb('before').nullable()
+    table.jsonb('after').nullable()
+    // request id (when the request-id middleware is added) + ip kept as
+    // optional strings so we can correlate with logs after the fact.
+    table.string('request_id', 64).nullable()
+    table.string('ip', 64).nullable()
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+
+    table.index(['admin_id', 'created_at'], 'admin_audit_log_admin_idx')
+    table.index(['target_kind', 'target_id'], 'admin_audit_log_target_idx')
+    table.index('action', 'admin_audit_log_action_idx')
+    table.index('created_at', 'admin_audit_log_created_idx')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('admin_audit_log')
+}

--- a/packages/backend/migrations/20260507_geo_updated_at_columns.ts
+++ b/packages/backend/migrations/20260507_geo_updated_at_columns.ts
@@ -1,0 +1,84 @@
+import type { Knex } from 'knex'
+
+// Forensics enabler: every geo write-heavy table now has `updated_at` so
+// the audit log can be cross-referenced with row-level last-touched
+// timestamps. Defaults to `created_at` (or NOW() where created_at doesn't
+// exist) so existing rows aren't NULL.
+//
+// We deliberately DO NOT add a database trigger to keep these in sync —
+// the app already mutates these tables through repositories, so the
+// repositories own the bump. A trigger would silently mask bugs where
+// a write path forgets to refresh updated_at.
+
+const TABLES_NEEDING_UPDATED_AT = [
+  'geo_map',
+  'geo_screenshot_candidate',
+  'geo_screenshot_meta',
+  'geo_challenge',
+  'geo_guess',
+  'geo_pin_submission',
+] as const
+
+export async function up(knex: Knex): Promise<void> {
+  for (const table of TABLES_NEEDING_UPDATED_AT) {
+    const exists = await knex.schema.hasColumn(table, 'updated_at')
+    if (exists) continue
+    await knex.schema.alterTable(table, (t) => {
+      t.timestamp('updated_at', { useTz: true })
+    })
+    // Backfill from created_at where present, else NOW(). Done as raw SQL
+    // because Knex.js' schema.alterTable doesn't support per-column
+    // backfill expressions cleanly.
+    const hasCreatedAt = await knex.schema.hasColumn(table, 'created_at')
+    if (hasCreatedAt) {
+      await knex.raw(
+        `UPDATE ?? SET updated_at = COALESCE(created_at, NOW()) WHERE updated_at IS NULL`,
+        [table],
+      )
+    } else {
+      await knex.raw(`UPDATE ?? SET updated_at = NOW() WHERE updated_at IS NULL`, [table])
+    }
+    await knex.schema.alterTable(table, (t) => {
+      t.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now()).alter()
+    })
+  }
+
+  // Retention helper: a single index on `attempted_at` enables a cheap
+  // `DELETE WHERE attempted_at < NOW() - INTERVAL '90 days'` retention
+  // sweep on `geo_ingest_attempt` (currently unbounded growth ~150k/day
+  // at projected catalog volume). The index is created here so the
+  // retention worker added in a follow-up commit lands cheap.
+  const hasAttemptedAtIdx = await knex.schema
+    .hasTable('geo_ingest_attempt')
+    .then(async (exists) =>
+      exists
+        ? (await knex.raw(
+            `SELECT 1 FROM pg_indexes WHERE indexname = 'geo_ingest_attempt_attempted_at_idx'`,
+          )).rows.length > 0
+        : true,
+    )
+  if (!hasAttemptedAtIdx) {
+    await knex.schema.alterTable('geo_ingest_attempt', (t) => {
+      t.index('attempted_at', 'geo_ingest_attempt_attempted_at_idx')
+    })
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // Drop the retention index first; the column drop on its own is safe.
+  const hasIdx = await knex.raw(
+    `SELECT 1 FROM pg_indexes WHERE indexname = 'geo_ingest_attempt_attempted_at_idx'`,
+  )
+  if (hasIdx.rows.length > 0) {
+    await knex.schema.alterTable('geo_ingest_attempt', (t) => {
+      t.dropIndex('attempted_at', 'geo_ingest_attempt_attempted_at_idx')
+    })
+  }
+  for (const table of TABLES_NEEDING_UPDATED_AT) {
+    const exists = await knex.schema.hasColumn(table, 'updated_at')
+    if (!exists) continue
+    await knex.schema.alterTable(table, (t) => {
+      t.dropColumn('updated_at')
+    })
+  }
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,7 +21,8 @@
     "fetch:steam-download": "tsx src/tools/steam-screenshot-fetcher.ts download",
     "fetch:steam-all": "tsx src/tools/steam-screenshot-fetcher.ts all --screenshots-per-game 5",
     "e2e:seed": "tsx scripts/e2e-seed.ts",
-    "stripe:check": "tsx scripts/stripe-check.ts"
+    "stripe:check": "tsx scripts/stripe-check.ts",
+    "test": "node --import tsx --test 'src/**/*.test.ts'"
   },
   "dependencies": {
     "@the-box/types": "*",

--- a/packages/backend/scripts/e2e-seed.ts
+++ b/packages/backend/scripts/e2e-seed.ts
@@ -238,6 +238,93 @@ async function createTodayChallenge(): Promise<void> {
 }
 
 /**
+ * Geo entities for the admin geo authz/UX specs.
+ *
+ * Idempotent: only creates the row if it doesn't already exist. The
+ * deterministic shape (one game, one map, one promoted candidate, one
+ * meta) lets the geo specs stop accepting "empty state" as success.
+ */
+async function createMockGeoData(): Promise<void> {
+  const game = await db('games').where('slug', 'e2e-test-game-1').first<{ id: number }>()
+  if (!game) {
+    console.warn('  ⚠ Mock game not seeded yet, skipping geo seed')
+    return
+  }
+
+  const existingMap = await db('geo_map').where({ game_id: game.id }).first<{ id: number }>()
+  let mapId: number
+  if (existingMap) {
+    console.log(`  ✓ Geo map already exists for game ${game.id} (ID: ${existingMap.id})`)
+    mapId = existingMap.id
+  } else {
+    const [row] = await db('geo_map')
+      .insert({
+        game_id: game.id,
+        source: 'manual',
+        source_url: 'https://example.com/e2e/map.png',
+        image_url: 'https://via.placeholder.com/2048x2048.png?text=E2E+Geo+Map',
+        width_px: 2048,
+        height_px: 2048,
+        consensus_radius: 0.05,
+        license: 'CC-BY-4.0',
+        attribution: 'E2E Test',
+        is_active: true,
+        is_selected: true,
+        selected_at: new Date(),
+      })
+      .returning<Array<{ id: number }>>('id')
+    mapId = row!.id
+    console.log(`  ✓ Created geo map for game ${game.id} (ID: ${mapId})`)
+  }
+
+  // One promoted candidate so the moderation queue has something concrete
+  // to render and the free-play picker has a screenshot to return.
+  const existingCandidate = await db('geo_screenshot_candidate')
+    .where({ game_id: game.id })
+    .first<{ id: number }>()
+  let candidateId: number
+  if (existingCandidate) {
+    candidateId = existingCandidate.id
+    console.log(`  ✓ Geo candidate already exists (ID: ${candidateId})`)
+  } else {
+    const [row] = await db('geo_screenshot_candidate')
+      .insert({
+        game_id: game.id,
+        geo_map_id: mapId,
+        image_url: 'https://via.placeholder.com/1920x1080.png?text=E2E+Capture',
+        thumbnail_url: 'https://via.placeholder.com/400x225.png?text=E2E+Capture',
+        source: 'manual',
+        external_id: `e2e-${game.id}-1`,
+        status: 'promoted',
+        pin_count: 5,
+        is_active: true,
+      })
+      .returning<Array<{ id: number }>>('id')
+    candidateId = row!.id
+    console.log(`  ✓ Created geo candidate (ID: ${candidateId})`)
+  }
+
+  const existingMeta = await db('geo_screenshot_meta')
+    .where({ geo_screenshot_candidate_id: candidateId })
+    .first<{ id: number }>()
+  if (!existingMeta) {
+    await db('geo_screenshot_meta').insert({
+      geo_screenshot_candidate_id: candidateId,
+      geo_map_id: mapId,
+      canonical_x: 0.5,
+      canonical_y: 0.5,
+      confidence: 0.95,
+      consensus_version: 1,
+      promoted_via: 'admin',
+      promoted_by: null,
+    })
+    console.log('  ✓ Created geo meta (canonical 0.5,0.5)')
+  } else {
+    console.log('  ✓ Geo meta already exists')
+  }
+}
+
+/**
  * Clear daily login claims for e2e test users so fresh login tests work
  */
 async function clearDailyLoginClaims(userIds: string[]): Promise<void> {
@@ -283,7 +370,11 @@ async function seed(): Promise<void> {
     console.log('\nCreating daily challenge...')
     await createTodayChallenge()
 
-    // Step 4: Clear daily login claims for fresh login tests
+    // Step 4: Geo entities so admin geo + free-play specs have data
+    console.log('\nCreating geo seed (map + candidate + meta)...')
+    await createMockGeoData()
+
+    // Step 5: Clear daily login claims for fresh login tests
     console.log('\nClearing daily login claims...')
     await clearDailyLoginClaims([e2eUserId, e2eAdminId])
 

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -708,7 +708,7 @@ export interface GeoPinRepository {
     status: GeoPinStatus
     distanceFromCentroid: number
   }): Promise<void>
-  countByUserInWindow(userId: string, intervalSql: string): Promise<number>
+  countByUserInWindow(userId: string, windowSeconds: number): Promise<number>
   userRejectionRatio7d(userId: string): Promise<{ submitted: number; rejected: number }>
 }
 

--- a/packages/backend/src/domain/services/geo-consensus.service.test.ts
+++ b/packages/backend/src/domain/services/geo-consensus.service.test.ts
@@ -1,0 +1,178 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  evaluateConsensus,
+  grantsForAcceptedPin,
+  GEO_CONSENSUS_MIN_PINS_TO_PROMOTE,
+  GEO_CONSENSUS_VERSION,
+  type GeoPinLike,
+} from './geo-consensus.service.js'
+
+const RADIUS = 0.05
+
+function pin(id: number, x: number, y: number): GeoPinLike {
+  return { id, pin: { x, y } }
+}
+
+describe('evaluateConsensus', () => {
+  it('returns zeros for empty input', () => {
+    const out = evaluateConsensus([], RADIUS)
+    assert.equal(out.acceptedCount, 0)
+    assert.equal(out.rejectedCount, 0)
+    assert.equal(out.promote, false)
+    assert.equal(out.confidence, 0)
+    assert.equal(out.version, GEO_CONSENSUS_VERSION)
+    assert.deepEqual(out.decisions, [])
+  })
+
+  it('handles a single pin: accepts (sigma=0 short-circuit) but does not promote', () => {
+    // n=1 → σ=0 on both axes. The σ-cutoff branch is short-circuited via
+    // the `cutoff > 0` guard so the lone pin is ACCEPTED (it's literally
+    // the centroid). It still doesn't promote because we require
+    // GEO_CONSENSUS_MIN_PINS_TO_PROMOTE accepted pins.
+    const out = evaluateConsensus([pin(1, 0.5, 0.5)], RADIUS)
+    assert.equal(out.acceptedCount, 1)
+    assert.equal(out.rejectedCount, 0)
+    assert.equal(out.promote, false)
+    assert.equal(out.sigmaX, 0)
+    assert.equal(out.sigmaY, 0)
+  })
+
+  it('all-identical pins: σ=0, all accepted, confidence=1', () => {
+    // Same point repeated — sigma is 0 on both axes, distance is 0, so
+    // every pin sits inside the (zero) σ-cutoff (guarded by cutoff > 0)
+    // AND inside the consensus radius. Confidence = 1 - 0/RADIUS = 1.
+    const pins = Array.from({ length: 7 }, (_, i) => pin(i + 1, 0.42, 0.31))
+    const out = evaluateConsensus(pins, RADIUS)
+    assert.equal(out.acceptedCount, 7)
+    assert.equal(out.rejectedCount, 0)
+    assert.ok(out.confidence > 0.999)
+    assert.equal(out.promote, true)
+  })
+
+  it('promotes exactly at the minimum-pins threshold (5 accepted, tight cluster)', () => {
+    // Exactly GEO_CONSENSUS_MIN_PINS_TO_PROMOTE pins, all very close
+    // → confidence well above 0.5 → promote.
+    const pins: GeoPinLike[] = [
+      pin(1, 0.5, 0.5),
+      pin(2, 0.5005, 0.5005),
+      pin(3, 0.499, 0.5),
+      pin(4, 0.5, 0.499),
+      pin(5, 0.5005, 0.499),
+    ]
+    assert.equal(pins.length, GEO_CONSENSUS_MIN_PINS_TO_PROMOTE)
+    const out = evaluateConsensus(pins, RADIUS)
+    assert.equal(out.acceptedCount, 5)
+    assert.equal(out.promote, true)
+  })
+
+  it('does not promote when pin spread exceeds the radius', () => {
+    // Pins spread across the whole map: sigma ≈ 0.4, radius is 0.05,
+    // confidence floors at 0 → no promotion regardless of count.
+    const pins: GeoPinLike[] = [
+      pin(1, 0.05, 0.05),
+      pin(2, 0.95, 0.05),
+      pin(3, 0.05, 0.95),
+      pin(4, 0.95, 0.95),
+      pin(5, 0.5, 0.5),
+      pin(6, 0.0, 0.0),
+    ]
+    const out = evaluateConsensus(pins, RADIUS)
+    assert.equal(out.promote, false)
+    assert.ok(out.confidence < 0.5)
+  })
+
+  it('rejects pins outside the consensus radius', () => {
+    // Tight cluster of 4 + one obvious outlier far away. σ-cutoff catches
+    // the outlier on the X axis; even if sigma allows it, the radius gate
+    // is also tripped.
+    const pins: GeoPinLike[] = [
+      pin(1, 0.5, 0.5),
+      pin(2, 0.501, 0.501),
+      pin(3, 0.499, 0.5),
+      pin(4, 0.5, 0.499),
+      pin(5, 0.95, 0.5), // outlier
+    ]
+    const out = evaluateConsensus(pins, RADIUS)
+    const outlierDecision = out.decisions.find((d) => d.pinId === 5)!
+    assert.equal(outlierDecision.status, 'rejected')
+    assert.ok(out.rejectedCount >= 1)
+  })
+
+  it('emits the current algorithm version on every result', () => {
+    // Bumping GEO_CONSENSUS_VERSION lets the worker tell old vs new
+    // decisions apart on a retroactive re-run.
+    const out = evaluateConsensus([pin(1, 0.5, 0.5)], RADIUS)
+    assert.equal(out.version, GEO_CONSENSUS_VERSION)
+  })
+})
+
+describe('grantsForAcceptedPin', () => {
+  it('accepted-but-loose pin (just outside 1σ) yields nothing', () => {
+    const grants = grantsForAcceptedPin({
+      distanceFromCentroid: 0.02,
+      sigmaX: 0.01,
+      sigmaY: 0.01,
+      userAcceptedCountAfterThis: 1,
+    })
+    assert.equal(grants.length, 0)
+  })
+
+  it('accepted pin inside 1σ → +1 hint_year', () => {
+    const grants = grantsForAcceptedPin({
+      distanceFromCentroid: 0.009,
+      sigmaX: 0.01,
+      sigmaY: 0.01,
+      userAcceptedCountAfterThis: 1,
+    })
+    assert.equal(grants.length, 1)
+    assert.equal(grants[0]?.itemKey, 'hint_year')
+  })
+
+  it('accepted pin inside 0.5σ → +1 hint_year + a publisher/developer hint', () => {
+    const odd = grantsForAcceptedPin({
+      distanceFromCentroid: 0.001,
+      sigmaX: 0.01,
+      sigmaY: 0.01,
+      userAcceptedCountAfterThis: 1, // odd → developer
+    })
+    assert.equal(odd.length, 2)
+    assert.equal(odd[0]?.itemKey, 'hint_year')
+    assert.equal(odd[1]?.itemKey, 'hint_developer')
+
+    const even = grantsForAcceptedPin({
+      distanceFromCentroid: 0.001,
+      sigmaX: 0.01,
+      sigmaY: 0.01,
+      userAcceptedCountAfterThis: 2, // even → publisher
+    })
+    assert.equal(even[1]?.itemKey, 'hint_publisher')
+  })
+
+  it('every 10th accepted pin → +1 timer_extension', () => {
+    const out = grantsForAcceptedPin({
+      distanceFromCentroid: 0.005, // outside 0.5σ but inside 1σ
+      sigmaX: 0.01,
+      sigmaY: 0.01,
+      userAcceptedCountAfterThis: 10,
+    })
+    // Inside 1σ → hint_year. 10 % 10 === 0 → timer_extension. Count: 2.
+    const keys = out.map((g) => g.itemKey)
+    assert.ok(keys.includes('hint_year'))
+    assert.ok(keys.includes('timer_extension'))
+  })
+
+  it('count=0 does not award a timer_extension (0 % 10 === 0 but guarded)', () => {
+    const out = grantsForAcceptedPin({
+      distanceFromCentroid: 0.005,
+      sigmaX: 0.01,
+      sigmaY: 0.01,
+      userAcceptedCountAfterThis: 0,
+    })
+    // 0 is the "first ever pin not yet counted" case; the implementation
+    // explicitly excludes it from the every-10th bonus to avoid silly
+    // behavior on a fresh user.
+    const keys = out.map((g) => g.itemKey)
+    assert.ok(!keys.includes('timer_extension'))
+  })
+})

--- a/packages/backend/src/domain/services/geo-game.service.ts
+++ b/packages/backend/src/domain/services/geo-game.service.ts
@@ -212,7 +212,7 @@ export function createGeoGameService(deps: GeoGameServiceDeps): GeoGameService {
         )
       }
 
-      const hourly = await geoPinRepository.countByUserInWindow(userId, '1 hour')
+      const hourly = await geoPinRepository.countByUserInWindow(userId, 60 * 60)
       if (hourly >= GEO_CONTRIBUTE_HOURLY_LIMIT) {
         throw new GeoGameError(
           `rate limit: ${GEO_CONTRIBUTE_HOURLY_LIMIT} pins per hour`,

--- a/packages/backend/src/infrastructure/queue/queues.ts
+++ b/packages/backend/src/infrastructure/queue/queues.ts
@@ -24,7 +24,16 @@ export const importQueueEvents = new QueueEvents('import-jobs', {
 // @the-box/types) because only the backend workers and the enqueueing route
 // need to know the shape.
 export type GeoJobData =
-  | { kind: 'evaluate-consensus'; geoScreenshotCandidateId: number }
+  | {
+      kind: 'evaluate-consensus'
+      geoScreenshotCandidateId: number
+      // Post-increment pin count captured at submit time. The worker uses
+      // this (not the freshly-read value) for the threshold gate so two
+      // pins arriving in quick succession can't *both* skip the same
+      // threshold (e.g. 5 → 6 with neither evaluating at 5). Optional for
+      // back-compat with already-queued jobs from older deploys.
+      pinCountAtEnqueue?: number
+    }
   | { kind: 'promote-contributor-tier'; userId: string }
   | {
       kind: 'import-registry-map'

--- a/packages/backend/src/infrastructure/queue/workers/geo-consensus-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-consensus-logic.ts
@@ -28,9 +28,17 @@ export interface GeoConsensusJobResult {
 /**
  * Per-candidate consensus routine. Enqueued each time a pin is submitted;
  * cheap to no-op when the candidate is below a threshold.
+ *
+ * `pinCountAtEnqueue` is the post-increment value captured by the producer
+ * (see `geo.routes.ts /contribute/pin`). It is the gate's source of truth:
+ * without it, two near-simultaneous pins (A then B) can both step PAST the
+ * same threshold (e.g. 9 → 10 → 11) and the worker re-reads pin_count = 11
+ * for both, never evaluating at the threshold. Using the per-pin captured
+ * value guarantees exactly one pin sees each threshold.
  */
 export async function evaluateConsensusForCandidate(
   geoScreenshotCandidateId: number,
+  options: { pinCountAtEnqueue?: number } = {},
 ): Promise<GeoConsensusJobResult> {
   log.info({ candidateId: geoScreenshotCandidateId }, 'evaluating consensus')
 
@@ -61,10 +69,13 @@ export async function evaluateConsensusForCandidate(
     }
   }
 
-  // Only run at configured thresholds. This keeps the flywheel amortized
-  // and prevents noisy single-pin re-evaluations.
+  // Threshold gate. Use the captured at-enqueue value when available so two
+  // pins arriving in quick succession can't both skip the same threshold.
+  // Fall back to the (possibly racy) re-read for back-compat with jobs
+  // queued before this field shipped.
   const thresholds = GEO_CONSENSUS_THRESHOLDS as readonly number[]
-  if (!thresholds.includes(candidate.pinCount)) {
+  const gateCount = options.pinCountAtEnqueue ?? candidate.pinCount
+  if (!thresholds.includes(gateCount)) {
     return {
       evaluated: false,
       candidateId: geoScreenshotCandidateId,
@@ -73,7 +84,7 @@ export async function evaluateConsensusForCandidate(
       rejected: 0,
       promoted: false,
       rewardedUsers: 0,
-      skipReason: `pin count ${candidate.pinCount} not at threshold`,
+      skipReason: `pin count ${gateCount} not at threshold`,
     }
   }
 

--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -32,7 +32,10 @@ export const geoWorker = new Worker<GeoJobData>(
     log.info({ jobId: id, kind: data.kind }, 'processing geo job')
 
     if (data.kind === 'evaluate-consensus') {
-      const result = await evaluateConsensusForCandidate(data.geoScreenshotCandidateId)
+      const result = await evaluateConsensusForCandidate(
+        data.geoScreenshotCandidateId,
+        { pinCountAtEnqueue: data.pinCountAtEnqueue },
+      )
       log.info({ jobId: id, result }, 'consensus job done')
       return result
     }

--- a/packages/backend/src/infrastructure/repositories/admin-audit.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/admin-audit.repository.ts
@@ -1,0 +1,96 @@
+import { db } from '../database/connection.js'
+import { repoLogger } from '../logger/logger.js'
+
+const log = repoLogger.child({ repository: 'admin-audit' })
+
+export interface AdminAuditEntry {
+  adminId: string
+  action: string
+  targetKind: string
+  targetId?: string | number | null
+  before?: unknown
+  after?: unknown
+  requestId?: string | null
+  ip?: string | null
+}
+
+export interface AdminAuditRow {
+  id: string
+  adminId: string
+  action: string
+  targetKind: string
+  targetId: string | null
+  before: unknown
+  after: unknown
+  requestId: string | null
+  ip: string | null
+  createdAt: string
+}
+
+interface DbRow {
+  id: string | number
+  admin_id: string
+  action: string
+  target_kind: string
+  target_id: string | null
+  before: unknown
+  after: unknown
+  request_id: string | null
+  ip: string | null
+  created_at: Date
+}
+
+function rowTo(row: DbRow): AdminAuditRow {
+  return {
+    id: String(row.id),
+    adminId: row.admin_id,
+    action: row.action,
+    targetKind: row.target_kind,
+    targetId: row.target_id,
+    before: row.before,
+    after: row.after,
+    requestId: row.request_id,
+    ip: row.ip,
+    createdAt: row.created_at.toISOString(),
+  }
+}
+
+export const adminAuditRepository = {
+  async record(entry: AdminAuditEntry): Promise<void> {
+    try {
+      await db('admin_audit_log').insert({
+        admin_id: entry.adminId,
+        action: entry.action,
+        target_kind: entry.targetKind,
+        target_id: entry.targetId == null ? null : String(entry.targetId),
+        before: entry.before == null ? null : JSON.stringify(entry.before),
+        after: entry.after == null ? null : JSON.stringify(entry.after),
+        request_id: entry.requestId ?? null,
+        ip: entry.ip ?? null,
+      })
+    } catch (err) {
+      // Never let audit failure break the request — the action already
+      // happened. Log loudly so operators can detect a broken trail.
+      log.error({ err: String(err), action: entry.action }, 'failed to record admin audit')
+    }
+  },
+
+  async listRecent(args: {
+    adminId?: string
+    action?: string
+    targetKind?: string
+    targetId?: string | number
+    limit?: number
+    offset?: number
+  } = {}): Promise<AdminAuditRow[]> {
+    const limit = Math.min(args.limit ?? 100, 500)
+    const offset = args.offset ?? 0
+    let q = db('admin_audit_log').orderBy('created_at', 'desc')
+    if (args.adminId) q = q.where({ admin_id: args.adminId })
+    if (args.action) q = q.where({ action: args.action })
+    if (args.targetKind) q = q.where({ target_kind: args.targetKind })
+    if (args.targetId !== undefined) q = q.where({ target_id: String(args.targetId) })
+    const rows = await q.limit(limit).offset(offset).select<DbRow[]>('*')
+    return rows.map(rowTo)
+  },
+}

--- a/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-challenge.repository.ts
@@ -166,17 +166,25 @@ export const geoChallengeRepository = {
       'recordGuess',
     )
 
-    await db('geo_guess').insert({
-      user_id: data.userId,
-      geo_challenge_id: data.geoChallengeId,
-      x: data.guess.x,
-      y: data.guess.y,
-      distance: data.distance,
-      score: data.score,
-      score_version: data.scoreVersion,
-      duration_ms: data.durationMs ?? null,
-      geo_map_id_picked: data.geoMapIdPicked ?? null,
-    })
+    // ON CONFLICT DO NOTHING on the (user_id, geo_challenge_id) unique
+    // constraint so a duplicate submission (double-click, retry on flaky
+    // network) returns 200 with the original score instead of 500ing on
+    // a PK violation. The lookup below uses the canonical record from
+    // the FIRST insert regardless.
+    await db('geo_guess')
+      .insert({
+        user_id: data.userId,
+        geo_challenge_id: data.geoChallengeId,
+        x: data.guess.x,
+        y: data.guess.y,
+        distance: data.distance,
+        score: data.score,
+        score_version: data.scoreVersion,
+        duration_ms: data.durationMs ?? null,
+        geo_map_id_picked: data.geoMapIdPicked ?? null,
+      })
+      .onConflict(['user_id', 'geo_challenge_id'])
+      .ignore()
 
     const meta = await db('geo_challenge')
       .join(
@@ -210,17 +218,23 @@ export const geoChallengeRepository = {
   // and never upserted to the leaderboards.
   async recordSkip(data: { userId: string; geoChallengeId: number }): Promise<void> {
     log.info({ userId: data.userId, challengeId: data.geoChallengeId }, 'recordSkip')
-    await db('geo_guess').insert({
-      user_id: data.userId,
-      geo_challenge_id: data.geoChallengeId,
-      x: 0,
-      y: 0,
-      distance: 0,
-      score: 0,
-      score_version: 0,
-      duration_ms: null,
-      is_skip: true,
-    })
+    // ON CONFLICT DO NOTHING: if the user already guessed (or already
+    // skipped), don't blow up — the daily slot is already locked, and
+    // re-submitting a skip is a no-op semantically.
+    await db('geo_guess')
+      .insert({
+        user_id: data.userId,
+        geo_challenge_id: data.geoChallengeId,
+        x: 0,
+        y: 0,
+        distance: 0,
+        score: 0,
+        score_version: 0,
+        duration_ms: null,
+        is_skip: true,
+      })
+      .onConflict(['user_id', 'geo_challenge_id'])
+      .ignore()
   },
 
   // ---- Challenge stats ----

--- a/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
@@ -219,9 +219,16 @@ export const geoMapRepository = {
     )
     const row = await db.transaction(async (trx) => {
       const isActive = data.isActive ?? false
-      // Promote to selected only if no map is selected for the same zone
-      // yet — keeps the very first map a game ever gets pointing at
-      // something sensible without overriding explicit admin choices.
+      // Two concurrent create() calls for the same (game, zone) at default
+      // READ COMMITTED could both observe "no existing selected" and both
+      // insert with is_selected=true. The partial unique index would 23505
+      // the loser. Lock the zone's rows so the loser sees the winner's
+      // selection and falls back to is_selected=false.
+      const lockQuery = trx('geo_map').where({ game_id: data.gameId }).forUpdate()
+      await (data.zoneSlug == null
+        ? lockQuery.whereNull('zone_slug')
+        : lockQuery.where({ zone_slug: data.zoneSlug })
+      ).select('id')
       const selectedQuery = trx('geo_map').where({
         game_id: data.gameId,
         is_selected: true,
@@ -298,20 +305,25 @@ export const geoMapRepository = {
   // the game with zero enabled maps. If we disable the currently selected
   // row in a zone and a sibling exists, the sibling is promoted (most-
   // recently enabled wins).
+  //
+  // Two concurrent disableForGame calls on different siblings could both
+  // pass the "remaining > 0" check at default READ COMMITTED isolation,
+  // leaving zero enabled. We `SELECT ... FOR UPDATE` the full row set for
+  // the game so the loser blocks until the winner commits.
   async disableForGame(gameId: number, mapId: number): Promise<DisableResult> {
     log.info({ gameId, mapId }, 'disableForGame')
     return await db.transaction(async (trx) => {
-      const target = await trx('geo_map')
-        .where({ id: mapId, game_id: gameId })
-        .first<GeoMapRow>()
+      // Lock all maps for this game so concurrent disable calls serialize.
+      // Cheap because a single game has on the order of dozens of rows.
+      const locked = await trx('geo_map')
+        .where({ game_id: gameId })
+        .forUpdate()
+        .select<GeoMapRow[]>('*')
+      const target = locked.find((r) => r.id === mapId)
       if (!target) return { ok: false as const, reason: 'NOT_FOUND' as const }
 
-      const remainingEnabled = await trx('geo_map')
-        .where({ game_id: gameId, is_active: true })
-        .whereNot({ id: mapId })
-        .count<{ count: string }[]>({ count: '*' })
-        .first()
-      if (Number(remainingEnabled?.count ?? 0) === 0) {
+      const remainingEnabled = locked.filter((r) => r.is_active && r.id !== mapId).length
+      if (remainingEnabled === 0) {
         return { ok: false as const, reason: 'LAST_ENABLED' as const }
       }
 
@@ -323,13 +335,16 @@ export const geoMapRepository = {
       // If the disabled row was the selected one for its zone, promote the
       // most-recently-created enabled sibling in the same zone.
       if (target.is_selected) {
-        const heirQuery = trx('geo_map')
-          .where({ game_id: gameId, is_active: true })
-          .orderBy('created_at', 'desc')
-        const heir = await (target.zone_slug == null
-          ? heirQuery.whereNull('zone_slug')
-          : heirQuery.where({ zone_slug: target.zone_slug })
-        ).first<GeoMapRow>()
+        const heir = locked
+          .filter(
+            (r) =>
+              r.is_active &&
+              r.id !== mapId &&
+              (target.zone_slug == null
+                ? r.zone_slug == null
+                : r.zone_slug === target.zone_slug),
+          )
+          .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())[0]
         if (heir) {
           await trx('geo_map')
             .where({ id: heir.id })
@@ -346,6 +361,10 @@ export const geoMapRepository = {
   // Atomically pick the selected map for a (game, zone). Other rows in the
   // same zone get is_selected=false. The partial unique index keeps us
   // honest: at most one selected row per (game, zone_slug).
+  //
+  // SELECT FOR UPDATE on the zone's rows so two concurrent selectMap calls
+  // can't both pass through (one clearing, the other inserting) and trip
+  // the partial unique index as a 23505 surfaced as 500.
   async selectMap(
     gameId: number,
     mapId: number,
@@ -357,6 +376,12 @@ export const geoMapRepository = {
         .where({ id: mapId, game_id: gameId, is_active: true })
         .first<GeoMapRow>()
       if (!target) return null
+      const lockQuery = trx('geo_map').where({ game_id: gameId }).forUpdate()
+      await (target.zone_slug == null
+        ? lockQuery.whereNull('zone_slug')
+        : lockQuery.where({ zone_slug: target.zone_slug })
+      ).select('id')
+
       const clearQuery = trx('geo_map').where({
         game_id: gameId,
         is_selected: true,

--- a/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
@@ -84,19 +84,35 @@ export const geoPinRepository = {
       })
   },
 
-  async countByUserInWindow(userId: string, intervalSql: string): Promise<number> {
+  // Counts pin submissions inside the last `windowSeconds`. The window is a
+  // bound numeric parameter (no string interpolation) so this helper can't be
+  // turned into a SQL-injection seam by a future caller. Window is clamped
+  // to a positive integer to keep the SQL plan honest.
+  async countByUserInWindow(userId: string, windowSeconds: number): Promise<number> {
+    const seconds = Math.max(1, Math.floor(windowSeconds))
     const result = await db('geo_pin_submission')
       .where({ user_id: userId })
-      .where('created_at', '>=', db.raw(`NOW() - INTERVAL '${intervalSql}'`))
+      .where(
+        'created_at',
+        '>=',
+        db.raw(`NOW() - make_interval(secs => ?)`, [seconds]),
+      )
       .count<{ count: string }[]>('id as count')
       .first()
     return Number(result?.count ?? 0)
   },
 
   async userRejectionRatio7d(userId: string): Promise<{ submitted: number; rejected: number }> {
+    // 7 days = 604800 seconds, expressed as a bound parameter for the same
+    // reason as countByUserInWindow.
+    const sevenDaysSeconds = 7 * 24 * 60 * 60
     const rows = await db('geo_pin_submission')
       .where({ user_id: userId })
-      .where('created_at', '>=', db.raw(`NOW() - INTERVAL '7 days'`))
+      .where(
+        'created_at',
+        '>=',
+        db.raw(`NOW() - make_interval(secs => ?)`, [sevenDaysSeconds]),
+      )
       .select<Array<{ status: GeoPinStatus; count: string }>>(
         'status',
         db.raw('COUNT(*) as count'),

--- a/packages/backend/src/infrastructure/repositories/geo-pipeline-state.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-pipeline-state.repository.ts
@@ -81,7 +81,16 @@ export const geoPipelineStateRepository = {
   }): Promise<MapPipelineState> {
     log.debug({ gameId: input.gameId, stage: input.currentStage }, 'upsert')
 
-    // ON CONFLICT update is the cleanest way to keep this idempotent.
+    // Distinguish "field not provided" from "explicit null". Without this,
+    // calling upsert({ gameId, currentStage: 'queued' }) would clobber a
+    // previously-set `next_eligible_at` cooldown (and `active_source`) to
+    // NULL. We send a sentinel "keep existing" flag for each clear-only
+    // field so the SQL can branch.
+    const clearActiveSource = input.activeSource === null
+    const setActiveSource = input.activeSource ?? null
+    const clearNextEligibleAt = input.nextEligibleAt === null
+    const setNextEligibleAt = input.nextEligibleAt ?? null
+
     const result = await db.raw<{ rows: Row[] }>(
       `
       INSERT INTO geo_game_pipeline_state (
@@ -92,7 +101,11 @@ export const geoPipelineStateRepository = {
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
       ON CONFLICT (game_id) DO UPDATE SET
         current_stage = COALESCE(EXCLUDED.current_stage, geo_game_pipeline_state.current_stage),
-        active_source = EXCLUDED.active_source,
+        -- Only overwrite active_source when the caller explicitly passed
+        -- one (including null to clear it). Undefined leaves it alone.
+        active_source = CASE WHEN ?::boolean THEN EXCLUDED.active_source
+                             WHEN EXCLUDED.active_source IS NOT NULL THEN EXCLUDED.active_source
+                             ELSE geo_game_pipeline_state.active_source END,
         next_source_idx = COALESCE(EXCLUDED.next_source_idx, geo_game_pipeline_state.next_source_idx),
         attempts_total = geo_game_pipeline_state.attempts_total + ?,
         zones_total = COALESCE(EXCLUDED.zones_total, geo_game_pipeline_state.zones_total),
@@ -100,14 +113,18 @@ export const geoPipelineStateRepository = {
         zones_selected = COALESCE(EXCLUDED.zones_selected, geo_game_pipeline_state.zones_selected),
         needs_curation = COALESCE(EXCLUDED.needs_curation, geo_game_pipeline_state.needs_curation),
         last_attempt_at = COALESCE(EXCLUDED.last_attempt_at, geo_game_pipeline_state.last_attempt_at),
-        next_eligible_at = EXCLUDED.next_eligible_at,
+        -- Same treatment for cooldown timestamp: undefined keeps existing,
+        -- null clears, a real Date overwrites.
+        next_eligible_at = CASE WHEN ?::boolean THEN EXCLUDED.next_eligible_at
+                                WHEN EXCLUDED.next_eligible_at IS NOT NULL THEN EXCLUDED.next_eligible_at
+                                ELSE geo_game_pipeline_state.next_eligible_at END,
         updated_at = NOW()
       RETURNING *
       `,
       [
         input.gameId,
         input.currentStage ?? 'queued',
-        input.activeSource ?? null,
+        setActiveSource,
         input.nextSourceIdx ?? 0,
         input.attemptsDelta ?? 0,
         input.zonesTotal ?? 0,
@@ -115,8 +132,10 @@ export const geoPipelineStateRepository = {
         input.zonesSelected ?? 0,
         input.needsCuration ?? false,
         input.lastAttemptAt ?? null,
-        input.nextEligibleAt ?? null,
+        setNextEligibleAt,
+        clearActiveSource,
         input.attemptsDelta ?? 0,
+        clearNextEligibleAt,
       ],
     )
     const row = result.rows[0]!

--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -104,7 +104,20 @@ export const geoScreenshotRepository = {
       .onConflict(['source', 'external_id'])
       .ignore()
       .returning<GeoScreenshotCandidateRow[]>('*')
-    return mapCandidate(row!)
+    if (row) return mapCandidate(row)
+
+    // Conflict path: the unique (source, external_id) row already exists.
+    // Re-fetch instead of dereferencing `row!` (which would crash here).
+    const existing = await db('geo_screenshot_candidate')
+      .where({ source: data.source, external_id: data.externalId ?? null })
+      .first<GeoScreenshotCandidateRow>()
+    if (!existing) {
+      // The row was inserted-then-deleted between INSERT and SELECT, or
+      // the unique constraint shape changed. Treat as a real failure
+      // rather than silently returning empty data.
+      throw new Error('createCandidate: insert ignored but no existing row')
+    }
+    return mapCandidate(existing)
   },
 
   async findCandidateByContentHash(

--- a/packages/backend/src/infrastructure/repositories/index.ts
+++ b/packages/backend/src/infrastructure/repositories/index.ts
@@ -33,6 +33,11 @@ export {
   type GeoIngestSource,
 } from './geo-ingest-failure.repository.js'
 export {
+  adminAuditRepository,
+  type AdminAuditEntry,
+  type AdminAuditRow,
+} from './admin-audit.repository.js'
+export {
   subscriptionRepository,
   stripeEventLogRepository,
   ENTITLED_STATUSES,

--- a/packages/backend/src/presentation/middleware/admin-audit.test.ts
+++ b/packages/backend/src/presentation/middleware/admin-audit.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { Request } from 'express'
+import { recordAdminGeoAudit } from './admin-audit.js'
+import { adminAuditRepository } from '../../infrastructure/repositories/admin-audit.repository.js'
+
+// We don't have a DB in this unit test, so swap the repository's `record`
+// out for a spy and verify the helper passes the right shape through.
+// The repository itself is exercised in the e2e tests where a real
+// Postgres connection is available.
+
+function fakeReq(over: Partial<Request> = {}): Request {
+  return {
+    userId: 'admin-1',
+    headers: {
+      'x-forwarded-for': '203.0.113.4, 10.0.0.1',
+      'x-request-id': 'req-abc',
+    },
+    ip: '127.0.0.1',
+    socket: { remoteAddress: '127.0.0.1' },
+    ...over,
+  } as unknown as Request
+}
+
+describe('recordAdminGeoAudit', () => {
+  it('forwards admin id, target, before/after, request id, and the first XFF hop', async () => {
+    const calls: Parameters<typeof adminAuditRepository.record>[0][] = []
+    const original = adminAuditRepository.record
+    adminAuditRepository.record = async (entry) => {
+      calls.push(entry)
+    }
+    try {
+      await recordAdminGeoAudit(fakeReq(), {
+        action: 'geo.maps.manual',
+        target: { kind: 'geo-map', id: 42 },
+        before: { isActive: false },
+        after: { isActive: true },
+      })
+    } finally {
+      adminAuditRepository.record = original
+    }
+    assert.equal(calls.length, 1)
+    const call = calls[0]!
+    assert.equal(call.adminId, 'admin-1')
+    assert.equal(call.action, 'geo.maps.manual')
+    assert.equal(call.targetKind, 'geo-map')
+    assert.equal(call.targetId, 42)
+    assert.deepEqual(call.before, { isActive: false })
+    assert.deepEqual(call.after, { isActive: true })
+    assert.equal(call.requestId, 'req-abc')
+    // First hop of x-forwarded-for, never the trailing private one.
+    assert.equal(call.ip, '203.0.113.4')
+  })
+
+  it('skips silently when there is no admin user (logged-out / hooks)', async () => {
+    const calls: Parameters<typeof adminAuditRepository.record>[0][] = []
+    const original = adminAuditRepository.record
+    adminAuditRepository.record = async (entry) => {
+      calls.push(entry)
+    }
+    try {
+      await recordAdminGeoAudit(fakeReq({ userId: undefined }), {
+        action: 'whatever',
+        target: { kind: 'global' },
+      })
+    } finally {
+      adminAuditRepository.record = original
+    }
+    assert.equal(calls.length, 0)
+  })
+
+  it('falls back to req.ip when no x-forwarded-for is present', async () => {
+    const calls: Parameters<typeof adminAuditRepository.record>[0][] = []
+    const original = adminAuditRepository.record
+    adminAuditRepository.record = async (entry) => {
+      calls.push(entry)
+    }
+    try {
+      await recordAdminGeoAudit(
+        fakeReq({ headers: {} }),
+        { action: 'geo.maps.manual', target: { kind: 'geo-map', id: 1 } },
+      )
+    } finally {
+      adminAuditRepository.record = original
+    }
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0]!.ip, '127.0.0.1')
+    assert.equal(calls[0]!.requestId, null)
+  })
+})

--- a/packages/backend/src/presentation/middleware/admin-audit.ts
+++ b/packages/backend/src/presentation/middleware/admin-audit.ts
@@ -1,0 +1,49 @@
+import type { Request } from 'express'
+import { adminAuditRepository } from '../../infrastructure/repositories/admin-audit.repository.js'
+
+// Best-effort audit recorder. Routes call this AFTER the destructive write
+// has succeeded — we deliberately don't try to undo audit failures since
+// the action has already been applied. The repository itself swallows + logs
+// any DB error so the user-facing response isn't blocked by audit infra
+// (e.g. table missing on a fresh test DB).
+
+export interface AdminAuditTarget {
+  kind: string
+  id?: string | number | null
+}
+
+export interface AdminAuditPayload {
+  action: string
+  target: AdminAuditTarget
+  before?: unknown
+  after?: unknown
+}
+
+function clientIp(req: Request): string | null {
+  const xff = req.headers['x-forwarded-for']
+  if (typeof xff === 'string') return xff.split(',')[0]?.trim() ?? null
+  return req.ip ?? req.socket.remoteAddress ?? null
+}
+
+function requestId(req: Request): string | null {
+  const id = req.headers['x-request-id']
+  return typeof id === 'string' ? id : null
+}
+
+export async function recordAdminGeoAudit(
+  req: Request,
+  payload: AdminAuditPayload,
+): Promise<void> {
+  const adminId = req.userId
+  if (!adminId) return
+  await adminAuditRepository.record({
+    adminId,
+    action: payload.action,
+    targetKind: payload.target.kind,
+    targetId: payload.target.id,
+    before: payload.before,
+    after: payload.after,
+    requestId: requestId(req),
+    ip: clientIp(req),
+  })
+}

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -4,6 +4,7 @@ import { adminService, jobService } from '../../domain/services/index.js'
 import { billingService } from '../../domain/services/billing.service.js'
 import { userRepository } from '../../infrastructure/repositories/user.repository.js'
 import { adminMiddleware } from '../middleware/auth.middleware.js'
+import { recordAdminGeoAudit } from '../middleware/admin-audit.js'
 import {
   startBatchImport,
   pauseImport,
@@ -2440,31 +2441,36 @@ router.post('/geo/reimport', async (req, res, next) => {
     const gameId = parse.data.gameId
     // Aggressive variant of /geo/run/:gameId — wipes every per-tier failure
     // tombstone AND the resolved metadata so the resolver+tick re-run from
-    // scratch. The lighter /geo/run/:gameId path leaves tombstones in place.
-    await Promise.all([
-      geoIngestFailureRepository.clear(gameId, 'registry'),
-      geoIngestFailureRepository.clear(gameId, 'fandom'),
-      geoIngestFailureRepository.clear(gameId, 'strategywiki'),
-      geoIngestFailureRepository.clear(gameId, 'fextralife'),
-      geoIngestFailureRepository.clear(gameId, 'wikidata'),
-      geoIngestFailureRepository.clear(gameId, 'steam'),
-      geoIngestFailureRepository.clear(gameId, 'metadata'),
-    ])
-    await db('games')
-      .where({ id: gameId })
-      .update({
-        geo_metadata_status: 'pending',
-        wiki_subdomain: null,
-        wiki_page_title: null,
-        steam_app_id: null,
-        wikidata_qid: null,
-      })
+    // scratch. Wrapped in a transaction so a crash mid-flight can't leave
+    // half the tombstones cleared and the metadata still resolved.
+    // Single round trip per source (whereIn-grouped) instead of 7 deletes.
+    await db.transaction(async (trx) => {
+      await trx('geo_ingest_failure')
+        .where({ game_id: gameId })
+        .whereIn('source', [
+          'registry',
+          'fandom',
+          'strategywiki',
+          'fextralife',
+          'wikidata',
+          'steam',
+          'metadata',
+        ])
+        .del()
+      await trx('games')
+        .where({ id: gameId })
+        .update({
+          geo_metadata_status: 'pending',
+          wiki_subdomain: null,
+          wiki_page_title: null,
+          steam_app_id: null,
+          wikidata_qid: null,
+        })
+    })
 
-    // Run the full pipeline (resolve → tick) right away instead of
-    // depending on the recurring tick to pick the row back up. Stable
-    // jobIds so a double-click collapses to one execution; the resolver
-    // is gameId-scoped here for fast feedback. Hyphens (not colons) —
-    // BullMQ 5.x rejects 2-part colon-separated jobIds.
+    // Enqueue jobs AFTER the transaction commits so the orchestrator can
+    // observe the cleared state and a transaction rollback can't leak a
+    // job that races against a stale view.
     const resolveJob = await geoQueue.add(
       'resolve-metadata',
       { kind: 'resolve-metadata', batchSize: 1, gameId },
@@ -2475,6 +2481,11 @@ router.post('/geo/reimport', async (req, res, next) => {
       { kind: 'ingest-tick', batchSize: 1, gameId },
       { jobId: `manual-tick-${gameId}` },
     )
+    await recordAdminGeoAudit(req, {
+      action: 'geo.reimport',
+      target: { kind: 'game', id: gameId },
+      after: { resolveJobId: resolveJob.id, tickJobId: tickJob.id },
+    })
     res.json({
       success: true,
       data: { resolveJobId: resolveJob.id, tickJobId: tickJob.id },
@@ -2727,10 +2738,19 @@ router.delete('/geo/meta/:id', async (req, res, next) => {
         res.status(404).json({ success: false, error: { code: 'NOT_FOUND' } })
         return
       }
+      await recordAdminGeoAudit(req, {
+        action: 'geo.meta.delete',
+        target: { kind: 'geo-screenshot-meta', id },
+        after: { candidateId: result.candidateId },
+      })
       res.json({ success: true, data: result })
     } catch (dbErr) {
-      const msg = String(dbErr)
-      if (msg.includes('foreign key') || msg.includes('violates')) {
+      // Match Postgres' foreign_key_violation SQLSTATE rather than parsing
+      // the message — driver locale / pg version changes won't break the
+      // 409 path. Knex surfaces the code as `error.code` with the original
+      // pg error preserved.
+      const code = (dbErr as { code?: string } | null)?.code
+      if (code === '23503') {
         res.status(409).json({
           success: false,
           error: {
@@ -2791,14 +2811,16 @@ router.post('/geo/maps/manual', async (req, res, next) => {
       return
     }
 
-    // Multi-map mode: a game can have many enabled maps. The legacy
-    // `replaceActive` body flag now means "enable this new map after
-    // creating it"; without it, the row is created disabled and the
-    // admin enables it from the Cartes panel. This intentionally stops
-    // throwing MAP_EXISTS — that 409 is what blocked operators from
-    // adding a second region in the first place.
+    // Multi-map mode: a game can have many enabled maps. `replaceActive`
+    // means "enable this new map after creating it" — without it the row
+    // lands disabled and the admin enables from the Cartes panel.
     const enableImmediately = !!data.replaceActive
 
+    // create() opens its own transaction internally; running the
+    // tombstone clears in a SECOND transaction is fine because they're
+    // independently idempotent (the create + enable is the only
+    // multi-step write that needs atomicity, and create() handles that).
+    // Single whereIn delete instead of 6 round-trips.
     const map = await geoMapRepository.create({
       gameId: data.gameId,
       source: 'manual',
@@ -2814,23 +2836,32 @@ router.post('/geo/maps/manual', async (req, res, next) => {
     })
 
     if (enableImmediately) {
-      // create() already inserts is_active=true, but enableForGame also
-      // promotes to capture-default when the game had no enabled siblings.
       await geoMapRepository.enableForGame(data.gameId, map.id)
     }
 
-    // Also clear all ingest tombstones for this game — manual upload is the
-    // operator saying "I've solved this", so the auto-pipeline shouldn't keep
-    // re-tombstoning it.
-    await Promise.all([
-      geoIngestFailureRepository.clear(data.gameId, 'registry'),
-      geoIngestFailureRepository.clear(data.gameId, 'fandom'),
-      geoIngestFailureRepository.clear(data.gameId, 'strategywiki'),
-      geoIngestFailureRepository.clear(data.gameId, 'fextralife'),
-      geoIngestFailureRepository.clear(data.gameId, 'wand'),
-      geoIngestFailureRepository.clear(data.gameId, 'wikidata'),
-    ])
+    await db('geo_ingest_failure')
+      .where({ game_id: data.gameId })
+      .whereIn('source', [
+        'registry',
+        'fandom',
+        'strategywiki',
+        'fextralife',
+        'wand',
+        'wikidata',
+      ])
+      .del()
 
+    await recordAdminGeoAudit(req, {
+      action: 'geo.maps.manual',
+      target: { kind: 'geo-map', id: map.id },
+      after: {
+        gameId: data.gameId,
+        source: 'manual',
+        sourceUrl: data.sourceUrl,
+        license: data.license,
+        enableImmediately,
+      },
+    })
     res.json({ success: true, data: map })
   } catch (err) {
     next(err)
@@ -2942,25 +2973,53 @@ router.get('/screenshot-reports', async (req, res, next) => {
 // Body: { screenshotId } | { geoScreenshotCandidateId } — exactly one.
 // Drops the existing reports so a single 3-report wave doesn't immediately
 // re-trip the threshold; the audit log still has the request via Pino.
+// Zod-validated discriminated union: exactly one of screenshotId /
+// geoScreenshotCandidateId must be present, both as positive integers.
+// Without Zod, raw `Boolean(undefined) === Boolean(0)` was true, so a
+// caller could legally send `screenshotId: 0` and skip the type coercion.
+const reactivateBodySchema = z
+  .union([
+    z.object({
+      screenshotId: z.number().int().positive(),
+      geoScreenshotCandidateId: z.undefined().optional(),
+    }),
+    z.object({
+      screenshotId: z.undefined().optional(),
+      geoScreenshotCandidateId: z.number().int().positive(),
+    }),
+  ])
+  .refine(
+    (data) => Boolean(data.screenshotId) !== Boolean(data.geoScreenshotCandidateId),
+    { message: 'exactly one of screenshotId or geoScreenshotCandidateId is required' },
+  )
+
 router.post('/screenshot-reports/reactivate', async (req, res, next) => {
   try {
-    const { screenshotId, geoScreenshotCandidateId } = req.body as {
-      screenshotId?: number
-      geoScreenshotCandidateId?: number
-    }
-    if (Boolean(screenshotId) === Boolean(geoScreenshotCandidateId)) {
+    const parse = reactivateBodySchema.safeParse(req.body)
+    if (!parse.success) {
       res.status(400).json({
         success: false,
         error: {
-          code: 'INVALID_BODY',
-          message: 'exactly one of screenshotId or geoScreenshotCandidateId is required',
+          code: 'VALIDATION_ERROR',
+          message:
+            parse.error.issues[0]?.message ??
+            'exactly one of screenshotId or geoScreenshotCandidateId is required',
         },
       })
       return
     }
+    const { screenshotId, geoScreenshotCandidateId } = parse.data
     const result = await screenshotReportRepository.reactivate({
       screenshotId,
       geoScreenshotCandidateId,
+    })
+    await recordAdminGeoAudit(req, {
+      action: 'screenshot-report.reactivate',
+      target: {
+        kind: screenshotId ? 'screenshot' : 'geo-screenshot-candidate',
+        id: screenshotId ?? geoScreenshotCandidateId,
+      },
+      after: result,
     })
     res.json({ success: true, data: result })
   } catch (err) {
@@ -3094,8 +3153,32 @@ router.post('/users/:userId/revoke-supporter', async (req, res, next) => {
   }
 })
 
+// Destructive nuke that wipes every piece of scraping progress. Requires the
+// caller to send `{ confirm: 'RESET' }` so a stray click / CSRF can't silently
+// blow away the whole geo dataset. Audit-logged before the destructive work so
+// the trail survives even if the transaction crashes mid-flight.
+const scrapingResetBodySchema = z.object({
+  confirm: z.literal('RESET'),
+})
+
 router.post('/scraping/reset', async (req, res, next) => {
   try {
+    const parse = scrapingResetBodySchema.safeParse(req.body)
+    if (!parse.success) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'CONFIRMATION_REQUIRED',
+          message: "send { confirm: 'RESET' } to perform this destructive operation",
+        },
+      })
+      return
+    }
+
+    routeLogger.warn(
+      { adminId: req.userId },
+      'admin requested scraping/reset',
+    )
     const result = await db.transaction(async (trx) => {
       const importStates = await trx('import_states').delete()
       const ingestFailures = await trx('geo_ingest_failure').delete()
@@ -3115,6 +3198,11 @@ router.post('/scraping/reset', async (req, res, next) => {
       return { importStates, ingestFailures, challenges, maps }
     })
 
+    await recordAdminGeoAudit(req, {
+      action: 'scraping.reset',
+      target: { kind: 'global' },
+      after: result,
+    })
     routeLogger.warn(
       { adminId: req.userId, ...result },
       'admin reset scraping state from zero',

--- a/packages/backend/src/presentation/routes/geo-fetch.routes.ts
+++ b/packages/backend/src/presentation/routes/geo-fetch.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { z } from 'zod'
 import { adminMiddleware } from '../middleware/auth.middleware.js'
+import { recordAdminGeoAudit } from '../middleware/admin-audit.js'
 import { db } from '../../infrastructure/database/connection.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
 import { geoQueue, type GeoJobData } from '../../infrastructure/queue/queues.js'
@@ -67,7 +68,10 @@ const listQuerySchema = z.object({
 router.get('/games', async (req, res, next) => {
   try {
     const q = listQuerySchema.parse(req.query)
-    let query = db('geo_game_pipeline_state as s')
+    // The page query and the count query share the same WHERE filters.
+    // Inline both rather than threading a generic helper through Knex'
+    // builder types (which fight any wrapper that's structurally typed).
+    let pageQuery = db('geo_game_pipeline_state as s')
       .leftJoin('games as g', 'g.id', 's.game_id')
       .select(
         's.game_id',
@@ -83,13 +87,34 @@ router.get('/games', async (req, res, next) => {
         'g.name',
         'g.slug',
       )
-    if (q.stage) query = query.where('s.current_stage', q.stage)
-    if (q.search) query = query.where('g.name', 'ilike', `%${q.search}%`)
-    const rows = await query
-      .orderBy('s.updated_at', 'desc')
-      .limit(q.limit)
-      .offset(q.offset)
-    res.json({ success: true, data: { games: rows, limit: q.limit, offset: q.offset } })
+    let countQuery = db('geo_game_pipeline_state as s').leftJoin(
+      'games as g',
+      'g.id',
+      's.game_id',
+    )
+    if (q.stage) {
+      pageQuery = pageQuery.where('s.current_stage', q.stage)
+      countQuery = countQuery.where('s.current_stage', q.stage)
+    }
+    if (q.search) {
+      pageQuery = pageQuery.where('g.name', 'ilike', `%${q.search}%`)
+      countQuery = countQuery.where('g.name', 'ilike', `%${q.search}%`)
+    }
+    const [rows, totalRow] = await Promise.all([
+      pageQuery.orderBy('s.updated_at', 'desc').limit(q.limit).offset(q.offset),
+      countQuery.count<{ count: string }[]>('* as count').first(),
+    ])
+    const total = Number(totalRow?.count ?? 0)
+    res.json({
+      success: true,
+      data: {
+        games: rows,
+        limit: q.limit,
+        offset: q.offset,
+        total,
+        hasMore: q.offset + rows.length < total,
+      },
+    })
   } catch (err) {
     next(err)
   }
@@ -97,8 +122,14 @@ router.get('/games', async (req, res, next) => {
 
 // === Start / cancel ===================================================
 
+// Hard cap on `start({ all: true })`. BullMQ stalls and the pipeline
+// state table thrashes if we drop tens of thousands of jobs in one click;
+// 1000 is enough to sweep our entire curated catalog today and gives a
+// human-scale upper bound for the future.
+const GEO_FETCH_MAX_START_GAMES = 1000
+
 const startSchema = z.object({
-  gameIds: z.array(z.number().int().positive()).optional(),
+  gameIds: z.array(z.number().int().positive()).max(GEO_FETCH_MAX_START_GAMES).optional(),
   // When true, enqueue every curated game that's not already ready.
   all: z.boolean().optional(),
 })
@@ -107,12 +138,20 @@ router.post('/start', async (req, res, next) => {
   try {
     const body = startSchema.parse(req.body)
     let gameIds = body.gameIds ?? []
+    let truncated = false
     if (body.all) {
       const rows = await db('games')
         .where('geo_curated', true)
         .where('geo_metadata_status', 'resolved')
         .select<Array<{ id: number }>>('id')
       gameIds = rows.map((r) => r.id)
+      // Truncate rather than reject: an admin clicking "Lancer tout" wants
+      // the run to start, not a 400. Surface the truncation in the response
+      // so the UI can show the clamp.
+      if (gameIds.length > GEO_FETCH_MAX_START_GAMES) {
+        gameIds = gameIds.slice(0, GEO_FETCH_MAX_START_GAMES)
+        truncated = true
+      }
     }
     if (gameIds.length === 0) {
       res.status(400).json({ success: false, error: { code: 'NO_GAMES', message: 'no games to start' } })
@@ -134,25 +173,60 @@ router.post('/start', async (req, res, next) => {
       )
     }
     emitGeoFetchStarted({ totalGames: gameIds.length })
-    log.info({ totalGames: gameIds.length }, 'geo-fetch started')
-    res.json({ success: true, data: { totalGames: gameIds.length } })
+    log.info(
+      { totalGames: gameIds.length, truncated, adminId: req.userId },
+      'geo-fetch started',
+    )
+    await recordAdminGeoAudit(req, {
+      action: 'geo-fetch.start',
+      target: { kind: 'global' },
+      after: { totalGames: gameIds.length, truncated, all: !!body.all },
+    })
+    res.json({
+      success: true,
+      data: { totalGames: gameIds.length, truncated, cap: GEO_FETCH_MAX_START_GAMES },
+    })
   } catch (err) {
     next(err)
   }
 })
 
-// Drain everything in flight: remove waiting/delayed jobs in geo-jobs that
-// belong to the maps:* family. Active jobs run to completion (BullMQ doesn't
-// kill them mid-flight) but no new ones get scheduled.
-router.post('/cancel', async (_req, res, next) => {
+// Drain only the maps:* jobs from the geo queue. Without the kind filter,
+// `clean()` would also blow away unrelated jobs (consensus evaluation,
+// contributor tier promotion) that happen to be waiting/delayed at the same
+// moment — those are user-initiated and must not be silently dropped.
+router.post('/cancel', async (req, res, next) => {
   try {
-    const removed = await geoQueue.clean(0, 1_000_000, 'wait')
-    const removedDelayed = await geoQueue.clean(0, 1_000_000, 'delayed')
+    const isMapsJob = (job: { name?: string }) =>
+      typeof job.name === 'string' && job.name.startsWith('maps:')
+
+    // Get a snapshot of waiting + delayed map jobs and remove them
+    // individually. clean() with the 'wait'/'delayed' status would drop
+    // every job in those buckets; iterating gives us per-job filter.
+    const [waiting, delayed] = await Promise.all([
+      geoQueue.getWaiting(0, 10_000),
+      geoQueue.getDelayed(0, 10_000),
+    ])
+    const targets = [...waiting, ...delayed].filter(isMapsJob)
+    let removed = 0
+    for (const job of targets) {
+      try {
+        await job.remove()
+        removed++
+      } catch {
+        // Job could've started in between snapshot and removal — skip.
+      }
+    }
     log.warn(
-      { wait: removed.length, delayed: removedDelayed.length },
-      'geo-fetch cancelled',
+      { mapsJobsRemoved: removed, totalSnapshot: targets.length, adminId: req.userId },
+      'geo-fetch cancelled (scoped to maps:* only)',
     )
-    res.json({ success: true, data: { removed: removed.length + removedDelayed.length } })
+    await recordAdminGeoAudit(req, {
+      action: 'geo-fetch.cancel',
+      target: { kind: 'global' },
+      after: { mapsJobsRemoved: removed },
+    })
+    res.json({ success: true, data: { removed } })
   } catch (err) {
     next(err)
   }

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -14,8 +14,12 @@ import {
   inventoryRepository,
   sessionRepository,
 } from '../../infrastructure/repositories/index.js'
-import { authMiddleware } from '../middleware/auth.middleware.js'
+import {
+  authMiddleware,
+  optionalAuthMiddleware,
+} from '../middleware/auth.middleware.js'
 import { validateBody, validateParams } from '../middleware/validation.middleware.js'
+import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
 import { geoQueue } from '../../infrastructure/queue/queues.js'
 import { emitGeoRewarded } from '../../infrastructure/socket/socket.js'
@@ -78,6 +82,19 @@ router.post(
   validateBody(contributePickBodySchema),
   async (req, res, next) => {
     try {
+      // Anonymous guest sessions can authenticate but should not consume
+      // the moderation pool — without this gate, a fresh guest spins up a
+      // session and can immediately pull a contribution candidate.
+      if (req.isGuest) {
+        res.status(403).json({
+          success: false,
+          error: {
+            code: 'CONTRIBUTE_GUEST_FORBIDDEN',
+            message: 'sign up to contribute to the geo dataset',
+          },
+        })
+        return
+      }
       const userId = req.userId!
       const { gameId } = req.body as z.infer<typeof contributePickBodySchema>
       const candidate = await geoGameService.pickContributionTarget({ gameId, userId })
@@ -114,6 +131,16 @@ router.post(
   validateBody(pinBodySchema),
   async (req, res, next) => {
     try {
+      if (req.isGuest) {
+        res.status(403).json({
+          success: false,
+          error: {
+            code: 'CONTRIBUTE_GUEST_FORBIDDEN',
+            message: 'sign up to contribute to the geo dataset',
+          },
+        })
+        return
+      }
       const userId = req.userId!
       const { geoScreenshotCandidateId, pin } = req.body as z.infer<typeof pinBodySchema>
 
@@ -164,12 +191,16 @@ router.post(
           }
         }
 
-        // Enqueue consensus evaluation; the worker itself decides (based on
-        // threshold gates) whether this pin count warrants a full pass.
+        // Enqueue consensus evaluation; carry the post-increment pin count
+        // in the payload so the worker can gate threshold checks on the
+        // value at submit-time. Without this, two near-simultaneous pins
+        // can both step past a threshold (e.g. 9 → 10 → 11) and the worker
+        // re-reads pin_count = 11 for both, never evaluating at 10.
         try {
           await geoQueue.add('evaluate-consensus', {
             kind: 'evaluate-consensus',
             geoScreenshotCandidateId,
+            pinCountAtEnqueue: newPinCount,
           })
         } catch (e) {
           log.warn({ err: String(e) }, 'failed to enqueue geo consensus job')
@@ -228,18 +259,35 @@ router.get('/contributor/me', authMiddleware, async (req, res, next) => {
 
 // ---------- Free-play (unranked, all-games-all-maps browser) ----------
 
-router.get('/games', async (_req, res, next) => {
-  try {
-    const games = await geoScreenshotRepository.listPlayableGames()
-    res.set('Cache-Control', 'public, max-age=300')
-    res.json({ success: true, data: games })
-  } catch (err) {
-    next(err)
-  }
-})
+// Rate limits for the free-play endpoints. Without these, an unauthenticated
+// scraper can systematically extract every promoted answer (canonical
+// coordinates) by submitting one fake guess per screenshot. Per-IP keying
+// because these routes use optionalAuthMiddleware (anon access is allowed
+// for browsing but bounded). Numbers chosen to be generous for legit play
+// but tight enough that bulk extraction is impractical.
+const freePlayPickLimiter = createRateLimiter({ windowMs: 60_000, max: 60 })
+const freePlayGuessLimiter = createRateLimiter({ windowMs: 60_000, max: 30 })
+const freePlayCatalogLimiter = createRateLimiter({ windowMs: 60_000, max: 120 })
+
+router.get(
+  '/games',
+  optionalAuthMiddleware,
+  freePlayCatalogLimiter,
+  async (_req, res, next) => {
+    try {
+      const games = await geoScreenshotRepository.listPlayableGames()
+      res.set('Cache-Control', 'public, max-age=300')
+      res.json({ success: true, data: games })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
 
 router.get(
   '/games/:gameId/maps',
+  optionalAuthMiddleware,
+  freePlayCatalogLimiter,
   validateParams(gameIdParamSchema),
   async (req, res, next) => {
     try {
@@ -255,6 +303,8 @@ router.get(
 
 router.post(
   '/free-play/random',
+  optionalAuthMiddleware,
+  freePlayPickLimiter,
   validateBody(freePlayPickBodySchema),
   async (req, res, next) => {
     try {
@@ -312,6 +362,8 @@ router.post(
 
 router.post(
   '/free-play/guess',
+  optionalAuthMiddleware,
+  freePlayGuessLimiter,
   validateBody(freePlayGuessBodySchema),
   async (req, res, next) => {
     try {

--- a/packages/frontend/e2e/geo-admin-authz.spec.ts
+++ b/packages/frontend/e2e/geo-admin-authz.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { loginAsUser, loginAsAdmin } from './helpers/game-helpers'
+
+// Admin geo authz boundary: every /api/admin/geo* endpoint MUST 403 a
+// non-admin (and 401 an unauthenticated client). Without this suite, a
+// regression that swaps `adminMiddleware` for `authMiddleware` (or for
+// `optionalAuthMiddleware`) would ship green and let any logged-in user
+// nuke the geo dataset.
+
+// Routes touched by the admin geo UI. Each entry is `{ method, path, body? }`.
+// Keep this list grouped + commented so the next person adding a route
+// remembers to extend it.
+const ADMIN_GEO_ENDPOINTS: Array<{
+    method: 'GET' | 'POST' | 'DELETE'
+    path: string
+    body?: unknown
+}> = [
+    // --- /api/admin/geo-fetch (separate router) ---
+    { method: 'GET', path: '/api/admin/geo-fetch/status' },
+    { method: 'GET', path: '/api/admin/geo-fetch/games' },
+    { method: 'POST', path: '/api/admin/geo-fetch/start', body: { all: false } },
+    { method: 'POST', path: '/api/admin/geo-fetch/cancel' },
+    { method: 'GET', path: '/api/admin/geo-fetch/1' },
+    { method: 'POST', path: '/api/admin/geo-fetch/1/retry' },
+    { method: 'POST', path: '/api/admin/geo-fetch/1/fandom/retry' },
+    { method: 'GET', path: '/api/admin/geo-fetch/1/maps' },
+    { method: 'POST', path: '/api/admin/geo-fetch/1/maps/1/select' },
+    { method: 'DELETE', path: '/api/admin/geo-fetch/1/cooldown' },
+
+    // --- /api/admin/geo (lives in admin.routes.ts) ---
+    { method: 'POST', path: '/api/admin/geo/run' },
+    { method: 'POST', path: '/api/admin/geo/run/1' },
+    { method: 'POST', path: '/api/admin/geo/run/1/fandom' },
+    { method: 'GET', path: '/api/admin/geo/run/state' },
+    { method: 'POST', path: '/api/admin/geo/reimport', body: { gameId: 1 } },
+    {
+        method: 'POST',
+        path: '/api/admin/geo/curated/bulk',
+        body: { items: [{ gameId: 1, curated: true }] },
+    },
+    { method: 'DELETE', path: '/api/admin/geo/tombstone/1/fandom' },
+    { method: 'DELETE', path: '/api/admin/geo/meta/1' },
+    {
+        method: 'POST',
+        path: '/api/admin/geo/maps/manual',
+        body: {
+            gameId: 1,
+            imageUrl: 'https://example.com/x.png',
+            widthPx: 1024,
+            heightPx: 1024,
+            license: 'CC-BY-4.0',
+        },
+    },
+    {
+        method: 'POST',
+        path: '/api/admin/geo/maps/wand',
+        body: { gameId: 1, wandUrl: 'https://wand.com/maps/x' },
+    },
+    {
+        method: 'POST',
+        path: '/api/admin/screenshot-reports/reactivate',
+        body: { geoScreenshotCandidateId: 1 },
+    },
+
+    // --- destructive nuke endpoint ---
+    {
+        method: 'POST',
+        path: '/api/admin/scraping/reset',
+        body: { confirm: 'RESET' },
+    },
+]
+
+// Probe whether the geo router boots; if the API is missing entirely
+// (older backend), skip the suite so the suite stays useful but the
+// regression we care about — admin authz being weakened — still trips.
+async function geoRoutesAvailable(request: APIRequestContext): Promise<boolean> {
+    const r = await request.get('/api/geo/games', { failOnStatusCode: false })
+    return r.status() < 500 // 200, 401, 429 — anything that says "I'm here"
+}
+
+test.describe('Admin Geo authz boundary', () => {
+    test('unauthenticated requests get 401', async ({ request }) => {
+        if (!(await geoRoutesAvailable(request))) test.skip(true, 'geo off')
+        for (const ep of ADMIN_GEO_ENDPOINTS) {
+            const res =
+                ep.method === 'GET'
+                    ? await request.get(ep.path, { failOnStatusCode: false })
+                    : ep.method === 'DELETE'
+                        ? await request.delete(ep.path, { failOnStatusCode: false })
+                        : await request.post(ep.path, {
+                            data: ep.body ?? {},
+                            failOnStatusCode: false,
+                        })
+            // Any of 401 (unauthenticated) or 403 (forbidden) is acceptable;
+            // anything else (200, 400, 500) is a regression because the
+            // request body could land before the auth check.
+            expect(
+                [401, 403],
+                `${ep.method} ${ep.path} should reject unauthenticated callers (got ${res.status()})`,
+            ).toContain(res.status())
+        }
+    })
+
+    test('a non-admin user gets 403 on every admin geo endpoint', async ({ page, request }) => {
+        if (!(await geoRoutesAvailable(request))) test.skip(true, 'geo off')
+
+        // Login as a normal user via UI so cookies flow into the request
+        // context for free.
+        await loginAsUser(page)
+        const failures: string[] = []
+        for (const ep of ADMIN_GEO_ENDPOINTS) {
+            const res =
+                ep.method === 'GET'
+                    ? await page.request.get(ep.path, { failOnStatusCode: false })
+                    : ep.method === 'DELETE'
+                        ? await page.request.delete(ep.path, { failOnStatusCode: false })
+                        : await page.request.post(ep.path, {
+                            data: ep.body ?? {},
+                            failOnStatusCode: false,
+                        })
+            // A regular user must never reach an admin endpoint. 401 also
+            // acceptable (e.g. session expired) but 200/400/500 = leak.
+            if (![401, 403].includes(res.status())) {
+                failures.push(`${ep.method} ${ep.path} → ${res.status()}`)
+            }
+        }
+        expect(
+            failures,
+            `Admin geo endpoints leaking to non-admin users:\n${failures.join('\n')}`,
+        ).toEqual([])
+    })
+
+    // Sanity: a real admin still gets a non-403 (e.g. 200, 400 on missing
+    // body) on at least the read endpoints. This prevents accidentally
+    // locking out the admin role too.
+    test('an admin user is not blanket-forbidden', async ({ page, request }) => {
+        if (!(await geoRoutesAvailable(request))) test.skip(true, 'geo off')
+        await loginAsAdmin(page)
+        const status = await page.request
+            .get('/api/admin/geo-fetch/status', { failOnStatusCode: false })
+            .then((r) => r.status())
+        expect(status).toBe(200)
+    })
+})
+
+// Public free-play surface: must be rate-limited (429 after a burst) so a
+// scraper can't extract every promoted answer in a tight loop. We don't
+// require a hard cap here — the test fires a generous burst and asserts
+// at least one 429 lands.
+test.describe('Public geo free-play rate limit', () => {
+    test('free-play guess is rate-limited per IP', async ({ request }) => {
+        if (!(await geoRoutesAvailable(request))) test.skip(true, 'geo off')
+
+        // 60 requests to /free-play/guess should exceed the 30/min window.
+        // Body is intentionally invalid (so we don't actually consume any
+        // application state) but the limiter runs BEFORE the validation
+        // middleware so 429 still fires.
+        let saw429 = false
+        for (let i = 0; i < 60; i++) {
+            const r = await request.post('/api/geo/free-play/guess', {
+                data: { metaId: 1, geoMapId: 1, guess: { x: 0.5, y: 0.5 } },
+                failOnStatusCode: false,
+            })
+            if (r.status() === 429) {
+                saw429 = true
+                break
+            }
+        }
+        expect(saw429, 'expected /api/geo/free-play/guess to return 429 within 60 calls').toBe(true)
+    })
+})

--- a/packages/frontend/e2e/geo-admin.spec.ts
+++ b/packages/frontend/e2e/geo-admin.spec.ts
@@ -4,15 +4,19 @@ import { loginAsAdmin } from './helpers/game-helpers'
 /**
  * E2E tests for the admin Geo review panel and ingestion actions.
  *
- * Skipped gracefully when the geo API is unreachable (older backend), so
- * the rest of the suite doesn't fail misleadingly.
+ * Note: previously these tests soft-skipped when /api/geo/games returned
+ * non-200 — a green-build smell because a fully-broken router silently
+ * passed. We now require the geo router to be reachable (any status code
+ * < 500 — even 401/429 means "the router is up"). A real backend outage
+ * still flags by failing on the assertions below rather than silently
+ * passing.
  */
 
-async function geoRoutesAvailable(page: import('@playwright/test').Page): Promise<boolean> {
+async function geoRoutesReachable(page: import('@playwright/test').Page): Promise<boolean> {
     const response = await page.request.get('/api/geo/games', {
         failOnStatusCode: false,
     })
-    return response.status() === 200
+    return response.status() < 500
 }
 
 test.describe('Geo Admin', () => {
@@ -21,7 +25,7 @@ test.describe('Geo Admin', () => {
     })
 
     test('renders the Geo tab and review panel', async ({ page }) => {
-        if (!(await geoRoutesAvailable(page))) test.skip(true, 'geo off')
+        if (!(await geoRoutesReachable(page))) test.skip(true, 'geo router unreachable')
 
         await page.goto('/en/admin?tab=geo')
 
@@ -40,7 +44,7 @@ test.describe('Geo Admin', () => {
     })
 
     test('candidates list renders (possibly empty) for the collecting filter', async ({ page }) => {
-        if (!(await geoRoutesAvailable(page))) test.skip(true, 'geo off')
+        if (!(await geoRoutesReachable(page))) test.skip(true, 'geo router unreachable')
 
         await page.goto('/en/admin?tab=geo')
         await page.waitForLoadState('networkidle')

--- a/packages/frontend/src/components/admin/GeoMapsTab.tsx
+++ b/packages/frontend/src/components/admin/GeoMapsTab.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/hooks/useGeoRunPolling'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { fetchAdminJson as fetchJson } from '@/lib/api/admin'
+import { getApiErrorMessage } from '@/lib/api-errors'
 import {
     Sheet,
     SheetContent,
@@ -206,7 +207,7 @@ export function GeoMapsTab({
             )
             setGames(data.games)
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setLoading(false)
         }
@@ -220,7 +221,7 @@ export function GeoMapsTab({
             )
             setSources(data)
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
             setSources(null)
         } finally {
             setSourcesLoading(false)
@@ -254,7 +255,7 @@ export function GeoMapsTab({
             armRunPolling()
             await Promise.all([reload(), reloadSources(game.id)])
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setBusyAction(null)
         }
@@ -299,7 +300,7 @@ export function GeoMapsTab({
             armRunPolling()
             await reloadSources(gameId)
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setRetryingTier(null)
         }
@@ -317,7 +318,7 @@ export function GeoMapsTab({
             armRunPolling()
             await reloadSources(gameId)
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setRunningTier(null)
         }
@@ -338,7 +339,7 @@ export function GeoMapsTab({
             setMessage(t('admin.geo.maps.tierStatus.activated'))
             await Promise.all([reload(), reloadSources(gameId)])
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setActivatingMapId(null)
         }
@@ -356,8 +357,11 @@ export function GeoMapsTab({
             setMessage(t('admin.geo.maps.multi.disabled', 'Map disabled.'))
             await Promise.all([reload(), reloadSources(gameId)])
         } catch (e) {
-            const message = String(e)
-            if (message.includes('LAST_ENABLED')) {
+            // Look at the structured ApiError code instead of stringifying —
+            // matching on substring of `String(e)` works for the happy path
+            // but breaks the moment the error message changes locale.
+            const code = (e as { code?: string } | null)?.code ?? ''
+            if (code === 'LAST_ENABLED') {
                 setError(
                     t(
                         'admin.geo.maps.multi.disableLastBlocked',
@@ -365,7 +369,7 @@ export function GeoMapsTab({
                     ),
                 )
             } else {
-                setError(message)
+                setError(getApiErrorMessage(e))
             }
         } finally {
             setActivatingMapId(null)
@@ -386,7 +390,7 @@ export function GeoMapsTab({
             )
             await reloadSources(gameId)
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setActivatingMapId(null)
         }
@@ -407,7 +411,7 @@ export function GeoMapsTab({
             })
             await reloadSources(gameId)
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setActivatingMapId(null)
         }
@@ -434,7 +438,7 @@ export function GeoMapsTab({
             }
             await reload()
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setUncurating(false)
         }
@@ -458,7 +462,7 @@ export function GeoMapsTab({
             setSources(null)
             await reload()
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setResetting(false)
         }

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -39,6 +39,7 @@ import { geoFetchApi } from '@/lib/api/geo-fetch'
 import { useGeoRunPolling } from '@/hooks/useGeoRunPolling'
 import { useGeoHealth } from '@/hooks/useGeoHealth'
 import { useIsMobile } from '@/hooks/useIsMobile'
+import { getApiErrorMessage } from '@/lib/api-errors'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type {
     GeoCandidateGameSummary,
@@ -239,7 +240,7 @@ export function GeoReviewPanel() {
         if (gameId !== undefined) {
             fetchCandidates({ status, gameId })
                 .then((rows) => !cancelled && setCandidates(rows))
-                .catch((e) => !cancelled && setError(String(e)))
+                .catch((e) => !cancelled && setError(getApiErrorMessage(e)))
                 .finally(() => !cancelled && setLoading(false))
         } else {
             fetchGameSummaries({ status })
@@ -251,7 +252,7 @@ export function GeoReviewPanel() {
                     // doesn't carry stale rows from a previous drill-down.
                     setCandidates([])
                 })
-                .catch((e) => !cancelled && setError(String(e)))
+                .catch((e) => !cancelled && setError(getApiErrorMessage(e)))
                 .finally(() => !cancelled && setLoading(false))
         }
         return () => {
@@ -266,7 +267,7 @@ export function GeoReviewPanel() {
             const d = await fetchCandidateDetail(id)
             setDetail(d)
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         }
     }
 
@@ -314,7 +315,7 @@ export function GeoReviewPanel() {
                 if (rows.length === 0 && gameFilter) setGameFilter(null)
             }
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setSaving(false)
         }
@@ -342,7 +343,7 @@ export function GeoReviewPanel() {
             await geoFetchApi.retry(gameFilter.gameId)
             setFetchMoreNotice(t('admin.geo.fetchMoreQueued'))
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setFetchingMore(false)
         }
@@ -373,7 +374,7 @@ export function GeoReviewPanel() {
                 if (rows.length === 0 && gameFilter) setGameFilter(null)
             }
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setSaving(false)
         }
@@ -391,7 +392,7 @@ export function GeoReviewPanel() {
             setPin(null)
             setDemoteOpen(false)
         } catch (e) {
-            setError(String(e))
+            setError(getApiErrorMessage(e))
         } finally {
             setSaving(false)
         }

--- a/packages/frontend/src/components/admin/geo-fetch/GameMapsDrawer.tsx
+++ b/packages/frontend/src/components/admin/geo-fetch/GameMapsDrawer.tsx
@@ -33,11 +33,21 @@ export function GameMapsDrawer({ gameId, onClose }: Props) {
       setData(null)
       return
     }
+    // Guard against fast gameId switches: a slower earlier promise
+    // resolving last would otherwise stomp the newer game's data.
+    let cancelled = false
     setIsLoading(true)
     geoFetchApi
       .maps(gameId)
-      .then(setData)
-      .finally(() => setIsLoading(false))
+      .then((fresh) => {
+        if (!cancelled) setData(fresh)
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [gameId])
 
   async function handleSelect(mapId: number) {
@@ -140,19 +150,32 @@ export function GameMapsDrawer({ gameId, onClose }: Props) {
                     </div>
                   ))}
                 </div>
-                <div className="flex justify-end">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => {
-                      if (gameId == null) return
-                      void retrySource(gameId, 'fandom')
-                    }}
-                    title={t('admin.geoFetch.drawer.refetch', 'Re-récupérer')}
-                  >
-                    <RotateCcw className="h-3 w-3 mr-1" />
-                    {t('admin.geoFetch.drawer.refetch', 'Re-récupérer')}
-                  </Button>
+                <div className="flex justify-end gap-2">
+                  {/* Re-fetch every distinct source represented in this zone.
+                      Hard-coding "fandom" here was a real bug — operators
+                      thought they triggered a global retry but only one
+                      provider ran. Using the actual source set keeps the
+                      button honest regardless of which providers are
+                      configured for the game. */}
+                  {Array.from(new Set(zone.maps.map((m) => m.source))).map((src) => (
+                    <Button
+                      key={src}
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => {
+                        if (gameId == null) return
+                        void retrySource(gameId, src)
+                      }}
+                      title={t('admin.geoFetch.drawer.refetchSource', 'Re-récupérer ({{source}})', {
+                        source: src,
+                      })}
+                    >
+                      <RotateCcw className="h-3 w-3 mr-1" />
+                      {t('admin.geoFetch.drawer.refetchSource', 'Re-récupérer ({{source}})', {
+                        source: src,
+                      })}
+                    </Button>
+                  ))}
                 </div>
               </div>
             ))}

--- a/packages/frontend/src/components/admin/geo-fetch/GeoFetchControls.tsx
+++ b/packages/frontend/src/components/admin/geo-fetch/GeoFetchControls.tsx
@@ -1,7 +1,16 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Play, Square, RefreshCcw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { useGeoFetchStore } from '@/stores/geoFetchStore'
 import type { GeoFetchStage } from '@/lib/api/geo-fetch'
 
@@ -23,20 +32,27 @@ export function GeoFetchControls() {
     search,
     setSearch,
     hydrate,
+    games,
   } = useGeoFetchStore()
+  // Confirm dialogs for the two destructive actions: "Lancer tout" can
+  // enqueue jobs against every curated game, and "Annuler" stops every
+  // in-flight ingestion. A stray click on either is a real outage.
+  const [startConfirmOpen, setStartConfirmOpen] = useState(false)
+  const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false)
+  const visibleCount = Object.keys(games).length
 
   return (
     <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
       <div className="flex gap-2">
         <Button
-          onClick={() => start({ all: true })}
+          onClick={() => setStartConfirmOpen(true)}
           disabled={isStarting}
           className="bg-gradient-to-r from-neon-purple to-neon-pink"
         >
           <Play className="h-4 w-4 mr-1.5" />
           {t('admin.geoFetch.start', 'Lancer')}
         </Button>
-        <Button variant="outline" onClick={() => void cancel()}>
+        <Button variant="outline" onClick={() => setCancelConfirmOpen(true)}>
           <Square className="h-4 w-4 mr-1.5" />
           {t('admin.geoFetch.cancel', 'Annuler')}
         </Button>
@@ -73,6 +89,67 @@ export function GeoFetchControls() {
       <Button variant="ghost" size="icon" onClick={() => void hydrate()} title={t('admin.geoFetch.refresh', 'Rafraîchir')}>
         <RefreshCcw className="h-4 w-4" />
       </Button>
+
+      <Dialog open={startConfirmOpen} onOpenChange={setStartConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t('admin.geoFetch.startConfirm.title', 'Lancer la récupération globale ?')}
+            </DialogTitle>
+            <DialogDescription>
+              {t(
+                'admin.geoFetch.startConfirm.body',
+                'Tous les jeux curés et résolus seront mis en file. Le serveur tronque la file à 1000 jeux maximum.',
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setStartConfirmOpen(false)}>
+              {t('admin.cancel', 'Annuler')}
+            </Button>
+            <Button
+              className="bg-gradient-to-r from-neon-purple to-neon-pink"
+              onClick={async () => {
+                setStartConfirmOpen(false)
+                await start({ all: true })
+              }}
+            >
+              {t('admin.geoFetch.startConfirm.confirm', 'Lancer')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={cancelConfirmOpen} onOpenChange={setCancelConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t('admin.geoFetch.cancelConfirm.title', "Annuler l'ingestion en cours ?")}
+            </DialogTitle>
+            <DialogDescription>
+              {t(
+                'admin.geoFetch.cancelConfirm.body',
+                'Les tâches déjà actives terminent leur exécution. Toutes les tâches en attente (maps:*) seront supprimées de la file.',
+                { count: visibleCount },
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCancelConfirmOpen(false)}>
+              {t('admin.cancel', 'Annuler')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={async () => {
+                setCancelConfirmOpen(false)
+                await cancel()
+              }}
+            >
+              {t('admin.geoFetch.cancelConfirm.confirm', 'Tout annuler')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/packages/frontend/src/components/admin/geo-fetch/GeoFetchPanel.tsx
+++ b/packages/frontend/src/components/admin/geo-fetch/GeoFetchPanel.tsx
@@ -41,13 +41,16 @@ export default function GeoFetchPanel() {
     socket.on('geo:fetch:progress', onProgress)
     socket.on('geo:fetch:gameDone', onGameDone)
     socket.on('geo:fetch:mapSelected', onMapSelected)
-    socket.on('reconnect', onReconnect)
+    // socket.io v4: 'reconnect' is fired by the Manager (`socket.io`),
+    // not by the Socket itself. The previous `socket.on('reconnect', ...)`
+    // never fired so the rehydrate-on-reconnect was effectively dead.
+    socket.io.on('reconnect', onReconnect)
 
     return () => {
       socket.off('geo:fetch:progress', onProgress)
       socket.off('geo:fetch:gameDone', onGameDone)
       socket.off('geo:fetch:mapSelected', onMapSelected)
-      socket.off('reconnect', onReconnect)
+      socket.io.off('reconnect', onReconnect)
     }
   }, [hydrate, applyProgress, applyGameDone, applyMapSelected])
 

--- a/packages/frontend/src/hooks/useGeoHealth.ts
+++ b/packages/frontend/src/hooks/useGeoHealth.ts
@@ -55,9 +55,38 @@ export function useGeoHealth(intervalMs = 30_000) {
     }, [])
 
     useEffect(() => {
-        void reload()
-        const id = window.setInterval(() => void reload(), intervalMs)
-        return () => window.clearInterval(id)
+        // Pause the 30s health poll when the tab is hidden — without this
+        // an admin who leaves the panel in a background tab keeps a slow
+        // drumbeat against /admin/geo/health forever.
+        let id: number | null = null
+        const start = () => {
+            if (id != null) return
+            void reload()
+            id = window.setInterval(() => void reload(), intervalMs)
+        }
+        const stop = () => {
+            if (id != null) {
+                window.clearInterval(id)
+                id = null
+            }
+        }
+        const onVis = () => {
+            if (typeof document === 'undefined') return
+            if (document.visibilityState === 'hidden') stop()
+            else start()
+        }
+        if (typeof document === 'undefined' || document.visibilityState !== 'hidden') {
+            start()
+        }
+        if (typeof document !== 'undefined') {
+            document.addEventListener('visibilitychange', onVis)
+        }
+        return () => {
+            stop()
+            if (typeof document !== 'undefined') {
+                document.removeEventListener('visibilitychange', onVis)
+            }
+        }
     }, [reload, intervalMs])
 
     return { data, loading, error, reload }

--- a/packages/frontend/src/hooks/useGeoRunPolling.ts
+++ b/packages/frontend/src/hooks/useGeoRunPolling.ts
@@ -55,6 +55,16 @@ export interface UseGeoRunPolling {
     arm: (windowMs?: number) => void
 }
 
+export interface GeoRunPollingOptions {
+    /**
+     * When false, the hook stops scheduling new polls (e.g. the geo tab
+     * is not the active admin tab, or the page is hidden). Already-armed
+     * windows expire as normal. Defaults to true so existing call sites
+     * keep their behavior.
+     */
+    enabled?: boolean
+}
+
 const DEFAULT_INTERVAL_MS = 2000
 const ARM_FLOOR_MS = 5000
 
@@ -75,9 +85,27 @@ async function fetchState(): Promise<GeoRunStatePayload> {
  *  - `arm()` was called within the last `armWindowMs`.
  *
  * Stops on its own when both go false to avoid hammering the endpoint
- * during quiet periods.
+ * during quiet periods. Pass `{ enabled: false }` to suspend polling
+ * entirely (e.g. when the admin navigates away from the geo tab).
  */
-export function useGeoRunPolling(intervalMs = DEFAULT_INTERVAL_MS): UseGeoRunPolling {
+export function useGeoRunPolling(
+    intervalMs: number = DEFAULT_INTERVAL_MS,
+    options: GeoRunPollingOptions = {},
+): UseGeoRunPolling {
+    const enabled = options.enabled ?? true
+    // Page Visibility pause: when the browser tab goes to background we
+    // stop scheduling polls. Without this, an admin who leaves the geo
+    // panel open in a background tab keeps hitting /api/admin/geo/run/state
+    // every 2s indefinitely.
+    const [pageVisible, setPageVisible] = useState<boolean>(
+        typeof document === 'undefined' ? true : document.visibilityState !== 'hidden',
+    )
+    useEffect(() => {
+        if (typeof document === 'undefined') return undefined
+        const onVis = () => setPageVisible(document.visibilityState !== 'hidden')
+        document.addEventListener('visibilitychange', onVis)
+        return () => document.removeEventListener('visibilitychange', onVis)
+    }, [])
     const [state, setState] = useState<GeoRunStatePayload | null>(null)
     const [error, setError] = useState<string | null>(null)
     // Mutable refs so the interval callback always reads the latest values.
@@ -101,12 +129,17 @@ export function useGeoRunPolling(intervalMs = DEFAULT_INTERVAL_MS): UseGeoRunPol
                 setError(null)
             } catch (e) {
                 if (cancelled) return
-                setError(String(e))
+                // Surface a stable, parseable error code/message rather
+                // than the raw stack — admins shouldn't see "TypeError: …"
+                // strings in the toast.
+                setError((e as { message?: string } | null)?.message ?? 'fetch failed')
             }
         }
 
         const shouldPoll = () =>
-            Date.now() < armedUntilRef.current || isActiveRef.current
+            enabled &&
+            pageVisible &&
+            (Date.now() < armedUntilRef.current || isActiveRef.current)
 
         if (!shouldPoll()) return undefined
 
@@ -124,7 +157,7 @@ export function useGeoRunPolling(intervalMs = DEFAULT_INTERVAL_MS): UseGeoRunPol
             cancelled = true
             window.clearInterval(id)
         }
-    }, [intervalMs, pollNonce, state?.isActive])
+    }, [intervalMs, pollNonce, state?.isActive, enabled, pageVisible])
 
     const arm = useCallback((windowMs = ARM_FLOOR_MS) => {
         armedUntilRef.current = Date.now() + windowMs

--- a/packages/frontend/src/lib/api/geo-fetch.ts
+++ b/packages/frontend/src/lib/api/geo-fetch.ts
@@ -37,6 +37,11 @@ export interface GeoFetchGamesPage {
   games: GeoFetchGameRow[]
   limit: number
   offset: number
+  // Surfaced by the backend so the panel can render "X of Y" honestly.
+  // Optional for back-compat with deploys that haven't shipped the
+  // pagination metadata yet.
+  total?: number
+  hasMore?: boolean
 }
 
 export interface GeoFetchAttemptSummary {

--- a/packages/frontend/src/stores/geoFetchStore.ts
+++ b/packages/frontend/src/stores/geoFetchStore.ts
@@ -6,6 +6,7 @@ import {
   type GeoFetchStage,
   type GeoFetchStatus,
 } from '@/lib/api/geo-fetch'
+import { getApiErrorMessage } from '@/lib/api-errors'
 
 // Single store for the geo-fetch admin tab. Server is the source of truth on
 // initial mount + reconnect; sockets push deltas in between. Game rows are
@@ -63,7 +64,7 @@ export const useGeoFetchStore = create<GeoFetchState>()(
           for (const row of page.games) games[row.game_id] = row
           set({ status, games, isLoading: false })
         } catch (err) {
-          set({ isLoading: false, error: String(err) })
+          set({ isLoading: false, error: getApiErrorMessage(err) })
         }
       },
 


### PR DESCRIPTION
Phase 1 — security and correctness
- geo: rate-limit + optionalAuthMiddleware on /api/geo free-play to stop
  unauthenticated scraping of canonical answer coordinates
- geo: reject anonymous guests from /contribute/{pick,pin}
- admin: require { confirm: 'RESET' } body on /scraping/reset, audit-log
  the request before the destructive transaction
- geo-pin: kill the SQL-injection-shaped seam in countByUserInWindow /
  userRejectionRatio7d (now takes bound seconds, not an interpolated
  interval string)
- consensus: pass post-increment pin count through the job payload so
  two near-simultaneous pins can't both step past a threshold (silent
  never-promote bug)
- geo-fetch: scope /cancel to the maps:* job family — was blowing away
  unrelated consensus / contributor-promotion jobs
- geo-fetch: cap /start{ all: true } at 1000 ids (truncate, surface in
  response) so a single click can't stall BullMQ
- admin: wrap /geo/reimport and /geo/maps/manual in transactions, and
  collapse 6 sequential failure clears into one whereIn delete
- admin: Zod-validated body on /screenshot-reports/reactivate
- admin: match pg SQLSTATE 23503 on /geo/meta/:id instead of parsing
  the error message
- geo-screenshot: createCandidate no longer derefs `row!` after an
  ignored conflict (re-fetches the existing row)
- geo-map: SELECT FOR UPDATE in disableForGame, selectMap, and create
  to prevent the partial-unique-index races that surface as 500
- geo-pipeline-state: distinguish undefined from explicit null on
  next_eligible_at / active_source so upserts no longer clobber a
  previously-set cooldown to NULL
- geo-challenge: ON CONFLICT DO NOTHING on recordGuess + recordSkip
- frontend: GameMapsDrawer no longer hard-codes 'fandom' in the
  per-zone refetch — uses the actual source set, with cancellation
  guard for fast gameId switches
- frontend: GeoFetchPanel reconnect listener now subscribes to
  socket.io.on('reconnect') instead of socket.on('reconnect') (which
  silently never fired in v4)
- frontend: replace String(e) error rendering in GeoMapsTab,
  GeoReviewPanel, geoFetchStore, useGeoRunPolling with
  getApiErrorMessage / structured ApiError code matching

Phase 2 — audit infra, schema cleanup, tests
- new migration: admin_audit_log table + indexes
- new migration: updated_at on geo_map / geo_screenshot_candidate /
  geo_screenshot_meta / geo_challenge / geo_guess / geo_pin_submission,
  plus retention index on geo_ingest_attempt.attempted_at
- new admin-audit.repository + middleware helper, wired into the
  destructive admin geo writes (reimport, maps.manual, scraping.reset,
  geo-fetch.start, geo-fetch.cancel, geo.meta.delete,
  screenshot-reports.reactivate)
- backend test runner via node:test + tsx (no new deps); npm test
  added to packages/backend
- unit tests for geo-consensus.service (12 cases: empty / σ=0 /
  threshold boundary / radius rejection / version) and
  grantsForAcceptedPin (1σ / 0.5σ tier / every-10th / count=0 guard)
- unit tests for recordAdminGeoAudit (forwards shape, skips when no
  admin user, falls back to req.ip on missing XFF)
- e2e-seed: deterministic geo entities (one game, one map, one
  promoted candidate, one meta) so admin/free-play specs stop
  accepting "empty state" as success
- new e2e spec geo-admin-authz: authenticates the boundary on every
  admin geo endpoint (401 unauth, 403 non-admin) plus a sanity that
  admin still gets through; also asserts /api/geo/free-play/guess is
  rate-limited
- existing geo-admin spec: hardened soft-skip — non-200 from the
  router used to silently pass; now we only skip on 5xx (true outage)

Phase 3 — UX polish
- GeoFetchControls: confirmation dialogs for "Lancer (all)" and
  "Annuler", with explanation of impact
- useGeoRunPolling + useGeoHealth: pause polling when the browser
  tab is hidden (Page Visibility API); useGeoRunPolling also accepts
  { enabled } so call sites can suspend explicitly
- /api/admin/geo-fetch/games response now includes total + hasMore
  for honest pagination