### PR TITLE
feat(geo): pin-drop pop animation paired with placement haptic

### DIFF
--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -27,11 +27,18 @@ const FUCHSIA_DIVICON = createDiv('fuchsia')
 const EMERALD_DIVICON = createDiv('emerald')
 
 // Colors + box-shadow are sourced from the design tokens exposed on :root
-// in src/index.css so this stays in sync with the rest of the UI.
+// in src/index.css so this stays in sync with the rest of the UI. The
+// fuchsia variant carries `geo-map-marker-pop` so the player's pin
+// animates in on placement (CSS keyframe in index.css, gated on
+// prefers-reduced-motion). The emerald canonical marker is intentionally
+// static — it appears at round-end and shouldn't compete with the result
+// overlay for attention.
 function createDiv(color: 'fuchsia' | 'emerald'): L.DivIcon {
     const fill = color === 'fuchsia' ? 'var(--neon-pink)' : 'var(--success)'
+    const className =
+        color === 'fuchsia' ? 'geo-map-marker geo-map-marker-pop' : 'geo-map-marker'
     return L.divIcon({
-        className: 'geo-map-marker',
+        className,
         html: `<span style="display:block;width:16px;height:16px;border-radius:9999px;background:${fill};box-shadow:var(--glow-md);"></span>`,
         iconSize: [16, 16],
         iconAnchor: [8, 8],

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -410,3 +410,31 @@ body {
   outline: 2px solid var(--neon-pink);
   outline-offset: -2px;
 }
+
+/* Pin-drop entrance — runs once when a fresh fuchsia DivIcon mounts
+   (i.e. the player drops a pin). The Marker only renders when `pin` is
+   truthy, so this fires on placement, not on drag-to-refine. Paired
+   with the existing vibrate(10) for a unified visual + haptic beat.
+   Gated on prefers-reduced-motion so vestibular-sensitive users get a
+   static pin instead. */
+@keyframes geo-pin-pop {
+  0% {
+    transform: scale(0.4);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.18);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .geo-map-marker-pop > span {
+    animation: geo-pin-pop 220ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+    transform-origin: center;
+  }
+}


### PR DESCRIPTION
## Summary

The UX persona's "delight tier" suggestion from the geo review: a 220 ms scale-bounce on the fuchsia DivIcon when the player drops a pin. Sells the action-verb flip ("Drop pin" → "Confirm pin") that the dock CTA already does, and unifies the visual + the existing `vibrate(10)` haptic into a single beat.

This is the last item from the persona meeting; everything else has shipped in #176, #179, #181, #184.

## Changes

- New `@keyframes geo-pin-pop` in `index.css` with a small overshoot cubic-bezier (`cubic-bezier(0.34, 1.56, 0.64, 1)`) so the pop has a snappy-but-soft landing.
- Gated under `@media (prefers-reduced-motion: no-preference)` — vestibular-sensitive users see a static pin (WCAG 2.3.3 *Animation from Interactions*).
- Applied via a new `geo-map-marker-pop` class on the **fuchsia** DivIcon only. The emerald canonical marker stays static so it doesn't compete with the result overlay for attention at reveal time.
- Animation runs on element mount — the `<Marker>` only renders when `pin` is truthy, so a fresh DOM element is created each time the player drops a pin. Drag-to-refine doesn't re-trigger the animation, which is the right behavior (drag is fluid, the bounce would interrupt).

## Test plan

- [x] `npm run build:frontend` typechecks + builds clean
- [x] ESLint clean on touched files
- [x] Backend test suite (81 / 81) green via pre-commit
- [ ] Manual: drop a pin on `/fr/geo` → fuchsia dot scales in with a small overshoot, pairs with the haptic tick
- [ ] Manual: drag the pin to refine → no re-animation (smooth glide)
- [ ] Manual: enable "Reduce motion" in OS settings → pin appears statically
- [ ] Manual: at round reveal, emerald canonical marker appears without animation

https://claude.ai/code/session_01XcEgEPjRxFj8oYk1JuCkba

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcEgEPjRxFj8oYk1JuCkba)_