### PR TITLE
feat(geo): confidence-weighted consensus (v2)

### DIFF
--- a/packages/backend/src/domain/services/geo-consensus.service.test.ts
+++ b/packages/backend/src/domain/services/geo-consensus.service.test.ts
@@ -1,8 +1,10 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import type { GeoPinConfidence } from '@the-box/types'
 import {
   evaluateConsensus,
   grantsForAcceptedPin,
+  GEO_CONSENSUS_CONFIDENCE_WEIGHTS,
   GEO_CONSENSUS_MIN_PINS_TO_PROMOTE,
   GEO_CONSENSUS_VERSION,
   type GeoPinLike,
@@ -10,8 +12,8 @@ import {
 
 const RADIUS = 0.05
 
-function pin(id: number, x: number, y: number): GeoPinLike {
-  return { id, pin: { x, y } }
+function pin(id: number, x: number, y: number, confidence?: GeoPinConfidence): GeoPinLike {
+  return confidence == null ? { id, pin: { x, y } } : { id, pin: { x, y }, confidence }
 }
 
 describe('evaluateConsensus', () => {
@@ -104,6 +106,102 @@ describe('evaluateConsensus', () => {
     // decisions apart on a retroactive re-run.
     const out = evaluateConsensus([pin(1, 0.5, 0.5)], RADIUS)
     assert.equal(out.version, GEO_CONSENSUS_VERSION)
+  })
+
+  it('confidence weights pull the centroid toward the "sure" pin', () => {
+    // Three pins on a horizontal line. The lone "sure" (weight 1.0)
+    // pin sits at x=0.4; the two "guess" (weight 0.33) pins sit at
+    // x=0.6. Unweighted mean would land at 0.533; weighted mean must
+    // be < 0.5 because the "sure" pin outweighs both "guess" pins
+    // combined (1.0 vs 0.66).
+    const pins: GeoPinLike[] = [
+      pin(1, 0.4, 0.5, 1),
+      pin(2, 0.6, 0.5, 3),
+      pin(3, 0.6, 0.5, 3),
+    ]
+    const out = evaluateConsensus(pins, RADIUS)
+    assert.ok(
+      out.centroid.x < 0.5,
+      `expected weighted centroid < 0.5 but got ${out.centroid.x}`,
+    )
+    assert.ok(out.centroid.x < 0.533) // strictly tighter than unweighted
+  })
+
+  it('all-equal confidences match the unweighted result', () => {
+    // Same set of pin positions, once with no confidence and once
+    // with every pin marked "approx" (weight 0.66). Centroids and
+    // sigmas must agree because the weights factor out of both the
+    // numerator and the denominator.
+    const positions: Array<[number, number]> = [
+      [0.4, 0.4],
+      [0.45, 0.42],
+      [0.5, 0.5],
+      [0.52, 0.48],
+      [0.48, 0.45],
+    ]
+    const unweighted = evaluateConsensus(
+      positions.map(([x, y], i) => pin(i + 1, x, y)),
+      RADIUS,
+    )
+    const weighted = evaluateConsensus(
+      positions.map(([x, y], i) => pin(i + 1, x, y, 2)),
+      RADIUS,
+    )
+    assert.ok(Math.abs(unweighted.centroid.x - weighted.centroid.x) < 1e-9)
+    assert.ok(Math.abs(unweighted.centroid.y - weighted.centroid.y) < 1e-9)
+    assert.ok(Math.abs(unweighted.sigmaX - weighted.sigmaX) < 1e-9)
+    assert.ok(Math.abs(unweighted.sigmaY - weighted.sigmaY) < 1e-9)
+  })
+
+  it('exposes a 1.0/0.66/0.33 weight table for confidences 1/2/3', () => {
+    // The weights are part of the algorithm's public contract — if a
+    // future tweak changes them, the version bump will trip the
+    // version test, and this test pins the values themselves.
+    assert.equal(GEO_CONSENSUS_CONFIDENCE_WEIGHTS[1], 1.0)
+    assert.equal(GEO_CONSENSUS_CONFIDENCE_WEIGHTS[2], 0.66)
+    assert.equal(GEO_CONSENSUS_CONFIDENCE_WEIGHTS[3], 0.33)
+  })
+
+  it('a low-confidence outlier shifts the centroid less than a high-confidence one', () => {
+    // Tight cluster of four "sure" pins around (0.5, 0.5) plus one
+    // outlier at (0.7, 0.5). When the outlier is "sure" it pulls the
+    // mean further than when it is a "guess".
+    const cluster: GeoPinLike[] = [
+      pin(1, 0.5, 0.5, 1),
+      pin(2, 0.501, 0.5, 1),
+      pin(3, 0.499, 0.5, 1),
+      pin(4, 0.5, 0.501, 1),
+    ]
+    const sureOut = evaluateConsensus([...cluster, pin(5, 0.7, 0.5, 1)], RADIUS)
+    const guessOut = evaluateConsensus([...cluster, pin(5, 0.7, 0.5, 3)], RADIUS)
+    assert.ok(
+      guessOut.centroid.x < sureOut.centroid.x,
+      `guess outlier should pull less: sure ${sureOut.centroid.x}, guess ${guessOut.centroid.x}`,
+    )
+  })
+
+  it('mixing legacy (no confidence) pins with rated pins is supported', () => {
+    // Legacy rows have NULL confidence; the formula treats them as
+    // "sure" so a v2 re-run over a pre-confidence dataset produces
+    // the same result as v1 would on it.
+    const allLegacy = evaluateConsensus(
+      [
+        pin(1, 0.5, 0.5),
+        pin(2, 0.501, 0.5),
+        pin(3, 0.499, 0.5),
+      ],
+      RADIUS,
+    )
+    const allSure = evaluateConsensus(
+      [
+        pin(1, 0.5, 0.5, 1),
+        pin(2, 0.501, 0.5, 1),
+        pin(3, 0.499, 0.5, 1),
+      ],
+      RADIUS,
+    )
+    assert.ok(Math.abs(allLegacy.centroid.x - allSure.centroid.x) < 1e-9)
+    assert.ok(Math.abs(allLegacy.sigmaX - allSure.sigmaX) < 1e-9)
   })
 })
 

--- a/packages/backend/src/domain/services/geo-consensus.service.ts
+++ b/packages/backend/src/domain/services/geo-consensus.service.ts
@@ -1,5 +1,5 @@
 import type { DomainLogger } from '../ports/logger.js'
-import type { GeoPoint, GeoPinStatus } from '@the-box/types'
+import type { GeoPinConfidence, GeoPoint, GeoPinStatus } from '@the-box/types'
 
 // Pin count thresholds at which the consensus worker should recompute.
 export const GEO_CONSENSUS_THRESHOLDS = [5, 10, 20, 50] as const
@@ -12,12 +12,31 @@ export const GEO_CONSENSUS_MIN_PINS_TO_PROMOTE = 5
 export const GEO_CONSENSUS_SIGMA_MULTIPLIER = 2
 
 // Current consensus algorithm version; bumped alongside formula changes so a
-// retroactive re-run can distinguish old vs new decisions.
-export const GEO_CONSENSUS_VERSION = 1
+// retroactive re-run can distinguish old vs new decisions. v2 introduces
+// confidence-weighted centroid + variance.
+export const GEO_CONSENSUS_VERSION = 2
+
+// Self-reported confidence buckets translate to multiplicative weights on
+// the pin's contribution to centroid + variance. "Sure" pins count
+// fully; "approximate" pins ⅔; "guesses" ⅓. Pins without a recorded
+// confidence (legacy rows or contributors who skipped the chip) are
+// treated as "sure" — same behaviour as v1, so re-running v2 over a
+// pre-confidence dataset is a no-op.
+export const GEO_CONSENSUS_CONFIDENCE_WEIGHTS: Record<GeoPinConfidence, number> = {
+  1: 1.0,
+  2: 0.66,
+  3: 0.33,
+}
+
+function weightFor(confidence: GeoPinConfidence | undefined): number {
+  if (confidence == null) return 1.0
+  return GEO_CONSENSUS_CONFIDENCE_WEIGHTS[confidence]
+}
 
 export interface GeoPinLike {
   id: number
   pin: GeoPoint
+  confidence?: GeoPinConfidence
 }
 
 export interface GeoConsensusDecision {
@@ -39,12 +58,19 @@ export interface GeoConsensusResult {
 }
 
 /**
- * Compute mean/σ on each axis and mark pins outside σ-multiplier * σ OR
- * outside the map's consensus radius as rejected. Promotion to canonical
- * requires ≥ min-pins AND a tight enough cluster (confidence > 0.5).
+ * Compute weighted mean/σ on each axis and mark pins outside σ-multiplier
+ * * σ OR outside the map's consensus radius as rejected. Promotion to
+ * canonical requires ≥ min-pins AND a tight enough cluster (confidence
+ * > 0.5).
  *
- * Confidence is a bounded, interpretable signal: 1 when all pins sit on top
- * of each other, 0 when the spread equals the map's consensus radius.
+ * Each pin contributes proportionally to its self-reported confidence:
+ * "sure" (1.0), "approx" (0.66), "guess" (0.33). Pins without a
+ * recorded confidence count fully — preserving v1 behaviour for the
+ * historical dataset and for contributors who skip the chip.
+ *
+ * Cluster confidence is a bounded, interpretable signal: 1 when all
+ * pins sit on top of each other, 0 when the spread equals the map's
+ * consensus radius.
  */
 export function evaluateConsensus(
   pins: GeoPinLike[],
@@ -65,25 +91,36 @@ export function evaluateConsensus(
     }
   }
 
-  let sumX = 0
-  let sumY = 0
-  for (const { pin } of pins) {
-    sumX += pin.x
-    sumY += pin.y
+  // Weighted centroid. Total weight is also the divisor for variance,
+  // so a "guess"-only cluster has the same shape as the equivalent
+  // "sure" cluster — the weights only matter when confidences are mixed.
+  let sumW = 0
+  let sumWX = 0
+  let sumWY = 0
+  for (const { pin, confidence } of pins) {
+    const w = weightFor(confidence)
+    sumW += w
+    sumWX += w * pin.x
+    sumWY += w * pin.y
   }
-  const meanX = sumX / n
-  const meanY = sumY / n
+  // Defensive: every weight in our table is > 0 and we just rejected n=0,
+  // so sumW can never legitimately be 0. Falling back to 1 keeps a future
+  // weight=0 bucket from short-circuiting into a NaN centroid.
+  const denom = sumW > 0 ? sumW : 1
+  const meanX = sumWX / denom
+  const meanY = sumWY / denom
 
   let sqX = 0
   let sqY = 0
-  for (const { pin } of pins) {
+  for (const { pin, confidence } of pins) {
+    const w = weightFor(confidence)
     const dx = pin.x - meanX
     const dy = pin.y - meanY
-    sqX += dx * dx
-    sqY += dy * dy
+    sqX += w * dx * dx
+    sqY += w * dy * dy
   }
-  const sigmaX = Math.sqrt(sqX / n)
-  const sigmaY = Math.sqrt(sqY / n)
+  const sigmaX = Math.sqrt(sqX / denom)
+  const sigmaY = Math.sqrt(sqY / denom)
 
   const cutoffX = GEO_CONSENSUS_SIGMA_MULTIPLIER * sigmaX
   const cutoffY = GEO_CONSENSUS_SIGMA_MULTIPLIER * sigmaY

--- a/packages/backend/src/infrastructure/queue/workers/geo-consensus-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-consensus-logic.ts
@@ -121,7 +121,7 @@ export async function evaluateConsensusForCandidate(
   for (const p of pending) pinOwners.set(p.id, p.userId)
 
   const result = geoConsensusService.evaluate(
-    pending.map((p) => ({ id: p.id, pin: p.pin })),
+    pending.map((p) => ({ id: p.id, pin: p.pin, confidence: p.confidence })),
     map.consensusRadius,
   )
 

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1545,7 +1545,7 @@ router.post('/geo/candidates/:id/override', async (req, res, next) => {
         return
       }
       const consensus = evaluateConsensus(
-        pins.map((p) => ({ id: p.id, pin: p.pin })),
+        pins.map((p) => ({ id: p.id, pin: p.pin, confidence: p.confidence })),
         map.consensusRadius,
       )
       canonicalX = consensus.centroid.x


### PR DESCRIPTION
## Summary

Follow-up to #174. The contribution chip ships the data; this PR makes the consensus algorithm actually use it. Each pin contributes proportionally to its self-reported confidence when the centroid and per-axis σ are computed.

| Confidence | Weight |
|---|---|
| 1 — "Sure" | 1.0 |
| 2 — "Approximate" | 0.66 |
| 3 — "Guessing" | 0.33 |
| undefined (legacy rows + chip-skipped pins) | 1.0 |

`GEO_CONSENSUS_VERSION` bumps to **2** so the worker's retroactive-replay path can tell old and new decisions apart.

The math:

```
meanX = Σ(wᵢ · xᵢ) / Σwᵢ
σ²X   = Σ(wᵢ · (xᵢ − meanX)²) / Σwᵢ        (Y axis symmetric)
```

A `Σwᵢ > 0` guard keeps the centroid from going `NaN` if a future weight bucket is added with a 0 weight (current weights are all > 0, so n=0 is the only path to `Σwᵢ = 0` and that branch returns early already).

## Backwards compatibility

A re-run of v2 over the **historical** (pre-confidence) dataset is a **no-op**:
- All confidences are NULL → all weights are 1.0 → the formulas collapse to the v1 unweighted forms.
- Verified by a test ("legacy NULL pins behave identically to all-sure pins").

## Files

- `packages/backend/src/domain/services/geo-consensus.service.ts` — adds optional `confidence` to `GeoPinLike`, exports `GEO_CONSENSUS_CONFIDENCE_WEIGHTS`, bumps `GEO_CONSENSUS_VERSION` to 2, switches centroid + variance to weighted formulas.
- `packages/backend/src/domain/services/geo-consensus.service.test.ts` — 5 new weighted-scenario tests; the original 7 tests are untouched and still pass.
- `packages/backend/src/infrastructure/queue/workers/geo-consensus-logic.ts` — passes `confidence` through to `evaluate()`.
- `packages/backend/src/presentation/routes/admin.routes.ts` — same threading on the admin re-run route.

## Test plan

- [x] `npm run build:types && npm run build:backend && npm run build:frontend`
- [x] `npm run lint`
- [x] `npm test` — **81 / 81 pass** (was 76; 5 new tests cover the weighted paths)
- [ ] Manual: drop pins with mixed confidences on a candidate → consensus worker promotes when the **weighted** confidence ≥ 0.5
- [ ] Manual: re-trigger consensus on a pre-#174 candidate (all NULL confidences) → centroid + decisions match v1 byte-for-byte

## Out of scope

- **Reward grants** in `grantsForAcceptedPin` are still distance-vs-σ — they don't read confidence directly. Could be tightened later (e.g. reduce the every-10th-pin bonus on guess-heavy contributors), but not in this PR.
- The frontend "Sure / Approx / Guess" chip already shipped in #174; this PR doesn't touch the UI.

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_