### PR TITLE
feat(pwa): add iOS Safari install hint

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2001,6 +2001,13 @@
     "updateAvailable": "A new version is available",
     "refresh": "Refresh",
     "offlineReady": "Ready to work offline",
-    "offlineBanner": "You are offline — some features are unavailable"
+    "offlineBanner": "You are offline — some features are unavailable",
+    "iosInstall": {
+      "title": "Install The Box on your home screen",
+      "tap": "Tap",
+      "then": "then",
+      "addToHome": "Add to Home Screen",
+      "dismiss": "Dismiss"
+    }
   }
 }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2001,6 +2001,13 @@
     "updateAvailable": "Une nouvelle version est disponible",
     "refresh": "Actualiser",
     "offlineReady": "Prêt à fonctionner hors ligne",
-    "offlineBanner": "Vous êtes hors ligne — certaines fonctionnalités sont indisponibles"
+    "offlineBanner": "Vous êtes hors ligne — certaines fonctionnalités sont indisponibles",
+    "iosInstall": {
+      "title": "Installez The Box sur votre écran d'accueil",
+      "tap": "Touchez",
+      "then": "puis",
+      "addToHome": "Ajouter à l'écran d'accueil",
+      "dismiss": "Fermer"
+    }
   }
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { Toaster } from '@/components/ui/sonner'
 import { ErrorBoundary, LazyComponentErrorBoundary } from '@/components/ErrorBoundary'
-import { PWAUpdatePrompt, OfflineIndicator } from '@/components/pwa'
+import { PWAUpdatePrompt, OfflineIndicator, IOSInstallHint } from '@/components/pwa'
 import { DailyRewardModal } from '@/components/daily-login'
 import { useDailyLoginStore } from '@/stores/dailyLoginStore'
 import { useSession } from '@/lib/auth-client'
@@ -181,9 +181,10 @@ function App() {
       {/* Global toast notifications (sonner) */}
       <Toaster />
 
-      {/* PWA: offline banner + service-worker update toast */}
+      {/* PWA: offline banner + service-worker update toast + iOS Safari install hint */}
       <OfflineIndicator />
       <PWAUpdatePrompt />
+      <IOSInstallHint />
     </ErrorBoundary>
   )
 }

--- a/packages/frontend/src/components/pwa/IOSInstallHint.tsx
+++ b/packages/frontend/src/components/pwa/IOSInstallHint.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Share, X, Plus } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const DISMISS_KEY = 'pwa:ios-hint-dismissed-at'
+const DISMISS_TTL_MS = 1000 * 60 * 60 * 24 * 30
+const SHOW_DELAY_MS = 3000
+
+function shouldShowHint(): boolean {
+  if (typeof window === 'undefined') return false
+  const ua = navigator.userAgent
+  const isIOS =
+    /iPad|iPhone|iPod/.test(ua) ||
+    (ua.includes('Mac') && 'ontouchend' in document)
+  if (!isIOS) return false
+
+  // Only Safari on iOS can install a PWA; Chrome/Firefox-on-iOS just bookmark.
+  const isSafari = /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS/.test(ua)
+  if (!isSafari) return false
+
+  const isStandalone =
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (navigator as { standalone?: boolean }).standalone === true
+  if (isStandalone) return false
+
+  const dismissedAt = Number(localStorage.getItem(DISMISS_KEY) || 0)
+  if (dismissedAt && Date.now() - dismissedAt < DISMISS_TTL_MS) return false
+
+  return true
+}
+
+export function IOSInstallHint() {
+  const { t } = useTranslation()
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!shouldShowHint()) return
+    const id = window.setTimeout(() => setVisible(true), SHOW_DELAY_MS)
+    return () => window.clearTimeout(id)
+  }, [])
+
+  if (!visible) return null
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, String(Date.now()))
+    } catch {
+      // localStorage unavailable (private mode) — accept the loss; user can dismiss again next visit.
+    }
+    setVisible(false)
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-labelledby="ios-install-title"
+      className={cn(
+        'fixed inset-x-3 bottom-3 z-50 rounded-xl border bg-card/95 shadow-lg backdrop-blur',
+        'border-border p-4 flex gap-3 items-start',
+      )}
+    >
+      <div className="flex-1 min-w-0">
+        <p id="ios-install-title" className="text-sm font-semibold text-foreground">
+          {t('pwa.iosInstall.title')}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground flex items-center gap-1 flex-wrap">
+          {t('pwa.iosInstall.tap')}{' '}
+          <Share className="h-3.5 w-3.5 text-primary inline-block" aria-hidden="true" />{' '}
+          {t('pwa.iosInstall.then')}{' '}
+          <Plus className="h-3.5 w-3.5 text-primary inline-block" aria-hidden="true" />{' '}
+          {t('pwa.iosInstall.addToHome')}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label={t('pwa.iosInstall.dismiss')}
+        className="text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/packages/frontend/src/components/pwa/index.ts
+++ b/packages/frontend/src/components/pwa/index.ts
@@ -1,3 +1,4 @@
 export { PWAUpdatePrompt } from './PWAUpdatePrompt'
 export { OfflineIndicator } from './OfflineIndicator'
 export { InstallPromptButton } from './InstallPromptButton'
+export { IOSInstallHint } from './IOSInstallHint'


### PR DESCRIPTION
## Summary

Closes the iOS gap from the PWA v1 planning meeting: iOS Safari doesn't fire `beforeinstallprompt`, so the existing install button never surfaces for iPhone/iPad users. This adds a small, one-time dismissible bottom card (appears ~3s after load) that walks them through Share → Add to Home Screen with inline icons.

- Detects iOS Safari only (gates out Chrome/Firefox-on-iOS where the share sheet only bookmarks)
- Hides automatically when the app is already running standalone (`display-mode: standalone` or legacy `navigator.standalone`)
- Dismissal persists for 30 days in localStorage; falls back gracefully in private mode

## Test plan

- [x] `npm run build:frontend` — green, precaches 100 entries
- [x] `npm run lint` — clean
- [ ] Smoke test on iPhone Safari: hint appears 3s after load, dismiss persists
- [ ] Smoke test on iPhone Chrome: hint does NOT appear (gated on Safari UA)
- [ ] Smoke test on installed iOS PWA: hint does NOT appear (standalone check)
- [ ] Smoke test on Android Chrome / desktop: hint does NOT appear (iOS UA check)

https://claude.ai/code/session_01KhncPgueKaZeVeNChcASNa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhncPgueKaZeVeNChcASNa)_