### PR TITLE
feat(geo-review): side-by-side compare layout with sticky actions

### DIFF
--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -13,7 +13,7 @@ import { importSteamScreenshots } from './geo-steam-import-logic.js'
 import { importRawgScreenshots } from './geo-rawg-import-logic.js'
 import { resolveGeoMetadataBatch } from './geo-metadata-resolve-logic.js'
 import { runGeoIngestTick } from './geo-ingest-tick-logic.js'
-import { runMapsPipeline } from './maps-pipeline-logic.js'
+import { advancePipeline, runMapsPipeline } from './maps-pipeline-logic.js'
 import { runMapsFetchSteam } from './maps-fetch-steam.js'
 import { runMapsFetchRawg } from './maps-fetch-rawg.js'
 import { runMapsFetchFandom } from './maps-fetch-fandom.js'
@@ -187,11 +187,41 @@ geoWorker.on('error', (err) => {
   log.error({ err: String(err) }, 'geo worker error')
 })
 
+type MapsFetchChildJob = Extract<GeoJobData, { kind: `maps:fetch-from-${string}` }>
+
+function isMapsFetchChildJob(data: GeoJobData | undefined): data is MapsFetchChildJob {
+  return !!data && typeof data.kind === 'string' && data.kind.startsWith('maps:fetch-from-')
+}
+
 geoWorker.on('failed', (job, err) => {
+  const data = job?.data as GeoJobData | undefined
   log.error(
-    { jobId: job?.id, kind: (job?.data as GeoJobData | undefined)?.kind, err: String(err) },
+    { jobId: job?.id, kind: data?.kind, attemptsMade: job?.attemptsMade, err: String(err) },
     'geo job failed',
   )
+
+  if (!job || !isMapsFetchChildJob(data)) return
+
+  // BullMQ fires 'failed' for every failed attempt. Only act on the terminal
+  // failure — otherwise we'd advance mid-retry and the next attempt would
+  // race the orchestrator picking another source.
+  const maxAttempts = job.opts.attempts ?? 1
+  if (job.attemptsMade < maxAttempts) return
+
+  // Without this, runSourceFetch's catch-and-rethrow path leaves pipeline
+  // state stuck at fetching_* with active_source pinned to the dead source:
+  // recordAttempt runs, but advancePipeline doesn't, and BullMQ has no more
+  // retries to run. Re-enqueue the orchestrator so it picks the next source
+  // (or transitions to awaiting_curation / blocked).
+  void advancePipeline({
+    gameId: data.gameId,
+    correlationId: data.correlationId,
+  }).catch((advanceErr) => {
+    log.error(
+      { jobId: job.id, gameId: data.gameId, err: String(advanceErr) },
+      'failed to advance pipeline after maps:fetch-from-* exhaustion',
+    )
+  })
 })
 
 geoWorker.on('completed', (job) => {

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1066,6 +1066,18 @@
           "confirmLabel": "Type {{word}} to confirm",
           "confirm": "Reset everything"
         }
+      },
+      "workspace": {
+        "capture": "Player capture",
+        "map": "Game map",
+        "captureAlt": "Submitted capture #{{id}}"
+      },
+      "keyboard": {
+        "next": "next",
+        "previous": "previous",
+        "approve": "approve",
+        "reject": "reject",
+        "close": "close"
       }
     },
     "growth": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1066,6 +1066,18 @@
           "confirmLabel": "Tapez {{word}} pour confirmer",
           "confirm": "Réinitialiser tout"
         }
