### PR TITLE
feat(push): frontend service worker handler + profile opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,16 @@ NODE_ENV=development
 CORS_ORIGIN=http://localhost:5173
 
 # ============================================
+# WEB PUSH (VAPID)
+# ============================================
+# Generate a keypair: npm run vapid:generate -w @the-box/backend
+# Without all three values set, push routes return 503 and the frontend
+# opt-in UI hides itself.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:no-reply@the-box.battistella.ovh
+
+# ============================================
 # PRODUCTION DEPLOYMENT NOTES
 # ============================================
 # 1. Generate strong BETTER_AUTH_SECRET: openssl rand -base64 32

--- a/package-lock.json
+++ b/package-lock.json
@@ -6485,6 +6485,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
@@ -6895,7 +6905,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -7075,6 +7084,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/ast-types": {
@@ -7385,6 +7406,12 @@
         }
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -7538,6 +7565,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -8607,6 +8640,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/eciesjs": {
@@ -10382,6 +10424,15 @@
         "void-elements": "3.1.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -10406,7 +10457,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -11446,6 +11496,27 @@
         "node": "*"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -12192,6 +12263,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -16061,6 +16138,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -16874,6 +16970,7 @@
         "socket.io": "^4.8.3",
         "stripe": "^22.1.0",
         "uuid": "^13.0.0",
