### PR TITLE
feat(geo): live &quot;pins today&quot; counter on the empty state

### DIFF
--- a/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
@@ -102,6 +102,22 @@ export const geoPinRepository = {
     return Number(result?.count ?? 0)
   },
 
+  // Total pins submitted today (UTC). Cheap aggregate read used by the
+  // public "X épingles posées aujourd'hui" social-proof counter on the
+  // empty/first-run state. Counts every submission regardless of status
+  // — a contribution is a contribution, accepted or not.
+  async countSinceUtcMidnight(): Promise<number> {
+    const result = await db('geo_pin_submission')
+      .where(
+        'created_at',
+        '>=',
+        db.raw(`date_trunc('day', NOW() AT TIME ZONE 'UTC')`),
+      )
+      .count<{ count: string }[]>('id as count')
+      .first()
+    return Number(result?.count ?? 0)
+  },
+
   async userRejectionRatio7d(userId: string): Promise<{ submitted: number; rejected: number }> {
     // 7 days = 604800 seconds, expressed as a bound parameter for the same
     // reason as countByUserInWindow.

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -284,6 +284,25 @@ router.get(
   },
 )
 
+// Public dataset social-proof counter: total pins submitted today
+// (UTC). Surfaced on the empty/first-run state so a cold visitor
+// immediately sees they're joining an active community. Cached for
+// 30 s so a paged hit doesn't translate to a per-request COUNT(*).
+router.get(
+  '/stats/today',
+  optionalAuthMiddleware,
+  freePlayCatalogLimiter,
+  async (_req, res, next) => {
+    try {
+      const totalPinsToday = await geoPinRepository.countSinceUtcMidnight()
+      res.set('Cache-Control', 'public, max-age=30')
+      res.json({ success: true, data: { totalPinsToday } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
 router.get(
   '/games/:gameId/maps',
   optionalAuthMiddleware,

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1812,6 +1812,8 @@
           "two": "Tap the map where you think the screenshot was taken.",
           "three": "Confirm — your pin joins the dataset."
         },
+        "pinsToday_one": "{{formatted}} pin dropped today by the community",
+        "pinsToday_other": "{{formatted}} pins dropped today by the community",
         "cta": "Pick a game"
       },
       "map": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1812,6 +1812,8 @@
           "two": "Tape sur la carte là où tu penses que la capture a été prise.",
           "three": "Confirme — ton épingle rejoint le dataset."
         },
+        "pinsToday_one": "{{formatted}} épingle posée aujourd'hui par la communauté",
+        "pinsToday_other": "{{formatted}} épingles posées aujourd'hui par la communauté",
         "cta": "Choisir un jeu"
       },
       "map": {

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -8,6 +8,7 @@ import type {
     GeoPlayableGame,
     GeoPoint,
     GeoScreenshotCandidate,
+    GeoTodayStats,
 } from '@the-box/types'
 
 export class GeoApiError extends Error {
@@ -95,6 +96,10 @@ export const geoApi = {
 
     listGameMaps(gameId: number): Promise<GeoMap[]> {
         return request<GeoMap[]>(`/api/geo/games/${gameId}/maps`)
+    },
+
+    getTodayStats(): Promise<GeoTodayStats> {
+        return request<GeoTodayStats>('/api/geo/stats/today')
     },
 
     pickFreePlay(input: {

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/components/ui/button'
 import { useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useFullscreen } from '@/hooks/useFullscreen'
+import { geoApi } from '@/lib/api/geo'
 import { GamePicker } from '@/components/geo/GamePicker'
 import { MapPicker } from '@/components/geo/MapPicker'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
@@ -92,6 +93,10 @@ export default function GeoPlayPage() {
 
     const [gamePickerOpen, setGamePickerOpen] = useState(false)
     const [mapPickerOpen, setMapPickerOpen] = useState(false)
+    // Cold-start social proof: count of pins submitted today (UTC).
+    // One-shot fetch on mount; null until it lands so the empty state
+    // doesn't flash a misleading "0 pins today" placeholder.
+    const [pinsToday, setPinsToday] = useState<number | null>(null)
 
     // Fullscreen target: the entire immersive deck. Putting the wrapper
     // ref on the outer container means the screenshot, map, dock and
@@ -104,6 +109,23 @@ export default function GeoPlayPage() {
     useEffect(() => {
         loadGames()
     }, [loadGames])
+
+    // Boot: pull the dataset social-proof counter. Failure is silent —
+    // the empty state degrades gracefully when this number is null.
+    useEffect(() => {
+        let cancelled = false
+        geoApi
+            .getTodayStats()
+            .then((stats) => {
+                if (!cancelled) setPinsToday(stats.totalPinsToday)
+            })
+            .catch(() => {
+                /* ignore — counter is decorative, not blocking */
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [])
 
     useEffect(() => {
         if (currentGameId != null && !view && phase === 'idle') {
@@ -201,6 +223,8 @@ export default function GeoPlayPage() {
                         authRequired={phase === 'authRequired'}
                         loginHref={localizedPath('/login')}
                         registerHref={localizedPath('/register')}
+                        pinsToday={pinsToday}
+                        language={i18n.language}
                         canIgnoreCurrent={
                             phase === 'exhausted' &&
                             currentGameId != null &&
@@ -322,6 +346,8 @@ function ScreenshotPanel({
     authRequired,
     loginHref,
     registerHref,
+    pinsToday,
+    language,
     canIgnoreCurrent,
     errorMessage,
     onPickGame,
@@ -337,6 +363,8 @@ function ScreenshotPanel({
     authRequired: boolean
     loginHref: string
     registerHref: string
+    pinsToday: number | null
+    language: string
     canIgnoreCurrent: boolean
     errorMessage: string | null
     onPickGame: () => void
@@ -485,6 +513,23 @@ function ScreenshotPanel({
                         )}
                     </p>
                 </div>
+                {/* Cold-start social proof: only render once we have a
+                    real number from the server, and only when there's
+                    actually been activity today (>0). A "0 pins today"
+                    chip would do the opposite of social proof. */}
+                {pinsToday != null && pinsToday > 0 && (
+                    <p
+                        className="inline-flex items-center gap-1.5 rounded-full bg-neon-pink/10 px-3 py-1 text-xs text-white/90"
+                        aria-live="polite"
+                    >
+                        <Sparkles className="h-3 w-3 text-neon-pink" aria-hidden />
+                        {t('geo.play.empty.pinsToday', {
+                            defaultValue: '{{count}} pins dropped today by the community',
+                            count: pinsToday,
+                            formatted: pinsToday.toLocaleString(language),
+                        })}
+                    </p>
+                )}
                 <ol className="text-left text-xs text-muted-foreground/90 space-y-1.5 max-w-xs">
                     <li className="flex gap-2">
                         <span className="font-semibold text-neon-pink">1.</span>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1130,6 +1130,13 @@ export interface GeoPlayableGame {
   screenshotCount: number
 }
 
+// Public dataset social-proof counter — total pins submitted since UTC
+// midnight. Surfaced on the empty/first-run state so a cold visitor
+// immediately sees they're joining an active community.
+export interface GeoTodayStats {
+  totalPinsToday: number
+}
+
 // View returned by `POST /api/geo/free-play/random`. Mirrors the daily
 // challenge view minus the challenge wrapper — there is no challenge id
 // because nothing is persisted server-side.


### PR DESCRIPTION
## Summary

Phase 2 follow-up. Cold-start social proof: renders a small "X épingles posées aujourd'hui par la communauté" pill below the 3-step explainer in the geo empty state. The persona review specifically called this out — a first-time visitor needs to see they're joining an active community.

The pill only renders once the count comes back **> 0** — a "0 pins today" chip would do the opposite of social proof.

## Backend

- `packages/backend/src/infrastructure/repositories/geo-pin.repository.ts` — new `countSinceUtcMidnight()`. Bound `date_trunc('day', NOW() AT TIME ZONE 'UTC')` so no string interpolation, plan stays honest. Counts every submission regardless of status (a contribution is a contribution, accepted or not).
- `packages/backend/src/presentation/routes/geo.routes.ts` — new `GET /api/geo/stats/today`. `optionalAuth` so anonymous visitors see it, behind the existing 120/min catalog limiter, `Cache-Control: public, max-age=30` so paged hits don't translate to per-request COUNT(*).

## Frontend

- `packages/types/src/index.ts` — new `GeoTodayStats { totalPinsToday: number }`.
- `packages/frontend/src/lib/api/geo.ts` — `geoApi.getTodayStats()` wrapper.
- `packages/frontend/src/pages/GeoPlayPage.tsx` — one-shot fetch on mount with cancellation in the cleanup; failure is silent because the counter is decorative, not blocking. Pill renders inside `ScreenshotPanel`'s empty branch with i18n-pluralized copy and a locale-formatted number.
- `packages/frontend/public/locales/{en,fr}/translation.json` — `geo.play.empty.pinsToday_{one,other}` keys with `{{formatted}}` interpolation.

## Test plan

- [x] `npm run build:types && npm run build:backend && npm run build:frontend` — typecheck passes
- [x] `npm run lint`
- [ ] Manual: visit `/fr/geo` with no game selected → counter pill appears below the 3-step explainer when there's been activity today
- [ ] Manual: counter is hidden if `totalPinsToday === 0` (no false social proof)
- [ ] Manual: number formatted per locale (`1 234` in fr-FR, `1,234` in en-US)
- [ ] Manual: backend `curl -i /api/geo/stats/today` → 200 with `Cache-Control: public, max-age=30`

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_