### PR TITLE
feat(geo): un-gate free-play and ship mobile-first minimums

### DIFF
--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -18,7 +18,6 @@ import {
   authMiddleware,
   optionalAuthMiddleware,
 } from '../middleware/auth.middleware.js'
-import { requirePremium } from '../middleware/require-premium.middleware.js'
 import { validateBody, validateParams } from '../middleware/validation.middleware.js'
 import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
@@ -302,14 +301,14 @@ router.get(
   },
 )
 
-// Free-play (the guessing surface) is premium-gated while the mode is
-// in alpha. authMiddleware before requirePremium so anonymous callers
-// get 401 (login flow) and authenticated free users get 402 (upsell
-// flow), matching the UX everywhere else premium gates exist.
+// Free-play is open to every authenticated user — the immediate goal
+// is dataset growth (screenshot ↔ map-coordinate pairs). The future
+// "guess the location" gameplay layered on top of this dataset will be
+// premium, but the contribution surface stays free. Anonymous callers
+// still get 401 so the UI can prompt for sign-in.
 router.post(
   '/free-play/random',
   authMiddleware,
-  requirePremium,
   freePlayPickLimiter,
   validateBody(freePlayPickBodySchema),
   async (req, res, next) => {
@@ -369,7 +368,6 @@ router.post(
 router.post(
   '/free-play/guess',
   authMiddleware,
-  requirePremium,
   freePlayGuessLimiter,
   validateBody(freePlayGuessBodySchema),
   async (req, res, next) => {

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1756,6 +1756,7 @@
   "geo": {
     "daily": {
       "screenshot": "Screenshot",
+      "screenshotOf": "Screenshot from {{game}}",
       "score": "Score",
       "distance": "Distance",
       "pinCount_one": "{{count}} pin on this capture",
@@ -1831,6 +1832,12 @@
       "allDone": {
         "title": "You've completed The Box!",
         "body": "Bravo! You've guessed every screenshot in every game in your catalog. We'll ping you when new ones are added."
+      },
+      "auth": {
+        "title": "Sign in to drop pins",
+        "body": "Help us map the world of video games — drop a pin where each scene takes place.",
+        "login": "Sign in",
+        "register": "Create account"
       }
     },
     "fullscreen": {
@@ -1978,11 +1985,6 @@
       "title": "Premium members only",
       "description": "This feature is part of The Box Premium.",
       "ctaLabel": "See Premium plans"
-    },
-    "geo": {
-      "title": "Geo mode — Premium access",
-      "description": "Geo mode is in alpha and reserved for Premium subscribers during this phase. You can still contribute to grow the dataset for free from your profile.",
-      "ctaLabel": "Unlock Geo with Premium"
     }
   }
 }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1756,6 +1756,7 @@
   "geo": {
     "daily": {
       "screenshot": "Capture d'écran",
+      "screenshotOf": "Capture d'écran de {{game}}",
       "score": "Score",
       "distance": "Distance",
       "pinCount_one": "{{count}} épingle sur cette capture",
@@ -1831,6 +1832,12 @@
       "allDone": {
         "title": "Vous avez terminé The Box !",
         "body": "Bravo ! Vous avez deviné toutes les captures de tous les jeux de votre catalogue. Nous vous préviendrons quand de nouvelles seront ajoutées."
+      },
+      "auth": {
+        "title": "Connecte-toi pour poser des épingles",
+        "body": "Aide-nous à cartographier l'univers du jeu vidéo — épingle où se passe chaque scène.",
+        "login": "Se connecter",
+        "register": "Créer un compte"
       }
     },
     "fullscreen": {
@@ -1978,11 +1985,6 @@
       "title": "Réservé aux membres Premium",
       "description": "Cette fonctionnalité est incluse dans l'abonnement Premium.",
       "ctaLabel": "Voir les offres Premium"
-    },
-    "geo": {
-      "title": "Mode Geo — accès Premium",
-      "description": "Le mode Geo est en alpha et réservé aux abonnés Premium pendant cette phase. Tu peux toujours contribuer à enrichir le dataset gratuitement depuis ton profil.",
-      "ctaLabel": "Débloquer Geo avec Premium"
     }
   }
 }

--- a/packages/frontend/src/components/geo/GamePicker.tsx
+++ b/packages/frontend/src/components/geo/GamePicker.tsx
@@ -266,13 +266,13 @@ function GameCard({
                             decoding="async"
                         />
                     ) : (
-                        <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                        <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground" lang="en">
                             {game.name}
                         </div>
                     )}
                 </div>
                 <div className="p-3 space-y-1">
-                    <p className="font-medium text-sm leading-tight line-clamp-2">{game.name}</p>
+                    <p className="font-medium text-sm leading-tight line-clamp-2" lang="en">{game.name}</p>
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
                         <span className="inline-flex items-center gap-1">
                             <MapPin className="h-3 w-3" aria-hidden />

--- a/packages/frontend/src/components/geo/ImmersiveLayout.tsx
+++ b/packages/frontend/src/components/geo/ImmersiveLayout.tsx
@@ -42,7 +42,7 @@ export function ImmersiveLayout({
                 'relative flex flex-col bg-black text-foreground',
                 isImmersive
                     ? 'fixed inset-0 z-50 h-[100dvh]'
-                    : 'h-[calc(100dvh-3.5rem)] md:h-[calc(100dvh-4rem)]',
+                    : 'min-h-[100svh] h-[calc(100dvh-3.5rem)] md:h-[calc(100dvh-4rem)]',
             )}
             data-immersive={isImmersive ? 'true' : 'false'}
         >
@@ -50,16 +50,21 @@ export function ImmersiveLayout({
             {topRight && (
                 <div
                     className="absolute right-3 top-3 z-30 flex items-center gap-2"
-                    style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
+                    style={{
+                        paddingTop: 'env(safe-area-inset-top, 0px)',
+                        paddingRight: 'env(safe-area-inset-right, 0px)',
+                    }}
                 >
                     {topRight}
                 </div>
             )}
 
-            {/* Deck — both panels are always visible. Stacked rows on mobile,
-                two columns on desktop. */}
+            {/* Deck — both panels are always visible. On mobile the map gets
+                visual priority (the user's active surface) with the photo
+                kept reference-sized above; on tablet/desktop they go
+                side-by-side at equal width. */}
             <div className="flex-1 relative overflow-hidden">
-                <div className="absolute inset-0 grid grid-rows-2 md:grid-rows-1 md:grid-cols-2">
+                <div className="absolute inset-0 grid grid-rows-[minmax(38%,1fr)_minmax(45%,1.2fr)] md:grid-rows-1 md:grid-cols-2">
                     <Panel
                         id="geo-panel-photo"
                         tag={

--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -104,6 +104,12 @@ export function MapCanvasLeaflet({
                 zoomControl
                 scrollWheelZoom
                 doubleClickZoom={false}
+                bounceAtZoomLimits={false}
+                touchZoom
+                zoomSnap={0.5}
+                zoomDelta={0.5}
+                keyboard
+                keyboardPanDelta={50}
                 style={{ height: '100%', width: '100%', background: 'var(--background)' }}
             >
                 {tiles ? (
@@ -122,7 +128,30 @@ export function MapCanvasLeaflet({
                         onPick={(p) => onPin(p)}
                     />
                 )}
-                {pinLatLng && <Marker position={pinLatLng} icon={FUCHSIA_DIVICON} />}
+                {pinLatLng && (
+                    <Marker
+                        position={pinLatLng}
+                        icon={FUCHSIA_DIVICON}
+                        draggable={!disabled && !!onPin}
+                        eventHandlers={
+                            !disabled && onPin
+                                ? {
+                                      // Drag-to-refine: after the initial
+                                      // tap-drop, the player can slide the
+                                      // pin into a better spot without
+                                      // re-aiming.
+                                      dragend: (e) => {
+                                          const { lat, lng } = (e.target as L.Marker).getLatLng()
+                                          onPin({
+                                              x: clamp01(lng / widthPx),
+                                              y: clamp01(lat / heightPx),
+                                          })
+                                      },
+                                  }
+                                : undefined
+                        }
+                    />
+                )}
                 {canonicalLatLng && (
                     <Marker position={canonicalLatLng} icon={EMERALD_DIVICON} />
                 )}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -394,3 +394,19 @@ body {
   font-weight: 600;
   letter-spacing: 0.04em;
 }
+
+/* Leaflet zoom controls — Leaflet's default 26x26 px buttons fail
+   WCAG 2.5.5 / 2.5.8 on mobile. Bump them to 44 px so thumb taps land
+   reliably. Visual style is otherwise inherited from Leaflet's CSS. */
+.leaflet-bar a,
+.leaflet-bar a:hover {
+  width: 44px;
+  height: 44px;
+  line-height: 44px;
+  font-size: 18px;
+}
+
+.leaflet-container:focus-visible {
+  outline: 2px solid var(--neon-pink);
+  outline-offset: -2px;
+}

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -15,9 +15,10 @@ import {
     Sparkles,
     Trophy,
 } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import { PremiumGate } from '@/components/PremiumGate'
 import { useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useFullscreen } from '@/hooks/useFullscreen'
 import { GamePicker } from '@/components/geo/GamePicker'
 import { MapPicker } from '@/components/geo/MapPicker'
@@ -38,12 +39,9 @@ import { cn } from '@/lib/utils'
  * the daily-challenge store, so a free-play round can never write to the
  * leaderboard or pollute the daily resume.
  */
-// Default export at the bottom wraps this in `<PremiumGate>` so all the
-// hooks inside still run unconditionally — putting the gate above the
-// hooks would skip them on the upsell render and break Rules of Hooks
-// the next time entitlement flips. Keep this as a named function.
-function GeoPlayContent() {
+export default function GeoPlayPage() {
     const { i18n } = useTranslation()
+    const { localizedPath } = useLocalizedPath()
 
     const {
         games,
@@ -168,10 +166,14 @@ function GeoPlayContent() {
                 screenshot={
                     <ScreenshotPanel
                         imageUrl={view?.candidate.imageUrl ?? null}
+                        gameName={currentGame?.name ?? null}
                         loading={phase === 'loading' || (currentGameId != null && phase === 'idle')}
                         empty={currentGameId == null}
                         exhausted={phase === 'exhausted'}
                         allCompleted={allGamesCompleted}
+                        authRequired={phase === 'authRequired'}
+                        loginHref={localizedPath('/login')}
+                        registerHref={localizedPath('/register')}
                         canIgnoreCurrent={
                             phase === 'exhausted' &&
                             currentGameId != null &&
@@ -280,10 +282,14 @@ function GeoPlayContent() {
 
 function ScreenshotPanel({
     imageUrl,
+    gameName,
     loading,
     empty,
     exhausted,
     allCompleted,
+    authRequired,
+    loginHref,
+    registerHref,
     canIgnoreCurrent,
     errorMessage,
     onPickGame,
@@ -291,10 +297,14 @@ function ScreenshotPanel({
     onIgnoreCurrent,
 }: {
     imageUrl: string | null
+    gameName: string | null
     loading: boolean
     empty: boolean
     exhausted: boolean
     allCompleted: boolean
+    authRequired: boolean
+    loginHref: string
+    registerHref: string
     canIgnoreCurrent: boolean
     errorMessage: string | null
     onPickGame: () => void
@@ -379,6 +389,42 @@ function ScreenshotPanel({
         )
     }
 
+    if (authRequired) {
+        return (
+            <div
+                className="flex h-full w-full flex-col items-center justify-center px-6 text-center gap-4"
+                role="status"
+            >
+                <div className="rounded-full bg-neon-pink/10 p-4">
+                    <MapPin className="h-8 w-8 text-neon-pink" aria-hidden />
+                </div>
+                <div className="space-y-1 max-w-sm">
+                    <h2 className="text-lg font-semibold">
+                        {t('geo.play.auth.title', 'Sign in to drop pins')}
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                        {t(
+                            'geo.play.auth.body',
+                            'Help us map the world of video games — drop a pin where each scene takes place.',
+                        )}
+                    </p>
+                </div>
+                <div className="flex flex-wrap items-center justify-center gap-2">
+                    <Button asChild className="gradient-gaming hover:opacity-90 min-h-12">
+                        <Link to={loginHref}>
+                            {t('geo.play.auth.login', 'Sign in')}
+                        </Link>
+                    </Button>
+                    <Button asChild variant="outline" className="min-h-12">
+                        <Link to={registerHref}>
+                            {t('geo.play.auth.register', 'Create account')}
+                        </Link>
+                    </Button>
+                </div>
+            </div>
+        )
+    }
+
     if (errorMessage) {
         return (
             <div
@@ -428,13 +474,17 @@ function ScreenshotPanel({
         )
     }
 
+    const altText = gameName
+        ? t('geo.daily.screenshotOf', 'Screenshot from {{game}}', { game: gameName })
+        : t('geo.daily.screenshot', 'Screenshot')
     return (
         <img
             src={safeUrl}
-            alt={t('geo.daily.screenshot', 'Screenshot')}
+            alt={altText}
             className="h-full w-full object-contain"
             loading="eager"
             decoding="async"
+            fetchPriority="high"
         />
     )
 }
@@ -573,10 +623,10 @@ function Dock({
                 <button
                     type="button"
                     onClick={onChangeGame}
-                    className="inline-flex items-center gap-1 rounded-full border border-white/20 px-2.5 py-0.5 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                    className="inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-black/40 min-h-11 px-3 py-2 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
                 >
                     <Gamepad2 className="h-3 w-3" aria-hidden />
-                    <span className="max-w-[10rem] truncate">
+                    <span className="max-w-[12rem] truncate" lang={gameLabel ? 'en' : undefined}>
                         {gameLabel ?? t('geo.play.changeGame', 'Choose game')}
                     </span>
                 </button>
@@ -584,10 +634,10 @@ function Dock({
                     <button
                         type="button"
                         onClick={onChangeMap}
-                        className="inline-flex items-center gap-1 rounded-full border border-white/20 px-2.5 py-0.5 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                        className="inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-black/40 min-h-11 px-3 py-2 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
                     >
                         <MapIcon className="h-3 w-3" aria-hidden />
-                        <span className="max-w-[10rem] truncate">
+                        <span className="max-w-[12rem] truncate" lang={mapLabel ? 'en' : undefined}>
                             {mapLabel ?? t('geo.play.changeMap', 'Choose map')}
                         </span>
                     </button>
@@ -600,7 +650,7 @@ function Dock({
                     variant="ghost"
                     size="icon"
                     onClick={onPrevious}
-                    className="text-white/80 hover:text-white"
+                    className="h-12 w-12 min-h-12 min-w-12 text-white/80 hover:text-white"
                     disabled={!canGoPrevious || submitting || loading}
                     aria-label={t('geo.play.previous', 'Previous screenshot')}
                     title={t('geo.play.previous', 'Previous screenshot')}
@@ -611,7 +661,7 @@ function Dock({
                     type="button"
                     variant="ghost"
                     onClick={onShuffleAllGames}
-                    className="text-white/80 hover:text-white"
+                    className="min-h-12 text-white/80 hover:text-white"
                     disabled={submitting || loading}
                     aria-label={t('geo.play.shuffleAllGames', 'Random game')}
                     title={t('geo.play.shuffleAllGames', 'Random game')}
@@ -626,7 +676,7 @@ function Dock({
                     variant="ghost"
                     size="icon"
                     onClick={onNext}
-                    className="text-white/80 hover:text-white"
+                    className="h-12 w-12 min-h-12 min-w-12 text-white/80 hover:text-white"
                     disabled={!canGoNext || submitting || loading}
                     aria-label={t('geo.play.nextScreenshot', 'Next screenshot')}
                     title={t('geo.play.nextScreenshot', 'Next screenshot')}
@@ -640,7 +690,7 @@ function Dock({
                     <Button
                         type="button"
                         onClick={onNextRound}
-                        className="gradient-gaming hover:opacity-90 min-h-11 min-w-32"
+                        className="gradient-gaming hover:opacity-90 min-h-12 min-w-32"
                     >
                         {t('geo.play.next', 'Next round')}
                         <ArrowRight className="h-4 w-4 ml-2" aria-hidden />
@@ -650,7 +700,7 @@ function Dock({
                         type="button"
                         onClick={onSubmit}
                         disabled={!canSubmit || submitting}
-                        className="gradient-gaming hover:opacity-90 min-h-11 min-w-32"
+                        className="gradient-gaming hover:opacity-90 min-h-12 min-w-32"
                     >
                         {submitting ? (
                             <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden />
@@ -665,10 +715,3 @@ function Dock({
     )
 }
 
-export default function GeoPlayPage() {
-    return (
-        <PremiumGate feature="geo" alpha>
-            <GeoPlayContent />
-        </PremiumGate>
-    )
-}

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -17,7 +17,17 @@ type Phase =
     | 'submitting'
     | 'revealed'
     | 'error'
+    | 'authRequired'
     | 'exhausted'
+
+// Returns true when the API rejected us because we're not signed in. We
+// look at both the HTTP status and the error code so the UI can show the
+// same login prompt regardless of which auth path the backend hit.
+function isAuthError(err: unknown): boolean {
+    if (!(err instanceof GeoApiError)) return false
+    if (err.status === 401) return true
+    return err.code === 'UNAUTHORIZED' || err.code === 'AUTH_ERROR'
+}
 
 const GAMES_TTL_MS = 5 * 60 * 1000
 // WHERE NOT IN payload cap on the backend. Older plays simply roll off
@@ -156,7 +166,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                     await get().rerollScreenshot()
                 } catch (err) {
                     set({
-                        phase: 'error',
+                        phase: isAuthError(err) ? 'authRequired' : 'error',
                         errorMessage: getApiErrorMessage(err),
                         errorCode: err instanceof GeoApiError ? err.code : null,
                     })
@@ -223,8 +233,11 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                     // dedicated phase so the UI can offer a "reset
                     // history" affordance instead of looking broken.
                     const code = err instanceof GeoApiError ? err.code : null
+                    let phase: Phase = 'error'
+                    if (code === 'ALL_PLAYED') phase = 'exhausted'
+                    else if (isAuthError(err)) phase = 'authRequired'
                     set({
-                        phase: code === 'ALL_PLAYED' ? 'exhausted' : 'error',
+                        phase,
                         errorMessage: getApiErrorMessage(err),
                         errorCode: code,
                     })
@@ -313,6 +326,13 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             },
 
             setPendingGuess(p) {
+                const prev = get().pendingGuess
+                // Skip the set when the click landed on the exact same
+                // normalized point — Leaflet emits redundant clicks
+                // during pinch-zoom on Android and we don't want every
+                // one to trigger a re-render of the map canvas.
+                if (prev && p && prev.x === p.x && prev.y === p.y) return
+                if (!prev && !p) return
                 set({ pendingGuess: p })
             },
 
@@ -352,7 +372,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                     return result
                 } catch (err) {
                     set({
-                        phase: 'error',
+                        phase: isAuthError(err) ? 'authRequired' : 'error',
                         errorMessage: getApiErrorMessage(err),
                         errorCode: err instanceof GeoApiError ? err.code : null,
                     })


### PR DESCRIPTION
## Summary

**Strategic intent.** Geo's product goal is to grow the screenshot ↔ map-coordinate dataset that a future "guess the location" premium mode will be built on. Locking the *contribution* surface behind a paywall worked against that goal. This PR un-gates free-play for everyone and pays down the worst mobile UX problems found in a four-persona review (mobile product designer, frontend engineer, accessibility specialist, first-time-user playtest). The premium hat moves to the future GeoGuessr-style game, not the dataset capture.

## What's in the box

**Un-gate (the headline change)**
- Drops `requirePremium` from `POST /api/geo/free-play/random` and `/free-play/guess`.
- Removes the `<PremiumGate feature="geo" alpha>` wrapper around `GeoPlayPage`.
- Retires the `premiumGate.geo.*` i18n keys in EN + FR.
- Authenticated users who didn't have premium now get the actual game; the change is reversible — `requirePremium` is still available for whatever ships behind the paywall later.

**Mobile-first minimums** (high-impact / low-risk subset of the persona review)
- `ImmersiveLayout`: map-dominant split on phones (`grid-rows-[minmax(38%,1fr)_minmax(45%,1.2fr)]`), side-by-side at md+. `min-h-[100svh]` floor, right safe-area inset for landscape iPhones.
- Dock prev/next/shuffle buttons + game/map pills bumped to ≥44 CSS px (WCAG 2.5.5/2.5.8). Primary CTA grows to `min-h-12`. Game pill expands to `max-w-[12rem]` + solid `bg-black/40` for stable contrast over busy screenshots.
- Leaflet zoom controls enlarged to 44 px in global CSS; map container gets a `focus-visible` ring (WCAG 2.4.7). MapContainer learns `touchZoom`, `zoomSnap`/`zoomDelta=0.5`, `keyboard`. The dropped pin is now `draggable` so players can refine without re-aiming.
- Screenshot `<img>` gets a dynamic alt that names the game and `fetchPriority="high"` for the active capture.
- English game titles inside FR pages are wrapped in `<span lang="en">` (WCAG 3.1.2) on the dock pills and inside the `GamePicker` grid.

**Auth handling on the un-gated surface**
- New `authRequired` phase in `useGeoFreePlayStore` triggered when `/free-play/*` returns 401. The page renders a friendly "Sign in to drop pins" card with localized login + register CTAs, instead of the silent error message the playtest persona bailed on. Triggered in `selectGame`, `rerollScreenshot`, and `submitGuess`.
- `setPendingGuess` now dedups identical points to suppress redundant Leaflet click events on Android pinch-zoom.

## Out of scope (deliberately)

The persona review surfaced larger Phase 2 items (two-step pin with confirm sheet + haptics, dock redesign with full-width CTA on its own row, "I don't know" skip + 3-step confidence chip, real-world-game-first seeding for cold-start sessions, deferred login wall after N anonymous pins, live "X pins today" social-proof counter). Each of those touches the data model, gameplay loop, or session shape and deserves its own PRD. This PR keeps to the minimum viable set so it can be reviewed quickly and reverted cleanly if anything goes sideways.

The remaining a11y blockers (live-region announcement on pin placement, non-tap pin-placement alternative, gradient-CTA contrast, reflow at 320 CSS px / 200% zoom, `prefers-reduced-motion` guard) are tracked for Phase 3.

## Risks

- The endpoints retain `authMiddleware`, so anonymous abuse surface is unchanged — a logged-out user gets 401 like before. Existing per-IP rate limits still apply (60/min pick, 30/min guess).
- Leaflet `tap`/`tapTolerance` were dropped from the diff after typecheck — those props were removed in modern `react-leaflet`. The MapContainer keeps its existing pointer-event handling.
- No migrations, no data changes.

## Test plan

- [x] `npm run build:types && npm run build:backend && npm run build:frontend` — typecheck passes
- [x] `npm run lint`
- [x] `npm test` — 76/76 backend unit tests pass (frontend has no unit tests)
- [ ] Manual: visit `/fr/geo` un-authenticated → expect the "Sign in to drop pins" card (not the upsell)
- [ ] Manual: log in as a free user → free-play is reachable end-to-end (pick game → drop pin → submit)
- [ ] Manual: drop a pin, then drag the marker → submit uses the dragged-to position
- [ ] Manual on a phone: thumb-zone test the dock buttons + the Leaflet `+`/`−` zoom buttons (all ≥44 px)
- [ ] Manual: French screen reader (VoiceOver/TalkBack) reads "The Legend of Zelda" with English phonemes thanks to `lang="en"`

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_