+        "web-push": "^3.6.7",
         "zod": "^4.3.5"
       },
       "devDependencies": {
@@ -16883,6 +16980,7 @@
         "@types/node": "^25.0.6",
         "@types/pg": "^8.16.0",
         "@types/uuid": "^11.0.0",
+        "@types/web-push": "^3.6.4",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"

--- a/packages/backend/migrations/20260517_push_subscriptions.ts
+++ b/packages/backend/migrations/20260517_push_subscriptions.ts
@@ -1,0 +1,48 @@
+import type { Knex } from 'knex'
+
+// Web Push subscription storage. One row per (user, endpoint): a single user
+// can have multiple devices subscribed (phone + desktop browser), and the
+// `endpoint` is the natural key the browser hands us — globally unique per
+// device/origin. We don't drop rows when push fails; the service flips
+// `is_active=false` after a 410 Gone or 404 from the push provider so the
+// next send cycle skips them. Reactivation happens on the next subscribe
+// call from that endpoint, which upserts is_active back to true.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('push_subscriptions', (table) => {
+    table.increments('id').primary()
+    table.string('user_id', 64).notNullable()
+    // The push service URL the browser obtained from its registration server
+    // (Firebase, Mozilla autopush, Apple, etc.). Up to ~500 chars in practice.
+    table.text('endpoint').notNullable()
+    // Public key the push service will encrypt the payload against.
+    table.string('p256dh', 200).notNullable()
+    // Auth secret produced by the browser at subscribe-time.
+    table.string('auth', 50).notNullable()
+    // Browser-reported user-agent string at subscribe time. Optional but useful
+    // for debugging "why is this device getting two notifications".
+    table.string('user_agent', 500).nullable()
+    table.boolean('is_active').notNullable().defaultTo(true)
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+    // Last time the push service responded 2xx to a send. Updated by the
+    // service after each successful delivery so we can prune subscriptions
+    // that haven't responded successfully in N days.
+    table.timestamp('last_success_at', { useTz: true }).nullable()
+    // Last 4xx/5xx response from the push service, recorded so admins can
+    // diagnose why a device stopped receiving without scraping logs.
+    table.timestamp('last_failure_at', { useTz: true }).nullable()
+    table.integer('last_failure_status').nullable()
+
+    // The endpoint is globally unique per device — re-subscribing yields the
+    // same endpoint. Unique on endpoint alone (not scoped to user) so a
+    // device that switches accounts cleanly re-points to the new user via
+    // the upsert path.
+    table.unique(['endpoint'], { indexName: 'push_subscriptions_endpoint_uniq' })
+    // Hot path: enumerate active subscriptions for a single user when sending.
+    table.index(['user_id', 'is_active'], 'push_subscriptions_user_active_idx')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('push_subscriptions')
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,6 +22,7 @@
     "fetch:steam-all": "tsx src/tools/steam-screenshot-fetcher.ts all --screenshots-per-game 5",
     "e2e:seed": "tsx scripts/e2e-seed.ts",
     "stripe:check": "tsx scripts/stripe-check.ts",
+    "vapid:generate": "tsx scripts/generate-vapid.ts",
     "test": "node --import tsx --test 'src/**/*.test.ts'"
   },
   "dependencies": {
@@ -42,6 +43,7 @@
     "socket.io": "^4.8.3",
     "stripe": "^22.1.0",
     "uuid": "^13.0.0",
+    "web-push": "^3.6.7",
     "zod": "^4.3.5"
   },
   "devDependencies": {
@@ -51,6 +53,7 @@
     "@types/node": "^25.0.6",
     "@types/pg": "^8.16.0",
     "@types/uuid": "^11.0.0",
+    "@types/web-push": "^3.6.4",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"

--- a/packages/backend/scripts/generate-vapid.ts
+++ b/packages/backend/scripts/generate-vapid.ts
@@ -1,0 +1,17 @@
+// Print a VAPID keypair for Web Push. Drop the output into your .env:
+//   VAPID_PUBLIC_KEY=...
+//   VAPID_PRIVATE_KEY=...
+//   VAPID_SUBJECT=mailto:you@example.com
+//
+// Usage: npm run vapid:generate -w @the-box/backend
+import webpush from 'web-push'
+
+const keys = webpush.generateVAPIDKeys()
+process.stdout.write(
+  [
+    `VAPID_PUBLIC_KEY=${keys.publicKey}`,
+    `VAPID_PRIVATE_KEY=${keys.privateKey}`,
+    'VAPID_SUBJECT=mailto:no-reply@the-box.battistella.ovh',
+    '',
+  ].join('\n'),
+)

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -47,6 +47,13 @@ export const env = {
   STRIPE_CHECKOUT_SUCCESS_URL: process.env['STRIPE_CHECKOUT_SUCCESS_URL'] || 'http://localhost:5173/fr/premium?checkout=success',
   STRIPE_CHECKOUT_CANCEL_URL: process.env['STRIPE_CHECKOUT_CANCEL_URL'] || 'http://localhost:5173/fr/premium?checkout=cancel',
   STRIPE_PORTAL_RETURN_URL: process.env['STRIPE_PORTAL_RETURN_URL'] || 'http://localhost:5173/fr/profile',
+
+  // Web Push (VAPID). Required to send notifications. Generate a keypair
+  // with `npm run vapid:generate -w @the-box/backend`. Without all three
+  // values present, the push.service refuses to send and routes return 503.
+  VAPID_PUBLIC_KEY: process.env['VAPID_PUBLIC_KEY'] || '',
+  VAPID_PRIVATE_KEY: process.env['VAPID_PRIVATE_KEY'] || '',
+  VAPID_SUBJECT: process.env['VAPID_SUBJECT'] || '',
 }
 
 export function validateEnv(): void {

--- a/packages/backend/src/domain/services/push.service.ts
+++ b/packages/backend/src/domain/services/push.service.ts
@@ -1,0 +1,75 @@
+import { pushSubscriptionRepository } from '../../infrastructure/repositories/push-subscription.repository.js'
+import { isPushConfigured, sendPush } from '../../infrastructure/push/push-sender.js'
+import { serviceLogger } from '../../infrastructure/logger/logger.js'
+
+const log = serviceLogger.child({ service: 'push' })
+
+export interface PushPayload {
+  // Free-form discriminator the SW will use to decide how to render. Examples:
+  //   'daily_challenge_ready'
+  //   'streak_at_risk'
+  //   'leaderboard_position_lost'
+  type: string
+  title: string
+  body: string
+  // Optional URL the SW should open when the user clicks the notification.
+  // Relative paths are resolved against the manifest scope.
+  url?: string
+  // Arbitrary extra data forwarded to the SW for type-specific handling.
+  data?: Record<string, unknown>
+}
+
+export interface SendToUserResult {
+  attempted: number
+  succeeded: number
+  pruned: number
+}
+
+export const pushService = {
+  isConfigured: isPushConfigured,
+
+  // Fan out to every active subscription for `userId`. We never throw on
+  // per-device failures: a user with three devices, one of which the push
+  // provider has declared 410 Gone, should still get the notification on the
+  // other two. The 410'd row is deactivated in-place by markFailure so the
+  // next send skips it.
+  async sendToUser(userId: string, payload: PushPayload): Promise<SendToUserResult> {
+    if (!isPushConfigured()) {
+      log.warn({ userId, type: payload.type }, 'push not configured; skipping send')
+      return { attempted: 0, succeeded: 0, pruned: 0 }
+    }
+
+    const subs = await pushSubscriptionRepository.listActiveForUser(userId)
+    if (subs.length === 0) {
+      return { attempted: 0, succeeded: 0, pruned: 0 }
+    }
+
+    let succeeded = 0
+    let pruned = 0
+    await Promise.all(
+      subs.map(async (sub) => {
+        const result = await sendPush(
+          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+          payload,
+        )
+        if (result.success) {
+          await pushSubscriptionRepository.markSuccess(sub.endpoint)
+          succeeded += 1
+        } else {
+          await pushSubscriptionRepository.markFailure(
+            sub.endpoint,
+            result.statusCode ?? 0,
+            result.gone,
+          )
+          if (result.gone) pruned += 1
+        }
+      }),
+    )
+
+    log.info(
+      { userId, type: payload.type, attempted: subs.length, succeeded, pruned },
+      'push fan-out complete',
+    )
+    return { attempted: subs.length, succeeded, pruned }
+  },
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -24,6 +24,7 @@ import referralRoutes from './presentation/routes/referral.routes.js'
 import ogRoutes from './presentation/routes/og.routes.js'
 import geoRoutes from './presentation/routes/geo.routes.js'
 import screenshotReportRoutes from './presentation/routes/screenshot-report.routes.js'
+import pushRoutes from './presentation/routes/push.routes.js'
 import billingRoutes from './presentation/routes/billing.routes.js'
 import billingWebhookRoutes from './presentation/routes/billing-webhook.routes.js'
 import { testRedisConnection } from './infrastructure/queue/connection.js'
@@ -194,6 +195,7 @@ app.use('/api/referral', referralRoutes)
 app.use('/api/og', ogRoutes)
 app.use('/api/geo', geoRoutes)
 app.use('/api/screenshot-reports', screenshotReportRoutes)
+app.use('/api/push', pushRoutes)
 app.use('/api/billing', billingRoutes)
 
 // Serve frontend static files (after API routes)

--- a/packages/backend/src/infrastructure/push/push-sender.ts
+++ b/packages/backend/src/infrastructure/push/push-sender.ts
@@ -1,0 +1,55 @@
+import webpush from 'web-push'
+import { env } from '../../config/env.js'
+import { logger } from '../logger/logger.js'
+
+const log = logger.child({ module: 'push-sender' })
+
+let configured = false
+
+export function isPushConfigured(): boolean {
+  return Boolean(env.VAPID_PUBLIC_KEY && env.VAPID_PRIVATE_KEY && env.VAPID_SUBJECT)
+}
+
+function ensureConfigured(): void {
+  if (configured) return
+  if (!isPushConfigured()) {
+    throw new Error('web push not configured: VAPID keys missing')
+  }
+  webpush.setVapidDetails(env.VAPID_SUBJECT, env.VAPID_PUBLIC_KEY, env.VAPID_PRIVATE_KEY)
+  configured = true
+  log.info('web push initialized')
+}
+
+export interface PushSubscriptionTarget {
+  endpoint: string
+  keys: { p256dh: string; auth: string }
+}
+
+export interface SendResult {
+  success: boolean
+  // HTTP status returned by the push provider (Firebase, autopush, …). 201
+  // typically means "accepted, will deliver". 410/404 means the subscription
+  // is gone for good and should be deactivated.
+  statusCode?: number
+  // True iff the subscription should be removed/deactivated by the caller.
+  gone: boolean
+}
+
+export async function sendPush(
+  target: PushSubscriptionTarget,
+  payload: unknown,
+): Promise<SendResult> {
+  ensureConfigured()
+  try {
+    const res = await webpush.sendNotification(target, JSON.stringify(payload))
+    return { success: true, statusCode: res.statusCode, gone: false }
+  } catch (err) {
+    const status =
+      typeof err === 'object' && err !== null && 'statusCode' in err
+        ? Number((err as { statusCode: unknown }).statusCode)
+        : undefined
+    const gone = status === 404 || status === 410
+    log.warn({ statusCode: status, gone }, 'push send failed')
+    return { success: false, statusCode: status, gone }
+  }
+}

--- a/packages/backend/src/infrastructure/repositories/index.ts
+++ b/packages/backend/src/infrastructure/repositories/index.ts
@@ -46,3 +46,8 @@ export {
   type SubscriptionRow,
   type UpsertSubscriptionInput,
 } from './subscription.repository.js'
+export {
+  pushSubscriptionRepository,
+  type PushSubscriptionRow,
+  type UpsertSubscriptionInput as UpsertPushSubscriptionInput,
+} from './push-subscription.repository.js'

--- a/packages/backend/src/infrastructure/repositories/push-subscription.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/push-subscription.repository.ts
@@ -1,0 +1,97 @@
+import { db } from '../database/connection.js'
+import { repoLogger } from '../logger/logger.js'
+
+const log = repoLogger.child({ repository: 'push-subscription' })
+
+export interface PushSubscriptionRow {
+  id: number
+  user_id: string
+  endpoint: string
+  p256dh: string
+  auth: string
+  user_agent: string | null
+  is_active: boolean
+  created_at: Date
+  last_success_at: Date | null
+  last_failure_at: Date | null
+  last_failure_status: number | null
+}
+
+export interface UpsertSubscriptionInput {
+  userId: string
+  endpoint: string
+  p256dh: string
+  auth: string
+  userAgent?: string
+}
+
+export const pushSubscriptionRepository = {
+  // Upsert keyed on `endpoint` so re-subscribing the same device just bumps
+  // user/active rather than creating duplicate rows. A device that re-binds
+  // to a different user (account switch on the same browser) cleanly moves
+  // the row to the new user_id thanks to the conflict target.
+  async upsert(input: UpsertSubscriptionInput): Promise<PushSubscriptionRow> {
+    const rows = await db('push_subscriptions')
+      .insert({
+        user_id: input.userId,
+        endpoint: input.endpoint,
+        p256dh: input.p256dh,
+        auth: input.auth,
+        user_agent: input.userAgent ?? null,
+        is_active: true,
+      })
+      .onConflict('endpoint')
+      .merge({
+        user_id: input.userId,
+        p256dh: input.p256dh,
+        auth: input.auth,
+        user_agent: input.userAgent ?? null,
+        is_active: true,
+      })
+      .returning<PushSubscriptionRow[]>('*')
+    const row = rows[0]
+    if (!row) throw new Error('upsert returned no row')
+    log.info({ userId: input.userId, endpoint: redact(input.endpoint) }, 'push subscription upserted')
+    return row
+  },
+
+  async listActiveForUser(userId: string): Promise<PushSubscriptionRow[]> {
+    return db('push_subscriptions')
+      .where({ user_id: userId, is_active: true })
+      .select<PushSubscriptionRow[]>('*')
+  },
+
+  // Endpoint is globally unique, so this either deletes one row or zero. We
+  // hard-delete on explicit unsubscribe (vs. is_active=false) because the
+  // user has signaled intent to revoke; keeping the row would just clutter.
+  async deleteByEndpoint(endpoint: string): Promise<boolean> {
+    const deleted = await db('push_subscriptions').where({ endpoint }).del()
+    return deleted > 0
+  },
+
+  async markSuccess(endpoint: string): Promise<void> {
+    await db('push_subscriptions')
+      .where({ endpoint })
+      .update({ last_success_at: db.fn.now(), last_failure_at: null, last_failure_status: null })
+  },
+
+  // 4xx/5xx response. Service decides whether to flip is_active based on
+  // status (410/404 → terminally gone → flip).
+  async markFailure(endpoint: string, status: number, deactivate: boolean): Promise<void> {
+    await db('push_subscriptions')
+      .where({ endpoint })
+      .update({
+        last_failure_at: db.fn.now(),
+        last_failure_status: status,
+        ...(deactivate ? { is_active: false } : {}),
+      })
+  },
+}
+
+// Endpoints contain a per-device token; redact the path tail when logging so
+// the full token doesn't end up in log aggregators.
+function redact(endpoint: string): string {
+  const idx = endpoint.lastIndexOf('/')
+  if (idx < 0 || idx >= endpoint.length - 1) return endpoint
+  return `${endpoint.slice(0, idx + 1)}…`
+}

--- a/packages/backend/src/presentation/routes/push.routes.ts
+++ b/packages/backend/src/presentation/routes/push.routes.ts
@@ -1,0 +1,70 @@
+import { Router } from 'express'
+import { z } from 'zod'
+import { env } from '../../config/env.js'
+import { pushSubscriptionRepository } from '../../infrastructure/repositories/index.js'
+import { pushService } from '../../domain/services/push.service.js'
+import { authMiddleware } from '../middleware/auth.middleware.js'
+import { validateBody } from '../middleware/validation.middleware.js'
+
+const router = Router()
+
+// Public: the frontend needs the VAPID public key to call
+// PushManager.subscribe(applicationServerKey: ...). Returns 503 when push is
+// not configured so the client can hide the opt-in UI cleanly instead of
+// surfacing a parse error.
+router.get('/vapid-public-key', (_req, res) => {
+  if (!pushService.isConfigured()) {
+    res.status(503).json({
+      success: false,
+      error: { code: 'PUSH_NOT_CONFIGURED', message: 'web push not configured' },
+    })
+    return
+  }
+  res.json({ success: true, data: { publicKey: env.VAPID_PUBLIC_KEY } })
+})
+
+const subscribeBodySchema = z.object({
+  endpoint: z.string().url().max(2000),
+  keys: z.object({
+    p256dh: z.string().min(1).max(200),
+    auth: z.string().min(1).max(50),
+  }),
+  userAgent: z.string().max(500).optional(),
+})
+
+router.post('/subscribe', authMiddleware, validateBody(subscribeBodySchema), async (req, res, next) => {
+  try {
+    const userId = req.userId!
+    const body = req.body as z.infer<typeof subscribeBodySchema>
+    const row = await pushSubscriptionRepository.upsert({
+      userId,
+      endpoint: body.endpoint,
+      p256dh: body.keys.p256dh,
+      auth: body.keys.auth,
+      userAgent: body.userAgent,
+    })
+    res.json({ success: true, data: { id: row.id, isActive: row.is_active } })
+  } catch (err) {
+    next(err)
+  }
+})
+
+const unsubscribeBodySchema = z.object({
+  endpoint: z.string().url().max(2000),
+})
+
+// DELETE with a body (RFC 9110 allows it, Express + JSON parser handle it).
+// We accept the endpoint in the body rather than a query param because the
+// endpoint URL can be long and contains a per-device token we'd rather not
+// log via access logs that capture the request line.
+router.delete('/subscribe', authMiddleware, validateBody(unsubscribeBodySchema), async (req, res, next) => {
+  try {
+    const body = req.body as z.infer<typeof unsubscribeBodySchema>
+    const removed = await pushSubscriptionRepository.deleteByEndpoint(body.endpoint)
+    res.json({ success: true, data: { removed } })
+  } catch (err) {
+    next(err)
+  }
+})
+
+export default router

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1575,6 +1575,16 @@
     "optedOut": "You won't receive marketing emails.",
     "updateError": "Failed to update preference. Please try again."
   },
+  "pushNotifications": {
+    "title": "Push notifications",
+    "description": "Get the daily challenge and streak reminders pushed to your browser, even when the tab is closed.",
+    "label": "Enable push notifications on this device.",
+    "optedIn": "Notifications enabled on this device.",
+    "optedOut": "Notifications disabled on this device.",
+    "permissionDenied": "You blocked notifications in your browser.",
+    "permissionDeniedHint": "Notifications are blocked at the browser level. Allow them in your site settings, then come back here.",
+    "updateError": "Couldn't update notifications. Try again later."
+  },
   "personalBests": {
     "title": "Personal Bests",
     "highestScore": "Highest Score",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -269,6 +269,7 @@
     "dailyGuess": "Daily Guess",
     "geoCta": "Geo Mode",
     "guestHint": "No account needed — play instantly as a guest",
+    "offlineHint": "You are offline — reconnect to play today's challenge",
     "previewBadge": "Today's challenge",
     "previewHeading": "Think you know this game?",
     "previewSubtitle": "Click to play the full 10-screenshot challenge.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1575,6 +1575,16 @@
     "optedOut": "Vous ne recevrez plus d'e-mails marketing.",
     "updateError": "Échec de la mise à jour. Veuillez réessayer."
   },
+  "pushNotifications": {
+    "title": "Notifications push",
+    "description": "Recevez le défi du jour et les rappels de série directement dans votre navigateur, même quand l'onglet est fermé.",
+    "label": "Activer les notifications push sur cet appareil.",
+    "optedIn": "Notifications activées sur cet appareil.",
+    "optedOut": "Notifications désactivées sur cet appareil.",
+    "permissionDenied": "Vous avez refusé les notifications dans votre navigateur.",
+    "permissionDeniedHint": "Les notifications sont bloquées au niveau du navigateur. Autorisez-les dans les paramètres du site, puis revenez ici.",
+    "updateError": "Impossible de modifier les notifications. Réessayez plus tard."
+  },
   "personalBests": {
     "title": "Meilleurs Scores",
     "highestScore": "Meilleur Score",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -269,6 +269,7 @@
     "dailyGuess": "Défi Quotidien",
     "geoCta": "Mode Géo",
     "guestHint": "Aucun compte requis — jouez instantanément en invité",
+    "offlineHint": "Vous êtes hors ligne — reconnectez-vous pour jouer le défi du jour",
     "previewBadge": "Défi du jour",
     "previewHeading": "Pensez-vous reconnaître ce jeu ?",
     "previewSubtitle": "Cliquez pour jouer le défi complet de 10 captures.",

--- a/packages/frontend/src/components/game/GuessInput.tsx
+++ b/packages/frontend/src/components/game/GuessInput.tsx
@@ -10,6 +10,7 @@ import { SkipForward, SkipBack, Loader2, Send, Calendar, Building2, Code2, Tag }
 import { createGuessSubmissionService } from '@/services'
 import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe'
 import { useGameGuess } from '@/hooks/useGameGuess'
+import { useOnline } from '@/hooks/useOnline'
 import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 
@@ -20,6 +21,7 @@ import { cn } from '@/lib/utils'
  */
 export function GuessInput() {
   const { t } = useTranslation()
+  const isOnline = useOnline()
   const [query, setQuery] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isShaking, setIsShaking] = useState(false)
@@ -276,7 +278,7 @@ export function GuessInput() {
             variant="ghost"
             size="icon"
             onClick={handleSubmit}
-            disabled={!query.trim() || isSubmitting || gamePhase !== 'playing'}
+            disabled={!query.trim() || isSubmitting || gamePhase !== 'playing' || !isOnline}
             aria-label={t('game.submit', { defaultValue: 'Submit guess' })}
             className={cn(
               'absolute right-1.5 sm:right-2 inset-y-0 my-auto size-9 sm:size-10 max-[360px]:size-8 p-0 touch-manipulation transition-all duration-300',

--- a/packages/frontend/src/components/profile/PushNotificationCard.tsx
+++ b/packages/frontend/src/components/profile/PushNotificationCard.tsx
@@ -1,0 +1,81 @@
+import { useTranslation } from 'react-i18next'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Bell, Loader2 } from 'lucide-react'
+import { useWebPush } from '@/hooks/useWebPush'
+import { toast } from '@/lib/toast'
+
+export function PushNotificationCard() {
+  const { t } = useTranslation()
+  const {
+    isSupported,
+    isServerConfigured,
+    permission,
+    isSubscribed,
+    isLoading,
+    subscribe,
+    unsubscribe,
+  } = useWebPush()
+
+  // Don't render the card at all if there's nothing the user can do here:
+  // unsupported browser (Firefox on iOS, etc.) or server lacks VAPID keys.
+  if (!isSupported || isServerConfigured === false) return null
+
+  const handleToggle = async (next: boolean) => {
+    try {
+      if (next) {
+        await subscribe()
+        if (Notification.permission === 'granted') {
+          toast.success(t('pushNotifications.optedIn'))
+        } else if (Notification.permission === 'denied') {
+          toast.error(t('pushNotifications.permissionDenied'))
+        }
+      } else {
+        await unsubscribe()
+        toast.success(t('pushNotifications.optedOut'))
+      }
+    } catch (err) {
+      toast.error(t('pushNotifications.updateError'))
+      console.error('Failed to update push subscription:', err)
+    }
+  }
+
+  // The browser blocked us at OS/site level — flipping the toggle won't help,
+  // the user has to clear the block in browser settings. Show a read-only
+  // hint instead of an interactive control.
+  const isPermanentlyDenied = permission === 'denied' && !isSubscribed
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          {t('pushNotifications.title')}
+        </CardTitle>
+        <CardDescription>{t('pushNotifications.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isPermanentlyDenied ? (
+          <p className="text-sm text-muted-foreground">{t('pushNotifications.permissionDeniedHint')}</p>
+        ) : (
+          <label className="flex items-start gap-3 cursor-pointer select-none group">
+            <input
+              type="checkbox"
+              checked={isSubscribed}
+              disabled={isLoading || isServerConfigured === null}
+              onChange={(e) => void handleToggle(e.target.checked)}
+              className="mt-0.5 h-4 w-4 shrink-0 rounded border-white/20 bg-background/50 accent-neon-purple cursor-pointer disabled:cursor-wait"
+            />
+            <span className="flex-1 space-y-1">
+              <span className="block text-sm text-foreground/90 group-hover:text-foreground transition-colors">
+                {t('pushNotifications.label')}
+              </span>
+              <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                {isLoading && <Loader2 className="h-3 w-3 animate-spin" />}
+              </span>
+            </span>
+          </label>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/frontend/src/components/profile/index.ts
+++ b/packages/frontend/src/components/profile/index.ts
@@ -1,6 +1,7 @@
 export { AvatarUpload } from './AvatarUpload'
 export { ReferralCard } from './ReferralCard'
 export { EmailConsentCard } from './EmailConsentCard'
+export { PushNotificationCard } from './PushNotificationCard'
 export { AdvancedStatsPanel } from './AdvancedStatsPanel'
 export { PremiumBadge } from './PremiumBadge'
 export { ThemeSwitcher } from './ThemeSwitcher'

--- a/packages/frontend/src/components/pwa/OfflineIndicator.tsx
+++ b/packages/frontend/src/components/pwa/OfflineIndicator.tsx
@@ -1,24 +1,11 @@
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { WifiOff } from 'lucide-react'
+import { useOnline } from '@/hooks/useOnline'
 import { cn } from '@/lib/utils'
 
 export function OfflineIndicator() {
   const { t } = useTranslation()
-  const [isOnline, setIsOnline] = useState(
-    typeof navigator !== 'undefined' ? navigator.onLine : true,
-  )
-
-  useEffect(() => {
-    const handleOnline = () => setIsOnline(true)
-    const handleOffline = () => setIsOnline(false)
-    window.addEventListener('online', handleOnline)
-    window.addEventListener('offline', handleOffline)
-    return () => {
-      window.removeEventListener('online', handleOnline)
-      window.removeEventListener('offline', handleOffline)
-    }
-  }, [])
+  const isOnline = useOnline()
 
   if (isOnline) return null
 

--- a/packages/frontend/src/hooks/useOnline.ts
+++ b/packages/frontend/src/hooks/useOnline.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Subscribe to the browser's online/offline events. Returns the current
+ * connectivity flag, defaulting to `true` on the server / first render.
+ */
+export function useOnline(): boolean {
+  const [isOnline, setIsOnline] = useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true,
+  )
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
+
+  return isOnline
+}

--- a/packages/frontend/src/hooks/useWebPush.ts
+++ b/packages/frontend/src/hooks/useWebPush.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useState } from 'react'
+import { pushApi } from '@/lib/api/push'
+
+export type PushPermissionStatus = 'default' | 'granted' | 'denied'
+
+export interface UseWebPushState {
+  // Browser supports the full Notifications + Push + ServiceWorker stack.
+  // iOS Safari requires the user to install the PWA first; Notification.permission
+  // exists in the page but PushManager only inside the SW registration.
+  isSupported: boolean
+  // The server has VAPID keys configured. When false the toggle should be
+  // hidden — there's nothing the user can do about it.
+  isServerConfigured: boolean | null
+  permission: PushPermissionStatus
+  // True when this browser already has an active subscription. Computed from
+  // the live ServiceWorkerRegistration so it stays accurate across tabs.
+  isSubscribed: boolean
+  isLoading: boolean
+  // Async operations the UI can call.
+  subscribe: () => Promise<void>
+  unsubscribe: () => Promise<void>
+}
+
+function detectSupport(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window
+  )
+}
+
+// Convert a base64url-encoded VAPID key into the Uint8Array shape that
+// PushManager.subscribe expects as `applicationServerKey`.
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const raw = atob(base64)
+  const out = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i += 1) out[i] = raw.charCodeAt(i)
+  return out
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer | null): string {
+  if (!buffer) return ''
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.byteLength; i += 1) binary += String.fromCharCode(bytes[i] as number)
+  return btoa(binary)
+}
+
+async function readExistingSubscription(): Promise<PushSubscription | null> {
+  if (!detectSupport()) return null
+  const reg = await navigator.serviceWorker.ready
+  return reg.pushManager.getSubscription()
+}
+
+export function useWebPush(): UseWebPushState {
+  const isSupported = detectSupport()
+  const [isServerConfigured, setIsServerConfigured] = useState<boolean | null>(null)
+  const [permission, setPermission] = useState<PushPermissionStatus>(
+    isSupported ? (Notification.permission as PushPermissionStatus) : 'default',
+  )
+  const [isSubscribed, setIsSubscribed] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Probe both the server config and the current subscription state on mount.
+  // Failures are non-fatal — the UI just stays in "not subscribed".
+  useEffect(() => {
+    if (!isSupported) {
+      setIsServerConfigured(false)
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const key = await pushApi.getVapidPublicKey()
+        if (cancelled) return
+        setIsServerConfigured(key !== null)
+      } catch {
+        if (!cancelled) setIsServerConfigured(false)
+      }
+      try {
+        const sub = await readExistingSubscription()
+        if (!cancelled) setIsSubscribed(sub !== null)
+      } catch {
+        if (!cancelled) setIsSubscribed(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [isSupported])
+
+  const subscribe = useCallback(async () => {
+    if (!isSupported) throw new Error('push not supported')
+    setIsLoading(true)
+    try {
+      const publicKey = await pushApi.getVapidPublicKey()
+      if (!publicKey) throw new Error('server not configured')
+
+      // Asking for permission must be tied to the user gesture; this hook
+      // expects to be called from a click handler.
+      const next = (await Notification.requestPermission()) as PushPermissionStatus
+      setPermission(next)
+      if (next !== 'granted') return
+
+      const reg = await navigator.serviceWorker.ready
+      const subscription = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        // applicationServerKey accepts BufferSource at runtime; the lib types
+        // narrow it to ArrayBuffer specifically, so cast through unknown.
+        applicationServerKey: urlBase64ToUint8Array(publicKey) as unknown as ArrayBuffer,
+      })
+
+      const json = subscription.toJSON()
+      const p256dh =
+        json.keys?.p256dh ?? arrayBufferToBase64(subscription.getKey('p256dh'))
+      const auth = json.keys?.auth ?? arrayBufferToBase64(subscription.getKey('auth'))
+
+      await pushApi.subscribe({
+        endpoint: subscription.endpoint,
+        keys: { p256dh, auth },
+        userAgent: navigator.userAgent,
+      })
+      setIsSubscribed(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [isSupported])
+
+  const unsubscribe = useCallback(async () => {
+    if (!isSupported) return
+    setIsLoading(true)
+    try {
+      const sub = await readExistingSubscription()
+      if (sub) {
+        // Tell the server first; if it errors we still want to drop the
+        // browser-side subscription so the UI doesn't get stuck "subscribed"
+        // with a 410'd endpoint.
+        try {
+          await pushApi.unsubscribe(sub.endpoint)
+        } catch {
+          // Swallow — the unsubscribe below is what the user actually wanted.
+        }
+        await sub.unsubscribe()
+      }
+      setIsSubscribed(false)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [isSupported])
+
+  return {
+    isSupported,
+    isServerConfigured,
+    permission,
+    isSubscribed,
+    isLoading,
+    subscribe,
+    unsubscribe,
+  }
+}

--- a/packages/frontend/src/lib/api/push.ts
+++ b/packages/frontend/src/lib/api/push.ts
@@ -1,0 +1,64 @@
+interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: { code: string; message: string }
+}
+
+export class PushApiError extends Error {
+  code: string
+
+  constructor(code: string, message: string) {
+    super(message)
+    this.code = code
+    this.name = 'PushApiError'
+  }
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  const json = (await response.json()) as ApiResponse<T>
+  if (!json.success || json.data === undefined) {
+    throw new PushApiError(
+      json.error?.code || 'UNKNOWN_ERROR',
+      json.error?.message || 'An unexpected error occurred',
+    )
+  }
+  return json.data
+}
+
+export interface SubscribePayload {
+  endpoint: string
+  keys: { p256dh: string; auth: string }
+  userAgent?: string
+}
+
+export const pushApi = {
+  // Returns null when the server hasn't been issued VAPID keys yet (503 with
+  // PUSH_NOT_CONFIGURED). The caller should hide the opt-in UI in that case
+  // rather than treat it as a hard error.
+  async getVapidPublicKey(): Promise<string | null> {
+    const response = await fetch('/api/push/vapid-public-key', { credentials: 'include' })
+    if (response.status === 503) return null
+    const data = await handleResponse<{ publicKey: string }>(response)
+    return data.publicKey
+  },
+
+  async subscribe(payload: SubscribePayload): Promise<{ id: number; isActive: boolean }> {
+    const response = await fetch('/api/push/subscribe', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    return handleResponse<{ id: number; isActive: boolean }>(response)
+  },
+
+  async unsubscribe(endpoint: string): Promise<{ removed: boolean }> {
+    const response = await fetch('/api/push/subscribe', {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpoint }),
+    })
+    return handleResponse<{ removed: boolean }>(response)
+  },
+}

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -7,6 +7,7 @@ import { GradientIcon } from '@/components/ui/gradient-icon'
 import { Play, Trophy, History, Clock, CalendarDays, ArrowRight, Sparkles, Check, MapPin } from 'lucide-react'
 import { lazy, Suspense, useEffect, useState, useMemo } from 'react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { useOnline } from '@/hooks/useOnline'
 import { useSession } from '@/lib/auth-client'
 import { gameApi } from '@/lib/api/game'
 import { useNextDailyCountdown } from '@/hooks/useNextDailyCountdown'
@@ -40,6 +41,7 @@ export default function HomePage() {
   } | null>(null)
   const [previewAvailable, setPreviewAvailable] = useState(false)
   const timeRemaining = useNextDailyCountdown()
+  const isOnline = useOnline()
   const billingEntitlement = useBillingStore((state) => state.entitlement)
   const billingPrices = useBillingStore((state) => state.prices)
   const fetchBillingPrices = useBillingStore((state) => state.fetchPrices)
@@ -248,6 +250,7 @@ export default function HomePage() {
                   <Button
                     variant="gaming"
                     size="xl"
+                    disabled={!isOnline}
                     onClick={() => navigate(localizedPath('/play'))}
                     className="gap-2 sm:gap-3 text-sm sm:text-base md:text-lg px-6 sm:px-8 md:px-10 lg:px-12 w-full sm:w-auto"
                   >
@@ -274,6 +277,11 @@ export default function HomePage() {
               {!isTodayCompleted && !session && (
                 <p className="text-xs sm:text-sm text-muted-foreground">
                   {t('home.guestHint')}
+                </p>
+              )}
+              {!isTodayCompleted && !isOnline && (
+                <p className="text-xs sm:text-sm text-warning">
+                  {t('home.offlineHint')}
                 </p>
               )}
             </div>

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -17,6 +17,7 @@ import {
   AvatarUpload,
   ReferralCard,
   EmailConsentCard,
+  PushNotificationCard,
   AdvancedStatsPanel,
   PremiumBadge,
   ThemeSwitcher,
@@ -347,6 +348,16 @@ export default function ProfilePage() {
                                 initialConsent={userProfile.emailMarketingConsent}
                                 updatedAt={userProfile.emailConsentUpdatedAt}
                             />
+                        </motion.div>
+                    )}
+
+                    {userProfile && !userProfile.isGuest && (
+                        <motion.div
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.45 }}
+                        >
+                            <PushNotificationCard />
                         </motion.div>
                     )}
 

--- a/packages/frontend/src/sw.ts
+++ b/packages/frontend/src/sw.ts
@@ -1,0 +1,171 @@
+/// <reference lib="WebWorker" />
+
+// Custom service worker for The Box (vite-plugin-pwa injectManifest mode).
+// Replaces the previous generateSW config 1:1 for caching, then layers on
+// the push + notificationclick handlers that generateSW can't host.
+
+import { cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching'
+import { NavigationRoute, registerRoute } from 'workbox-routing'
+import { CacheFirst, NetworkFirst, StaleWhileRevalidate } from 'workbox-strategies'
+import { ExpirationPlugin } from 'workbox-expiration'
+import { CacheableResponsePlugin } from 'workbox-cacheable-response'
+
+declare const self: ServiceWorkerGlobalScope
+
+// Injected at build time by vite-plugin-pwa with the precache manifest.
+precacheAndRoute(self.__WB_MANIFEST)
+cleanupOutdatedCaches()
+
+// SPA navigation fallback — same denylist as the previous generateSW config.
+registerRoute(
+  new NavigationRoute(
+    async ({ event }) => {
+      try {
+        return await fetch((event as FetchEvent).request)
+      } catch {
+        const cache = await caches.match('/index.html')
+        return cache ?? Response.error()
+      }
+    },
+    {
+      denylist: [/^\/api/, /^\/socket\.io/, /^\/uploads/],
+    },
+  ),
+)
+
+// Game screenshots — large images, immutable per URL, safe to serve from cache.
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/uploads/'),
+  new CacheFirst({
+    cacheName: 'screenshots',
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({ maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 30 }),
+    ],
+  }),
+)
+
+// i18n bundles — small JSON, fine to revalidate in the background.
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/locales/') && url.pathname.endsWith('.json'),
+  new StaleWhileRevalidate({
+    cacheName: 'i18n-locales',
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({ maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 7 }),
+    ],
+  }),
+)
+
+// API GETs — try the network with a 4s budget, fall back to a recent cached
+// response so the app stays usable through brief blips. Auth endpoints are
+// excluded since stale auth state is worse than a clear failure.
+registerRoute(
+  ({ url, request }) =>
+    request.method === 'GET' &&
+    url.pathname.startsWith('/api/') &&
+    !url.pathname.startsWith('/api/auth/'),
+  new NetworkFirst({
+    cacheName: 'api',
+    networkTimeoutSeconds: 4,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 60 * 5 }),
+    ],
+  }),
+)
+
+// ---------------------------------------------------------------------------
+// Web Push
+// ---------------------------------------------------------------------------
+
+interface PushPayload {
+  type: string
+  title: string
+  body: string
+  url?: string
+  data?: Record<string, unknown>
+}
+
+// Best-effort payload parse: even if the server sends a malformed payload (or
+// none at all, which Apple does for VoIP-style "wake up" pushes), we still
+// surface a generic notification so the user knows something happened.
+function parsePushPayload(event: PushEvent): PushPayload {
+  if (!event.data) return fallbackPayload()
+  try {
+    const parsed = event.data.json() as Partial<PushPayload>
+    if (parsed && typeof parsed.title === 'string' && typeof parsed.body === 'string') {
+      return {
+        type: typeof parsed.type === 'string' ? parsed.type : 'generic',
+        title: parsed.title,
+        body: parsed.body,
+        url: typeof parsed.url === 'string' ? parsed.url : undefined,
+        data: parsed.data,
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return fallbackPayload()
+}
+
+function fallbackPayload(): PushPayload {
+  return {
+    type: 'generic',
+    title: 'The Box',
+    body: 'Vous avez une notification.',
+  }
+}
+
+self.addEventListener('push', (event: PushEvent) => {
+  const payload = parsePushPayload(event)
+  // Coalesce: a second push with the same `tag` replaces the first instead
+  // of stacking, which avoids a notification queue if the user hasn't opened
+  // the app in a few days. `renotify` is widely supported in browsers but
+  // missing from the lib.dom.d.ts NotificationOptions type, hence the cast.
+  const options = {
+    body: payload.body,
+    icon: '/pwa-192x192.png',
+    badge: '/pwa-64x64.png',
+    tag: payload.type,
+    renotify: true,
+    data: { url: payload.url ?? '/', ...(payload.data ?? {}) },
+  } as NotificationOptions
+  event.waitUntil(self.registration.showNotification(payload.title, options))
+})
+
+self.addEventListener('notificationclick', (event: NotificationEvent) => {
+  event.notification.close()
+  const data = (event.notification.data ?? {}) as { url?: string }
+  const target = data.url ?? '/'
+  event.waitUntil(
+    (async () => {
+      const allClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+      // Reuse an existing window if one is already on the same scope —
+      // matches the manifest's launch_handler client_mode: navigate-existing.
+      for (const client of allClients) {
+        if ('focus' in client) {
+          await client.focus()
+          if ('navigate' in client && client.url !== new URL(target, self.location.origin).href) {
+            try {
+              await (client as WindowClient).navigate(target)
+            } catch {
+              // navigate() can reject for cross-origin or bfcache cases; the
+              // focus is enough — user lands on whatever page was open.
+            }
+          }
+          return
+        }
+      }
+      await self.clients.openWindow(target)
+    })(),
+  )
+})
+
+// Allow the page to trigger an immediate activation when the user clicks the
+// PWAUpdatePrompt "refresh" toast — registerType: 'prompt' relies on this.
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    void self.skipWaiting()
+  }
+})

--- a/packages/frontend/tsconfig.app.json
+++ b/packages/frontend/tsconfig.app.json
@@ -28,5 +28,6 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/sw.ts"]
 }

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.sw.json" }
   ]
 }

