### PR TITLE
feat(frontend): forward ErrorBoundary errors to a reporting endpoint

### DIFF
--- a/packages/frontend/src/components/ErrorBoundary.tsx
+++ b/packages/frontend/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, type ReactNode, type ErrorInfo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AlertTriangle, RefreshCw, Home } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { reportError } from '@/lib/errorReporter'
 
 interface ErrorBoundaryProps {
   children: ReactNode
@@ -41,16 +42,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    // Log error to console in development
-    if (import.meta.env.DEV) {
-      console.error('Error Boundary caught an error:', error, errorInfo)
-    }
-
-    // Store error info in state
     this.setState({ errorInfo })
-
-    // TODO: Log error to error reporting service (e.g., Sentry)
-    // logErrorToService(error, errorInfo)
+    reportError(error, errorInfo)
   }
 
   handleReset = (): void => {

--- a/packages/frontend/src/lib/errorReporter.ts
+++ b/packages/frontend/src/lib/errorReporter.ts
@@ -1,0 +1,75 @@
+import type { ErrorInfo } from 'react'
+
+interface ErrorReportPayload {
+  name: string
+  message: string
+  stack?: string
+  componentStack?: string
+  url: string
+  userAgent: string
+  timestamp: string
+  appVersion?: string
+}
+
+const STACK_LINE_LIMIT = 50
+
+function buildPayload(error: Error, errorInfo?: ErrorInfo): ErrorReportPayload {
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack?.split('\n').slice(0, STACK_LINE_LIMIT).join('\n'),
+    componentStack: errorInfo?.componentStack
+      ?.split('\n')
+      .slice(0, STACK_LINE_LIMIT)
+      .join('\n') ?? undefined,
+    url: typeof window !== 'undefined' ? window.location.href : '',
+    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+    timestamp: new Date().toISOString(),
+    appVersion: import.meta.env.VITE_APP_VERSION,
+  }
+}
+
+/**
+ * Report an unhandled error caught by an ErrorBoundary.
+ *
+ * In development the error is logged to the console. In production, if
+ * `VITE_ERROR_REPORTING_URL` is configured, the payload is forwarded via
+ * `navigator.sendBeacon` (with a `fetch` fallback). Failures are swallowed so
+ * reporting can never trigger a secondary crash.
+ */
+export function reportError(error: Error, errorInfo?: ErrorInfo): void {
+  const payload = buildPayload(error, errorInfo)
+
+  if (import.meta.env.DEV) {
+    console.error('[ErrorBoundary]', payload)
+    return
+  }
+
+  const endpoint = import.meta.env.VITE_ERROR_REPORTING_URL
+  if (!endpoint) {
+    console.error('[ErrorBoundary]', payload)
+    return
+  }
+
+  try {
+    const body = JSON.stringify(payload)
+
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      const blob = new Blob([body], { type: 'application/json' })
+      const sent = navigator.sendBeacon(endpoint, blob)
+      if (sent) return
+    }
+
+    void fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+      credentials: 'omit',
+    }).catch(() => {
+      /* ignore — reporting must never throw */
+    })
+  } catch {
+    /* ignore — reporting must never throw */
+  }
+}


### PR DESCRIPTION
Replaces the long-standing TODO in ErrorBoundary with a reportError
utility that posts unhandled UI errors to VITE_ERROR_REPORTING_URL via
sendBeacon (with a fetch fallback) in production, and falls back to a
console log when no endpoint is configured or in development.

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m