### PR TITLE
feat(geo): two-step pin with haptic confirmation

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1790,6 +1790,7 @@
       "changeGame": "Choose game",
       "changeMap": "Choose map",
       "submit": "Drop pin",
+      "confirm": "Confirm pin",
       "next": "Next round",
       "reroll": "New screenshot",
       "shuffleAllGames": "Random game",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1790,6 +1790,7 @@
       "changeGame": "Changer de jeu",
       "changeMap": "Changer de carte",
       "submit": "Placer l'épingle",
+      "confirm": "Confirmer la position",
       "next": "Suivant",
       "reroll": "Nouvelle capture",
       "shuffleAllGames": "Jeu aléatoire",

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import type { GeoPoint } from '@the-box/types'
 import {
-    ArrowLeft,
     ArrowRight,
+    Check,
     ChevronLeft,
     ChevronRight,
     EyeOff,
@@ -39,6 +40,21 @@ import { cn } from '@/lib/utils'
  * the daily-challenge store, so a free-play round can never write to the
  * leaderboard or pollute the daily resume.
  */
+// Light haptic feedback for the two-step pin flow. Called on the
+// initial pin drop (single tick) and again on submit (longer pulse).
+// `navigator.vibrate` is a no-op on iOS Safari and any browser without
+// the Vibration API — failure is silent and there's nothing to fall
+// back to, so we just guard the call.
+function vibrate(pattern: number | number[]): void {
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+        try {
+            navigator.vibrate(pattern)
+        } catch {
+            /* ignore — Android sometimes throws if the page is hidden */
+        }
+    }
+}
+
 export default function GeoPlayPage() {
     const { i18n } = useTranslation()
     const { localizedPath } = useLocalizedPath()
@@ -147,7 +163,18 @@ export default function GeoPlayPage() {
         !!view &&
         (selectedMap != null || maps.length === 1)
 
+    // Two-step pin: first map tap drops a draft (light tick), then the
+    // dock CTA confirms (longer pulse). Haptics are a no-op on iOS Safari
+    // and any browser without the Vibration API, which is fine — the
+    // visual CTA flip carries the same signal.
+    const handleMapPin = (p: GeoPoint | null) => {
+        const wasEmpty = !pendingGuess
+        setPendingGuess(p)
+        if (p && wasEmpty) vibrate(10)
+    }
+
     const handleSubmit = async () => {
+        vibrate([15, 25, 15])
         await submitGuess()
     }
 
@@ -206,7 +233,7 @@ export default function GeoPlayPage() {
                                     : null
                             }
                             disabled={phase !== 'ready'}
-                            onPin={setPendingGuess}
+                            onPin={handleMapPin}
                             showGuessLine={
                                 phase === 'revealed' &&
                                 !!correctMap &&
@@ -701,13 +728,18 @@ function Dock({
                         onClick={onSubmit}
                         disabled={!canSubmit || submitting}
                         className="gradient-gaming hover:opacity-90 min-h-12 min-w-32"
+                        aria-live="polite"
                     >
                         {submitting ? (
                             <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden />
+                        ) : canSubmit ? (
+                            <Check className="h-4 w-4 mr-2" aria-hidden />
                         ) : (
-                            <ArrowLeft className="h-4 w-4 mr-2 rotate-180" aria-hidden />
+                            <MapPin className="h-4 w-4 mr-2" aria-hidden />
                         )}
-                        {t('geo.play.submit', 'Drop pin')}
+                        {canSubmit
+                            ? t('geo.play.confirm', 'Confirm pin')
+                            : t('geo.play.submit', 'Drop pin')}
                     </Button>
                 )}
             </div>


### PR DESCRIPTION
## Summary

Phase 2 follow-up to the geo persona review. Replaces the single-tap commit on the geo-pin page with a two-step pattern: tap on the map to drop a draft pin, then tap the dock CTA to confirm.

- The CTA now mirrors pin state: **"Drop pin"** with a `MapPin` icon while disabled, flipping to **"Confirm pin"** (`Check` icon) the moment a draft pin exists. Submit only fires on the second tap.
- A light haptic (`10ms`) fires on the first map tap; a stronger pattern (`[15, 25, 15]`) fires on submit. The `vibrate()` helper guards against the API being absent (iOS Safari) and against the rare Android case where calling vibrate on a hidden page throws — failure is silent and the visual CTA flip carries the same signal.
- `aria-live="polite"` on the CTA so AT users hear the label flip when they place a pin.

Why now: every persona in the recent review flagged single-tap-commit as risky on a touch map ("fat-finger" commits pollute the dataset, which is the whole product goal here). Two-step is the cheapest fix that pays for itself in dataset quality.

## Files

- `packages/frontend/src/pages/GeoPlayPage.tsx` — new `vibrate()` helper, `handleMapPin()` wrapping `setPendingGuess`, CTA label/icon switches on `canSubmit`. Drops the unused `ArrowLeft` import; adds `Check` and `GeoPoint`.
- `packages/frontend/public/locales/{en,fr}/translation.json` — adds `geo.play.confirm` next to the existing `geo.play.submit`.

## Out of scope

The persona review flagged drag-to-refine as the natural companion to two-step pin (drop → drag → confirm). That's already part of PR #163; this PR doesn't depend on it but composes nicely with it.

## Test plan

- [x] `npm run build:types && npm run build:frontend` — typecheck passes
- [x] `npm run lint`
- [x] `npm test` — 76/76 backend unit tests pass
- [ ] Manual: tap a map location → CTA label changes from "Drop pin" to "Confirm pin", short vibration on Android
- [ ] Manual: tap the CTA → submit fires with a longer haptic; result overlay appears
- [ ] Manual on iOS Safari: vibrate is a no-op, CTA flip still fires (visual signal)
- [ ] Manual with VoiceOver/TalkBack: label change is announced when a pin is placed

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_