### PR TITLE
feat(geo): self-reported confidence on contribution pins

### DIFF
--- a/packages/backend/migrations/20260508_geo_pin_confidence.ts
+++ b/packages/backend/migrations/20260508_geo_pin_confidence.ts
@@ -1,0 +1,42 @@
+import type { Knex } from 'knex'
+
+// Adds `confidence` to geo_pin_submission so contributors can flag
+// how sure they are when they drop a pin (1=sure, 2=approx, 3=guess).
+// Captured for both contribution pins and free-play guesses.
+//
+// The column is nullable because:
+//   1. Existing rows have no confidence to backfill (we can't infer
+//      it without the player), so they should explicitly read as
+//      "unspecified".
+//   2. The UI keeps confidence optional — submitting without picking
+//      a chip is allowed and treated as "sure" by the future
+//      consensus weighter (defined in a follow-up; this migration
+//      only adds storage).
+//
+// CHECK constraint enforces the {1,2,3} range so no rogue value can
+// land via a future bug or a hand-rolled INSERT.
+
+export async function up(knex: Knex): Promise<void> {
+  const exists = await knex.schema.hasColumn('geo_pin_submission', 'confidence')
+  if (exists) return
+  await knex.schema.alterTable('geo_pin_submission', (t) => {
+    t.smallint('confidence').nullable()
+  })
+  await knex.raw(
+    `ALTER TABLE geo_pin_submission
+       ADD CONSTRAINT geo_pin_submission_confidence_range
+       CHECK (confidence IS NULL OR confidence BETWEEN 1 AND 3)`,
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(
+    `ALTER TABLE geo_pin_submission
+       DROP CONSTRAINT IF EXISTS geo_pin_submission_confidence_range`,
+  )
+  const exists = await knex.schema.hasColumn('geo_pin_submission', 'confidence')
+  if (!exists) return
+  await knex.schema.alterTable('geo_pin_submission', (t) => {
+    t.dropColumn('confidence')
+  })
+}

--- a/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
@@ -1,6 +1,11 @@
 import { db } from '../database/connection.js'
 import { repoLogger } from '../logger/logger.js'
-import type { GeoPinStatus, GeoPinSubmission, GeoPoint } from '@the-box/types'
+import type {
+  GeoPinConfidence,
+  GeoPinStatus,
+  GeoPinSubmission,
+  GeoPoint,
+} from '@the-box/types'
 
 const log = repoLogger.child({ repository: 'geo-pin' })
 
@@ -11,18 +16,26 @@ export interface GeoPinSubmissionRow {
   x: number
   y: number
   status: GeoPinStatus
+  confidence: number | null
   distance_from_centroid: number | null
   reviewed_at: Date | null
   created_at: Date
 }
 
 function mapPin(row: GeoPinSubmissionRow): GeoPinSubmission {
+  // CHECK constraint already restricts confidence to {1,2,3}; the cast
+  // is just to match the narrowed wire type without re-validating.
+  const confidence =
+    row.confidence === 1 || row.confidence === 2 || row.confidence === 3
+      ? (row.confidence as GeoPinConfidence)
+      : undefined
   return {
     id: row.id,
     userId: row.user_id,
     geoScreenshotCandidateId: row.geo_screenshot_candidate_id,
     pin: { x: row.x, y: row.y },
     status: row.status,
+    confidence,
     distanceFromCentroid: row.distance_from_centroid ?? undefined,
     reviewedAt: row.reviewed_at?.toISOString(),
     createdAt: row.created_at.toISOString(),
@@ -34,6 +47,7 @@ export const geoPinRepository = {
     userId: string
     geoScreenshotCandidateId: number
     pin: GeoPoint
+    confidence?: GeoPinConfidence
   }): Promise<GeoPinSubmission | null> {
     log.info(
       { userId: data.userId, candidateId: data.geoScreenshotCandidateId },
@@ -48,6 +62,7 @@ export const geoPinRepository = {
         geo_screenshot_candidate_id: data.geoScreenshotCandidateId,
         x: data.pin.x,
         y: data.pin.y,
+        confidence: data.confidence ?? null,
       })
       .onConflict(['user_id', 'geo_screenshot_candidate_id'])
       .ignore()

--- a/packages/backend/src/presentation/routes/geo.routes.ts
+++ b/packages/backend/src/presentation/routes/geo.routes.ts
@@ -44,9 +44,17 @@ const pointSchema = z.object({
   y: z.number().min(0).max(1),
 })
 
+// Self-reported confidence on a pin: 1 = sure, 2 = approximate,
+// 3 = pure guess. Optional — an unspecified value is treated as
+// "sure" by the consensus weighter (defined in a follow-up).
+const confidenceSchema = z
+  .union([z.literal(1), z.literal(2), z.literal(3)])
+  .optional()
+
 const pinBodySchema = z.object({
   geoScreenshotCandidateId: z.number().int().positive(),
   pin: pointSchema,
+  confidence: confidenceSchema,
 })
 
 const contributePickBodySchema = z.object({
@@ -142,7 +150,7 @@ router.post(
         return
       }
       const userId = req.userId!
-      const { geoScreenshotCandidateId, pin } = req.body as z.infer<typeof pinBodySchema>
+      const { geoScreenshotCandidateId, pin, confidence } = req.body as z.infer<typeof pinBodySchema>
 
       const candidate = await geoScreenshotRepository.findCandidateById(geoScreenshotCandidateId)
       if (!candidate) {
@@ -165,6 +173,7 @@ router.post(
         userId,
         geoScreenshotCandidateId,
         pin,
+        confidence,
       })
 
       if (submission) {

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1877,7 +1877,13 @@
       "thanks": "Thanks — we'll let you know once other players agree on the spot.",
       "recent": "Recent rewards",
       "lockedTitle": "Tagging unlocks after a few daily games.",
-      "lockedProgress": "Progress"
+      "lockedProgress": "Progress",
+      "confidence": {
+        "label": "How confident are you?",
+        "sure": "Sure",
+        "approx": "Approximate",
+        "guess": "Guessing"
+      }
     },
     "profile": {
       "title": "Geo Crowdsourcer",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1877,7 +1877,13 @@
       "thanks": "Merci — nous vous préviendrons quand d'autres joueurs confirmeront l'emplacement.",
       "recent": "Récompenses récentes",
       "lockedTitle": "L'étiquetage se débloque après quelques parties quotidiennes.",
-      "lockedProgress": "Progression"
+      "lockedProgress": "Progression",
+      "confidence": {
+        "label": "Tu es sûr de toi ?",
+        "sure": "Sûr",
+        "approx": "À peu près",
+        "guess": "Au pif"
+      }
     },
     "profile": {
       "title": "Contributeur Géo",

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -5,6 +5,7 @@ import type {
     GeoFreePlayResult,
     GeoFreePlayView,
     GeoMap,
+    GeoPinConfidence,
     GeoPlayableGame,
     GeoPoint,
     GeoScreenshotCandidate,
@@ -77,6 +78,7 @@ export const geoApi = {
     submitPin(input: {
         geoScreenshotCandidateId: number
         pin: GeoPoint
+        confidence?: GeoPinConfidence
     }): Promise<{ received: boolean }> {
         return request<{ received: boolean }>('/api/geo/contribute/pin', {
             method: 'POST',

--- a/packages/frontend/src/pages/GeoContributePage.tsx
+++ b/packages/frontend/src/pages/GeoContributePage.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
+import type { GeoPinConfidence } from '@the-box/types'
 import { useSession } from '@/lib/auth-client'
 import { useGeoStore } from '@/stores/geoStore'
 import { connectGeoSocket } from '@/lib/geo-socket'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { HandCoins, Loader2, Lock, SkipForward } from 'lucide-react'
 
 export default function GeoContributePage() {
@@ -21,9 +23,11 @@ export default function GeoContributePage() {
         currentCandidate,
         currentCandidateMap,
         pendingPin,
+        pendingConfidence,
         errorMessage,
         pickContribution,
         setPendingPin,
+        setPendingConfidence,
         submitPin,
         recentRewards,
         contributor,
@@ -161,6 +165,18 @@ export default function GeoContributePage() {
                                 pin={pendingPin}
                                 onPin={setPendingPin}
                             />
+                            {/* Confidence chip — shown only after a pin is
+                                placed so it doesn't pre-bias the player.
+                                Skipping the chip is allowed; the server
+                                treats unspecified as "sure" today, and a
+                                follow-up will weight low-confidence pins
+                                proportionally less in consensus. */}
+                            {pendingPin && (
+                                <ConfidenceChips
+                                    value={pendingConfidence}
+                                    onChange={setPendingConfidence}
+                                />
+                            )}
                             <div className="flex items-center justify-between">
                                 <Button
                                     variant="outline"
@@ -212,6 +228,54 @@ export default function GeoContributePage() {
                     </CardContent>
                 </Card>
             )}
+        </div>
+    )
+}
+
+function ConfidenceChips({
+    value,
+    onChange,
+}: {
+    value: GeoPinConfidence | null
+    onChange: (c: GeoPinConfidence | null) => void
+}) {
+    const { t } = useTranslation()
+    // Three buckets, each carrying its weight intent for the future
+    // consensus tweak. The label keys live under
+    // geo.contribute.confidence.* so a translator can rephrase
+    // "Sure / Approx / Guess" without touching code.
+    const options: Array<{ value: GeoPinConfidence; key: string; fallback: string }> = [
+        { value: 1, key: 'geo.contribute.confidence.sure', fallback: 'Sure' },
+        { value: 2, key: 'geo.contribute.confidence.approx', fallback: 'Approximate' },
+        { value: 3, key: 'geo.contribute.confidence.guess', fallback: 'Guessing' },
+    ]
+    return (
+        <div role="radiogroup" aria-label={t('geo.contribute.confidence.label', 'How confident are you?')}>
+            <p className="text-xs text-muted-foreground mb-1.5">
+                {t('geo.contribute.confidence.label', 'How confident are you?')}
+            </p>
+            <div className="flex flex-wrap gap-2">
+                {options.map((opt) => {
+                    const selected = value === opt.value
+                    return (
+                        <button
+                            key={opt.value}
+                            type="button"
+                            role="radio"
+                            aria-checked={selected}
+                            onClick={() => onChange(selected ? null : opt.value)}
+                            className={cn(
+                                'inline-flex items-center min-h-11 px-3 py-2 rounded-full border text-xs transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink',
+                                selected
+                                    ? 'border-neon-pink bg-neon-pink/15 text-foreground'
+                                    : 'border-border text-muted-foreground hover:border-neon-pink/60 hover:text-foreground',
+                            )}
+                        >
+                            {t(opt.key, opt.fallback)}
+                        </button>
+                    )
+                })}
+            </div>
         </div>
     )
 }

--- a/packages/frontend/src/stores/geoStore.ts
+++ b/packages/frontend/src/stores/geoStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type {
     GeoMap,
+    GeoPinConfidence,
     GeoPoint,
     GeoRewardedEvent,
     GeoScreenshotCandidate,
@@ -19,6 +20,10 @@ interface GeoState {
     currentCandidate: GeoScreenshotCandidate | null
     currentCandidateMap: GeoMap | null
     pendingPin: GeoPoint | null
+    // Self-reported confidence on the pending pin (1=sure, 2=approx,
+    // 3=guess). Optional — null means the player hasn't picked,
+    // which the server treats as "sure".
+    pendingConfidence: GeoPinConfidence | null
 
     // Contributor profile block
     contributor: GeoContributorMe | null
@@ -29,6 +34,7 @@ interface GeoState {
 
     pickContribution: (gameId: number) => Promise<void>
     setPendingPin: (p: GeoPoint | null) => void
+    setPendingConfidence: (c: GeoPinConfidence | null) => void
     submitPin: () => Promise<boolean>
 
     loadContributor: () => Promise<void>
@@ -47,6 +53,7 @@ export const useGeoStore = create<GeoState>()((set, get) => ({
     currentCandidate: null,
     currentCandidateMap: null,
     pendingPin: null,
+    pendingConfidence: null,
     contributor: null,
     recentRewards: [],
     latestTierUp: null,
@@ -60,6 +67,7 @@ export const useGeoStore = create<GeoState>()((set, get) => ({
                 currentCandidate: candidate,
                 currentCandidateMap: map,
                 pendingPin: null,
+                pendingConfidence: null,
             })
         } catch (err) {
             set({
@@ -73,16 +81,22 @@ export const useGeoStore = create<GeoState>()((set, get) => ({
         set({ pendingPin: p })
     },
 
+    setPendingConfidence(c) {
+        set({ pendingConfidence: c })
+    },
+
     async submitPin() {
-        const { currentCandidate, pendingPin } = get()
+        const { currentCandidate, pendingPin, pendingConfidence } = get()
         if (!currentCandidate || !pendingPin) return false
         try {
             await geoApi.submitPin({
                 geoScreenshotCandidateId: currentCandidate.id,
                 pin: pendingPin,
+                confidence: pendingConfidence ?? undefined,
             })
             set({
                 pendingPin: null,
+                pendingConfidence: null,
                 currentCandidate: null,
                 currentCandidateMap: null,
                 phase: 'idle',
@@ -132,6 +146,7 @@ export const useGeoStore = create<GeoState>()((set, get) => ({
             currentCandidate: null,
             currentCandidateMap: null,
             pendingPin: null,
+            pendingConfidence: null,
         })
     },
 }))

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1184,7 +1184,17 @@ export interface GeoLeaderboardEntry {
 export interface GeoPinSubmissionInput {
   geoScreenshotCandidateId: number
   pin: GeoPoint
+  // Optional self-reported confidence — 1 = sure, 2 = approximate,
+  // 3 = pure guess. The consensus algorithm uses it as a weight; an
+  // unspecified value is treated as "sure".
+  confidence?: GeoPinConfidence
 }
+
+// Self-reported confidence on a pin submission. Stored as a smallint
+// in `geo_pin_submission.confidence` (CHECK 1–3); the type narrows to
+// the same domain on the wire so a future weighting tweak doesn't
+// have to chase string-vs-int representations.
+export type GeoPinConfidence = 1 | 2 | 3
 
 export type GeoPinStatus = 'pending' | 'accepted' | 'rejected'
 
@@ -1194,6 +1204,7 @@ export interface GeoPinSubmission {
   geoScreenshotCandidateId: number
   pin: GeoPoint
   status: GeoPinStatus
+  confidence?: GeoPinConfidence
   distanceFromCentroid?: number
   reviewedAt?: string
   createdAt: string


### PR DESCRIPTION
## Summary

The persona review's "3-step confidence chip" recommendation. Scoped to the **contribution** path (which is the surface that actually grows the dataset — free-play guesses are scored but not stored).

After a contributor drops a pin on `/<lang>/geo-contribute`, three chips appear above the action row:

| FR | EN |
|---|---|
| Sûr | Sure |
| À peu près | Approximate |
| Au pif | Guessing |

The selection is optional — skipping it is treated as "sure" by the server today. The chip only renders **after** the player has placed a pin so it doesn't pre-bias them. Standard `role="radiogroup"` + `role="radio"` + `aria-checked` for AT support; min-h-11 hit area.

## Why confidence (not weighting) right now

The existing **76/76** unit tests assume unweighted centroid/σ math in `evaluateConsensus`. Flipping that needs its own design pass + new tests. This PR captures the signal so the data exists when the algorithm change ships — a follow-up will weight low-confidence pins proportionally less.

## Files

**Backend**
- `packages/backend/migrations/20260508_geo_pin_confidence.ts` — adds nullable `smallint` column with a `CHECK (confidence IS NULL OR confidence BETWEEN 1 AND 3)` constraint so no rogue value can land via a future bug.
- `packages/backend/src/infrastructure/repositories/geo-pin.repository.ts` — `submit()` accepts and persists confidence; `mapPin()` narrows `1 | 2 | 3` back to the wire type.
- `packages/backend/src/presentation/routes/geo.routes.ts` — `pinBodySchema` accepts optional `z.union([z.literal(1), z.literal(2), z.literal(3)])`; the contribute handler threads it to the repo.

**Shared types**
- `packages/types/src/index.ts` — new `GeoPinConfidence = 1 | 2 | 3`, added to `GeoPinSubmissionInput` and `GeoPinSubmission`.

**Frontend**
- `packages/frontend/src/lib/api/geo.ts` — `geoApi.submitPin()` accepts confidence.
- `packages/frontend/src/stores/geoStore.ts` — `pendingConfidence` state + `setPendingConfidence` setter; sent on submit; cleared on `pickContribution` and `reset`.
- `packages/frontend/src/pages/GeoContributePage.tsx` — new `ConfidenceChips` component renders only when `pendingPin` is set.
- `packages/frontend/public/locales/{en,fr}/translation.json` — `geo.contribute.confidence.{label,sure,approx,guess}`.

## Test plan

- [x] `npm run build:types && npm run build:backend && npm run build:frontend`
- [x] `npm run lint`
- [x] `npm test` — 76/76 pass
- [ ] Migration: `npm run db:migrate` → `geo_pin_submission.confidence` exists, `CHECK` rejects 0 / 4 / 'foo'
- [ ] Manual: drop a pin on the contribute page → three chips appear → tap "À peu près" → submit → server stores `2`
- [ ] Manual: skip the chips and submit → row has `confidence = NULL`
- [ ] Manual VoiceOver/TalkBack: chips announce as a radio group, selection state is read

## Out of scope (follow-ups)

- **Consensus weighting** — apply `weight = { 1: 1.0, 2: 0.66, 3: 0.33 }` (or similar) to mean/σ math in `evaluateConsensus`. New unit tests.
- **Backfill UI for existing rows** — none planned; null reads as "unspecified" everywhere.
- **Free-play surfacing** — free-play guesses don't write to `geo_pin_submission`, so confidence there would be a no-op.

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_