### PR TITLE
feat(geo): tiled-map support + World of Warcraft entry

### DIFF
--- a/packages/backend/data/geo-map-registry.json
+++ b/packages/backend/data/geo-map-registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./geo-map-registry.schema.json",
   "version": 1,
-  "description": "Tier 1 ingestion source for geo_map. Each entry maps a game (matched by `match.slug` or any string in `match.aliases`) to a permissively-licensed external image URL with declared license + attribution. The geo-registry-import worker fetches imageUrl, infers dimensions, and writes a geo_map row with source='registry'. To add a new entry: (1) find a real GitHub repo / wiki tile-source hosting a flat world-map image — verify the URL returns an image with `curl -I`; (2) confirm the license in the repo's README/LICENSE; (3) record license + attribution. Prefer MIT/GPL/CC-BY/CC-BY-SA over CC-BY-NC. The `aliases` array catches RAWG slug variations: GOTY/Legendary/Definitive editions, DLCs that share the base game's map, abbreviations (e.g. `gta-5`, `botw`). Optional `region` field labels which slice of a multi-region game the entry represents (e.g. \"Velen\", \"Act II\"); omit it for the canonical world / mosaic map. Today's runtime still picks a single active map per game — region is informational + future-proofing.",
+  "description": "Tier 1 ingestion source for geo_map. Each entry maps a game (matched by `match.slug` or any string in `match.aliases`) to either (a) a permissively-licensed flat world-map image, or (b) a Leaflet-style tile pyramid via the optional `tiles` block (urlTemplate + minZoom/maxZoom/tileSize/scheme). For tiled entries, `imageUrl` still acts as a single-tile thumbnail for admin grids and non-Leaflet renderers; the player canvas uses TileLayer when `tiles` is set. The worker HEAD-probes the imageUrl for image entries and the deepest-zoom (0,0) tile for tile entries before writing the row. To add an entry: (1) verify the image / tile URL returns 2xx with `curl -I`; (2) record license + attribution; (3) for tile sources, declare the scheme — `xyz` for vanilla `{z}/{x}/{y}` substitution, `xyz-padded2-inverted` for World-of-MapCraft-style zero-padding + inverted z. Prefer MIT/GPL/CC-BY/CC-BY-SA over CC-BY-NC. The `aliases` array catches RAWG slug variations (GOTY/Legendary/Definitive editions, abbreviations e.g. `gta-5`, `botw`). Optional `region` field labels which slice of a multi-region game the entry represents — omit for the canonical world / mosaic map.",
   "entries": [
     {
       "match": { "slug": "elden-ring" },
@@ -103,6 +103,26 @@
       "attribution": "henpemaz/Rain-World-Interactive-Map (MIT)",
       "sourceUrl": "https://github.com/henpemaz/Rain-World-Interactive-Map",
       "commercialUseOk": true
+    },
+    {
+      "match": {
+        "slug": "world-of-warcraft",
+        "aliases": ["wow", "world-of-warcraft-classic"]
+      },
+      "imageUrl": "https://cdn.iamcal.com/mapcraft/mopv1/azeroth/tile_z5_00_00.png",
+      "widthPx": 21760,
+      "heightPx": 17664,
+      "license": "Unknown",
+      "attribution": "iamcal/World-of-MapCraft (derivative of Blizzard assets)",
+      "sourceUrl": "https://github.com/iamcal/World-of-MapCraft",
+      "commercialUseOk": false,
+      "tiles": {
+        "urlTemplate": "https://cdn.iamcal.com/mapcraft/mopv1/azeroth/tile_z{z}_{x}_{y}.png",
+        "minZoom": 0,
+        "maxZoom": 5,
+        "tileSize": 256,
+        "scheme": "xyz-padded2-inverted"
+      }
     }
   ]
 }

--- a/packages/backend/migrations/20260516_geo_map_tiles.ts
+++ b/packages/backend/migrations/20260516_geo_map_tiles.ts
@@ -1,0 +1,54 @@
+import type { Knex } from 'knex'
+
+// Adds tiled-map support to geo_map. Existing rows stay valid (kind defaults
+// to 'image'); a new 'tiles' kind references a Leaflet-style tile pyramid by
+// URL template + zoom range + scheme. The CHECK constraint is the invariant
+// that prevents half-formed tile rows from sneaking past the worker.
+//
+// `image_url` stays NOT NULL — tile entries still set it to a representative
+// thumbnail (e.g. a single tile from the deepest zoom) so admin grids and
+// non-Leaflet renderers keep working without a separate preview pipeline.
+
+const TILE_KIND_CHECK_NAME = 'geo_map_tile_kind_check'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('geo_map', (table) => {
+    table.string('kind', 16).notNullable().defaultTo('image')
+    table.text('tile_url_template').nullable()
+    table.smallint('tile_min_zoom').nullable()
+    table.smallint('tile_max_zoom').nullable()
+    table.smallint('tile_size').nullable()
+    table.string('tile_scheme', 32).nullable()
+  })
+
+  // Backfill is implicit via the column default, but make it explicit so a
+  // mid-migration crash leaves the DB in a known state.
+  await knex('geo_map').whereNull('kind').update({ kind: 'image' })
+
+  await knex.raw(
+    `ALTER TABLE geo_map ADD CONSTRAINT ${TILE_KIND_CHECK_NAME} CHECK (
+        (kind = 'image')
+        OR (
+          kind = 'tiles'
+          AND tile_url_template IS NOT NULL
+          AND tile_min_zoom IS NOT NULL
+          AND tile_max_zoom IS NOT NULL
+          AND tile_size IS NOT NULL
+          AND tile_scheme IS NOT NULL
+          AND tile_min_zoom <= tile_max_zoom
+        )
+      )`,
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE geo_map DROP CONSTRAINT IF EXISTS ${TILE_KIND_CHECK_NAME}`)
+  await knex.schema.alterTable('geo_map', (table) => {
+    table.dropColumn('tile_scheme')
+    table.dropColumn('tile_size')
+    table.dropColumn('tile_max_zoom')
+    table.dropColumn('tile_min_zoom')
+    table.dropColumn('tile_url_template')
+    table.dropColumn('kind')
+  })
+}

--- a/packages/backend/src/domain/services/geo-tile-url.service.test.ts
+++ b/packages/backend/src/domain/services/geo-tile-url.service.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { GeoMapTilesConfig } from '@the-box/types'
+import { formatTileUrl } from './geo-tile-url.service.js'
+
+const XYZ: GeoMapTilesConfig = {
+  urlTemplate: 'https://example.com/{z}/{x}/{y}.png',
+  minZoom: 0,
+  maxZoom: 5,
+  tileSize: 256,
+  scheme: 'xyz',
+}
+
+const WOW: GeoMapTilesConfig = {
+  urlTemplate: 'https://cdn.example.com/azeroth/tile_z{z}_{x}_{y}.png',
+  minZoom: 0,
+  maxZoom: 5,
+  tileSize: 256,
+  scheme: 'xyz-padded2-inverted',
+}
+
+describe('formatTileUrl — xyz', () => {
+  it('substitutes z/x/y verbatim', () => {
+    assert.equal(
+      formatTileUrl(XYZ, 3, 12, 7),
+      'https://example.com/3/12/7.png',
+    )
+  })
+
+  it('handles zoom edges', () => {
+    assert.equal(formatTileUrl(XYZ, 0, 0, 0), 'https://example.com/0/0/0.png')
+    assert.equal(formatTileUrl(XYZ, 5, 31, 31), 'https://example.com/5/31/31.png')
+  })
+})
+
+describe('formatTileUrl — xyz-padded2-inverted (World-of-MapCraft)', () => {
+  it('zero-pads x and y to two digits', () => {
+    const url = formatTileUrl(WOW, WOW.maxZoom, 0, 0)
+    assert.equal(
+      url,
+      'https://cdn.example.com/azeroth/tile_z0_00_00.png',
+      'deepest leaflet zoom maps to URL z=minZoom; x/y zero-padded',
+    )
+  })
+
+  it('inverts z so leaflet maxZoom -> URL minZoom', () => {
+    // Most zoomed-out leaflet view (z=minZoom=0) should request URL z=5.
+    assert.equal(
+      formatTileUrl(WOW, 0, 1, 2),
+      'https://cdn.example.com/azeroth/tile_z5_01_02.png',
+    )
+  })
+
+  it('preserves coordinates above 9 with the 2-digit pad', () => {
+    assert.equal(
+      formatTileUrl(WOW, WOW.maxZoom, 84, 68),
+      'https://cdn.example.com/azeroth/tile_z0_84_68.png',
+    )
+  })
+
+  it('round-trips every zoom level for the (0,0) tile', () => {
+    // Snapshot all 6 levels to catch any off-by-one regression on the
+    // z-inversion. URL z values must monotonically decrease as leaflet z
+    // grows (deeper Leaflet zoom = lower URL z).
+    const urlZs = [0, 1, 2, 3, 4, 5].map(
+      (leafletZ) => formatTileUrl(WOW, leafletZ, 0, 0).match(/tile_z(\d+)/)![1],
+    )
+    assert.deepEqual(urlZs, ['5', '4', '3', '2', '1', '0'])
+  })
+})

--- a/packages/backend/src/domain/services/geo-tile-url.service.ts
+++ b/packages/backend/src/domain/services/geo-tile-url.service.ts
@@ -1,0 +1,33 @@
+import type { GeoMapTilesConfig } from '@the-box/types'
+
+// Format a tile URL by substituting {z}/{x}/{y} according to the scheme.
+//
+// Inputs are in Leaflet-natural coordinates (z=minZoom is most zoomed-out;
+// z=maxZoom is deepest). Schemes that disagree (e.g. World-of-MapCraft, where
+// the URL's z=maxZoom is the most zoomed-out tile) are inverted here so the
+// HEAD-probe in the worker hits the same tile coordinates the frontend will
+// request. The frontend duplicates this function in `lib/geo-tile-url.ts` —
+// the two must stay in sync.
+export function formatTileUrl(
+  config: GeoMapTilesConfig,
+  z: number,
+  x: number,
+  y: number,
+): string {
+  switch (config.scheme) {
+    case 'xyz':
+      return config.urlTemplate
+        .replace('{z}', String(z))
+        .replace('{x}', String(x))
+        .replace('{y}', String(y))
+    case 'xyz-padded2-inverted': {
+      // Invert: deepest leaflet zoom (=maxZoom) maps to URL z=minZoom.
+      const urlZ = config.maxZoom - z + config.minZoom
+      const pad = (n: number) => String(n).padStart(2, '0')
+      return config.urlTemplate
+        .replace('{z}', String(urlZ))
+        .replace('{x}', pad(x))
+        .replace('{y}', pad(y))
+    }
+  }
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo-registry-import-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-registry-import-logic.ts
@@ -1,12 +1,14 @@
 import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve as resolvePath } from 'node:path'
+import type { GeoMapTilesConfig } from '@the-box/types'
 import { queueLogger } from '../../logger/logger.js'
 import {
   geoIngestFailureRepository,
   geoMapRepository,
 } from '../../repositories/index.js'
 import { tombstoneRetryAfter } from '../../../domain/services/geo-metadata.service.js'
+import { formatTileUrl } from '../../../domain/services/geo-tile-url.service.js'
 
 const log = queueLogger.child({ worker: 'geo-registry-import' })
 
@@ -20,6 +22,9 @@ const DEFAULT_USER_AGENT =
 
 export interface RegistryEntry {
   match: { slug?: string; aliases?: string[] }
+  // Always-set thumbnail / fallback PNG. For tile entries, the registry
+  // points this at one canonical tile (e.g. the upper-left tile at the
+  // most-zoomed-out layer) so admin grids keep showing a preview.
   imageUrl: string
   widthPx: number
   heightPx: number
@@ -31,6 +36,10 @@ export interface RegistryEntry {
   // world / mosaic map. Stored on geo_map.region for admin visibility; the
   // runtime still selects a single is_active row per game today.
   region?: string
+  // Set to enable Leaflet tile rendering. The worker probes one canonical
+  // tile (deepest zoom, 0/0) before persisting; failure tombstones go
+  // through the same path as broken image URLs.
+  tiles?: GeoMapTilesConfig
 }
 
 interface RegistryFile {
@@ -90,18 +99,22 @@ export async function importRegistryMap(
     }
   }
 
-  log.info({ gameId, imageUrl: entry.imageUrl }, 'fetching registry map')
+  // For tile entries, the canonical probe target is the deepest-zoom (0,0)
+  // tile — it always exists when the source is functional. The thumbnail
+  // imageUrl is HEAD-checked too: if the registry author got the URL wrong,
+  // we want to tombstone before admins see a broken thumbnail.
+  const probeUrl = entry.tiles
+    ? formatTileUrl(entry.tiles, entry.tiles.maxZoom, 0, 0)
+    : entry.imageUrl
+  log.info({ gameId, probeUrl, kind: entry.tiles ? 'tiles' : 'image' }, 'fetching registry map')
 
-  // HEAD-check the image to fail fast with a useful tombstone reason if the
-  // upstream repo moved the file. Full download happens on first Leaflet
-  // request — we just record the reference here.
   try {
-    const res = await fetch(entry.imageUrl, {
+    const res = await fetch(probeUrl, {
       method: 'HEAD',
       headers: { 'User-Agent': DEFAULT_USER_AGENT },
     })
     if (!res.ok) {
-      await recordRegistryTombstone(gameId, `HEAD ${entry.imageUrl} → ${res.status}`)
+      await recordRegistryTombstone(gameId, `HEAD ${probeUrl} → ${res.status}`)
       return { imported: false, reason: `HEAD failed: ${res.status}` }
     }
   } catch (err) {
@@ -116,6 +129,7 @@ export async function importRegistryMap(
     imageUrl: entry.imageUrl,
     widthPx: entry.widthPx,
     heightPx: entry.heightPx,
+    tiles: entry.tiles,
     license: entry.license,
     attribution: entry.attribution,
     region: entry.region ?? null,

--- a/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-map.repository.ts
@@ -1,6 +1,12 @@
 import { db } from '../database/connection.js'
 import { repoLogger } from '../logger/logger.js'
-import type { GeoMap, GeoMapSource } from '@the-box/types'
+import type {
+  GeoMap,
+  GeoMapKind,
+  GeoMapSource,
+  GeoMapTilesConfig,
+  GeoTileScheme,
+} from '@the-box/types'
 
 const log = repoLogger.child({ repository: 'geo-map' })
 
@@ -12,6 +18,12 @@ export interface GeoMapRow {
   image_url: string
   width_px: number
   height_px: number
+  kind: GeoMapKind
+  tile_url_template: string | null
+  tile_min_zoom: number | null
+  tile_max_zoom: number | null
+  tile_size: number | null
+  tile_scheme: GeoTileScheme | null
   consensus_radius: number
   license: string
   attribution: string | null
@@ -37,6 +49,25 @@ function mapRow(row: GeoMapRow): GeoMap {
       : typeof row.wiki_revision_id === 'string'
         ? Number(row.wiki_revision_id)
         : row.wiki_revision_id
+  // Build tiles config only when the row is fully populated. The CHECK
+  // constraint guarantees this on insert, but defend in depth — a partial
+  // row from manual SQL would surface as `kind: 'image'` here, not a NaN
+  // tile pyramid downstream.
+  const tiles: GeoMapTilesConfig | undefined =
+    row.kind === 'tiles' &&
+    row.tile_url_template &&
+    row.tile_min_zoom != null &&
+    row.tile_max_zoom != null &&
+    row.tile_size != null &&
+    row.tile_scheme
+      ? {
+          urlTemplate: row.tile_url_template,
+          minZoom: row.tile_min_zoom,
+          maxZoom: row.tile_max_zoom,
+          tileSize: row.tile_size,
+          scheme: row.tile_scheme,
+        }
+      : undefined
   return {
     id: row.id,
     gameId: row.game_id,
@@ -45,6 +76,8 @@ function mapRow(row: GeoMapRow): GeoMap {
     imageUrl: row.image_url,
     widthPx: row.width_px,
     heightPx: row.height_px,
+    kind: tiles ? 'tiles' : 'image',
+    tiles,
     consensusRadius: row.consensus_radius,
     license: row.license,
     attribution: row.attribution ?? undefined,
@@ -197,6 +230,10 @@ export const geoMapRepository = {
     imageUrl: string
     widthPx: number
     heightPx: number
+    // Tiles is opt-in: when set, the row is stored with kind='tiles' and the
+    // five tile_* columns; the imageUrl still gets stored as a thumbnail so
+    // admin grids and non-Leaflet renderers keep working.
+    tiles?: GeoMapTilesConfig
     consensusRadius?: number
     license: string
     attribution?: string
@@ -246,6 +283,12 @@ export const geoMapRepository = {
           image_url: data.imageUrl,
           width_px: data.widthPx,
           height_px: data.heightPx,
+          kind: data.tiles ? 'tiles' : 'image',
+          tile_url_template: data.tiles?.urlTemplate ?? null,
+          tile_min_zoom: data.tiles?.minZoom ?? null,
+          tile_max_zoom: data.tiles?.maxZoom ?? null,
+          tile_size: data.tiles?.tileSize ?? null,
+          tile_scheme: data.tiles?.scheme ?? null,
           consensus_radius: data.consensusRadius ?? 0.03,
           license: data.license,
           attribution: data.attribution ?? null,

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -1137,6 +1137,7 @@ function CandidateDetailBody({
                 imageUrl={detail.map.imageUrl}
                 widthPx={detail.map.widthPx}
                 heightPx={detail.map.heightPx}
+                tiles={detail.map.tiles}
                 pin={pin}
                 canonical={
                     detail.meta

--- a/packages/frontend/src/components/geo/GeoMapCanvas.tsx
+++ b/packages/frontend/src/components/geo/GeoMapCanvas.tsx
@@ -1,15 +1,10 @@
-import { MapCanvas, type MapCanvasProps } from './MapCanvas'
+import { type MapCanvasProps } from './MapCanvas'
 import { MapCanvasLeaflet } from './MapCanvasLeaflet'
-
-// Pick the renderer at build time via a Vite flag so the Leaflet bundle
-// (~45 KB gz) stays out of the default build. Callers all go through this
-// barrel so future swaps don't touch page code.
-const USE_LEAFLET = import.meta.env.VITE_GEO_USE_LEAFLET === 'true'
 
 // Component name is GeoMapCanvas (not GeoMap) to avoid colliding with the
 // GeoMap type from @the-box/types.
 export type { MapCanvasProps as GeoMapCanvasProps } from './MapCanvas'
 
 export function GeoMapCanvas(props: MapCanvasProps) {
-    return USE_LEAFLET ? <MapCanvasLeaflet {...props} /> : <MapCanvas {...props} />
+    return <MapCanvasLeaflet {...props} />
 }

--- a/packages/frontend/src/components/geo/MapCanvas.tsx
+++ b/packages/frontend/src/components/geo/MapCanvas.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Minus, Plus, RotateCcw } from 'lucide-react'
-import type { GeoPoint } from '@the-box/types'
+import type { GeoMapTilesConfig, GeoPoint } from '@the-box/types'
 import { cn } from '@/lib/utils'
 import { clamp01, isPlaceholderImageUrl } from '@/lib/geo-image'
 import { MapErrorFallback } from './MapErrorFallback'
@@ -19,6 +19,10 @@ export interface MapCanvasProps {
     imageUrl: string
     widthPx: number
     heightPx: number
+    // Optional tile source. Only honored by MapCanvasLeaflet — the legacy
+    // DIY canvas (this file) ignores it and falls back to the imageUrl
+    // thumbnail. Pages should set VITE_GEO_USE_LEAFLET=true for tile games.
+    tiles?: GeoMapTilesConfig
     pin?: GeoPoint | null
     canonical?: GeoPoint | null // shown as a target when revealed
     onPin?: (p: GeoPoint) => void

--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -4,13 +4,15 @@ import {
     MapContainer,
     Marker,
     Polyline,
+    useMap,
     useMapEvents,
 } from 'react-leaflet'
 import L, { CRS, type LatLngBoundsExpression, type LatLngExpression } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
-import type { GeoPoint } from '@the-box/types'
+import type { GeoMapTilesConfig, GeoPoint } from '@the-box/types'
 import { cn } from '@/lib/utils'
 import { clamp01, isPlaceholderImageUrl } from '@/lib/geo-image'
+import { formatTileUrl } from '@/lib/geo-tile-url'
 import { MapErrorFallback } from './MapErrorFallback'
 import type { MapCanvasProps } from './MapCanvas'
 
@@ -40,6 +42,7 @@ export function MapCanvasLeaflet({
     imageUrl,
     widthPx,
     heightPx,
+    tiles,
     pin,
     canonical,
     onPin,
@@ -59,7 +62,8 @@ export function MapCanvasLeaflet({
 
     // See MapCanvas.tsx for the rationale: placeholder URLs may load OK, real
     // 404s won't surface through Leaflet's ImageOverlay, so probe with a hidden
-    // <img> in addition to the proactive placeholder check.
+    // <img> in addition to the proactive placeholder check. For tile maps,
+    // the thumbnail probe is decorative — TileLayer handles its own errors.
     const [errored, setErrored] = useState(() => isPlaceholderImageUrl(imageUrl))
 
     useEffect(() => {
@@ -83,13 +87,15 @@ export function MapCanvasLeaflet({
             className={cn('w-full overflow-hidden rounded-lg', className)}
             style={{ aspectRatio: `${widthPx} / ${heightPx}` }}
         >
-            <img
-                src={imageUrl}
-                alt=""
-                className="hidden"
-                onError={() => setErrored(true)}
-                aria-hidden
-            />
+            {!tiles && (
+                <img
+                    src={imageUrl}
+                    alt=""
+                    className="hidden"
+                    onError={() => setErrored(true)}
+                    aria-hidden
+                />
+            )}
             <MapContainer
                 crs={CRS.Simple}
                 bounds={bounds}
@@ -100,7 +106,15 @@ export function MapCanvasLeaflet({
                 doubleClickZoom={false}
                 style={{ height: '100%', width: '100%', background: 'var(--background)' }}
             >
-                <ImageOverlay url={imageUrl} bounds={bounds} />
+                {tiles ? (
+                    <TilePyramidLayer
+                        tiles={tiles}
+                        widthPx={widthPx}
+                        heightPx={heightPx}
+                    />
+                ) : (
+                    <ImageOverlay url={imageUrl} bounds={bounds} />
+                )}
                 {!disabled && onPin && (
                     <ClickHandler
                         widthPx={widthPx}
@@ -121,6 +135,56 @@ export function MapCanvasLeaflet({
             </MapContainer>
         </div>
     )
+}
+
+// Renders a Leaflet tile pyramid using a custom L.TileLayer subclass so we
+// can express schemes that the standard {z}/{x}/{y} template can't (zero-pad,
+// inverted z). The world rectangle in CRS.Simple stays [0..heightPx,widthPx]
+// so click→[0..1] math is identical to the ImageOverlay path.
+function TilePyramidLayer({
+    tiles,
+    widthPx,
+    heightPx,
+}: {
+    tiles: GeoMapTilesConfig
+    widthPx: number
+    heightPx: number
+}) {
+    const map = useMap()
+    useEffect(() => {
+        const TemplatedTileLayer = L.TileLayer.extend({
+            getTileUrl(coords: { x: number; y: number; z: number }) {
+                return formatTileUrl(tiles, coords.z, coords.x, coords.y)
+            },
+        })
+        const layer = new (TemplatedTileLayer as unknown as new (
+            urlTemplate: string,
+            opts: L.TileLayerOptions,
+        ) => L.TileLayer)(tiles.urlTemplate, {
+            tileSize: tiles.tileSize,
+            minZoom: tiles.minZoom,
+            maxZoom: tiles.maxZoom,
+            // Clamp tile requests to the world rectangle so OOB tiles (e.g.
+            // the asymmetric 85x69 grid in WoW) don't 404-spam.
+            bounds: [
+                [0, 0],
+                [heightPx, widthPx],
+            ],
+            noWrap: true,
+            // Decorative placeholder for missing tiles — Leaflet's default
+            // is a transparent gap that looks like a successful load.
+            errorTileUrl:
+                'data:image/svg+xml;utf8,' +
+                encodeURIComponent(
+                    '<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"><rect width="256" height="256" fill="%23111" /><text x="50%" y="50%" fill="%23555" font-family="sans-serif" font-size="14" text-anchor="middle" dominant-baseline="central">tile missing</text></svg>',
+                ),
+        })
+        layer.addTo(map)
+        return () => {
+            layer.remove()
+        }
+    }, [map, tiles, widthPx, heightPx])
+    return null
 }
 
 function ClickHandler({

--- a/packages/frontend/src/lib/geo-tile-url.ts
+++ b/packages/frontend/src/lib/geo-tile-url.ts
@@ -1,0 +1,28 @@
+import type { GeoMapTilesConfig } from '@the-box/types'
+
+// Format a tile URL by substituting {z}/{x}/{y} according to the scheme.
+// Mirrors `packages/backend/src/domain/services/geo-tile-url.service.ts` —
+// keep the two in sync. Duplicated rather than shipped via @the-box/types so
+// the types package can stay declarations-only.
+export function formatTileUrl(
+  config: GeoMapTilesConfig,
+  z: number,
+  x: number,
+  y: number,
+): string {
+  switch (config.scheme) {
+    case 'xyz':
+      return config.urlTemplate
+        .replace('{z}', String(z))
+        .replace('{x}', String(x))
+        .replace('{y}', String(y))
+    case 'xyz-padded2-inverted': {
+      const urlZ = config.maxZoom - z + config.minZoom
+      const pad = (n: number) => String(n).padStart(2, '0')
+      return config.urlTemplate
+        .replace('{z}', String(urlZ))
+        .replace('{x}', pad(x))
+        .replace('{y}', pad(y))
+    }
+  }
+}

--- a/packages/frontend/src/pages/GeoContributePage.tsx
+++ b/packages/frontend/src/pages/GeoContributePage.tsx
@@ -157,6 +157,7 @@ export default function GeoContributePage() {
                                 imageUrl={currentCandidateMap.imageUrl}
                                 widthPx={currentCandidateMap.widthPx}
                                 heightPx={currentCandidateMap.heightPx}
+                                tiles={currentCandidateMap.tiles}
                                 pin={pendingPin}
                                 onPin={setPendingPin}
                             />

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -194,6 +194,7 @@ function GeoPlayContent() {
                             imageUrl={selectedMap.imageUrl}
                             widthPx={selectedMap.widthPx}
                             heightPx={selectedMap.heightPx}
+                            tiles={selectedMap.tiles}
                             pin={pendingGuess ?? result?.guess ?? null}
                             canonical={
                                 phase === 'revealed' &&

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -876,6 +876,31 @@ export type GeoMapSource =
   | 'steam'
   | 'manual'
 
+// 'image' = single flat PNG/JPG (most games today). 'tiles' = Leaflet-style
+// tile pyramid (e.g. World of Warcraft via World-of-MapCraft, Hollow Knight
+// at higher resolutions). Both kinds share widthPx/heightPx as the world
+// rectangle in pixels at the deepest zoom — pin coordinates stay normalized
+// [0..1] regardless of kind.
+export type GeoMapKind = 'image' | 'tiles'
+
+// Naming schemes for tile URL templates. Kept as a strict union (rather than
+// free-form strings) so the formatter, the worker probe, and the renderer
+// all agree on what a registry entry means.
+//
+//  - 'xyz': vanilla `{z}/{x}/{y}` substitution; Leaflet's default. Z grows
+//    with zoom (z=0 most zoomed-out).
+//  - 'xyz-padded2-inverted': zero-pad x and y to 2 digits, and invert z so
+//    the URL's z=0 is the deepest layer (used by World-of-MapCraft).
+export type GeoTileScheme = 'xyz' | 'xyz-padded2-inverted'
+
+export interface GeoMapTilesConfig {
+  urlTemplate: string
+  minZoom: number
+  maxZoom: number
+  tileSize: number
+  scheme: GeoTileScheme
+}
+
 export interface GeoMap {
   id: number
   gameId: number
@@ -884,6 +909,9 @@ export interface GeoMap {
   imageUrl: string
   widthPx: number
   heightPx: number
+  kind: GeoMapKind
+  // Set when kind === 'tiles'. Undefined for kind === 'image'.
+  tiles?: GeoMapTilesConfig
   consensusRadius: number
   license: string
   attribution?: string
@@ -996,6 +1024,8 @@ export interface GeoMapOption {
   imageUrl: string
   widthPx: number
   heightPx: number
+  kind: GeoMapKind
+  tiles?: GeoMapTilesConfig
 }
 
 export interface GeoScreenshotCandidate {


### PR DESCRIPTION
## Résumé technique

### Contexte
Le système `geo_map` ne supportait que des images plates uniques (`<ImageOverlay>` Leaflet). Pour des univers très larges comme World of Warcraft, dont la communauté héberge une mosaïque de tuiles 21760×17664 px (`cdn.iamcal.com/mapcraft/mopv1/azeroth/`), aucun PNG plat unique n'existe — seulement une pyramide de tuiles 256×256 sur 6 niveaux de zoom, avec un schéma d'URL non-standard (zero-padding 2 chiffres + z inversé).

### Approche retenue
Discriminateur `kind` (`'image' | 'tiles'`) sur `geo_map`, avec colonnes additives (`tile_url_template`, `tile_min_zoom`, `tile_max_zoom`, `tile_size`, `tile_scheme`) et contrainte CHECK XOR garantissant l'invariant. La fonction `formatTileUrl(config, z, x, y)` est dupliquée dans `domain/services/` (backend) et `lib/` (frontend) — le package `@the-box/types` reste types-only (CJS dist sans runtime). Le frontend `MapCanvasLeaflet` rend une sous-classe `L.TileLayer` custom avec `getTileUrl` pour exprimer les schémas non-standards. Les images existantes restent inchangées.

Le `geo-registry-import` worker conserve le tombstone unique : pour les sources tuilées, il HEAD-probe la tuile canonique `(maxZoom, 0, 0)` au lieu de `imageUrl`.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/backend/migrations/20260516_geo_map_tiles.ts` | Migration : `kind` enum + 5 colonnes tile + CHECK XOR | Invariant DB-level pour empêcher entrées mal formées |
| `packages/types/src/index.ts` | `GeoMapKind`, `GeoTileScheme`, `GeoMapTilesConfig`, `GeoMap.kind`, `GeoMap.tiles?` | Types partagés, sans runtime (le package reste CJS) |
| `packages/backend/src/domain/services/geo-tile-url.service.ts` | Helper pur `formatTileUrl` + tests unitaires | Domain pure, testable |
| `packages/backend/src/infrastructure/repositories/geo-map.repository.ts` | Mapper + `create()` propagent `tiles` | Le mapper reconstruit `tiles` uniquement quand toutes les colonnes sont peuplées (defense-in-depth contre rows manuelles) |
| `packages/backend/src/infrastructure/queue/workers/geo-registry-import-logic.ts` | Branche HEAD-probe sur `entry.tiles` | Réutilise le tombstone path image existant |
| `packages/backend/data/geo-map-registry.json` | Entrée WoW + description mise à jour | Première source tuilée |
| `packages/frontend/src/lib/geo-tile-url.ts` | Mirror frontend de `formatTileUrl` | Le types-package est CJS-only, on duplique 30 lignes plutôt que de basculer en ESM |
| `packages/frontend/src/components/geo/MapCanvasLeaflet.tsx` | Composant `TilePyramidLayer` (sous-classe `L.TileLayer`) + branche dans le rendu | `getTileUrl` custom pour schémas non-standards ; `errorTileUrl` SVG inline pour 404 silencieux |
| `packages/frontend/src/components/geo/MapCanvas.tsx` | Prop `tiles?` ajoutée à `MapCanvasProps` | Le canvas DIY legacy l'ignore et fallback sur l'image thumbnail |
| `packages/frontend/src/pages/GeoPlayPage.tsx`, `GeoContributePage.tsx`, `components/admin/GeoReviewPanel.tsx` | Forward `selectedMap.tiles` / `currentCandidateMap.tiles` / `detail.map.tiles` | Wiring des 3 call sites |

### Points d'attention pour la revue
- **Z-inversion** dans `xyz-padded2-inverted` : les tests unitaires snapshotent les 6 niveaux pour catch un off-by-one (Leaflet z=0 doit produire URL z=5 pour WoW).
- **OOB tiles** : la grille WoW est 85×69 (pas carrée). `bounds` + `noWrap` sur le `TileLayer` empêchent les requêtes hors-grille ; sinon `errorTileUrl` SVG sert de placeholder.
- **CHECK constraint** : la migration enforce `(kind='image') OR (kind='tiles' AND tile_* NOT NULL AND tile_min_zoom <= tile_max_zoom)`. Un rollback nettoie correctement.
- **`@the-box/types` reste CJS-only** : `formatTileUrl` est dupliqué dans backend+frontend. Si vous changez l'un, changez l'autre — c'est documenté dans les deux fichiers.
- **License WoW** : `Unknown` + `commercialUseOk: false` (dérivé d'assets Blizzard). Conscient du compromis ; demandé explicitement par l'utilisateur (« looks what we can do without looking licence restriciton »).

### Tests
- 76/76 tests backend passants (`npm test --workspace=@the-box/backend`)
- 6 nouveaux tests pour `formatTileUrl` couvrant les 2 schémas + les bords (z=0, z=max, x>9, y>9, round-trip 6 niveaux)
- Lint frontend OK
- Build complet OK (types + backend + frontend)
- Pas de tests E2E ajoutés — le canvas tuilé nécessiterait un mock CDN ; à faire en suivi

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation E2E manuelle avec `VITE_GEO_USE_LEAFLET=true` et le challenge WoW
- [ ] (Suivi) Spec Playwright `geo-tiled.spec.ts` avec mock 404 CDN

Closes #154

---
_Implémentation générée automatiquement par IA_