### PR TITLE
feat(geo): add &quot;I don&#39;t know&quot; skip affordance

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1791,6 +1791,7 @@
       "changeMap": "Choose map",
       "submit": "Drop pin",
       "confirm": "Confirm pin",
+      "skip": "I don't know — skip this one",
       "next": "Next round",
       "reroll": "New screenshot",
       "shuffleAllGames": "Random game",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1791,6 +1791,7 @@
       "changeMap": "Changer de carte",
       "submit": "Placer l'épingle",
       "confirm": "Confirmer la position",
+      "skip": "Je ne sais pas — passer celle-ci",
       "next": "Suivant",
       "reroll": "Nouvelle capture",
       "shuffleAllGames": "Jeu aléatoire",

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -280,6 +280,7 @@ export default function GeoPlayPage() {
                         }
                         onSubmit={handleSubmit}
                         onNextRound={() => void nextRound()}
+                        onSkip={() => void rerollScreenshot()}
                         canSubmit={canSubmit}
                         phase={phase}
                     />
@@ -674,6 +675,7 @@ function Dock({
     canGoNext,
     onSubmit,
     onNextRound,
+    onSkip,
     canSubmit,
     phase,
 }: {
@@ -684,6 +686,7 @@ function Dock({
     canGoNext: boolean
     onSubmit: () => void
     onNextRound: () => void
+    onSkip: () => void
     canSubmit: boolean
     phase: ReturnType<typeof useGeoFreePlayStore.getState>['phase']
 }) {
@@ -767,6 +770,23 @@ function Dock({
                         ? t('geo.play.confirm', 'Confirm pin')
                         : t('geo.play.submit', 'Drop pin')}
                 </Button>
+            )}
+
+            {/* Skip affordance — shown only while waiting for a pin (no
+                draft, not yet revealed). A discoverable "I don't know"
+                escape hatch protects dataset quality: a player who'd
+                otherwise drop a random guess can roll forward instead.
+                Hidden once a pin is placed so it doesn't fight the
+                primary "Confirm pin" CTA for attention. */}
+            {!revealed && !canSubmit && (
+                <button
+                    type="button"
+                    onClick={onSkip}
+                    disabled={submitting || loading}
+                    className="self-center text-xs text-white/60 underline-offset-4 hover:text-white hover:underline disabled:opacity-40 min-h-9 px-2"
+                >
+                    {t('geo.play.skip', "I don't know — skip this one")}
+                </button>
             )}
         </div>
     )


### PR DESCRIPTION
## Summary

Phase 2 follow-up. Adds a discoverable "I don't know — skip this one" link below the primary CTA in the geo-pin dock, shown only while waiting for a pin (no draft, not revealed). Without it, the only way forward is to drop a random guess on the map — the persona review specifically called out this dataset-quality risk ("forced guesses pollute data").

The handler delegates to the existing `rerollScreenshot()` action, which already advances to a fresh meta and excludes the previous one via the per-game played list — so a skipped screenshot won't loop back, and the history stack stays consistent.

The link hides itself once a pin is placed so it doesn't compete with the "Confirm pin" CTA for attention.

## Files

- `packages/frontend/src/pages/GeoPlayPage.tsx` — adds `onSkip` prop on the `Dock` component, threads `() => void rerollScreenshot()` from `GeoPlayPage`, renders a small text-button below the primary CTA when `!revealed && !canSubmit`.
- `packages/frontend/public/locales/{en,fr}/translation.json` — new `geo.play.skip` key.

## Out of scope

The persona review also recommended a 3-step **confidence chip** ("Sûr / À peu près / Au pif") to weight pins in consensus. That requires a `pins.confidence` enum + algorithm change and is parked for a PRD.

## Test plan

- [x] `npm run build:frontend` — typecheck + bundle pass
- [x] `npm run lint`
- [ ] Manual: pick a game, see skip link below the disabled "Drop pin" CTA → tap → loads a different screenshot
- [ ] Manual: drop a pin → skip link disappears, "Confirm pin" CTA enables
- [ ] Manual: submit a guess → on the revealed view, skip link is hidden (only the "Next round" CTA shows)

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_