### PR TITLE
feat(geo): pinch/double-tap/wheel zoom on the screenshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13708,6 +13708,20 @@
         }
       }
     },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-4.0.3.tgz",
+      "integrity": "sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -16940,6 +16954,7 @@
         "react-i18next": "^16.5.2",
         "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.12.0",
+        "react-zoom-pan-pinch": "^4.0.3",
         "socket.io-client": "^4.8.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -54,6 +54,7 @@
     "react-i18next": "^16.5.2",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.12.0",
+    "react-zoom-pan-pinch": "^4.0.3",
     "socket.io-client": "^4.8.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1805,6 +1805,7 @@
       "next": "Next round",
       "reroll": "New screenshot",
       "shuffleAllGames": "Random game",
+      "resetZoom": "Reset zoom",
       "previous": "Previous screenshot",
       "nextScreenshot": "Next screenshot",
       "tabs": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1805,6 +1805,7 @@
       "next": "Suivant",
       "reroll": "Nouvelle capture",
       "shuffleAllGames": "Jeu aléatoire",
+      "resetZoom": "Réinitialiser le zoom",
       "previous": "Capture précédente",
       "nextScreenshot": "Capture suivante",
       "tabs": {

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -1,5 +1,10 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
+import {
+    TransformComponent,
+    TransformWrapper,
+    useControls,
+} from 'react-zoom-pan-pinch'
 import type { GeoPoint } from '@the-box/types'
 import {
     ArrowRight,
@@ -606,15 +611,81 @@ function ScreenshotPanel({
     const altText = gameName
         ? t('geo.daily.screenshotOf', 'Screenshot from {{game}}', { game: gameName })
         : t('geo.daily.screenshot', 'Screenshot')
+    return <ZoomablePhoto src={safeUrl} alt={altText} />
+}
+
+/**
+ * Wraps a screenshot in a pinch/wheel/double-tap zoomable surface.
+ * Keyed on `src` so each new screenshot resets the transform — saves
+ * us from imperative `resetTransform()` calls on every round change.
+ *
+ * The persona designer flagged the letterboxed photo as the #1
+ * recognizability problem on mobile (a 16:9 cap squeezed into a
+ * third of the viewport kills detail). Pinch + drag-to-pan + a
+ * tap-and-hold reset gives players a way to inspect a region
+ * without leaving the deck or expanding into a separate dialog.
+ */
+function ZoomablePhoto({ src, alt }: { src: string; alt: string }) {
+    // Tracked via the library's onTransformed callback rather than a
+    // hook lookup — useTransformContext doesn't expose `transformState`
+    // in the public type, and reading it via `as any` would defeat
+    // strict typing. A scale state in the parent is cheap (one render
+    // per zoom transition) and works across library versions.
+    const [scale, setScale] = useState(1)
     return (
-        <img
-            src={safeUrl}
-            alt={altText}
-            className="h-full w-full object-contain"
-            loading="eager"
-            decoding="async"
-            fetchPriority="high"
-        />
+        <TransformWrapper
+            key={src}
+            initialScale={1}
+            minScale={1}
+            maxScale={5}
+            centerOnInit
+            doubleClick={{ mode: 'toggle', step: 1.5 }}
+            wheel={{ step: 0.2 }}
+            pinch={{ step: 5 }}
+            // Disable pan inertia so the photo stops the moment the
+            // finger lifts — keeps the photo predictable on a tiny
+            // mobile viewport. Pan itself stays enabled at all scales
+            // so a player who zooms in by accident can still drag.
+            panning={{ disabled: false, velocityDisabled: true }}
+            onTransform={(ref) => setScale(ref.state.scale)}
+        >
+            {scale > 1.01 && <ResetZoomButton />}
+            <TransformComponent
+                wrapperClass="!h-full !w-full"
+                contentClass="!h-full !w-full"
+            >
+                <img
+                    src={src}
+                    alt={alt}
+                    className="h-full w-full object-contain select-none"
+                    draggable={false}
+                    loading="eager"
+                    decoding="async"
+                    fetchPriority="high"
+                />
+            </TransformComponent>
+        </TransformWrapper>
+    )
+}
+
+/**
+ * Reset-zoom affordance. Mounted only when the photo is zoomed (the
+ * parent gates it), so this component can assume a useControls call is
+ * meaningful — at scale=1 it would have nothing to do.
+ */
+function ResetZoomButton() {
+    const { t } = useTranslation()
+    const { resetTransform } = useControls()
+    return (
+        <button
+            type="button"
+            onClick={() => resetTransform()}
+            className="absolute right-2 top-2 z-20 inline-flex items-center gap-1 rounded-full bg-black/60 px-3 py-1.5 text-xs text-white shadow backdrop-blur min-h-9 hover:bg-black/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+            aria-label={t('geo.play.resetZoom', 'Reset zoom')}
+        >
+            <RefreshCw className="h-3 w-3" aria-hidden />
+            {t('geo.play.resetZoom', 'Reset zoom')}
+        </button>
     )
 }
 


### PR DESCRIPTION
## Summary

The persona designer + playtest both flagged the letterboxed photo as the #1 recognizability problem on mobile — a 16:9 cap squeezed into a third of the viewport kills detail. This PR wraps the photo panel in `react-zoom-pan-pinch` so players can inspect a region without leaving the deck or expanding into a separate dialog.

- **Pinch** (touch) and **wheel** (desktop) zoom up to 5×.
- **Double-tap** toggles zoom (1× ↔ 1.5×).
- **Drag-to-pan** once zoomed; pan inertia disabled so the photo stops the moment the finger lifts.
- **Auto-reset on round change** via `key={src}` — each new screenshot re-mounts the wrapper at scale 1, no imperative reset call.
- **"Reset zoom" pill** renders only when the photo is actually zoomed (`scale > 1.01`), with a `min-h-9` hit area + focus ring + localized aria-label.

## Files

- `packages/frontend/package.json` + `package-lock.json` — adds `react-zoom-pan-pinch` (~10 KB gz). Loaded with the page bundle since it's used on first paint of an active round.
- `packages/frontend/src/pages/GeoPlayPage.tsx` — new `ZoomablePhoto` and `ResetZoomButton` components. The `<img>` is moved inside `<TransformComponent>`, with `select-none` and `draggable={false}` so single-finger drags trigger the library's pan, not a native image drag.
- `packages/frontend/public/locales/{en,fr}/translation.json` — new `geo.play.resetZoom` key.

## Why the parent-state pattern

`useTransformContext()` doesn't expose `transformState` in the public type, so the obvious "render Reset only when scale>1 inside the wrapper" approach won't typecheck. Instead I track `scale` via the supported `onTransform` callback in the parent and conditionally mount `<ResetZoomButton />`. Inside that component, `useControls()` always has a live wrapper context to read.

## Test plan

- [x] `npm run build:frontend`
- [x] `npm run lint`
- [x] `npm test` — **81/81 pass**
- [ ] Manual on a phone: pinch the screenshot → it zooms to ~5×; pan with one finger; tap "Reset zoom" → returns to 1×
- [ ] Manual: double-tap the photo → toggles to 1.5×, second double-tap returns to 1×
- [ ] Manual: hit "Next round" → next screenshot loads at scale=1 (the wrapper re-mounts via `key={src}`)
- [ ] Manual on desktop: scroll wheel over the photo zooms in/out
- [ ] Manual: zoom in on the photo, then switch to the map and pinch — the map's pinch is independent and unaffected

## What's left

- **Deferred login wall** (3 anon pins, signup-flush, stricter rate limits) — schema change, larger surface, deserves a PRD before code.

That's the last persona-flagged item that hasn't shipped.

https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019p2ApuHDY1n511MoM4ZZ5m)_