### PR TITLE
perf(geo): stabilize tile layer, drop GamePicker open-effect

### DIFF
--- a/packages/frontend/src/components/geo/GamePicker.tsx
+++ b/packages/frontend/src/components/geo/GamePicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { GeoPlayableGame } from '@the-box/types'
 import {
@@ -64,13 +64,18 @@ export function GamePicker({
         [ignoredGameIds],
     )
 
-    // Reset the search field every time the sheet re-opens — keeping a
-    // stale query across opens reads as a bug ("why am I still seeing my
-    // last search?") more often than as a convenience.
-    useEffect(() => {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing local state to the parent-controlled `open` transition; no external system to subscribe to.
-        if (open) setQuery('')
-    }, [open])
+    // Clear the search field on close — keeping a stale query across opens
+    // reads as a bug ("why am I still seeing my last search?") more often
+    // than as a convenience. Doing it on close (rather than on open in an
+    // effect) avoids the open→stale-query→cleared-query paint flash and
+    // means the input is already empty by the time the sheet animates in.
+    const handleOpenChange = useCallback(
+        (next: boolean) => {
+            if (!next) setQuery('')
+            onOpenChange(next)
+        },
+        [onOpenChange],
+    )
 
     const filtered = useMemo(() => {
         const q = query.trim().toLowerCase()
@@ -79,7 +84,7 @@ export function GamePicker({
     }, [games, query])
 
     return (
-        <Sheet open={open} onOpenChange={onOpenChange}>
+        <Sheet open={open} onOpenChange={handleOpenChange}>
             <SheetContent
                 side={isMobile ? 'bottom' : 'right'}
                 className={cn(

--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -185,6 +185,14 @@ function TilePyramidLayer({
     heightPx: number
 }) {
     const map = useMap()
+    // Depend on the *shallow scalar* tile config so a parent re-rendering
+    // with a fresh `tiles` object literal (same values, new identity)
+    // doesn't tear down and rebuild the entire layer — that triggers a
+    // full tile re-fetch on every parent state change. The `getTileUrl`
+    // closure still reads from the captured `tiles`, which is fine
+    // because the values it reads (scheme, urlTemplate, min/maxZoom)
+    // are exactly the deps we list.
+    const { scheme, urlTemplate, tileSize, minZoom, maxZoom } = tiles
     useEffect(() => {
         const TemplatedTileLayer = L.TileLayer.extend({
             getTileUrl(coords: { x: number; y: number; z: number }) {
@@ -194,10 +202,10 @@ function TilePyramidLayer({
         const layer = new (TemplatedTileLayer as unknown as new (
             urlTemplate: string,
             opts: L.TileLayerOptions,
-        ) => L.TileLayer)(tiles.urlTemplate, {
-            tileSize: tiles.tileSize,
-            minZoom: tiles.minZoom,
-            maxZoom: tiles.maxZoom,
+        ) => L.TileLayer)(urlTemplate, {
+            tileSize,
+            minZoom,
+            maxZoom,
             // Clamp tile requests to the world rectangle so OOB tiles (e.g.
             // the asymmetric 85x69 grid in WoW) don't 404-spam.
             bounds: [
@@ -221,7 +229,8 @@ function TilePyramidLayer({
         return () => {
             layer.remove()
         }
-    }, [map, tiles, widthPx, heightPx])
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- `tiles` is read via the captured closure but is identity-equivalent to the listed scalar fields; using the object directly would tear down the layer on every parent re-render.
+    }, [map, scheme, urlTemplate, tileSize, minZoom, maxZoom, widthPx, heightPx])
     return null
 }
 


### PR DESCRIPTION
## Summary

Two scoped polish items from the geo persona meeting that didn't fit the earlier PRs.

### 1. Stabilize Leaflet `TilePyramidLayer`

`TilePyramidLayer`'s `useEffect` depended on the whole `tiles` object. Any parent re-render that built a fresh `{ ...config }` literal — even with byte-for-byte identical values — tore down the entire `L.TileLayer` and re-fetched every tile in the viewport. This was visible as a tile flash whenever sibling state in `GeoPlayPage` changed.

Switch the dep array to **shallow scalar fields** (`scheme`, `urlTemplate`, `tileSize`, `minZoom`, `maxZoom`) plus the world bounds. The `getTileUrl` closure still reads `tiles` directly — that's safe because the values it needs are exactly the deps we list, so any *real* change rebuilds the layer; identity-only changes don't.

### 2. Drop the `useEffect(open)` in `GamePicker`

The picker reset `query` via a `useEffect([open])`. That fires *after* commit, so on each open you'd briefly render the stale search before the effect cleared it (then a second render with empty input). Move the reset into a wrapped `onOpenChange` that fires on **close** — so by the time the next open animates in, `query` is already `''`. No paint flash, no `react-hooks/set-state-in-effect` suppression.

## Test plan

- [x] `npm run build:frontend` typechecks + builds clean
- [x] ESLint clean on touched files (no new suppressions in GamePicker; the one in `MapCanvasLeaflet` is justified inline)
- [x] Backend test suite (81 / 81) green via pre-commit
- [x] `formatTileUrl` unit tests still pass for both `xyz` and `xyz-padded2-inverted` schemes — the closure's read of `tiles` for those scheme branches is unchanged
- [ ] Manual: open `/fr/geo` on a tile-pyramid map (e.g. WoW), trigger sibling re-renders (open the GamePicker, drop a pin) — tiles should not flash
- [ ] Manual: type in GamePicker search, close, re-open — input should be empty with no stale-query flicker

https://claude.ai/code/session_01XcEgEPjRxFj8oYk1JuCkba

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcEgEPjRxFj8oYk1JuCkba)_