### PR TITLE
feat(geo): reframe empty state around the dataset mission

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1804,9 +1804,14 @@
         "label": "Screenshot and map"
       },
       "empty": {
-        "title": "Pick a game to start",
-        "body": "Free play covers every game and every map in the catalog. No daily limits.",
-        "cta": "Browse games"
+        "title": "Help us map the world of video games",
+        "body": "Look at a screenshot, then drop a pin where the scene takes place on the game world map. Every pin grows a shared atlas that powers future location-guessing modes.",
+        "steps": {
+          "one": "Pick a game from your catalog.",
+          "two": "Tap the map where you think the screenshot was taken.",
+          "three": "Confirm — your pin joins the dataset."
+        },
+        "cta": "Pick a game"
       },
       "map": {
         "empty": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1804,9 +1804,14 @@
         "label": "Capture et carte"
       },
       "empty": {
-        "title": "Choisissez un jeu pour commencer",
-        "body": "Le mode libre couvre tous les jeux et toutes les cartes du catalogue. Sans limite quotidienne.",
-        "cta": "Parcourir les jeux"
+        "title": "Aide-nous à cartographier l'univers du jeu vidéo",
+        "body": "Regarde la capture d'écran, puis pose une épingle là où la scène se passe sur la carte du jeu. Chaque épingle enrichit un atlas partagé qui alimentera de futurs modes \"devine le lieu\".",
+        "steps": {
+          "one": "Choisis un jeu dans ton catalogue.",
+          "two": "Tape sur la carte là où tu penses que la capture a été prise.",
+          "three": "Confirme — ton épingle rejoint le dataset."
+        },
+        "cta": "Choisir un jeu"
       },
       "map": {
         "empty": {

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -471,22 +471,36 @@ function ScreenshotPanel({
         return (
             <div className="flex h-full w-full flex-col items-center justify-center px-6 text-center gap-4">
                 <div className="rounded-full bg-neon-pink/10 p-4">
-                    <Gamepad2 className="h-8 w-8 text-neon-pink" aria-hidden />
+                    <MapPin className="h-8 w-8 text-neon-pink" aria-hidden />
                 </div>
-                <div className="space-y-1 max-w-xs">
+                <div className="space-y-2 max-w-md">
                     <h2 className="text-lg font-semibold">
-                        {t('geo.play.empty.title', 'Pick a game to start')}
+                        {t('geo.play.empty.title', 'Help us map the world of video games')}
                     </h2>
                     <p className="text-sm text-muted-foreground">
                         {t(
                             'geo.play.empty.body',
-                            'Free play covers every game and every map in the catalog. No daily limits.',
+                            'Look at a screenshot, then drop a pin where the scene takes place on the game world map. Every pin grows a shared atlas that powers future location-guessing modes.',
                         )}
                     </p>
                 </div>
-                <Button onClick={onPickGame} className="gradient-gaming hover:opacity-90">
+                <ol className="text-left text-xs text-muted-foreground/90 space-y-1.5 max-w-xs">
+                    <li className="flex gap-2">
+                        <span className="font-semibold text-neon-pink">1.</span>
+                        <span>{t('geo.play.empty.steps.one', 'Pick a game from your catalog.')}</span>
+                    </li>
+                    <li className="flex gap-2">
+                        <span className="font-semibold text-neon-pink">2.</span>
+                        <span>{t('geo.play.empty.steps.two', 'Tap the map where you think the screenshot was taken.')}</span>
+                    </li>
+                    <li className="flex gap-2">
+                        <span className="font-semibold text-neon-pink">3.</span>
+                        <span>{t('geo.play.empty.steps.three', 'Confirm — your pin joins the dataset.')}</span>
+                    </li>
+                </ol>
+                <Button onClick={onPickGame} className="gradient-gaming hover:opacity-90 min-h-12">
                     <Gamepad2 className="h-4 w-4 mr-2" aria-hidden />
-                    {t('geo.play.empty.cta', 'Browse games')}
+                    {t('geo.play.empty.cta', 'Pick a game')}
                 </Button>
             </div>
         )


### PR DESCRIPTION
## Summary

Phase 2 follow-up. The free-play empty state used to read *"Free play covers every game and every map in the catalog. No daily limits."* — true but useless. The playtest persona's #1 finding was that a first-time player has no idea what to pin or why. Anonymous visitors already got the dataset framing in the auth-required card (#163); this PR brings the same framing to logged-in users hitting the empty state.

- **Title** leads with the mission: "Help us map the world of video games" / "Aide-nous à cartographier l'univers du jeu vidéo".
- **Body** explains the loop: look at screenshot → drop pin where the scene happens → atlas grows for future location-guessing modes.
- **Compact 3-step ordered list** spells the interaction out so the player isn't guessing which pin shape to drop or what the goal is.
- **Hero icon** switches Gamepad2 → MapPin to match the action; **CTA** tightens to "Pick a game" / "Choisir un jeu" (the previous "Browse games" understated the commitment).

Pure copy + JSX. No backend, no schema, no new deps.

## Files

- `packages/frontend/src/pages/GeoPlayPage.tsx` — empty state JSX rewritten with the mission framing + 3-step explainer.
- `packages/frontend/public/locales/{en,fr}/translation.json` — `geo.play.empty.{title,body,cta}` rewritten; new `geo.play.empty.steps.{one,two,three}` triplet in both locales.

## Test plan

- [x] `npm run build:frontend` — typecheck + bundle pass
- [x] `npm run lint`
- [ ] Manual: log in as a free user, land on `/fr/geo` with no game selected → empty state shows mission headline + 3 steps + "Choisir un jeu" CTA
- [ ] Manual: switch to `/en/geo` → English copy renders correctly
- [ ] Manual on mobile: 3-step list doesn't push the CTA below the fold; layout fits within the screenshot panel

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_