--- a/packages/frontend/tsconfig.sw.json
+++ b/packages/frontend/tsconfig.sw.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.sw.tsbuildinfo",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/sw.ts"],
+  "exclude": []
+}

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -79,6 +79,25 @@ export default defineConfig({
         theme_color: '#0a0a0f',
         lang: 'fr',
         categories: ['games', 'entertainment'],
+        launch_handler: {
+          client_mode: 'navigate-existing',
+        },
+        shortcuts: [
+          {
+            name: 'Défi du jour',
+            short_name: 'Jouer',
+            description: 'Lancer le défi quotidien',
+            url: '/fr/play',
+            icons: [{ src: 'pwa-192x192.png', sizes: '192x192', type: 'image/png' }],
+          },
+          {
+            name: 'Classement',
+            short_name: 'Classement',
+            description: 'Voir le classement quotidien et mensuel',
+            url: '/fr/leaderboard',
+            icons: [{ src: 'pwa-192x192.png', sizes: '192x192', type: 'image/png' }],
+          },
+        ],
         icons: [
           {
             src: 'pwa-64x64.png',

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
         ],
       },
       manifest: {
+        id: '/',
         name: 'The Box — Daily Video Game Guessing Challenge',
         short_name: 'The Box',
         description:
@@ -78,6 +79,8 @@ export default defineConfig({
         background_color: '#0a0a0f',
         theme_color: '#0a0a0f',
         lang: 'fr',
+        dir: 'ltr',
+        prefer_related_applications: false,
         categories: ['games', 'entertainment'],
         launch_handler: {
           client_mode: 'navigate-existing',

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -27,44 +27,12 @@ export default defineConfig({
     VitePWA({
       registerType: 'prompt',
       injectRegister: false,
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.ts',
       includeAssets: ['logo.svg', 'favicon.ico', 'apple-touch-icon-180x180.png'],
-      workbox: {
+      injectManifest: {
         globPatterns: ['**/*.{js,css,html,svg,ico,png,webp,woff,woff2}'],
-        cleanupOutdatedCaches: true,
-        navigateFallback: '/index.html',
-        navigateFallbackDenylist: [/^\/api/, /^\/socket\.io/, /^\/uploads/],
-        runtimeCaching: [
-          {
-            urlPattern: ({ url }) => url.pathname.startsWith('/uploads/'),
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'screenshots',
-              expiration: { maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 30 },
-              cacheableResponse: { statuses: [0, 200] },
-            },
-          },
-          {
-            urlPattern: ({ url }) => url.pathname.startsWith('/locales/') && url.pathname.endsWith('.json'),
-            handler: 'StaleWhileRevalidate',
-            options: {
-              cacheName: 'i18n-locales',
-              expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 7 },
-              cacheableResponse: { statuses: [0, 200] },
-            },
-          },
-          {
-            urlPattern: ({ url }) =>
-              url.pathname.startsWith('/api/') &&
-              !url.pathname.startsWith('/api/auth/'),
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'api',
-              networkTimeoutSeconds: 4,
-              expiration: { maxEntries: 50, maxAgeSeconds: 60 * 5 },
-              cacheableResponse: { statuses: [0, 200] },
-            },
-          },
-        ],
       },
       manifest: {
         id: '/',


### PR DESCRIPTION
## Summary
Frontend half of web push notifications, on top of the backend foundation merged in #183. After this lands, users can opt in from their profile and the server can reach them via `pushService.sendToUser()` (already merged). The daily-challenge scheduler that actually triggers sends ships in PR-C.

### Service worker
- **VitePWA mode change**: `generateSW` → `injectManifest`. Required because `generateSW` can't host custom event listeners.
- New `src/sw.ts` replicates the runtime caching from #168 byte-for-byte (screenshots `CacheFirst`, i18n `StaleWhileRevalidate`, API `NetworkFirst` with 4s timeout, SPA navigation fallback with the same `/api`/`/socket.io`/`/uploads` denylist) so the offline behavior is preserved.
- `push` handler: parses `{type,title,body,url,data}` payload with a generic fallback (so empty Apple "wake-up" pushes still surface something); `tag + renotify` coalesces repeats of the same `type`.
- `notificationclick` handler: focuses an existing window if any, else opens one — mirrors the `launch_handler.client_mode = navigate-existing` shipped in #175.
- Separate `tsconfig.sw.json` (WebWorker lib) so the SW types don't pollute the app config.

### Opt-in UI
- `pushApi` (lib/api/push.ts): `getVapidPublicKey` (returns `null` on 503 so the toggle can hide cleanly when the server lacks VAPID keys), `subscribe`, `unsubscribe`.
- `useWebPush()` hook: support detection, live subscription state from `pushManager.getSubscription()`, `subscribe()` / `unsubscribe()` with base64url → `Uint8Array` conversion for `applicationServerKey`.
- `PushNotificationCard` in profile, sibling of `EmailConsentCard`. Hidden entirely when:
  - browser doesn't support push (Firefox iOS, Safari < 16.4 unless installed, etc.)
  - server has no VAPID keys
- Renders a non-interactive "blocked at browser level" hint when `Notification.permission === 'denied'`, since flipping the toggle wouldn't unbreak it.
- Translations in fr/en.

## What's NOT in this PR
- No daily-challenge cron — sends still have to be triggered manually via `pushService`. PR-C adds the BullMQ scheduler.

## Test plan
- [x] `npm run build:frontend` — clean tsc + injectManifest build (`dist/sw.js` produced, 100 precache entries).
- [x] `npm run lint` — clean.
- [x] `npm test` — 76 tests pass.
- [ ] Set `VAPID_*` env vars, run `npm run dev`, open profile while logged in → toggle the card on → confirm browser permission prompt → confirm `POST /api/push/subscribe` succeeds and the row appears in `push_subscriptions`.
- [ ] Trigger a manual send from a node REPL: `pushService.sendToUser('<userId>', { type: 'manual_test', title: 'Hi', body: 'Test', url: '/fr/play' })` → confirm OS notification fires and clicking it opens `/fr/play` reusing the open tab.
- [ ] Toggle off → confirm the row is hard-deleted and the browser subscription is gone (`pushManager.getSubscription()` returns null).
- [ ] Confirm the card stays hidden when `VAPID_*` are unset.

https://claude.ai/code/session_01KhncPgueKaZeVeNChcASNa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhncPgueKaZeVeNChcASNa)_