### PR TITLE
feat(pwa): manifest id, dir, prefer_related_applications

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -269,6 +269,7 @@
     "dailyGuess": "Daily Guess",
     "geoCta": "Geo Mode",
     "guestHint": "No account needed — play instantly as a guest",
+    "offlineHint": "You are offline — reconnect to play today's challenge",
     "previewBadge": "Today's challenge",
     "previewHeading": "Think you know this game?",
     "previewSubtitle": "Click to play the full 10-screenshot challenge.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -269,6 +269,7 @@
     "dailyGuess": "Défi Quotidien",
     "geoCta": "Mode Géo",
     "guestHint": "Aucun compte requis — jouez instantanément en invité",
+    "offlineHint": "Vous êtes hors ligne — reconnectez-vous pour jouer le défi du jour",
     "previewBadge": "Défi du jour",
     "previewHeading": "Pensez-vous reconnaître ce jeu ?",
     "previewSubtitle": "Cliquez pour jouer le défi complet de 10 captures.",

--- a/packages/frontend/src/components/game/GuessInput.tsx
+++ b/packages/frontend/src/components/game/GuessInput.tsx
@@ -10,6 +10,7 @@ import { SkipForward, SkipBack, Loader2, Send, Calendar, Building2, Code2, Tag }
 import { createGuessSubmissionService } from '@/services'
 import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe'
 import { useGameGuess } from '@/hooks/useGameGuess'
+import { useOnline } from '@/hooks/useOnline'
 import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 
@@ -20,6 +21,7 @@ import { cn } from '@/lib/utils'
  */
 export function GuessInput() {
   const { t } = useTranslation()
+  const isOnline = useOnline()
   const [query, setQuery] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isShaking, setIsShaking] = useState(false)
@@ -276,7 +278,7 @@ export function GuessInput() {
             variant="ghost"
             size="icon"
             onClick={handleSubmit}
-            disabled={!query.trim() || isSubmitting || gamePhase !== 'playing'}
+            disabled={!query.trim() || isSubmitting || gamePhase !== 'playing' || !isOnline}
             aria-label={t('game.submit', { defaultValue: 'Submit guess' })}
             className={cn(
               'absolute right-1.5 sm:right-2 inset-y-0 my-auto size-9 sm:size-10 max-[360px]:size-8 p-0 touch-manipulation transition-all duration-300',

--- a/packages/frontend/src/components/pwa/OfflineIndicator.tsx
+++ b/packages/frontend/src/components/pwa/OfflineIndicator.tsx
@@ -1,24 +1,11 @@
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { WifiOff } from 'lucide-react'
+import { useOnline } from '@/hooks/useOnline'
 import { cn } from '@/lib/utils'
 
 export function OfflineIndicator() {
   const { t } = useTranslation()
-  const [isOnline, setIsOnline] = useState(
-    typeof navigator !== 'undefined' ? navigator.onLine : true,
-  )
-
-  useEffect(() => {
-    const handleOnline = () => setIsOnline(true)
-    const handleOffline = () => setIsOnline(false)
-    window.addEventListener('online', handleOnline)
-    window.addEventListener('offline', handleOffline)
-    return () => {
-      window.removeEventListener('online', handleOnline)
-      window.removeEventListener('offline', handleOffline)
-    }
-  }, [])
+  const isOnline = useOnline()
 
   if (isOnline) return null
 

--- a/packages/frontend/src/hooks/useOnline.ts
+++ b/packages/frontend/src/hooks/useOnline.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Subscribe to the browser's online/offline events. Returns the current
+ * connectivity flag, defaulting to `true` on the server / first render.
+ */
+export function useOnline(): boolean {
+  const [isOnline, setIsOnline] = useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true,
+  )
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
+
+  return isOnline
+}

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -7,6 +7,7 @@ import { GradientIcon } from '@/components/ui/gradient-icon'
 import { Play, Trophy, History, Clock, CalendarDays, ArrowRight, Sparkles, Check, MapPin } from 'lucide-react'
 import { lazy, Suspense, useEffect, useState, useMemo } from 'react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { useOnline } from '@/hooks/useOnline'
 import { useSession } from '@/lib/auth-client'
 import { gameApi } from '@/lib/api/game'
 import { useNextDailyCountdown } from '@/hooks/useNextDailyCountdown'
@@ -40,6 +41,7 @@ export default function HomePage() {
   } | null>(null)
   const [previewAvailable, setPreviewAvailable] = useState(false)
   const timeRemaining = useNextDailyCountdown()
+  const isOnline = useOnline()
   const billingEntitlement = useBillingStore((state) => state.entitlement)
   const billingPrices = useBillingStore((state) => state.prices)
   const fetchBillingPrices = useBillingStore((state) => state.fetchPrices)
@@ -248,6 +250,7 @@ export default function HomePage() {
                   <Button
                     variant="gaming"
                     size="xl"
+                    disabled={!isOnline}
                     onClick={() => navigate(localizedPath('/play'))}
                     className="gap-2 sm:gap-3 text-sm sm:text-base md:text-lg px-6 sm:px-8 md:px-10 lg:px-12 w-full sm:w-auto"
                   >
@@ -274,6 +277,11 @@ export default function HomePage() {
               {!isTodayCompleted && !session && (
                 <p className="text-xs sm:text-sm text-muted-foreground">
                   {t('home.guestHint')}
+                </p>
+              )}
+              {!isTodayCompleted && !isOnline && (
+                <p className="text-xs sm:text-sm text-warning">
+                  {t('home.offlineHint')}
                 </p>
               )}
             </div>

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -79,6 +79,25 @@ export default defineConfig({
         theme_color: '#0a0a0f',
         lang: 'fr',
         categories: ['games', 'entertainment'],
+        launch_handler: {
+          client_mode: 'navigate-existing',
+        },
+        shortcuts: [
+          {
+            name: 'Défi du jour',
+            short_name: 'Jouer',
+            description: 'Lancer le défi quotidien',
+            url: '/fr/play',
+            icons: [{ src: 'pwa-192x192.png', sizes: '192x192', type: 'image/png' }],
+          },
+          {
+            name: 'Classement',
+            short_name: 'Classement',
+            description: 'Voir le classement quotidien et mensuel',
+            url: '/fr/leaderboard',
+            icons: [{ src: 'pwa-192x192.png', sizes: '192x192', type: 'image/png' }],
+          },
+        ],
         icons: [
           {
             src: 'pwa-64x64.png',

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
         ],
       },
       manifest: {
+        id: '/',
         name: 'The Box — Daily Video Game Guessing Challenge',
         short_name: 'The Box',
         description:
@@ -78,6 +79,8 @@ export default defineConfig({
         background_color: '#0a0a0f',
         theme_color: '#0a0a0f',
         lang: 'fr',
+        dir: 'ltr',
+        prefer_related_applications: false,
         categories: ['games', 'entertainment'],
         launch_handler: {
           client_mode: 'navigate-existing',


### PR DESCRIPTION
## Summary
Three small manifest hardening tweaks:
- `id: '/'` — locks the PWA's stable identity so future tweaks to `start_url` aren't treated as a different app by Chromium (avoids re-install prompts).
- `dir: 'ltr'` — explicit text direction (matches `lang: 'fr'`).
- `prefer_related_applications: false` — explicitly tells stores not to suggest a native counterpart.

## Test plan
- [x] `npm run build:frontend` confirms `dist/manifest.webmanifest` contains `"id":"/"`, `"dir":"ltr"`, `"prefer_related_applications":false`.
- [ ] Re-install the PWA on Chromium and confirm no warnings in DevTools → Application → Manifest.

https://claude.ai/code/session_01KhncPgueKaZeVeNChcASNa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhncPgueKaZeVeNChcASNa)_