### PR TITLE
fix(a11y): roving tabindex + arrow-key nav in GamePicker/MapPicker

### DIFF
--- a/packages/frontend/src/components/geo/GamePicker.tsx
+++ b/packages/frontend/src/components/geo/GamePicker.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useState } from 'react'
+import { forwardRef, useCallback, useMemo, useState, type KeyboardEvent } from 'react'
+import { useRovingTabindex } from '@/hooks/useRovingTabindex'
 import { useTranslation } from 'react-i18next'
 import type { GeoPlayableGame } from '@the-box/types'
 import {
@@ -83,6 +84,19 @@ export function GamePicker({
         return games.filter((g) => g.name.toLowerCase().includes(q))
     }, [games, query])
 
+    // Roving tabindex for the radiogroup — Tab moves into the group at
+    // the currently-selected (or first) card, arrow keys cycle focus
+    // inside without firing onSelect, Space/Enter on a focused card
+    // commits via the button's native click semantics.
+    const initialIndex = Math.max(
+        0,
+        filtered.findIndex((g) => g.id === selectedGameId),
+    )
+    const { getItemProps } = useRovingTabindex<HTMLButtonElement>({
+        count: filtered.length,
+        initialIndex,
+    })
+
     return (
         <Sheet open={open} onOpenChange={handleOpenChange}>
             <SheetContent
@@ -152,7 +166,7 @@ export function GamePicker({
                             aria-label={t('geo.play.pickGame', 'Pick a game')}
                             className="grid grid-cols-1 gap-3 pt-2"
                         >
-                            {filtered.map((g) => {
+                            {filtered.map((g, index) => {
                                 const played = playedCountByGame?.[String(g.id)] ?? 0
                                 // Clamp to ≥0 in case the catalog count
                                 // shrank (e.g. an admin demoted a meta).
@@ -167,6 +181,7 @@ export function GamePicker({
                                 return (
                                     <li key={g.id}>
                                         <GameCard
+                                            {...getItemProps(index)}
                                             game={g}
                                             selected={selectedGameId === g.id}
                                             newCount={hasNew ? newCount : 0}
@@ -174,7 +189,7 @@ export function GamePicker({
                                             ignored={ignored}
                                             onSelect={() => {
                                                 onSelect(g.id)
-                                                onOpenChange(false)
+                                                handleOpenChange(false)
                                             }}
                                             onToggleIgnore={
                                                 onToggleIgnore
@@ -193,23 +208,32 @@ export function GamePicker({
     )
 }
 
-function GameCard({
-    game,
-    selected,
-    newCount,
-    completed,
-    ignored,
-    onSelect,
-    onToggleIgnore,
-}: {
+interface GameCardProps {
     game: GeoPlayableGame
     selected: boolean
     newCount: number
     completed: boolean
     ignored: boolean
+    tabIndex: number
+    onKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
     onSelect: () => void
     onToggleIgnore?: () => void
-}) {
+}
+
+const GameCard = forwardRef<HTMLButtonElement, GameCardProps>(function GameCard(
+    {
+        game,
+        selected,
+        newCount,
+        completed,
+        ignored,
+        tabIndex,
+        onKeyDown,
+        onSelect,
+        onToggleIgnore,
+    },
+    ref,
+) {
     const { t } = useTranslation()
     const cover = game.coverImageUrl && !isPlaceholderImageUrl(game.coverImageUrl)
         ? game.coverImageUrl
@@ -225,9 +249,12 @@ function GameCard({
             )}
         >
             <button
+                ref={ref}
                 type="button"
                 role="radio"
                 aria-checked={selected}
+                tabIndex={tabIndex}
+                onKeyDown={onKeyDown}
                 onClick={onSelect}
                 className="block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
             >
@@ -320,4 +347,4 @@ function GameCard({
             )}
         </div>
     )
-}
+})

--- a/packages/frontend/src/components/geo/MapPicker.tsx
+++ b/packages/frontend/src/components/geo/MapPicker.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { GeoMap } from '@the-box/types'
 import { Shuffle } from 'lucide-react'
@@ -9,6 +10,7 @@ import {
     SheetDescription,
 } from '@/components/ui/sheet'
 import { useIsMobile } from '@/hooks/useIsMobile'
+import { useRovingTabindex } from '@/hooks/useRovingTabindex'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
 import { cn } from '@/lib/utils'
 
@@ -39,6 +41,23 @@ export function MapPicker({
 }: MapPickerProps) {
     const { t } = useTranslation()
     const isMobile = useIsMobile()
+
+    // Total radio count includes the optional "any map" pseudo-option at
+    // index 0. Initial focus lands on the currently-selected map (or the
+    // "any" option / first map when none is selected) so Tab moves the
+    // ring to a sensible spot.
+    const itemCount = (showAnyMapOption ? 1 : 0) + maps.length
+    const initialIndex = (() => {
+        if (selectedMapId == null) return 0
+        const i = maps.findIndex((m) => m.id === selectedMapId)
+        if (i < 0) return 0
+        return showAnyMapOption ? i + 1 : i
+    })()
+    const { getItemProps } = useRovingTabindex<HTMLButtonElement>({
+        count: itemCount,
+        initialIndex,
+    })
+
     return (
         <Sheet open={open} onOpenChange={onOpenChange}>
             <SheetContent
@@ -74,6 +93,7 @@ export function MapPicker({
                             {showAnyMapOption && (
                                 <li>
                                     <AnyMapCard
+                                        {...getItemProps(0)}
                                         selected={selectedMapId == null}
                                         onSelect={() => {
                                             onSelect(null)
@@ -82,18 +102,22 @@ export function MapPicker({
                                     />
                                 </li>
                             )}
-                            {maps.map((m) => (
-                                <li key={m.id}>
-                                    <MapCard
-                                        map={m}
-                                        selected={selectedMapId === m.id}
-                                        onSelect={() => {
-                                            onSelect(m.id)
-                                            onOpenChange(false)
-                                        }}
-                                    />
-                                </li>
-                            ))}
+                            {maps.map((m, i) => {
+                                const index = showAnyMapOption ? i + 1 : i
+                                return (
+                                    <li key={m.id}>
+                                        <MapCard
+                                            {...getItemProps(index)}
+                                            map={m}
+                                            selected={selectedMapId === m.id}
+                                            onSelect={() => {
+                                                onSelect(m.id)
+                                                onOpenChange(false)
+                                            }}
+                                        />
+                                    </li>
+                                )
+                            })}
                         </ul>
                     )}
                 </div>
@@ -102,13 +126,26 @@ export function MapPicker({
     )
 }
 
-function AnyMapCard({ selected, onSelect }: { selected: boolean; onSelect: () => void }) {
+interface AnyMapCardProps {
+    selected: boolean
+    tabIndex: number
+    onKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
+    onSelect: () => void
+}
+
+const AnyMapCard = forwardRef<HTMLButtonElement, AnyMapCardProps>(function AnyMapCard(
+    { selected, tabIndex, onKeyDown, onSelect },
+    ref,
+) {
     const { t } = useTranslation()
     return (
         <button
+            ref={ref}
             type="button"
             role="radio"
             aria-checked={selected}
+            tabIndex={tabIndex}
+            onKeyDown={onKeyDown}
             onClick={onSelect}
             className={cn(
                 'group relative aspect-square w-full overflow-hidden rounded-lg border text-left transition',
@@ -126,26 +163,32 @@ function AnyMapCard({ selected, onSelect }: { selected: boolean; onSelect: () =>
             </div>
         </button>
     )
-}
+})
 
-function MapCard({
-    map,
-    selected,
-    onSelect,
-}: {
+interface MapCardProps {
     map: GeoMap
     selected: boolean
+    tabIndex: number
+    onKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
     onSelect: () => void
-}) {
+}
+
+const MapCard = forwardRef<HTMLButtonElement, MapCardProps>(function MapCard(
+    { map, selected, tabIndex, onKeyDown, onSelect },
+    ref,
+) {
     const { t } = useTranslation()
     const label = map.region ?? t('geo.daily.chooseMap.worldFallback', 'World map')
     const placeholder = isPlaceholderImageUrl(map.imageUrl)
     return (
         <button
+            ref={ref}
             type="button"
             role="radio"
             aria-checked={selected}
             aria-label={label}
+            tabIndex={tabIndex}
+            onKeyDown={onKeyDown}
             onClick={onSelect}
             className={cn(
                 'group relative aspect-square w-full overflow-hidden rounded-lg border bg-muted/30 text-left transition',
@@ -175,4 +218,4 @@ function MapCard({
             </div>
         </button>
     )
-}
+})

--- a/packages/frontend/src/hooks/useRovingTabindex.ts
+++ b/packages/frontend/src/hooks/useRovingTabindex.ts
@@ -1,0 +1,117 @@
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type KeyboardEvent,
+} from 'react'
+
+/**
+ * WAI-ARIA radiogroup roving-tabindex helper. The current item gets
+ * `tabIndex={0}` so Tab moves focus *into* the group; the rest get
+ * `tabIndex={-1}` so Tab from inside the group moves focus *out*. Arrow
+ * keys (and Home/End) cycle focus inside.
+ *
+ * The hook deliberately does **not** call any onSelect-style callback on
+ * arrow nav — that would close the parent sheet on every keystroke. The
+ * caller wires Space/Enter via the button's native click semantics; arrow
+ * keys only move focus + the visual ring.
+ *
+ * Treats arrow keys as 1-D (any-direction → next/previous). For a 2-col
+ * grid that means ArrowDown moves to the immediate next item rather than
+ * "the one below" — a small concession in exchange for code that doesn't
+ * have to know about the grid columns and stays correct after responsive
+ * breakpoints, search filtering, or item re-orders.
+ *
+ * Usage:
+ * ```tsx
+ * const { getItemProps } = useRovingTabindex<HTMLButtonElement>({ count: items.length, initialIndex })
+ * items.map((item, i) => <button key={item.id} {...getItemProps(i)} />)
+ * ```
+ */
+export function useRovingTabindex<T extends HTMLElement>({
+    count,
+    initialIndex = 0,
+}: {
+    count: number
+    initialIndex?: number
+}) {
+    // Stored index is the user's intent — possibly out of range when the
+    // list shrinks (e.g. a search filter). We clamp during render so
+    // consumers always see a valid index without a setState-in-effect.
+    const [storedIndex, setStoredIndex] = useState(() =>
+        Math.max(0, initialIndex),
+    )
+    const focusedIndex =
+        count > 0 ? Math.min(storedIndex, count - 1) : 0
+    const refsMap = useRef(new Map<number, T | null>())
+    // Tracks whether the user has actually moved focus via the keyboard
+    // yet. We only auto-focus the new index after they've moved focus
+    // once, so the hook doesn't yank focus on initial mount.
+    const userHasMoved = useRef(false)
+
+    const focusAt = useCallback(
+        (next: number) => {
+            if (count === 0) return
+            const clamped = ((next % count) + count) % count
+            userHasMoved.current = true
+            setStoredIndex(clamped)
+        },
+        [count],
+    )
+
+    // Imperatively focus the live DOM node *after* React has applied the
+    // tabIndex update, otherwise the browser may steal focus back to the
+    // last tabbable ancestor when the previously-focused element flips
+    // to tabIndex=-1.
+    useEffect(() => {
+        if (!userHasMoved.current) return
+        refsMap.current.get(focusedIndex)?.focus()
+    }, [focusedIndex])
+
+    const onKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            switch (e.key) {
+                case 'ArrowDown':
+                case 'ArrowRight':
+                    e.preventDefault()
+                    focusAt(focusedIndex + 1)
+                    break
+                case 'ArrowUp':
+                case 'ArrowLeft':
+                    e.preventDefault()
+                    focusAt(focusedIndex - 1)
+                    break
+                case 'Home':
+                    e.preventDefault()
+                    focusAt(0)
+                    break
+                case 'End':
+                    e.preventDefault()
+                    focusAt(count - 1)
+                    break
+            }
+        },
+        [focusedIndex, focusAt, count],
+    )
+
+    const getItemProps = useCallback(
+        (index: number) => ({
+            ref: (el: T | null) => {
+                if (el == null) refsMap.current.delete(index)
+                else refsMap.current.set(index, el)
+            },
+            tabIndex: index === focusedIndex ? 0 : -1,
+            onKeyDown,
+        }),
+        [focusedIndex, onKeyDown],
+    )
+
+    return {
+        focusedIndex,
+        getItemProps,
+        // Exposed so callers can sync focus to a newly-selected item
+        // without simulating a keypress (e.g. on prop changes).
+        setFocusedIndex: setStoredIndex,
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last severity-2 a11y item from the geo persona meeting: **proper WAI-ARIA radiogroup keyboard navigation** in `GamePicker` and `MapPicker`.

Both pickers already exposed `role="radio"` on each card and `aria-checked` on the selected one, but they had no roving tabindex and no arrow-key handler — so keyboard users had to Tab through every card individually, and the radiogroup pattern was ARIA-shaped without being ARIA-correct (WCAG 2.1.1 *Keyboard*, 4.1.2 *Name, Role, Value*).

## What landed

A shared `useRovingTabindex` hook (`packages/frontend/src/hooks/useRovingTabindex.ts`) that exposes a `getItemProps(index)` returning `{ ref, tabIndex, onKeyDown }`. The hook:

- Sets `tabIndex={0}` on the focused (or selected, on mount) item and `-1` on the rest, so Tab moves focus *into* the group at a sensible card and Tab *out* leaves the group entirely (single-stop behavior, per the WAI-ARIA APG radiogroup pattern).
- Handles `ArrowUp/Down/Left/Right` + `Home/End` in a 1-D linear order — the same code stays correct across the responsive grid changes (1-col on mobile, 2/3-col on tablets), search filtering, and item re-orders.
- Deliberately **does not** call `onSelect` on arrow nav. Closing the parent sheet on every keystroke would defeat the purpose. `Space`/`Enter` on a focused button commits via the native click semantics; arrow keys only move the visual focus ring.

`GamePicker` and `MapPicker` were converted to `forwardRef`-based card components and consume `getItemProps(i)` per item.

### Bonus fix

Spotted a pre-existing bug while wiring this up: `GamePicker` was calling `onOpenChange(false)` directly on item select instead of the wrapped `handleOpenChange(false)` that clears the search query (introduced in #181). So a player who typed a query, picked a game, then re-opened the picker would see their stale query. Routed through `handleOpenChange` now.

## Test plan

- [x] `npm run build:frontend` typechecks + builds clean
- [x] ESLint clean on touched files (no new suppressions)
- [x] Backend test suite (81 / 81) green via pre-commit
- [ ] Manual: open GamePicker, Tab in (lands on selected/first card), arrow keys cycle without closing the sheet, Space commits + closes
- [ ] Manual: same for MapPicker, including the "Surprise me" pseudo-option at index 0
- [ ] Manual: type in GamePicker search, arrow nav still works inside the filtered list, count drop doesn't strand focus
- [ ] VoiceOver / NVDA: announces "radio button, X, checked/not checked, N of M"

https://claude.ai/code/session_01XcEgEPjRxFj8oYk1JuCkba

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcEgEPjRxFj8oYk1JuCkba)_