### PR TITLE
refactor(geo): split context header from dock; full-width primary CTA

### DIFF
--- a/packages/frontend/src/components/geo/ImmersiveLayout.tsx
+++ b/packages/frontend/src/components/geo/ImmersiveLayout.tsx
@@ -8,6 +8,11 @@ interface ImmersiveLayoutProps {
     map: ReactNode
     // Top-right overlay (the fullscreen toggle, plus optional report button).
     topRight?: ReactNode
+    // Top header strip rendered above the deck. Used for context
+    // metadata that isn't itself an action — game/map labels, alpha
+    // banner, etc. Sized by its own intrinsic height so passing null
+    // collapses cleanly.
+    topBar?: ReactNode
     // Sticky bottom dock (skip / submit / next).
     bottomDock?: ReactNode
     // Result panel rendered as a non-blocking overlay above the dock.
@@ -30,6 +35,7 @@ export function ImmersiveLayout({
     screenshot,
     map,
     topRight,
+    topBar,
     bottomDock,
     resultOverlay,
     isImmersive,
@@ -56,6 +62,18 @@ export function ImmersiveLayout({
                     }}
                 >
                     {topRight}
+                </div>
+            )}
+
+            {/* Top context bar — game/map labels and any informational
+                copy. Sits above the deck so the dock can stay focused on
+                actions. Collapses to nothing when no children are passed. */}
+            {topBar && (
+                <div
+                    className="z-30 border-b border-white/10 bg-black/70 backdrop-blur"
+                    style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
+                >
+                    <div className="px-3 py-2 pr-16">{topBar}</div>
                 </div>
             )}
 
@@ -94,13 +112,15 @@ export function ImmersiveLayout({
             </div>
 
             {/* Result overlay — sits above the deck but below the dock so
-                the dock's Next button is always reachable. */}
+                the dock's Next button is always reachable. The bottom
+                offset clears the redesigned two-row dock (secondary
+                actions + primary CTA). */}
             {resultOverlay && (
                 <div
                     className="absolute left-0 right-0 z-30 px-3"
                     style={{
                         bottom:
-                            'calc(env(safe-area-inset-bottom, 0px) + 5.5rem)',
+                            'calc(env(safe-area-inset-bottom, 0px) + 7.5rem)',
                     }}
                 >
                     {resultOverlay}

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -260,13 +260,17 @@ export default function GeoPlayPage() {
                         />
                     ) : null
                 }
-                bottomDock={
-                    <Dock
+                topBar={
+                    <ContextHeader
                         gameLabel={currentGame?.name ?? null}
                         mapLabel={selectedMap?.region ?? null}
                         showMapButton={isMultiMap || currentGameId == null}
                         onChangeGame={() => setGamePickerOpen(true)}
                         onChangeMap={() => setMapPickerOpen(true)}
+                    />
+                }
+                bottomDock={
+                    <Dock
                         onShuffleAllGames={() => void pickRandomAcrossGames()}
                         onPrevious={goPrevious}
                         onNext={() => void goNext()}
@@ -606,12 +610,49 @@ function ResultOverlay({
     )
 }
 
-function Dock({
+function ContextHeader({
     gameLabel,
     mapLabel,
     showMapButton,
     onChangeGame,
     onChangeMap,
+}: {
+    gameLabel: string | null
+    mapLabel: string | null
+    showMapButton: boolean
+    onChangeGame: () => void
+    onChangeMap: () => void
+}) {
+    const { t } = useTranslation()
+    return (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-white/80">
+            <button
+                type="button"
+                onClick={onChangeGame}
+                className="inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-black/40 min-h-11 px-3 py-2 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+            >
+                <Gamepad2 className="h-3.5 w-3.5" aria-hidden />
+                <span className="max-w-[14rem] truncate" lang={gameLabel ? 'en' : undefined}>
+                    {gameLabel ?? t('geo.play.changeGame', 'Choose game')}
+                </span>
+            </button>
+            {showMapButton && (
+                <button
+                    type="button"
+                    onClick={onChangeMap}
+                    className="inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-black/40 min-h-11 px-3 py-2 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                >
+                    <MapIcon className="h-3.5 w-3.5" aria-hidden />
+                    <span className="max-w-[14rem] truncate" lang={mapLabel ? 'en' : undefined}>
+                        {mapLabel ?? t('geo.play.changeMap', 'Choose map')}
+                    </span>
+                </button>
+            )}
+        </div>
+    )
+}
+
+function Dock({
     onShuffleAllGames,
     onPrevious,
     onNext,
@@ -622,11 +663,6 @@ function Dock({
     canSubmit,
     phase,
 }: {
-    gameLabel: string | null
-    mapLabel: string | null
-    showMapButton: boolean
-    onChangeGame: () => void
-    onChangeMap: () => void
     onShuffleAllGames: () => void
     onPrevious: () => void
     onNext: () => void
@@ -643,35 +679,9 @@ function Dock({
     const loading = phase === 'loading'
     return (
         <div className="flex flex-col gap-2">
-            {/* Context row — game / map labels with quick-change links.
-                Tappable, so the player never has to leave the immersive
-                view to switch context. */}
-            <div className="flex items-center gap-2 text-xs text-white/80 min-h-[1.5rem]">
-                <button
-                    type="button"
-                    onClick={onChangeGame}
-                    className="inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-black/40 min-h-11 px-3 py-2 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
-                >
-                    <Gamepad2 className="h-3 w-3" aria-hidden />
-                    <span className="max-w-[12rem] truncate" lang={gameLabel ? 'en' : undefined}>
-                        {gameLabel ?? t('geo.play.changeGame', 'Choose game')}
-                    </span>
-                </button>
-                {showMapButton && (
-                    <button
-                        type="button"
-                        onClick={onChangeMap}
-                        className="inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-black/40 min-h-11 px-3 py-2 hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
-                    >
-                        <MapIcon className="h-3 w-3" aria-hidden />
-                        <span className="max-w-[12rem] truncate" lang={mapLabel ? 'en' : undefined}>
-                            {mapLabel ?? t('geo.play.changeMap', 'Choose map')}
-                        </span>
-                    </button>
-                )}
-            </div>
-
-            <div className="flex items-center gap-1.5 sm:gap-2">
+            {/* Secondary row — navigation through history + shuffle. Compact
+                so the primary CTA below it gets full visual weight. */}
+            <div className="flex items-center justify-center gap-1.5">
                 <Button
                     type="button"
                     variant="ghost"
@@ -710,39 +720,40 @@ function Dock({
                 >
                     <ChevronRight className="h-5 w-5" aria-hidden />
                 </Button>
-
-                <div className="flex-1" />
-
-                {revealed ? (
-                    <Button
-                        type="button"
-                        onClick={onNextRound}
-                        className="gradient-gaming hover:opacity-90 min-h-12 min-w-32"
-                    >
-                        {t('geo.play.next', 'Next round')}
-                        <ArrowRight className="h-4 w-4 ml-2" aria-hidden />
-                    </Button>
-                ) : (
-                    <Button
-                        type="button"
-                        onClick={onSubmit}
-                        disabled={!canSubmit || submitting}
-                        className="gradient-gaming hover:opacity-90 min-h-12 min-w-32"
-                        aria-live="polite"
-                    >
-                        {submitting ? (
-                            <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden />
-                        ) : canSubmit ? (
-                            <Check className="h-4 w-4 mr-2" aria-hidden />
-                        ) : (
-                            <MapPin className="h-4 w-4 mr-2" aria-hidden />
-                        )}
-                        {canSubmit
-                            ? t('geo.play.confirm', 'Confirm pin')
-                            : t('geo.play.submit', 'Drop pin')}
-                    </Button>
-                )}
             </div>
+
+            {/* Primary row — single full-width CTA. Fills the thumb-zone on
+                mobile and matches Fitts: bigger target, no neighbours
+                competing for taps. */}
+            {revealed ? (
+                <Button
+                    type="button"
+                    onClick={onNextRound}
+                    className="gradient-gaming hover:opacity-90 min-h-12 w-full"
+                >
+                    {t('geo.play.next', 'Next round')}
+                    <ArrowRight className="h-4 w-4 ml-2" aria-hidden />
+                </Button>
+            ) : (
+                <Button
+                    type="button"
+                    onClick={onSubmit}
+                    disabled={!canSubmit || submitting}
+                    className="gradient-gaming hover:opacity-90 min-h-12 w-full"
+                    aria-live="polite"
+                >
+                    {submitting ? (
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden />
+                    ) : canSubmit ? (
+                        <Check className="h-4 w-4 mr-2" aria-hidden />
+                    ) : (
+                        <MapPin className="h-4 w-4 mr-2" aria-hidden />
+                    )}
+                    {canSubmit
+                        ? t('geo.play.confirm', 'Confirm pin')
+                        : t('geo.play.submit', 'Drop pin')}
+                </Button>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Summary

Phase 2 follow-up. The geo-pin dock previously stacked metadata (game/map pills), navigation (prev/shuffle/next), and the primary CTA in one block — a Fitts and thumb-zone smell every persona in the review flagged. This PR splits the three concerns:

- **Top header bar** — game/map pills move above the deck via a new `topBar` slot on `ImmersiveLayout`. They're metadata, not actions, so they belong in a header, not the action zone. The pills get `max-w-[14rem]` (was 12rem) since they no longer fight the CTA for horizontal space, and they wrap to a second line on narrow phones.
- **Dock — two homogeneous rows.**
  - Top row: prev / shuffle / next, centered, smaller buttons (44–48 px each).
  - Bottom row: **single full-width primary CTA** (`w-full`). Owning its row gives it Fitts-class hit area and removes the "neighbour buttons compete for taps" problem on one-handed mobile use.

## Files

- `packages/frontend/src/components/geo/ImmersiveLayout.tsx` — adds the `topBar?: ReactNode` prop. The bar carries `safe-area-inset-top` plus `pr-16` so it doesn't collide with the top-right fullscreen toggle.
- `packages/frontend/src/pages/GeoPlayPage.tsx` — extracts a new `ContextHeader` component for the pills; trims `Dock` to drop pill props and reorganizes its inner layout. The `resultOverlay` bottom offset moves from `5.5rem` to `7.5rem` to clear the taller two-row dock.

## Out of scope (still tracked from Phase 2)

- "Je ne sais pas" skip + 3-step confidence chip — schema work, deferred to a PRD.
- Real-world-game-first seeding for cold-start sessions — schema work.
- Live "X pins today" social-proof counter — needs Socket.io wiring.
- Photo pinch-zoom + loupe long-press — pure frontend, next candidate after this lands.

## Test plan

- [x] `npm run build:frontend` — typecheck + bundle pass
- [x] `npm run lint`
- [x] `npm test` — 76/76 backend unit tests pass
- [ ] Manual on a phone: game/map pills visible above the screenshot panel, no overlap with the fullscreen toggle on the right
- [ ] Manual: primary CTA spans the full dock width, prev/shuffle/next sit centered above it
- [ ] Manual: open the result overlay (after a guess) — overlay sits above the taller dock without clipping
- [ ] Manual: long game name (e.g. "The Legend of Zelda: Breath of the Wild") truncates inside the pill instead of pushing the layout

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_