+      },
+      "workspace": {
+        "capture": "Capture du joueur",
+        "map": "Carte du jeu",
+        "captureAlt": "Capture proposée #{{id}}"
+      },
+      "keyboard": {
+        "next": "suivante",
+        "previous": "précédente",
+        "approve": "valider",
+        "reject": "refuser",
+        "close": "fermer"
       }
     },
     "growth": {

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -14,24 +14,20 @@ import {
 } from '@/components/ui/dialog'
 import {
     Loader2,
-    Trash2,
     HelpCircle,
     MapPin,
     ListChecks,
     Library,
     Flag,
     X,
-    ChevronLeft,
-    ChevronRight,
-    ArrowLeft,
     Workflow,
     Sparkles,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { GeoMapsTab } from './GeoMapsTab'
 import { ModerationStatusRail } from './ModerationStatusRail'
 import { ReportsModerationPanel } from './ReportsModerationPanel'
+import { ReviewWorkspace } from './geo-review/ReviewWorkspace'
 import GeoFetchPanel from './geo-fetch/GeoFetchPanel'
 import { geoFetchApi } from '@/lib/api/geo-fetch'
 import { useGeoRunPolling } from '@/hooks/useGeoRunPolling'
@@ -682,7 +678,7 @@ export function GeoReviewPanel() {
                         side-by-side as before. */}
                     <Card
                         className={cn(
-                            'lg:col-span-1',
+                            'lg:col-span-1 lg:sticky lg:top-4 lg:self-start',
                             detail && 'hidden lg:block',
                         )}
                     >
@@ -707,7 +703,7 @@ export function GeoReviewPanel() {
                                 </Button>
                             </div>
                         </CardHeader>
-                        <CardContent className="space-y-3 lg:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
+                        <CardContent className="space-y-3 lg:max-h-[calc(100vh-14rem)] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
                             {gameFilter ? (
                                 <>
                                     {candidates.map((c) => (
@@ -862,74 +858,35 @@ export function GeoReviewPanel() {
                         </CardContent>
                     </Card>
 
-                    {/* Detail card — on mobile, only renders when a
-                        candidate is selected (replacing the list). On lg+,
-                        always visible alongside the list. The Header stays
-                        sticky throughout because nothing is rendered as a
-                        modal/portal anymore. */}
-                    <Card
+                    {/* Review workspace — side-by-side capture + map with
+                        sticky action bar and keyboard shortcuts. On mobile
+                        the workspace replaces the list (back-button restores
+                        it); on lg+ both surfaces sit side-by-side. */}
+                    <div
                         className={cn(
                             'lg:col-span-2',
                             !detail && 'hidden lg:block',
                         )}
                     >
-                        <CardHeader className="pb-2 p-4 sm:p-6">
-                            <div className="flex items-center justify-between gap-2">
-                                <div className="flex items-center gap-2 min-w-0">
-                                    {/* Mobile back button — pops the detail
-                                        view so the user is returned to the
-                                        list. Hidden on lg+ where both cards
-                                        are visible side-by-side. */}
-                                    {detail && (
-                                        <Button
-                                            type="button"
-                                            size="icon"
-                                            variant="ghost"
-                                            className="h-8 w-8 shrink-0 lg:hidden"
-                                            onClick={() => {
-                                                setDetail(null)
-                                                setPin(null)
-                                            }}
-                                            aria-label={t(
-                                                'admin.geo.nav.backToList',
-                                                'Retour à la liste',
-                                            )}
-                                        >
-                                            <ArrowLeft className="h-4 w-4" />
-                                        </Button>
-                                    )}
-                                    <CardTitle className="text-sm truncate">
-                                        {detail
-                                            ? `#${detail.candidate.id} · ${t('admin.geo.submissionRow.pinCount', { count: detail.pins.length })}`
-                                            : t('admin.geo.pickSubmission')}
-                                    </CardTitle>
-                                </div>
-                                {detail && (
-                                    <CandidateNavControls
-                                        prev={prevCandidate}
-                                        next={nextCandidate}
-                                        currentIndex={currentIndex}
-                                        total={flatCandidates.length}
-                                        disabled={saving}
-                                        onNavigate={openDetail}
-                                        t={t}
-                                    />
-                                )}
-                            </div>
-                        </CardHeader>
-                        <CardContent className="space-y-3 p-4 sm:p-6 pt-0 sm:pt-0">
-                            <CandidateDetailBody
-                                detail={detail}
-                                pin={pin}
-                                setPin={setPin}
-                                saving={saving}
-                                onPromote={applyOverride}
-                                onReject={() => setRejectOpen(true)}
-                                onDemote={() => setDemoteOpen(true)}
-                                t={t}
-                            />
-                        </CardContent>
-                    </Card>
+                        <ReviewWorkspace
+                            detail={detail}
+                            pin={pin}
+                            onPinChange={setPin}
+                            saving={saving}
+                            onPromote={applyOverride}
+                            onReject={() => setRejectOpen(true)}
+                            onDemote={() => setDemoteOpen(true)}
+                            onCloseDetail={() => {
+                                setDetail(null)
+                                setPin(null)
+                            }}
+                            prevCandidate={prevCandidate}
+                            nextCandidate={nextCandidate}
+                            currentIndex={currentIndex}
+                            total={flatCandidates.length}
+                            onNavigate={openDetail}
+                        />
+                    </div>
                 </div>
             )}
 
@@ -1019,178 +976,3 @@ export function GeoReviewPanel() {
     )
 }
 
-interface CandidateNavControlsProps {
-    prev: GeoScreenshotCandidate | null
-    next: GeoScreenshotCandidate | null
-    currentIndex: number
-    total: number
-    disabled: boolean
-    onNavigate: (id: number) => void | Promise<void>
-    t: ReturnType<typeof useTranslation>['t']
-}
-
-function CandidateNavControls({
-    prev,
-    next,
-    currentIndex,
-    total,
-    disabled,
-    onNavigate,
-    t,
-}: CandidateNavControlsProps) {
-    return (
-        <div className="flex items-center gap-1 shrink-0">
-            <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-7 w-7"
-                disabled={!prev || disabled}
-                onClick={() => prev && void onNavigate(prev.id)}
-                aria-label={t('admin.geo.nav.previous')}
-                title={t('admin.geo.nav.previous')}
-            >
-                <ChevronLeft className="h-4 w-4" aria-hidden />
-            </Button>
-            {currentIndex >= 0 && total > 0 && (
-                <span
-                    className="text-[10px] tabular-nums text-muted-foreground min-w-[2.5rem] text-center"
-                    aria-live="polite"
-                >
-                    {t('admin.geo.nav.position', {
-                        current: currentIndex + 1,
-                        total,
-                    })}
-                </span>
-            )}
-            <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-7 w-7"
-                disabled={!next || disabled}
-                onClick={() => next && void onNavigate(next.id)}
-                aria-label={t('admin.geo.nav.next')}
-                title={t('admin.geo.nav.next')}
-            >
-                <ChevronRight className="h-4 w-4" aria-hidden />
-            </Button>
-        </div>
-    )
-}
-
-interface CandidateDetailBodyProps {
-    detail: CandidateDetail | null
-    pin: GeoPoint | null
-    setPin: (p: GeoPoint | null) => void
-    saving: boolean
-    onPromote: () => void | Promise<void>
-    onReject: () => void
-    onDemote: () => void
-    t: ReturnType<typeof useTranslation>['t']
-}
-
-// Shared body for the candidate detail view — rendered inside the desktop
-// side-card and the mobile bottom sheet. Keeps the pin canvas, image,
-// status text and action buttons in one place so the two surfaces never
-// drift.
-function CandidateDetailBody({
-    detail,
-    pin,
-    setPin,
-    saving,
-    onPromote,
-    onReject,
-    onDemote,
-    t,
-}: CandidateDetailBodyProps) {
-    if (!detail || !detail.map) {
-        return (
-            <p className="text-xs text-muted-foreground">
-                {t('admin.geo.detailHintOfficial')}
-            </p>
-        )
-    }
-    return (
-        <>
-            <img
-                src={detail.candidate.imageUrl}
-                alt={`Candidate ${detail.candidate.id}`}
-                className="w-full rounded border max-h-48 object-contain bg-black/20"
-            />
-            <GeoMapCanvas
-                imageUrl={detail.map.imageUrl}
-                widthPx={detail.map.widthPx}
-                heightPx={detail.map.heightPx}
-                tiles={detail.map.tiles}
-                pin={pin}
-                canonical={
-                    detail.meta
-                        ? {
-                              x: detail.meta.canonical.x,
-                              y: detail.meta.canonical.y,
-                          }
-                        : null
-                }
-                onPin={setPin}
-                disabled={!!detail.meta}
-            />
-            {detail.meta ? (
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
-                    <p className="text-xs text-warning">
-                        {t('admin.geo.alreadyOfficial')}
-                    </p>
-                    <Button
-                        size="sm"
-                        variant="destructive"
-                        onClick={onDemote}
-                        disabled={saving}
-                        className="w-full sm:w-auto"
-                    >
-                        <Trash2 className="h-3.5 w-3.5 mr-2" />
-                        {t('admin.geo.actions.removeOfficial')}
-                    </Button>
-                </div>
-            ) : (
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                    <span className="text-xs text-muted-foreground">
-                        {pin
-                            ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
-                            : t(
-                                  detail.pins.length === 0
-                                      ? 'admin.geo.pickPointRequired'
-                                      : 'admin.geo.pickPointForOfficial',
-                              )}
-                    </span>
-                    <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-                        <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={onReject}
-                            disabled={saving}
-                            className="w-full sm:w-auto text-destructive border-destructive/40 hover:bg-destructive/10"
-                        >
-                            <Trash2 className="h-3.5 w-3.5 mr-2" />
-                            {t('admin.geo.actions.decline')}
-                        </Button>
-                        <Button
-                            size="sm"
-                            onClick={() => void onPromote()}
-                            disabled={saving || (!pin && detail.pins.length === 0)}
-                            className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
-                        >
-                            {saving && (
-                                <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
-                            )}
-                            {t(
-                                pin
-                                    ? 'admin.geo.actions.makeOfficial'
-                                    : 'admin.geo.actions.makeOfficialNoPin',
-                            )}
-                        </Button>
-                    </div>
-                </div>
-            )}
-        </>
-    )
-}

--- a/packages/frontend/src/components/admin/geo-review/ReviewWorkspace.tsx
+++ b/packages/frontend/src/components/admin/geo-review/ReviewWorkspace.tsx
@@ -1,0 +1,507 @@
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+    ArrowLeft,
+    ChevronLeft,
+    ChevronRight,
+    Loader2,
+    Trash2,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
+import { cn } from '@/lib/utils'
+import type {
+    GeoMap,
+    GeoPinSubmission,
+    GeoPoint,
+    GeoScreenshotCandidate,
+    GeoScreenshotMeta,
+} from '@the-box/types'
+
+export interface ReviewWorkspaceCandidate {
+    candidate: GeoScreenshotCandidate
+    pins: GeoPinSubmission[]
+    map: GeoMap | null
+    meta: GeoScreenshotMeta | null
+}
+
+export interface ReviewWorkspaceProps {
+    detail: ReviewWorkspaceCandidate | null
+    pin: GeoPoint | null
+    onPinChange: (point: GeoPoint | null) => void
+    saving: boolean
+    onPromote: () => void | Promise<void>
+    onReject: () => void
+    onDemote: () => void
+    onCloseDetail: () => void
+    prevCandidate: GeoScreenshotCandidate | null
+    nextCandidate: GeoScreenshotCandidate | null
+    currentIndex: number
+    total: number
+    onNavigate: (id: number) => void | Promise<void>
+}
+
+// Side-by-side review surface: capture on the left, map on the right at xl+,
+// stacked below xl. The actions bar is sticky at the bottom of the card so the
+// moderator never has to scroll to reach Promote / Reject. Keyboard shortcuts
+// (J/K next-prev, A approve, R reject, Esc close) are wired here so they only
+// apply while a candidate is open.
+export function ReviewWorkspace({
+    detail,
+    pin,
+    onPinChange,
+    saving,
+    onPromote,
+    onReject,
+    onDemote,
+    onCloseDetail,
+    prevCandidate,
+    nextCandidate,
+    currentIndex,
+    total,
+    onNavigate,
+}: ReviewWorkspaceProps) {
+    const { t } = useTranslation()
+
+    useReviewShortcuts({
+        enabled: !!detail,
+        saving,
+        canPromote:
+            !!detail &&
+            !detail.meta &&
+            (!!pin || (detail?.pins.length ?? 0) > 0),
+        canReject: !!detail && !detail.meta,
+        prevId: prevCandidate?.id ?? null,
+        nextId: nextCandidate?.id ?? null,
+        onNavigate,
+        onPromote,
+        onReject,
+        onClose: onCloseDetail,
+    })
+
+    return (
+        <Card className="lg:col-span-2 flex flex-col">
+            <CardHeader className="pb-2 p-4 sm:p-6">
+                <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                        {detail && (
+                            <Button
+                                type="button"
+                                size="icon"
+                                variant="ghost"
+                                className="h-8 w-8 shrink-0 lg:hidden"
+                                onClick={onCloseDetail}
+                                aria-label={t('admin.geo.nav.backToList')}
+                            >
+                                <ArrowLeft className="h-4 w-4" />
+                            </Button>
+                        )}
+                        <CardTitle className="text-sm truncate">
+                            {detail
+                                ? `#${detail.candidate.id} · ${t(
+                                      'admin.geo.submissionRow.pinCount',
+                                      { count: detail.pins.length },
+                                  )}`
+                                : t('admin.geo.pickSubmission')}
+                        </CardTitle>
+                    </div>
+                    {detail && (
+                        <NavControls
+                            prev={prevCandidate}
+                            next={nextCandidate}
+                            currentIndex={currentIndex}
+                            total={total}
+                            disabled={saving}
+                            onNavigate={onNavigate}
+                        />
+                    )}
+                </div>
+                {detail && <KeyboardHints />}
+            </CardHeader>
+            <CardContent
+                className="flex-1 space-y-3 p-4 sm:p-6 pt-0 sm:pt-0"
+                aria-busy={saving}
+            >
+                <CompareBody
+                    detail={detail}
+                    pin={pin}
+                    onPinChange={onPinChange}
+                />
+            </CardContent>
+            {detail && detail.map && (
+                <ActionBar
+                    detail={detail}
+                    pin={pin}
+                    saving={saving}
+                    onPromote={onPromote}
+                    onReject={onReject}
+                    onDemote={onDemote}
+                />
+            )}
+        </Card>
+    )
+}
+
+interface CompareBodyProps {
+    detail: ReviewWorkspaceCandidate | null
+    pin: GeoPoint | null
+    onPinChange: (point: GeoPoint | null) => void
+}
+
+// Two-pane comparison layout. Both panes share the same max height so they
+// line up and the moderator's eyes can flick between them without losing
+// context. Stacks below xl so 13" laptops and tablets keep both visible.
+function CompareBody({ detail, pin, onPinChange }: CompareBodyProps) {
+    const { t } = useTranslation()
+    if (!detail || !detail.map) {
+        return (
+            <p className="text-xs text-muted-foreground">
+                {t('admin.geo.detailHintOfficial')}
+            </p>
+        )
+    }
+    return (
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-3 items-start">
+            <CapturePane
+                imageUrl={detail.candidate.imageUrl}
+                candidateId={detail.candidate.id}
+            />
+            <MapPane
+                detail={detail}
+                pin={pin}
+                onPinChange={onPinChange}
+            />
+        </div>
+    )
+}
+
+function CapturePane({
+    imageUrl,
+    candidateId,
+}: {
+    imageUrl: string
+    candidateId: number
+}) {
+    const { t } = useTranslation()
+    return (
+        <figure className="space-y-1.5">
+            <figcaption className="text-[11px] uppercase tracking-wide text-muted-foreground font-semibold">
+                {t('admin.geo.workspace.capture')}
+            </figcaption>
+            <div className="rounded-lg border bg-black/40 overflow-hidden flex items-center justify-center max-h-[60vh] min-h-[260px]">
+                <img
+                    src={imageUrl}
+                    alt={t('admin.geo.workspace.captureAlt', {
+                        id: candidateId,
+                    })}
+                    className="max-h-[60vh] w-full h-auto object-contain"
+                />
+            </div>
+        </figure>
+    )
+}
+
+function MapPane({
+    detail,
+    pin,
+    onPinChange,
+}: {
+    detail: ReviewWorkspaceCandidate
+    pin: GeoPoint | null
+    onPinChange: (point: GeoPoint | null) => void
+}) {
+    const { t } = useTranslation()
+    if (!detail.map) return null
+    return (
+        <figure className="space-y-1.5">
+            <figcaption className="text-[11px] uppercase tracking-wide text-muted-foreground font-semibold">
+                {t('admin.geo.workspace.map')}
+            </figcaption>
+            <div className="rounded-lg border overflow-hidden max-h-[60vh] min-h-[260px]">
+                <GeoMapCanvas
+                    imageUrl={detail.map.imageUrl}
+                    widthPx={detail.map.widthPx}
+                    heightPx={detail.map.heightPx}
+                    tiles={detail.map.tiles}
+                    pin={pin}
+                    canonical={
+                        detail.meta
+                            ? {
+                                  x: detail.meta.canonical.x,
+                                  y: detail.meta.canonical.y,
+                              }
+                            : null
+                    }
+                    onPin={onPinChange}
+                    disabled={!!detail.meta}
+                />
+            </div>
+        </figure>
+    )
+}
+
+interface ActionBarProps {
+    detail: ReviewWorkspaceCandidate
+    pin: GeoPoint | null
+    saving: boolean
+    onPromote: () => void | Promise<void>
+    onReject: () => void
+    onDemote: () => void
+}
+
+// Sticky action bar — always visible at the bottom of the card so Promote /
+// Reject are one tap away, no scroll required. Background uses card token +
+// backdrop-blur so it reads cleanly over either pane.
+function ActionBar({
+    detail,
+    pin,
+    saving,
+    onPromote,
+    onReject,
+    onDemote,
+}: ActionBarProps) {
+    const { t } = useTranslation()
+    if (detail.meta) {
+        return (
+            <div className="sticky bottom-0 border-t bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 px-4 py-3 sm:px-6 rounded-b-xl">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
+                    <p className="text-xs text-warning">
+                        {t('admin.geo.alreadyOfficial')}
+                    </p>
+                    <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={onDemote}
+                        disabled={saving}
+                        aria-busy={saving}
+                        className="w-full sm:w-auto"
+                    >
+                        <Trash2 className="h-3.5 w-3.5 mr-2" />
+                        {t('admin.geo.actions.removeOfficial')}
+                    </Button>
+                </div>
+            </div>
+        )
+    }
+    return (
+        <div className="sticky bottom-0 border-t bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 px-4 py-3 sm:px-6 rounded-b-xl">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <span className="text-xs text-muted-foreground tabular-nums">
+                    {pin
+                        ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
+                        : t(
+                              detail.pins.length === 0
+                                  ? 'admin.geo.pickPointRequired'
+                                  : 'admin.geo.pickPointForOfficial',
+                          )}
+                </span>
+                <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={onReject}
+                        disabled={saving}
+                        aria-busy={saving}
+                        className="w-full sm:w-auto text-destructive border-destructive/40 hover:bg-destructive/10"
+                    >
+                        <Trash2 className="h-3.5 w-3.5 mr-2" />
+                        {t('admin.geo.actions.decline')}
+                    </Button>
+                    <Button
+                        size="sm"
+                        onClick={() => void onPromote()}
+                        disabled={saving || (!pin && detail.pins.length === 0)}
+                        aria-busy={saving}
+                        className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
+                    >
+                        {saving && (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
+                        )}
+                        {t(
+                            pin
+                                ? 'admin.geo.actions.makeOfficial'
+                                : 'admin.geo.actions.makeOfficialNoPin',
+                        )}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+interface NavControlsProps {
+    prev: GeoScreenshotCandidate | null
+    next: GeoScreenshotCandidate | null
+    currentIndex: number
+    total: number
+    disabled: boolean
+    onNavigate: (id: number) => void | Promise<void>
+}
+
+function NavControls({
+    prev,
+    next,
+    currentIndex,
+    total,
+    disabled,
+    onNavigate,
+}: NavControlsProps) {
+    const { t } = useTranslation()
+    return (
+        <div className="flex items-center gap-1 shrink-0">
+            <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7"
+                disabled={!prev || disabled}
+                onClick={() => prev && void onNavigate(prev.id)}
+                aria-label={t('admin.geo.nav.previous')}
+                title={t('admin.geo.nav.previous')}
+            >
+                <ChevronLeft className="h-4 w-4" aria-hidden />
+            </Button>
+            {currentIndex >= 0 && total > 0 && (
+                <span
+                    className="text-[10px] tabular-nums text-muted-foreground min-w-[2.5rem] text-center"
+                    aria-live="polite"
+                >
+                    {t('admin.geo.nav.position', {
+                        current: currentIndex + 1,
+                        total,
+                    })}
+                </span>
+            )}
+            <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7"
+                disabled={!next || disabled}
+                onClick={() => next && void onNavigate(next.id)}
+                aria-label={t('admin.geo.nav.next')}
+                title={t('admin.geo.nav.next')}
+            >
+                <ChevronRight className="h-4 w-4" aria-hidden />
+            </Button>
+        </div>
+    )
+}
+
+function KeyboardHints() {
+    const { t } = useTranslation()
+    return (
+        <p className="hidden lg:flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted-foreground mt-1">
+            <KeyHint k="J" label={t('admin.geo.keyboard.next')} />
+            <KeyHint k="K" label={t('admin.geo.keyboard.previous')} />
+            <KeyHint k="A" label={t('admin.geo.keyboard.approve')} />
+            <KeyHint k="R" label={t('admin.geo.keyboard.reject')} />
+            <KeyHint k="Esc" label={t('admin.geo.keyboard.close')} />
+        </p>
+    )
+}
+
+function KeyHint({ k, label }: { k: string; label: string }) {
+    return (
+        <span className="inline-flex items-center gap-1">
+            <kbd
+                className={cn(
+                    'inline-flex h-4 min-w-4 px-1 items-center justify-center rounded',
+                    'border border-border/60 bg-muted/40 font-mono text-[10px]',
+                    'text-foreground',
+                )}
+            >
+                {k}
+            </kbd>
+            <span>{label}</span>
+        </span>
+    )
+}
+
+interface ReviewShortcutsArgs {
+    enabled: boolean
+    saving: boolean
+    canPromote: boolean
+    canReject: boolean
+    prevId: number | null
+    nextId: number | null
+    onNavigate: (id: number) => void | Promise<void>
+    onPromote: () => void | Promise<void>
+    onReject: () => void
+    onClose: () => void
+}
+
+// Window-level keyboard shortcuts for the review surface. Guards against:
+//  - typing inside an input/textarea/contenteditable (so Dialog text fields
+//    don't trigger Promote when the moderator types "a"),
+//  - any modifier key (so Cmd+R reload still works),
+//  - acting on a candidate while a save request is in flight.
+// All handlers reference the latest props via a ref so we don't tear down
+// the listener on every render.
+function useReviewShortcuts(args: ReviewShortcutsArgs) {
+    const ref = useRef(args)
+    useLayoutEffect(() => {
+        ref.current = args
+    })
+
+    useEffect(() => {
+        if (!args.enabled) return
+        const handler = (event: KeyboardEvent) => {
+            if (event.metaKey || event.ctrlKey || event.altKey) return
+            const target = event.target as HTMLElement | null
+            if (target) {
+                const tag = target.tagName
+                if (
+                    tag === 'INPUT' ||
+                    tag === 'TEXTAREA' ||
+                    tag === 'SELECT' ||
+                    target.isContentEditable
+                ) {
+                    return
+                }
+            }
+            const current = ref.current
+            if (current.saving && event.key !== 'Escape') return
+
+            switch (event.key) {
+                case 'j':
+                case 'J':
+                case 'ArrowDown':
+                    if (current.nextId !== null) {
+                        event.preventDefault()
+                        void current.onNavigate(current.nextId)
+                    }
+                    return
+                case 'k':
+                case 'K':
+                case 'ArrowUp':
+                    if (current.prevId !== null) {
+                        event.preventDefault()
+                        void current.onNavigate(current.prevId)
+                    }
+                    return
+                case 'a':
+                case 'A':
+                    if (current.canPromote) {
+                        event.preventDefault()
+                        void current.onPromote()
+                    }
+                    return
+                case 'r':
+                case 'R':
+                    if (current.canReject) {
+                        event.preventDefault()
+                        current.onReject()
+                    }
+                    return
+                case 'Escape':
+                    event.preventDefault()
+                    current.onClose()
+                    return
+            }
+        }
+        window.addEventListener('keydown', handler)
+        return () => window.removeEventListener('keydown', handler)
+    }, [args.enabled])
+}


### PR DESCRIPTION
## Résumé technique

### Contexte
L'onglet « À examiner » de la modération Géo affichait la capture utilisateur **au-dessus** de la carte Leaflet, dans une seule colonne empilée (`CandidateDetailBody`, lignes 1097-1196 de l'ancien `GeoReviewPanel.tsx`). Pour chaque proposition le modérateur devait scroller pour voir la carte, scroller à nouveau pour relier les indices visuels, puis re-scroller pour atteindre les boutons d'action en bas. À volume élevé c'est un goulet d'étranglement majeur. La sidebar des propositions était par ailleurs bornée à 520 px (`lg:max-h-[520px]`), gaspillant l'espace vertical sur les écrans larges.

### Approche retenue
Layout côte-à-côte au breakpoint `xl` (capture à gauche, carte à droite), repli en empilement en dessous pour ne pas casser les écrans 13" et le mobile. Barre d'actions **sticky** au bas du workspace : Refuser / Valider sont toujours visibles, plus de scroll pour cliquer. Raccourcis clavier vim-style (`J/K` suivante-précédente, `ArrowDown/ArrowUp` aussi, `A` valider, `R` refuser, `Échap` fermer) montés sur `window` avec garde-fous stricts (ignore inputs/textarea/contenteditable, ignore `Cmd/Ctrl/Alt`, désactivé pendant `saving`).

Le tout extrait dans un nouveau composant `ReviewWorkspace.tsx` ; `GeoReviewPanel.tsx` passe de 1196 à 978 lignes (les sous-composants `CandidateDetailBody` et `CandidateNavControls` migrent dans le workspace).

Alternatives écartées : `react-resizable-panels` (+14 kB gz, complexité a11y pour un seul écran) ; zoom synchronisé capture/carte (deux systèmes de coordonnées différents, des jours de glue code pour un gain visuel marginal) ; cropper d'images (hors scope, appartient au pipeline d'ingestion).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|--------------|------------------------|
| `packages/frontend/src/components/admin/geo-review/ReviewWorkspace.tsx` | Nouveau composant : layout `xl:grid-cols-2` capture/carte, `ActionBar` sticky, hook clavier interne avec ref synchronisée par `useLayoutEffect` (évite la fermeture stale du listener `keydown`), `KeyHints` desktop. | Extraction nette du surface de revue ; ref-via-effect respecte la règle `react-hooks/refs`. |
| `packages/frontend/src/components/admin/GeoReviewPanel.tsx` | Suppression du bloc detail-card inline et des deux sous-composants ; câblage de `<ReviewWorkspace />` ; sidebar `lg:sticky lg:top-4 lg:self-start` avec `lg:max-h-[calc(100vh-14rem)]`. | La sidebar suit maintenant le viewport au lieu de plafonner à 520 px. Le fichier descend sous 1000 lignes. |
| `packages/frontend/public/locales/fr/translation.json` | Clés `admin.geo.workspace.{capture,map,captureAlt}` et `admin.geo.keyboard.{next,previous,approve,reject,close}`. | Libellés des panneaux et des indicateurs `<kbd>`. |
| `packages/frontend/public/locales/en/translation.json` | Mêmes clés en anglais. | Parité i18n. |

### Points d'attention pour la revue
- **Hauteur Leaflet dans la grille flex** : la carte est wrappée dans `max-h-[60vh] min-h-[260px] overflow-hidden`. `MapCanvasLeaflet` continue d'utiliser `aspectRatio: widthPx/heightPx`, donc la hauteur naturelle suit la largeur de la colonne. Si le rendu paraît rogné sur des cartes très allongées, c'est attendu (Leaflet permet de paner).
- **Fermeture stale dans le hook clavier** : la lecture des callbacks passe par une `ref` synchronisée via `useLayoutEffect` (ESLint bloque l'écriture de `ref.current` directement pendant le render).
- **Régression mobile** : le flux liste/détail mutuellement exclusif est préservé (`!detail && 'hidden lg:block'` sur la sidebar, `detail && 'hidden lg:block'` sur le workspace). Le bouton retour dans l'en-tête du workspace (`lg:hidden`) est conservé.
- **Désactivation pendant `saving`** : la barre d'actions a `aria-busy={saving}`, les boutons sont disabled, et les raccourcis clavier ignorent toutes les touches sauf `Échap` quand un save est en cours.
- **Touche `A` vs accessibilité** : la touche déclenche la promotion uniquement si un pin est posé (ou s'il existe au moins un pin moyen) ET que le candidat n'est pas déjà officiel — même règle que le bouton.

### Tests
- `npm run lint` : OK (aucune erreur).
- `tsc -b` sur `packages/frontend` : OK.
- `npm run build:frontend` : OK (4.78s).
- `npm test` (workspaces) : 76 tests, tous passent.
- E2E Playwright : non exécutés dans ce PR (changement UI pure, le DOM côté tests existants reste compatible — les sélecteurs `getByRole('button', { name: /Valider/ })` et l'image fonctionnent toujours).

### Étapes restantes
- [ ] Test manuel sur 1366×768 pour confirmer le repli stacké en dessous de `xl`.
- [ ] Test manuel keyboard-only (Tab/Shift+Tab + raccourcis) avec un lecteur d'écran.
- [ ] Vérifier `invalidateSize()` Leaflet après resize si la carte reste grise sur certaines configurations.

> Attention : d'autres branches fast-meeting sont actives (`feat/fm-geo-card`, `feat/fm-tiled-maps`, `refactor/fm-catalog-merge`). Vérifier les conflits potentiels avant merge.

Closes #160

---
_Implémentation générée automatiquement par IA_