### PR TITLE
fix(a11y): wire up SheetDescription, derive pinAnnouncement during render

### DIFF
--- a/packages/frontend/src/components/admin/geo-fetch/GameMapsDrawer.tsx
+++ b/packages/frontend/src/components/admin/geo-fetch/GameMapsDrawer.tsx
@@ -4,6 +4,7 @@ import { Star, Check, RotateCcw } from 'lucide-react'
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
@@ -67,6 +68,12 @@ export function GameMapsDrawer({ gameId, onClose }: Props) {
       <SheetContent side="right" className="w-full sm:max-w-3xl overflow-y-auto">
         <SheetHeader>
           <SheetTitle>{t('admin.geoFetch.drawer.title', 'Cartes du jeu')}</SheetTitle>
+          <SheetDescription className="sr-only">
+            {t(
+              'admin.geoFetch.drawer.description',
+              'Side-by-side map candidates per zone. Click "Choisir" to set the canonical map for this game.',
+            )}
+          </SheetDescription>
         </SheetHeader>
 
         {isLoading && (

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
@@ -159,6 +160,9 @@ export function Header() {
             <SheetContent side="left" className="w-[280px] sm:w-[320px]">
               <SheetHeader>
                 <SheetTitle className="text-left">{t('common.menu')}</SheetTitle>
+                <SheetDescription className="sr-only">
+                  {t('common.menuDescription', 'Site navigation and account links')}
+                </SheetDescription>
               </SheetHeader>
               <div className="flex flex-col gap-2 mt-6">
                 <NavigationLinks isMobile={true} t={t} localizedPath={localizedPath} onMobileClick={() => setMobileMenuOpen(false)} showPremiumUpsell={showPremiumUpsell} />

--- a/packages/frontend/src/components/rewards/RewardsInboxBell.tsx
+++ b/packages/frontend/src/components/rewards/RewardsInboxBell.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import {
     Sheet,
     SheetContent,
+    SheetDescription,
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet'
@@ -93,6 +94,12 @@ export function RewardsInboxBell({ className }: RewardsInboxBellProps) {
             <SheetContent side="right" className="w-full sm:max-w-md">
                 <SheetHeader>
                     <SheetTitle>{t('rewards.inboxTitle')}</SheetTitle>
+                    <SheetDescription className="sr-only">
+                        {t(
+                            'rewards.inboxDescription',
+                            'Recent reward grants from milestones, payouts, and reactivation campaigns.',
+                        )}
+                    </SheetDescription>
                 </SheetHeader>
                 <div className="mt-6 flex flex-col gap-3 overflow-y-auto pb-4">
                     {isLoading && unclaimed.length === 0 ? (

--- a/packages/frontend/src/components/ui/sheet.tsx
+++ b/packages/frontend/src/components/ui/sheet.tsx
@@ -61,7 +61,6 @@ const SheetContent = React.forwardRef<
       ref={ref}
       data-slot="sheet-content"
       className={cn(sheetVariants({ side }), className)}
-      aria-describedby={undefined}
       {...props}
     >
       {children}

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -103,13 +103,6 @@ export default function GeoPlayPage() {
     // One-shot fetch on mount; null until it lands so the empty state
     // doesn't flash a misleading "0 pins today" placeholder.
     const [pinsToday, setPinsToday] = useState<number | null>(null)
-    // Screen-reader announcement for the placed pin. The CTA's
-    // aria-live carries the action signal ("Drop pin" → "Confirm
-    // pin"); this carries the spatial signal ("placed at 42 %, 67 %")
-    // so an AT user knows roughly where their pin landed without
-    // sighted feedback. Mirrors what the persona a11y review asked
-    // for under WCAG 2.4.6 / 4.1.3.
-    const [pinAnnouncement, setPinAnnouncement] = useState('')
 
     // Fullscreen target: the entire immersive deck. Putting the wrapper
     // ref on the outer container means the screenshot, map, dock and
@@ -146,25 +139,21 @@ export default function GeoPlayPage() {
         }
     }, [currentGameId, view, phase, rerollScreenshot])
 
-    // Announce the placed pin to screen readers. Coordinates are
-    // rounded to whole percent so the message stays terse — anything
-    // finer is noise once verbalized. Cleared when the pin is removed
-    // (e.g. after a round resets) so the live region doesn't replay
-    // the last announcement on phase changes.
-    useEffect(() => {
-        if (!pendingGuess) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing an aria-live region; the rule's docs flag the React→external pattern as a legitimate exception.
-            setPinAnnouncement('')
-            return
-        }
-        setPinAnnouncement(
-            t('geo.play.pinPlacedAria', {
-                defaultValue: 'Pin placed at {{x}}%, {{y}}%',
-                x: Math.round(pendingGuess.x * 100),
-                y: Math.round(pendingGuess.y * 100),
-            }),
-        )
-    }, [pendingGuess, t])
+    // Screen-reader announcement for the placed pin. Derived directly
+    // from `pendingGuess` so the live region updates on the same render
+    // that drops the pin — no useState/useEffect dance, no cascading
+    // re-renders, no risk of stale strings (cf. WCAG 2.4.6 / 4.1.3).
+    // Coordinates are rounded to whole percent so the message stays
+    // terse — finer detail is noise once verbalized. Empty string when
+    // there's no draft pin so the live region doesn't replay the last
+    // announcement on phase changes.
+    const pinAnnouncement = pendingGuess
+        ? t('geo.play.pinPlacedAria', {
+              defaultValue: 'Pin placed at {{x}}%, {{y}}%',
+              x: Math.round(pendingGuess.x * 100),
+              y: Math.round(pendingGuess.y * 100),
+          })
+        : ''
 
     // Open the game picker for a fresh visitor with no selection — gives
     // them an obvious "what do I do here" cue instead of a blank canvas.


### PR DESCRIPTION
## Summary

Two follow-ups from the geo persona meeting that didn't fit in #176:

### 1. Wire up `SheetDescription` (a11y, WCAG 1.3.1 / 4.1.2)

The `Sheet` primitive forced `aria-describedby={undefined}` on every consumer, which **defeats Radix Dialog's auto-link to `SheetDescription`** — so even sheets that rendered a description (GamePicker, MapPicker, GeoMapsTab) weren't actually exposing it to screen readers. Drop the override and add a visually-hidden `SheetDescription` to the three sheets that didn't have one:

- `Header.tsx` — mobile menu drawer
- `RewardsInboxBell.tsx` — reward inbox drawer
- `admin/geo-fetch/GameMapsDrawer.tsx` — admin per-game map curation drawer

Result: AT users now hear a sentence of context after the title instead of a bare label.

### 2. Derive `pinAnnouncement` instead of mirroring it via state

`GeoPlayPage` had a `useState` + `useEffect` pair that mirrored `pendingGuess` into the `pinAnnouncement` aria-live string. The string is a pure projection of the draft pin — there's no external system to sync with — so derive it during render. One render pass instead of two, no stale-state risk on phase transitions, and the `react-hooks/set-state-in-effect` suppression introduced in #176 goes away.

## Test plan

- [x] `npm run build:frontend` typechecks + builds clean
- [x] ESLint clean on touched files (no new suppressions)
- [x] Backend test suite (76 / 76) green via pre-commit
- [ ] Manual a11y check: VoiceOver / NVDA reads description after title for all 6 Sheets
- [ ] Manual: drop a pin on `/fr/geo`, confirm aria-live announcement still fires correctly

https://claude.ai/code/session_01XcEgEPjRxFj8oYk1JuCkba

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcEgEPjRxFj8oYk1JuCkba)_