### PR TITLE
fix(geo): a11y must-fixes — pin announcement, tile-missing contrast

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1791,6 +1791,7 @@
       "changeMap": "Choose map",
       "submit": "Drop pin",
       "confirm": "Confirm pin",
+      "pinPlacedAria": "Pin placed at {{x}}%, {{y}}%",
       "skip": "I don't know — skip this one",
       "next": "Next round",
       "reroll": "New screenshot",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1791,6 +1791,7 @@
       "changeMap": "Changer de carte",
       "submit": "Placer l'épingle",
       "confirm": "Confirmer la position",
+      "pinPlacedAria": "Épingle posée à {{x}} %, {{y}} %",
       "skip": "Je ne sais pas — passer celle-ci",
       "next": "Suivant",
       "reroll": "Nouvelle capture",

--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -205,7 +205,11 @@ function TilePyramidLayer({
             errorTileUrl:
                 'data:image/svg+xml;utf8,' +
                 encodeURIComponent(
-                    '<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"><rect width="256" height="256" fill="%23111" /><text x="50%" y="50%" fill="%23555" font-family="sans-serif" font-size="14" text-anchor="middle" dominant-baseline="central">tile missing</text></svg>',
+                    // Text contrast bumped from #555 (~3:1 on #111) to
+                    // #999 (~7:1) to clear WCAG 1.4.11 for informational
+                    // text. The label is sub-fold rare, but readable
+                    // when it does appear.
+                    '<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"><rect width="256" height="256" fill="%23111" /><text x="50%" y="50%" fill="%23999" font-family="sans-serif" font-size="14" text-anchor="middle" dominant-baseline="central">tile missing</text></svg>',
                 ),
         })
         layer.addTo(map)

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -57,7 +57,7 @@ function vibrate(pattern: number | number[]): void {
 }
 
 export default function GeoPlayPage() {
-    const { i18n } = useTranslation()
+    const { t, i18n } = useTranslation()
     const { localizedPath } = useLocalizedPath()
 
     const {
@@ -97,6 +97,13 @@ export default function GeoPlayPage() {
     // One-shot fetch on mount; null until it lands so the empty state
     // doesn't flash a misleading "0 pins today" placeholder.
     const [pinsToday, setPinsToday] = useState<number | null>(null)
+    // Screen-reader announcement for the placed pin. The CTA's
+    // aria-live carries the action signal ("Drop pin" → "Confirm
+    // pin"); this carries the spatial signal ("placed at 42 %, 67 %")
+    // so an AT user knows roughly where their pin landed without
+    // sighted feedback. Mirrors what the persona a11y review asked
+    // for under WCAG 2.4.6 / 4.1.3.
+    const [pinAnnouncement, setPinAnnouncement] = useState('')
 
     // Fullscreen target: the entire immersive deck. Putting the wrapper
     // ref on the outer container means the screenshot, map, dock and
@@ -132,6 +139,25 @@ export default function GeoPlayPage() {
             void rerollScreenshot()
         }
     }, [currentGameId, view, phase, rerollScreenshot])
+
+    // Announce the placed pin to screen readers. Coordinates are
+    // rounded to whole percent so the message stays terse — anything
+    // finer is noise once verbalized. Cleared when the pin is removed
+    // (e.g. after a round resets) so the live region doesn't replay
+    // the last announcement on phase changes.
+    useEffect(() => {
+        if (!pendingGuess) {
+            setPinAnnouncement('')
+            return
+        }
+        setPinAnnouncement(
+            t('geo.play.pinPlacedAria', {
+                defaultValue: 'Pin placed at {{x}}%, {{y}}%',
+                x: Math.round(pendingGuess.x * 100),
+                y: Math.round(pendingGuess.y * 100),
+            }),
+        )
+    }, [pendingGuess, t])
 
     // Open the game picker for a fresh visitor with no selection — gives
     // them an obvious "what do I do here" cue instead of a blank canvas.
@@ -202,6 +228,12 @@ export default function GeoPlayPage() {
 
     return (
         <div ref={rootRef} className="bg-black">
+            {/* Visually hidden live region for the pin-placement
+                announcement. Lives at the top of the page so AT
+                cursors don't have to scrub down to find the result. */}
+            <div role="status" aria-live="polite" className="sr-only">
+                {pinAnnouncement}
+            </div>
             <ImmersiveLayout
                 isImmersive={fullscreen.isImmersive}
                 roundKey={`${currentGameId ?? 'none'}-${round}`}


### PR DESCRIPTION
## Summary

Two items from the persona a11y review's "must fix before launch" list, plus two audited as already passing.

### Live-region announcement on pin placement (WCAG 2.4.6 / 4.1.3)

A visually-hidden `role="status" aria-live="polite"` region at the top of the geo page announces *"Pin placed at X%, Y%"* / *"Épingle posée à X %, Y %"* when a pin is dropped. Coordinates are rounded to whole percent — anything finer is noise once verbalized. The region clears when the pin is removed so it doesn't replay the last announcement on phase changes.

The CTA already has `aria-live="polite"` on its label change (`Drop pin` → `Confirm pin`), which carries the *action* signal. This new region carries the *spatial* signal so an AT user knows roughly where their pin landed without sighted feedback.

### Tile-missing text contrast (WCAG 1.4.11)

Bumped the SVG text fill in the Leaflet tile fallback from `#555` (~3:1 on `#111`) to `#999` (~7:1). Rare placeholder, but readable when it appears.

### Audited along the way (no change needed)

- **Viewport meta (1.4.4)**: `index.html` declares `viewport-fit=cover, interactive-widget=resizes-content` with no `user-scalable=no` and no `maximum-scale=1` — pinch-zoom is allowed, **passes**.
- **Reduced motion (2.3.3)**: `index.css` already includes a global `@media (prefers-reduced-motion: reduce)` block that neutralizes animation duration — **passes**.

## Files

- `packages/frontend/src/pages/GeoPlayPage.tsx` — new state + effect that announces pin coordinates; new `<div role="status" aria-live="polite" className="sr-only">` at the top of the page.
- `packages/frontend/src/components/geo/MapCanvasLeaflet.tsx` — bump SVG text fill `#555` → `#999`.
- `packages/frontend/public/locales/{en,fr}/translation.json` — new `geo.play.pinPlacedAria` key with `{{x}}` / `{{y}}` interpolation.

## Test plan

- [x] `npm run build:frontend` — typecheck + bundle pass
- [x] `npm run lint`
- [x] `npm test` — 76/76 backend unit tests pass
- [ ] Manual with VoiceOver/TalkBack: drop a pin → screen reader announces "Pin placed at 42%, 67%"
- [ ] Manual: drag the pin → announcement updates with new coords
- [ ] Manual: trigger a tile-missing fallback (block tile fetches) → "tile missing" text is readable

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_