### PR TITLE
fix(geo): unstick maps pipeline when a child fetch exhausts retries

### DIFF
--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -13,7 +13,7 @@ import { importSteamScreenshots } from './geo-steam-import-logic.js'
 import { importRawgScreenshots } from './geo-rawg-import-logic.js'
 import { resolveGeoMetadataBatch } from './geo-metadata-resolve-logic.js'
 import { runGeoIngestTick } from './geo-ingest-tick-logic.js'
-import { runMapsPipeline } from './maps-pipeline-logic.js'
+import { advancePipeline, runMapsPipeline } from './maps-pipeline-logic.js'
 import { runMapsFetchSteam } from './maps-fetch-steam.js'
 import { runMapsFetchRawg } from './maps-fetch-rawg.js'
 import { runMapsFetchFandom } from './maps-fetch-fandom.js'
@@ -187,11 +187,41 @@ geoWorker.on('error', (err) => {
   log.error({ err: String(err) }, 'geo worker error')
 })
 
+type MapsFetchChildJob = Extract<GeoJobData, { kind: `maps:fetch-from-${string}` }>
+
+function isMapsFetchChildJob(data: GeoJobData | undefined): data is MapsFetchChildJob {
+  return !!data && typeof data.kind === 'string' && data.kind.startsWith('maps:fetch-from-')
+}
+
 geoWorker.on('failed', (job, err) => {
+  const data = job?.data as GeoJobData | undefined
   log.error(
-    { jobId: job?.id, kind: (job?.data as GeoJobData | undefined)?.kind, err: String(err) },
+    { jobId: job?.id, kind: data?.kind, attemptsMade: job?.attemptsMade, err: String(err) },
     'geo job failed',
   )
+
+  if (!job || !isMapsFetchChildJob(data)) return
+
+  // BullMQ fires 'failed' for every failed attempt. Only act on the terminal
+  // failure — otherwise we'd advance mid-retry and the next attempt would
+  // race the orchestrator picking another source.
+  const maxAttempts = job.opts.attempts ?? 1
+  if (job.attemptsMade < maxAttempts) return
+
+  // Without this, runSourceFetch's catch-and-rethrow path leaves pipeline
+  // state stuck at fetching_* with active_source pinned to the dead source:
+  // recordAttempt runs, but advancePipeline doesn't, and BullMQ has no more
+  // retries to run. Re-enqueue the orchestrator so it picks the next source
+  // (or transitions to awaiting_curation / blocked).
+  void advancePipeline({
+    gameId: data.gameId,
+    correlationId: data.correlationId,
+  }).catch((advanceErr) => {
+    log.error(
+      { jobId: job.id, gameId: data.gameId, err: String(advanceErr) },
+      'failed to advance pipeline after maps:fetch-from-* exhaustion',
+    )
+  })
 })
 
 geoWorker.on('completed', (job) => {


### PR DESCRIPTION
## Summary

- The admin "Cartes des jeux" pipeline could leave games stuck forever on `Recherche images · steam` / `· rawg` (or any `fetching_*` stage) when the per-source fetch threw a non-permanent error and BullMQ exhausted all 5 retries.
- Root cause: `runSourceFetch` in `maps-fetch-runtime.ts` calls `recordAttempt` then re-throws to let BullMQ retry — but on the terminal failure, `advancePipeline()` is never enqueued, so `pipeline_state.current_stage` remains pinned at `fetching_*` with `active_source` set to the dead source.
- Fix: extend the `geoWorker.failed` listener to detect terminal exhaustion (`attemptsMade >= opts.attempts`) for `maps:fetch-from-*` jobs and re-enqueue the orchestrator. The pipeline then picks the next source or transitions to `awaiting_curation` / `blocked` like it should.

## Test plan

- [x] `npm run build:backend` typechecks (with `npm run build:types` first since `@the-box/types` had been updated upstream)
- [x] `npm test` — 76 backend tests pass (ran via the husky pre-commit hook)
- [ ] After merge, hit `POST /api/admin/geo-fetch/:gameId/retry` for the games already stuck pre-deploy to clear the orphaned state once
- [ ] Watch the admin Geo "Acquisition" tab and confirm a forced fetch failure (e.g. flip a Steam app id to one returning 403) advances to the next source instead of pinning the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)