### PR TITLE
fix(geo): make skip reroll a different shot and free zoom controls

### DIFF
--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -6,6 +6,7 @@ import {
     Polyline,
     useMap,
     useMapEvents,
+    ZoomControl,
 } from 'react-leaflet'
 import L, { CRS, type LatLngBoundsExpression, type LatLngExpression } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
@@ -106,7 +107,11 @@ export function MapCanvasLeaflet({
                 bounds={bounds}
                 maxBounds={bounds}
                 attributionControl={false}
-                zoomControl
+                // Default top-left collides with the panel's "Map" badge at
+                // left-3 top-3 (see ImmersiveLayout). Anchor the +/- pair
+                // bottom-right so it stays reachable on mobile (right thumb)
+                // and clear of the FullscreenToggle in the deck's top-right.
+                zoomControl={false}
                 scrollWheelZoom
                 doubleClickZoom={false}
                 bounceAtZoomLimits={false}
@@ -117,6 +122,7 @@ export function MapCanvasLeaflet({
                 keyboardPanDelta={50}
                 style={{ height: '100%', width: '100%', background: 'var(--background)' }}
             >
+                <ZoomControl position="bottomright" />
                 {tiles ? (
                     <TilePyramidLayer
                         tiles={tiles}

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -229,8 +229,14 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             },
 
             async rerollScreenshot() {
-                const { currentGameId, currentMapId, playedByGame } = get()
+                const { currentGameId, currentMapId, playedByGame, view: currentView } = get()
                 if (currentGameId == null) return
+                // Capture the current screenshot's metaId before clearing
+                // the view. It isn't in `playedByGame` yet (only submitted
+                // guesses are), so without this the API can re-roll onto
+                // the same screenshot — making "I don't know / skip" look
+                // broken on small per-game pools.
+                const currentMetaId = currentView?.meta.id ?? null
                 set({
                     phase: 'loading',
                     view: null,
@@ -241,7 +247,11 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                     errorCode: null,
                 })
                 try {
-                    const excludeMetaIds = playedByGame[currentGameId] ?? []
+                    const playedIds = playedByGame[currentGameId] ?? []
+                    const excludeMetaIds =
+                        currentMetaId != null && !playedIds.includes(currentMetaId)
+                            ? [...playedIds, currentMetaId]
+                            : playedIds
                     const view = await geoApi.pickFreePlay({
                         gameId: currentGameId,
                         geoMapId: currentMapId ?? undefined,


### PR DESCRIPTION
## Summary

Two unrelated bugs on `/geo` (free play) reported from mobile.

- **Skip button ("Je ne sais pas — passer celle-ci") felt inert.** `rerollScreenshot` only excluded already-submitted metaIds via `playedByGame`. The current view isn't in that list yet (only submitted guesses are recorded), so the API was free to return the same screenshot — pressing skip looked like nothing happened. Fix: push the live `view.meta.id` into `excludeMetaIds` before calling `pickFreePlay`.
- **Leaflet +/- zoom controls were unreachable.** Default `topleft` placement sat under the panel's "Carte" badge at `left-3 top-3` (see `ImmersiveLayout`). Fix: disable Leaflet's built-in control and mount `<ZoomControl position="bottomright" />` so it stays clear of both the badge and the fullscreen toggle in the deck's top-right.

## Test plan

- [ ] On `/fr/geo`, pick a game with multiple promoted screenshots and tap "Je ne sais pas — passer celle-ci" — a different screenshot should load each time.
- [ ] On a single-screenshot game, skip should still finish (loading clears, error or empty state surfaces — no stale image).
- [ ] On the map panel, +/- zoom buttons appear at the bottom-right and are tappable on mobile.
- [ ] Fullscreen toggle (top-right of the deck) and "Carte" badge (top-left of the map) are both unobstructed.
- [ ] Desktop (md+) split view: zoom controls don't collide with the fullscreen toggle.

https://claude.ai/code/session_01RugNdemBWhDvydonNgMvpq

---
_Generated by [Claude Code](https://claude.ai/code/session_01RugNdemBWhDvydonNgMvpq)_