### PR TITLE
feat(geo): coordinate input as a non-tap pin-placement alternative

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1793,6 +1793,14 @@
       "confirm": "Confirm pin",
       "pinPlacedAria": "Pin placed at {{x}}%, {{y}}%",
       "skip": "I don't know — skip this one",
+      "coords": {
+        "toggle": "Place pin by coordinates",
+        "formLabel": "Place a pin using x/y coordinates",
+        "x": "X (%)",
+        "y": "Y (%)",
+        "place": "Place pin",
+        "hint": "0% is the top-left corner of the map, 100% is the bottom-right."
+      },
       "next": "Next round",
       "reroll": "New screenshot",
       "shuffleAllGames": "Random game",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1793,6 +1793,14 @@
       "confirm": "Confirmer la position",
       "pinPlacedAria": "Épingle posée à {{x}} %, {{y}} %",
       "skip": "Je ne sais pas — passer celle-ci",
+      "coords": {
+        "toggle": "Placer l'épingle par coordonnées",
+        "formLabel": "Placer une épingle avec des coordonnées x/y",
+        "x": "X (%)",
+        "y": "Y (%)",
+        "place": "Placer l'épingle",
+        "hint": "0 % correspond au coin haut-gauche de la carte, 100 % au coin bas-droit."
+      },
       "next": "Suivant",
       "reroll": "Nouvelle capture",
       "shuffleAllGames": "Jeu aléatoire",

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { GeoPoint } from '@the-box/types'
 import {
@@ -337,6 +337,7 @@ export default function GeoPlayPage() {
                         onSubmit={handleSubmit}
                         onNextRound={() => void nextRound()}
                         onSkip={() => void rerollScreenshot()}
+                        onPlaceByCoords={handleMapPin}
                         canSubmit={canSubmit}
                         phase={phase}
                     />
@@ -753,6 +754,7 @@ function Dock({
     onSubmit,
     onNextRound,
     onSkip,
+    onPlaceByCoords,
     canSubmit,
     phase,
 }: {
@@ -764,6 +766,7 @@ function Dock({
     onSubmit: () => void
     onNextRound: () => void
     onSkip: () => void
+    onPlaceByCoords: (point: GeoPoint) => void
     canSubmit: boolean
     phase: ReturnType<typeof useGeoFreePlayStore.getState>['phase']
 }) {
@@ -865,7 +868,105 @@ function Dock({
                     {t('geo.play.skip', "I don't know — skip this one")}
                 </button>
             )}
+
+            {/* Non-tap pin-placement alternative for keyboard, switch
+                control and screen-reader users — Leaflet's keyboard
+                pan doesn't synthesize a click on Enter, so without
+                this they can't drop a pin at all. Native <details>
+                gives full keyboard support out of the box and stays
+                collapsed for sighted/touch users so it doesn't add
+                visual noise. WCAG 2.1.1 (Keyboard). */}
+            {!revealed && !canSubmit && (
+                <CoordinateInput
+                    onPlace={onPlaceByCoords}
+                    disabled={submitting || loading}
+                />
+            )}
         </div>
+    )
+}
+
+function CoordinateInput({
+    onPlace,
+    disabled,
+}: {
+    onPlace: (point: GeoPoint) => void
+    disabled: boolean
+}) {
+    const { t } = useTranslation()
+    const [x, setX] = useState('')
+    const [y, setY] = useState('')
+
+    const submit = (e: FormEvent) => {
+        e.preventDefault()
+        const xNum = Number.parseFloat(x)
+        const yNum = Number.parseFloat(y)
+        if (!Number.isFinite(xNum) || !Number.isFinite(yNum)) return
+        // Inputs are 0-100 percent; clamp + normalize to the [0..1]
+        // space the rest of the pipeline uses.
+        const clamp = (n: number) => Math.min(100, Math.max(0, n)) / 100
+        onPlace({ x: clamp(xNum), y: clamp(yNum) })
+    }
+
+    return (
+        <details className="self-center text-xs text-white/60">
+            <summary className="cursor-pointer underline-offset-4 hover:text-white hover:underline min-h-9 inline-flex items-center px-2">
+                {t('geo.play.coords.toggle', 'Place pin by coordinates')}
+            </summary>
+            <form
+                onSubmit={submit}
+                className="mt-2 flex flex-wrap items-end justify-center gap-2"
+                aria-label={t(
+                    'geo.play.coords.formLabel',
+                    'Place a pin using x/y coordinates',
+                )}
+            >
+                <label className="flex flex-col items-start gap-1 text-white/80">
+                    <span>{t('geo.play.coords.x', 'X (%)')}</span>
+                    <input
+                        type="number"
+                        inputMode="numeric"
+                        min={0}
+                        max={100}
+                        step={1}
+                        value={x}
+                        onChange={(e) => setX(e.target.value)}
+                        disabled={disabled}
+                        required
+                        className="w-20 rounded border border-white/20 bg-black/40 px-2 py-2 text-center text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                    />
+                </label>
+                <label className="flex flex-col items-start gap-1 text-white/80">
+                    <span>{t('geo.play.coords.y', 'Y (%)')}</span>
+                    <input
+                        type="number"
+                        inputMode="numeric"
+                        min={0}
+                        max={100}
+                        step={1}
+                        value={y}
+                        onChange={(e) => setY(e.target.value)}
+                        disabled={disabled}
+                        required
+                        className="w-20 rounded border border-white/20 bg-black/40 px-2 py-2 text-center text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                    />
+                </label>
+                <Button
+                    type="submit"
+                    variant="outline"
+                    className="min-h-11"
+                    disabled={disabled || x === '' || y === ''}
+                >
+                    {t('geo.play.coords.place', 'Place pin')}
+                </Button>
+            </form>
+            <p className="mt-1 text-[11px] text-white/50 max-w-xs mx-auto text-center">
+                {t(
+                    'geo.play.coords.hint',
+                    '0% is the top-left corner of the map, 100% is the bottom-right.',
+                )}
+            </p>
+        </details>
     )
 }
 


### PR DESCRIPTION
## Summary

The persona a11y review's last must-fix. Without this, keyboard, switch-control, and screen-reader users **can't drop a pin at all** — Leaflet's keyboard pan doesn't synthesize a click on Enter, and the existing `geo.map.ariaPin` translation already *promised* an alternative path. This PR ships it.

A native `<details>` disclosure below the dock CTA renders the trigger "Place pin by coordinates" / "Placer l'épingle par coordonnées". When expanded, two number inputs (X %, Y %) and a "Place pin" button drop a pin at the typed location. Inputs are clamped to `[0..100]` and normalized to the same `[0..1]` space the rest of the pipeline uses, then routed through the existing `handleMapPin` handler — so the placed pin gets the same haptics, aria-live announcement, and two-step confirm-step flow as a tap-placed pin.

Visible only while waiting for a pin (`!revealed && !canSubmit`) so it doesn't add noise once the player has committed. Sighted touch users see only a small underlined trigger; the inputs stay collapsed.

WCAG 2.1.1 (Keyboard).

## Files

- `packages/frontend/src/pages/GeoPlayPage.tsx` — adds `onPlaceByCoords` prop on `Dock`; new `CoordinateInput` component using native `<details>` + `<form>` + clamped/normalized submit.
- `packages/frontend/public/locales/{en,fr}/translation.json` — new `geo.play.coords.{toggle,formLabel,x,y,place,hint}` block.

## Why native `<details>` (not Radix)

Native `<details>` gives full keyboard support out of the box (Space/Enter to toggle, Tab to traverse), is announced correctly by every screen reader, and adds zero JS. The persona a11y review specifically asked for "numeric inputs or a coordinate grid" — number inputs are the lower-friction path, and the form's submit handler clamps the values so the rest of the pipeline can stay pure.

## Test plan

- [x] `npm run build:frontend` — typecheck + bundle pass
- [x] `npm run lint`
- [ ] Manual keyboard-only: Tab to "Place pin by coordinates" → Enter expands → Tab through X/Y inputs → type values → Enter submits → pin lands → "Confirm pin" CTA flips
- [ ] Manual VoiceOver/TalkBack: form labels and hint are announced; pin-placement live region announces the resulting coordinates
- [ ] Manual: type 50 / 50 → pin lands at the centre of the map
- [ ] Manual: type 200 → input clamps to 100 on submit, pin lands at the right edge

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_