### PR TITLE
fix(push): scope writes by user_id, allowlist endpoint hosts, FK cascade, same-origin click

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -1,0 +1,181 @@
+# Web Push Notifications
+
+The Box delivers browser push notifications (daily challenge, streak risk, etc.) over the W3C Web Push protocol. This doc covers the end-to-end lifecycle: VAPID setup, the wire contract, fan-out, reliability behavior, and how the service worker renders incoming pushes.
+
+## Architecture
+
+```
+┌─────────────┐   subscribe     ┌──────────────┐   enqueue    ┌────────────┐
+│  Frontend   │ ───────────────▶│ /api/push    │ ────────────▶│ pushQueue  │
+│ (useWebPush │                 │  (Express)   │              │  (BullMQ)  │
+│   + sw.ts)  │ ◀─ push event ──┤              │              └─────┬──────┘
+└─────────────┘                 └──────────────┘                    │
+       ▲                                                            ▼
+       │                              ┌─────────────────────────────────┐
+       │                              │ push.worker.ts                   │
+       │                              │  • listActiveForUser            │
+       │                              │  • Promise.allSettled fan-out    │
+       │                              │  • web-push send (8s timeout)    │
+       │                              │  • mark success / failure / 410  │
+       │                              └─────────────┬────────────────────┘
+       │                                            │
+       │       FCM / Mozilla autopush / APNS        ▼
+       └───────────────────────────────  push provider edge
+```
+
+## Layer map
+
+| Layer | File | Role |
+|---|---|---|
+| Domain | `packages/backend/src/domain/services/push.service.ts` | `sendToUser(userId, payload)` — enqueues a fan-out job. |
+| Infrastructure | `packages/backend/src/infrastructure/push/push-sender.ts` | `web-push` wrapper with 8s timeout and three-way failure classification. |
+| Infrastructure | `packages/backend/src/infrastructure/repositories/push-subscription.repository.ts` | Subscription CRUD; all writes scoped by `(endpoint, user_id)`. |
+| Infrastructure | `packages/backend/src/infrastructure/queue/queues.ts` | `pushQueue` definition (4 attempts, exponential backoff). |
+| Infrastructure | `packages/backend/src/infrastructure/queue/workers/push.worker.ts` | BullMQ worker; concurrency 10. |
+| Infrastructure | `packages/backend/src/infrastructure/queue/workers/push-fanout-logic.ts` | Per-user fan-out with `Promise.allSettled`. |
+| Infrastructure | `packages/backend/src/infrastructure/queue/workers/prune-push-subscriptions-logic.ts` | Daily cron; hard-deletes dead rows >30 d old. |
+| Presentation | `packages/backend/src/presentation/routes/push.routes.ts` | `GET /vapid-public-key`, `POST /subscribe`, `DELETE /subscribe`. |
+| Frontend | `packages/frontend/src/hooks/useWebPush.ts` | Subscription lifecycle, cross-tab sync, iOS PWA detection. |
+| Frontend | `packages/frontend/src/components/profile/PushNotificationCard.tsx` | Profile settings toggle. |
+| Frontend | `packages/frontend/src/sw.ts` | Push event, click handler, `pushsubscriptionchange`, locale fallback. |
+| DB | `packages/backend/migrations/20260517_push_subscriptions.ts` | Initial schema. |
+| DB | `packages/backend/migrations/20260519_push_subscriptions_user_fk.ts` | Adds FK + `ON DELETE CASCADE`. |
+
+## VAPID setup
+
+Push deliveries are signed with a VAPID keypair so providers can rate-limit per app rather than per IP. Generate once per environment:
+
+```bash
+npm run vapid:generate -w @the-box/backend
+```
+
+Copy the three lines into the environment:
+
+```
+VAPID_PUBLIC_KEY=...
+VAPID_PRIVATE_KEY=...
+VAPID_SUBJECT=mailto:no-reply@the-box.battistella.ovh
+```
+
+When any of the three is missing:
+- `pushService.isConfigured()` returns `false`.
+- `GET /api/push/vapid-public-key` returns `503 PUSH_NOT_CONFIGURED`.
+- The frontend hides `PushNotificationCard` (treats 503 as "feature off").
+- `pushService.sendToUser` is a no-op (warns and returns `{ enqueued: false }`).
+
+### Key rotation
+
+Rotating VAPID keys invalidates every browser-side `applicationServerKey`, so the next send to each existing subscription returns 410 and the worker deactivates the row. Expect a one-time `pruned` spike. Plan a rotation by:
+
+1. Generating new keys with `npm run vapid:generate`.
+2. Deploying with the new key set.
+3. Watching `prune-push-subscriptions` and the worker `pruned` counter for the spike to settle.
+4. Users will silently re-subscribe on their next visit (the SW handles `pushsubscriptionchange`).
+
+## Wire contract
+
+### Frontend → backend
+
+`POST /api/push/subscribe` (auth-required, rate-limited to 10/min/user):
+
+```json
+{
+  "endpoint": "https://fcm.googleapis.com/fcm/send/<token>",
+  "keys": { "p256dh": "...", "auth": "..." },
+  "userAgent": "Mozilla/5.0 ..."
+}
+```
+
+`endpoint` host must be on the allowlist in `push.routes.ts` (FCM, Mozilla autopush, Apple, Windows). Off-allowlist hosts get a 400.
+
+`DELETE /api/push/subscribe` (auth-required, rate-limited to 30/min/user) — same body shape, `endpoint` only.
+
+### Backend → browser (push payload)
+
+Every payload that leaves `pushService.sendToUser` matches `PushPayload`:
+
+```ts
+interface PushPayload {
+  type: string                 // discriminator, e.g. 'daily_challenge_ready'
+  title: string                // localized at the call site
+  body: string                 // localized at the call site
+  url?: string                 // resolved as same-origin path on click
+  data?: Record<string, unknown>
+}
+```
+
+The SW uses `payload.type` (or `payload.data.id` if present) as the notification tag so events with the same id replace earlier ones, but distinct events don't accidentally overwrite each other.
+
+## Reliability
+
+### Fan-out
+
+`pushService.sendToUser` does not send anything synchronously. It enqueues a `send-to-user` job on `pushQueue`. The worker:
+
+1. Looks up active subscriptions with `pushSubscriptionRepository.listActiveForUser(userId)` (hits the partial `(user_id, is_active)` index).
+2. Sends to each device with `Promise.allSettled` — one slow provider can't stall siblings.
+3. Wraps every `webpush.sendNotification` call in an 8s `Promise.race` timeout.
+4. Classifies each failure:
+   - **gone** (404/410) — terminal. Row flipped to `is_active=false`. Counted as `pruned`.
+   - **retryable** (timeout, 5xx, 429) — bookkeeping only; the job rethrows so BullMQ retries the *whole user* with exponential backoff (4 attempts, base delay 5 s).
+   - **permanent** (other 4xx) — bookkeeping only; not retried.
+5. The job succeeds if at least one device delivered, or if every failure was permanent. It fails (and retries) only if every attempted device returned a retryable failure.
+
+### Per-user device cap
+
+`POST /subscribe` rejects the new subscription with `429 PUSH_DEVICE_CAP_REACHED` once the user has 20 active rows. Re-subscribing the same browser (existing endpoint) bypasses the cap because the upsert just rebinds in place.
+
+### Pruning
+
+`prune-push-subscriptions` runs daily at 02:00 UTC via `importQueue`. It hard-deletes rows where `is_active = false` AND `last_failure_at < now() - 30 d` (or where `last_failure_at IS NULL`, which only happens for old rows that were deactivated before the column existed).
+
+## Frontend behavior
+
+### Hook (`useWebPush`)
+
+Returns `{ isSupported, requiresPwaInstall, isServerConfigured, permission, isSubscribed, isLoading, subscribe, unsubscribe }`.
+
+- `isSupported` is `false` on iOS Safari outside an installed PWA (push only works inside the standalone app there).
+- `requiresPwaInstall` is the explicit "iOS, install required" flag — the card uses it to show an install hint instead of a non-functional toggle.
+- Cross-tab synchronization: a `permissions.query({name: 'notifications'})` change listener plus `visibilitychange` / `focus` listeners keep `permission` and `isSubscribed` honest when the user toggles in another tab or grants/blocks in browser settings.
+- A `useRef` re-entry guard prevents double-click double-subscribe.
+- `subscribe()` rolls back the browser-side subscription on a server error (cap reached, etc.) so the user can try again later without holding a useless endpoint.
+
+### Service worker (`sw.ts`)
+
+- `push` handler: parses payload, picks tag via `data.id ?? type`, calls `showNotification`. On malformed/empty payloads (Apple sometimes sends content-less wake-up pushes) it falls back to a localized "you have a new notification" string. The current locale is persisted by the page via `SET_LOCALE` postMessage and cached in `caches.open('app-state')` so it survives SW restarts.
+- `notificationclick` handler: same-origin guard on the click target — anything off-origin (or unparseable) falls back to `/`.
+- `pushsubscriptionchange` handler: when the browser rotates an endpoint, the SW re-subscribes (fetching the VAPID key via `/api/push/vapid-public-key`) and posts the new endpoint to the backend. The old endpoint is unsubscribed server-side.
+
+## Security
+
+- Repository writes are all `WHERE endpoint = ? AND user_id = ?` so a session-authed caller cannot mutate another user's row.
+- Endpoint hostnames are restricted to known push providers via Zod refinement on `POST /subscribe`.
+- The notification click handler resolves `url` against `self.location.origin` and falls back to `/` if it's off-origin (closes a phishing pivot via spoofed payloads).
+- Rate limiters on subscribe (10/min/user) and unsubscribe (30/min/user) blunt the obvious DoS / table-bloat angles.
+- VAPID `private` key is read from `VAPID_PRIVATE_KEY` only — the generation script writes to stdout for one-time copy, do not commit `.env`.
+
+## Operations cheat sheet
+
+| Symptom | First check |
+|---|---|
+| Card never appears | `GET /api/push/vapid-public-key`. If 503, set `VAPID_*` env vars. |
+| Card appears, toggle errors silently | Browser console for `PushApiError.code`. The card maps each code to a localized toast — see `toastKeyForError` in `PushNotificationCard.tsx`. |
+| Push delivered to phone but not laptop | Look at the row in `push_subscriptions` for the laptop endpoint: `is_active=false` + `last_failure_status=410` means the browser dropped it; user needs to toggle off+on. |
+| Sudden `pruned` spike | Did anything rotate the VAPID key? Match the timing against deploys. |
+| Send latency growing | `push.worker.ts` log line `push fan-out complete` includes `attempted/succeeded/pruned/retryable`. A growing `retryable` means a provider is slow — consider raising `SEND_TIMEOUT_MS` carefully. |
+
+## Triggering a push (for callers)
+
+```ts
+import { pushService } from '@/domain/services/push.service.js'
+
+await pushService.sendToUser('user-id-here', {
+  type: 'daily_challenge_ready',
+  title: 'New challenge available',
+  body: 'Your daily Box is ready.',
+  url: '/play',
+})
+```
+
+The call returns `{ enqueued: true, jobId }` immediately — actual delivery is best-effort and observable via BullMQ. Callers must already have the user's locale and produce localized copy at the call site (server-side i18n on payloads is a future tier).

--- a/packages/backend/migrations/20260519_push_subscriptions_user_fk.ts
+++ b/packages/backend/migrations/20260519_push_subscriptions_user_fk.ts
@@ -1,0 +1,32 @@
+import type { Knex } from 'knex'
+
+// 20260517 created push_subscriptions.user_id without a foreign key, so a
+// user deletion left dangling rows that the fan-out worker would keep
+// targeting until the push provider responded 410. This migration adds the
+// missing FK with ON DELETE CASCADE, matching the pattern used by every
+// other user-owned table (achievements, screenshot_reports, geo_*).
+//
+// We sweep orphan rows first because the FK creation will fail on any
+// existing user_id that no longer exists in the user table — and dev DBs
+// that ran 20260517 before this fix may already contain such rows.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DELETE FROM push_subscriptions
+    WHERE user_id NOT IN (SELECT id FROM "user")
+  `)
+
+  await knex.schema.alterTable('push_subscriptions', (table) => {
+    table
+      .foreign('user_id', 'push_subscriptions_user_id_fk')
+      .references('id')
+      .inTable('user')
+      .onDelete('CASCADE')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('push_subscriptions', (table) => {
+    table.dropForeign('user_id', 'push_subscriptions_user_id_fk')
+  })
+}

--- a/packages/backend/src/domain/services/push.service.test.ts
+++ b/packages/backend/src/domain/services/push.service.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { PushPayload } from '@the-box/types'
+import { createPushService, type PushServiceDeps } from './push.service.js'
+
+interface FakeState {
+  configured: boolean
+  enqueueCalls: Array<{ userId: string; payload: PushPayload }>
+  enqueueShouldThrow: boolean
+  enqueueResultId?: string
+  warnings: Array<{ obj: unknown; msg: string }>
+  infos: Array<{ obj: unknown; msg: string }>
+}
+
+function makeDeps(state: FakeState): PushServiceDeps {
+  return {
+    isConfigured: () => state.configured,
+    async enqueueSendToUser(userId, payload) {
+      state.enqueueCalls.push({ userId, payload })
+      if (state.enqueueShouldThrow) throw new Error('synthetic enqueue failure')
+      return { id: state.enqueueResultId ?? 'job-123' }
+    },
+    log: {
+      info: (obj: unknown, msg: unknown) =>
+        state.infos.push({ obj, msg: String(msg) }),
+      warn: (obj: unknown, msg: unknown) =>
+        state.warnings.push({ obj, msg: String(msg) }),
+    },
+  }
+}
+
+const PAYLOAD: PushPayload = {
+  type: 'daily_challenge_ready',
+  title: 'New challenge',
+  body: 'Your daily Box is ready.',
+}
+
+function freshState(overrides: Partial<FakeState> = {}): FakeState {
+  return {
+    configured: true,
+    enqueueCalls: [],
+    enqueueShouldThrow: false,
+    warnings: [],
+    infos: [],
+    ...overrides,
+  }
+}
+
+describe('pushService.sendToUser', () => {
+  it('enqueues a send-to-user job and returns the job id when configured', async () => {
+    const state = freshState({ enqueueResultId: 'abc-1' })
+    const service = createPushService(makeDeps(state))
+    const result = await service.sendToUser('user-1', PAYLOAD)
+    assert.deepEqual(result, { enqueued: true, jobId: 'abc-1' })
+    assert.equal(state.enqueueCalls.length, 1)
+    assert.deepEqual(state.enqueueCalls[0], { userId: 'user-1', payload: PAYLOAD })
+  })
+
+  it('forwards the user id and the full payload (type, title, body, url, data)', async () => {
+    const state = freshState()
+    const service = createPushService(makeDeps(state))
+    const richPayload: PushPayload = {
+      ...PAYLOAD,
+      url: '/play',
+      data: { challengeId: 42, locale: 'fr' },
+    }
+    await service.sendToUser('user-7', richPayload)
+    assert.deepEqual(state.enqueueCalls[0]?.payload, richPayload)
+    assert.equal(state.enqueueCalls[0]?.userId, 'user-7')
+  })
+
+  it('short-circuits with enqueued: false when isConfigured is false (no enqueue)', async () => {
+    const state = freshState({ configured: false })
+    const service = createPushService(makeDeps(state))
+    const result = await service.sendToUser('user-1', PAYLOAD)
+    assert.deepEqual(result, { enqueued: false })
+    assert.equal(state.enqueueCalls.length, 0)
+    // And it logs a warning so an operator can see the "feature off" path.
+    assert.equal(state.warnings.length, 1)
+  })
+
+  it('does not catch enqueue errors — they bubble up to the caller', async () => {
+    const state = freshState({ enqueueShouldThrow: true })
+    const service = createPushService(makeDeps(state))
+    await assert.rejects(
+      () => service.sendToUser('user-1', PAYLOAD),
+      /synthetic enqueue failure/,
+    )
+  })
+
+  it('returns enqueued: true even when the queue assigns no id (BullMQ optional id)', async () => {
+    // Inline the fake: the helper defaults to 'job-123' to keep the other
+    // tests terse, but here we deliberately want the dep to return no id.
+    const service = createPushService({
+      isConfigured: () => true,
+      enqueueSendToUser: async () => ({}),
+      log: { info: () => {}, warn: () => {} },
+    })
+    const result = await service.sendToUser('user-1', PAYLOAD)
+    assert.equal(result.enqueued, true)
+    assert.equal(result.jobId, undefined)
+  })
+
+  it('isConfigured exposes the dep predicate so callers can probe without enqueueing', async () => {
+    const state = freshState({ configured: false })
+    const service = createPushService(makeDeps(state))
+    assert.equal(service.isConfigured(), false)
+    state.configured = true
+    assert.equal(service.isConfigured(), true)
+  })
+})

--- a/packages/backend/src/domain/services/push.service.ts
+++ b/packages/backend/src/domain/services/push.service.ts
@@ -53,11 +53,12 @@ export const pushService = {
           payload,
         )
         if (result.success) {
-          await pushSubscriptionRepository.markSuccess(sub.endpoint)
+          await pushSubscriptionRepository.markSuccess(sub.endpoint, sub.user_id)
           succeeded += 1
         } else {
           await pushSubscriptionRepository.markFailure(
             sub.endpoint,
+            sub.user_id,
             result.statusCode ?? 0,
             result.gone,
           )

--- a/packages/backend/src/domain/services/push.service.ts
+++ b/packages/backend/src/domain/services/push.service.ts
@@ -1,5 +1,5 @@
-import { pushSubscriptionRepository } from '../../infrastructure/repositories/push-subscription.repository.js'
-import { isPushConfigured, sendPush } from '../../infrastructure/push/push-sender.js'
+import { isPushConfigured } from '../../infrastructure/push/push-sender.js'
+import { pushQueue } from '../../infrastructure/queue/queues.js'
 import { serviceLogger } from '../../infrastructure/logger/logger.js'
 
 const log = serviceLogger.child({ service: 'push' })
@@ -20,57 +20,28 @@ export interface PushPayload {
 }
 
 export interface SendToUserResult {
-  attempted: number
-  succeeded: number
-  pruned: number
+  enqueued: boolean
+  jobId?: string
 }
 
 export const pushService = {
   isConfigured: isPushConfigured,
 
-  // Fan out to every active subscription for `userId`. We never throw on
-  // per-device failures: a user with three devices, one of which the push
-  // provider has declared 410 Gone, should still get the notification on the
-  // other two. The 410'd row is deactivated in-place by markFailure so the
-  // next send skips it.
+  // Enqueue a push fan-out job. The actual per-device fan-out (with timeout,
+  // allSettled, retry, and 410-deactivation) runs inside push.worker.ts so
+  // the request thread isn't sitting on N round-trips to FCM. Callers get a
+  // synchronous "accepted" response — delivery is best-effort and observable
+  // via the BullMQ dashboards.
   async sendToUser(userId: string, payload: PushPayload): Promise<SendToUserResult> {
     if (!isPushConfigured()) {
-      log.warn({ userId, type: payload.type }, 'push not configured; skipping send')
-      return { attempted: 0, succeeded: 0, pruned: 0 }
+      log.warn({ userId, type: payload.type }, 'push not configured; skipping enqueue')
+      return { enqueued: false }
     }
-
-    const subs = await pushSubscriptionRepository.listActiveForUser(userId)
-    if (subs.length === 0) {
-      return { attempted: 0, succeeded: 0, pruned: 0 }
-    }
-
-    let succeeded = 0
-    let pruned = 0
-    await Promise.all(
-      subs.map(async (sub) => {
-        const result = await sendPush(
-          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
-          payload,
-        )
-        if (result.success) {
-          await pushSubscriptionRepository.markSuccess(sub.endpoint, sub.user_id)
-          succeeded += 1
-        } else {
-          await pushSubscriptionRepository.markFailure(
-            sub.endpoint,
-            sub.user_id,
-            result.statusCode ?? 0,
-            result.gone,
-          )
-          if (result.gone) pruned += 1
-        }
-      }),
-    )
-
-    log.info(
-      { userId, type: payload.type, attempted: subs.length, succeeded, pruned },
-      'push fan-out complete',
-    )
-    return { attempted: subs.length, succeeded, pruned }
+    const job = await pushQueue.add('send-to-user', {
+      kind: 'send-to-user',
+      userId,
+      payload,
+    })
+    return { enqueued: true, jobId: job.id }
   },
 }

--- a/packages/backend/src/domain/services/push.service.ts
+++ b/packages/backend/src/domain/services/push.service.ts
@@ -1,47 +1,74 @@
+import type { PushPayload } from '@the-box/types'
 import { isPushConfigured } from '../../infrastructure/push/push-sender.js'
-import { pushQueue } from '../../infrastructure/queue/queues.js'
 import { serviceLogger } from '../../infrastructure/logger/logger.js'
 
-const log = serviceLogger.child({ service: 'push' })
-
-export interface PushPayload {
-  // Free-form discriminator the SW will use to decide how to render. Examples:
-  //   'daily_challenge_ready'
-  //   'streak_at_risk'
-  //   'leaderboard_position_lost'
-  type: string
-  title: string
-  body: string
-  // Optional URL the SW should open when the user clicks the notification.
-  // Relative paths are resolved against the manifest scope.
-  url?: string
-  // Arbitrary extra data forwarded to the SW for type-specific handling.
-  data?: Record<string, unknown>
+// Lazy import: pulling queues.js at module load constructs a BullMQ Queue
+// and opens a Redis connection, which keeps the event loop alive forever
+// in unit tests that import this module. Importing inside the production
+// dep means tests using `createPushService(fakeDeps)` never trigger it.
+async function enqueueViaQueue(
+  userId: string,
+  payload: PushPayload,
+): Promise<{ id?: string }> {
+  const { pushQueue } = await import('../../infrastructure/queue/queues.js')
+  const job = await pushQueue.add('send-to-user', {
+    kind: 'send-to-user',
+    userId,
+    payload,
+  })
+  return { id: job.id }
 }
+
+// Re-export the wire type so existing imports (`import { PushPayload } from
+// '../../domain/services/push.service.js'`) keep compiling. New code should
+// import directly from '@the-box/types'.
+export type { PushPayload } from '@the-box/types'
 
 export interface SendToUserResult {
   enqueued: boolean
   jobId?: string
 }
 
-export const pushService = {
-  isConfigured: isPushConfigured,
-
-  // Enqueue a push fan-out job. The actual per-device fan-out (with timeout,
-  // allSettled, retry, and 410-deactivation) runs inside push.worker.ts so
-  // the request thread isn't sitting on N round-trips to FCM. Callers get a
-  // synchronous "accepted" response — delivery is best-effort and observable
-  // via the BullMQ dashboards.
-  async sendToUser(userId: string, payload: PushPayload): Promise<SendToUserResult> {
-    if (!isPushConfigured()) {
-      log.warn({ userId, type: payload.type }, 'push not configured; skipping enqueue')
-      return { enqueued: false }
-    }
-    const job = await pushQueue.add('send-to-user', {
-      kind: 'send-to-user',
-      userId,
-      payload,
-    })
-    return { enqueued: true, jobId: job.id }
-  },
+// Ports the service depends on. The default factory binds them to the
+// concrete BullMQ queue + push-sender; tests pass fakes via
+// `createPushService(deps)`. Keeps the service free of import cycles
+// against infrastructure for the parts that are interesting to test.
+export interface PushServiceDeps {
+  isConfigured: () => boolean
+  enqueueSendToUser: (userId: string, payload: PushPayload) => Promise<{ id?: string }>
+  log?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void }
 }
+
+const defaultLog = serviceLogger.child({ service: 'push' })
+
+const productionDeps: PushServiceDeps = {
+  isConfigured: isPushConfigured,
+  enqueueSendToUser: enqueueViaQueue,
+  log: defaultLog,
+}
+
+export function createPushService(deps: PushServiceDeps = productionDeps) {
+  const log = deps.log ?? { info: () => {}, warn: () => {} }
+
+  return {
+    isConfigured: deps.isConfigured,
+
+    // Enqueue a push fan-out job. The actual per-device fan-out (with
+    // timeout, allSettled, retry, and 410-deactivation) runs inside
+    // push.worker.ts so the request thread isn't sitting on N round-trips
+    // to FCM. Callers get a synchronous "accepted" response — delivery is
+    // best-effort and observable via the BullMQ dashboards.
+    async sendToUser(userId: string, payload: PushPayload): Promise<SendToUserResult> {
+      if (!deps.isConfigured()) {
+        log.warn({ userId, type: payload.type }, 'push not configured; skipping enqueue')
+        return { enqueued: false }
+      }
+      const { id } = await deps.enqueueSendToUser(userId, payload)
+      return { enqueued: true, jobId: id }
+    },
+  }
+}
+
+// Default singleton wired with concrete adapters. Routes and other domain
+// services use this; tests build their own via `createPushService(...)`.
+export const pushService = createPushService()

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -32,6 +32,7 @@ import { importQueue, geoQueue } from './infrastructure/queue/queues.js'
 import './infrastructure/queue/workers/import.worker.js'
 import './infrastructure/queue/workers/geo.worker.js'
 import './infrastructure/queue/workers/push.worker.js'
+import { pushService } from './domain/services/push.service.js'
 import { initializeSocketIO } from './infrastructure/socket/socket.js'
 
 // Validate environment
@@ -176,9 +177,36 @@ if (!fs.existsSync(avatarsPath)) {
   fs.mkdirSync(avatarsPath, { recursive: true })
 }
 
-// Health check
+// Lightweight liveness check. Always 200 so an orchestrator knows the
+// process is up; downstream dependency status lives on /healthz.
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() })
+})
+
+// Readiness check. Probes the dependencies the app actually needs to serve
+// requests (Postgres, Redis) and reports the optional capability flags
+// (web push, email) so dashboards can alert on a misconfigured environment
+// instead of waiting for the first user to hit a 503.
+app.get('/healthz', async (_req, res) => {
+  const [dbOk, redisOk] = await Promise.all([
+    testConnection().catch(() => false),
+    testRedisConnection().catch(() => false),
+  ])
+  const checks = {
+    db: dbOk,
+    redis: redisOk,
+    push: pushService.isConfigured(),
+    email: !!env.RESEND_API_KEY,
+  }
+  // db + redis are required; push and email are optional capabilities. If
+  // either required check is failing we report 503 so a load balancer or
+  // k8s readiness probe can route traffic away.
+  const ready = checks.db && checks.redis
+  res.status(ready ? 200 : 503).json({
+    status: ready ? 'ok' : 'degraded',
+    checks,
+    timestamp: new Date().toISOString(),
+  })
 })
 
 // API Routes

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -31,6 +31,7 @@ import { testRedisConnection } from './infrastructure/queue/connection.js'
 import { importQueue, geoQueue } from './infrastructure/queue/queues.js'
 import './infrastructure/queue/workers/import.worker.js'
 import './infrastructure/queue/workers/geo.worker.js'
+import './infrastructure/queue/workers/push.worker.js'
 import { initializeSocketIO } from './infrastructure/socket/socket.js'
 
 // Validate environment
@@ -319,6 +320,7 @@ async function start(): Promise<void> {
       'reactivation-scan',
       'milestone-account-age',
       'leaderboard-payout-monthly',
+      'prune-push-subscriptions',
     ]
     try {
       const repeatableJobs = await importQueue.getRepeatableJobs()
@@ -516,6 +518,24 @@ async function start(): Promise<void> {
       logger.info('scheduled recurring milestone-account-age job (daily at 04:00 UTC)')
     } catch (error) {
       logger.warn({ error: String(error) }, 'failed to schedule recurring milestone-account-age job')
+    }
+
+    // Daily prune of stale push subscriptions — 02:00 UTC. Hard-deletes
+    // rows the fan-out worker has already deactivated (410/404 from the
+    // push provider) once they've been silent for >30 days. Without this
+    // the table grows monotonically with churned browsers / reinstalls.
+    try {
+      await importQueue.add(
+        'prune-push-subscriptions',
+        {},
+        {
+          repeat: { pattern: '0 2 * * *', tz: 'UTC' },
+          jobId: 'prune-push-subscriptions-recurring',
+        },
+      )
+      logger.info('scheduled recurring prune-push-subscriptions job (daily at 02:00 UTC)')
+    } catch (error) {
+      logger.warn({ error: String(error) }, 'failed to schedule recurring prune-push-subscriptions job')
     }
 
     // Monthly leaderboard payout — 1st of each month at 00:30 UTC. Awards

--- a/packages/backend/src/infrastructure/push/push-sender.ts
+++ b/packages/backend/src/infrastructure/push/push-sender.ts
@@ -33,7 +33,16 @@ export interface SendResult {
   statusCode?: number
   // True iff the subscription should be removed/deactivated by the caller.
   gone: boolean
+  // True iff the failure was transient (timeout, 5xx, network) and the
+  // caller should retry with backoff. 4xx (except 404/410) is non-retryable.
+  retryable: boolean
 }
+
+// Per-send timeout. Some FCM/Mozilla edge nodes can hang for the full Node
+// socket timeout (~minutes), which would head-of-line block the fan-out
+// worker batch. We wrap each send in a hard timeout that the worker treats
+// as a transient failure (retryable=true).
+const SEND_TIMEOUT_MS = 8_000
 
 export async function sendPush(
   target: PushSubscriptionTarget,
@@ -41,15 +50,35 @@ export async function sendPush(
 ): Promise<SendResult> {
   ensureConfigured()
   try {
-    const res = await webpush.sendNotification(target, JSON.stringify(payload))
-    return { success: true, statusCode: res.statusCode, gone: false }
+    const res = await Promise.race([
+      webpush.sendNotification(target, JSON.stringify(payload)),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new PushTimeoutError(SEND_TIMEOUT_MS)), SEND_TIMEOUT_MS),
+      ),
+    ])
+    return { success: true, statusCode: res.statusCode, gone: false, retryable: false }
   } catch (err) {
+    if (err instanceof PushTimeoutError) {
+      log.warn({ timeoutMs: err.timeoutMs }, 'push send timed out')
+      return { success: false, gone: false, retryable: true }
+    }
     const status =
       typeof err === 'object' && err !== null && 'statusCode' in err
         ? Number((err as { statusCode: unknown }).statusCode)
         : undefined
     const gone = status === 404 || status === 410
-    log.warn({ statusCode: status, gone }, 'push send failed')
-    return { success: false, statusCode: status, gone }
+    // 5xx (and unknown / network errors with no status) → retryable. 4xx
+    // (400/401/403/413/429) is non-retryable: BullMQ would just rerun and
+    // get the same error.
+    const retryable = !gone && (status === undefined || status >= 500 || status === 429)
+    log.warn({ statusCode: status, gone, retryable }, 'push send failed')
+    return { success: false, statusCode: status, gone, retryable }
+  }
+}
+
+class PushTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`push send timed out after ${timeoutMs}ms`)
+    this.name = 'PushTimeoutError'
   }
 }

--- a/packages/backend/src/infrastructure/queue/queues.ts
+++ b/packages/backend/src/infrastructure/queue/queues.ts
@@ -116,3 +116,33 @@ export const geoQueue = new Queue<GeoJobData>('geo-jobs', {
 export const geoQueueEvents = new QueueEvents('geo-jobs', {
   connection: redisConnectionOptions,
 })
+
+// Push fan-out queue. One job per (userId, payload) — the worker handles the
+// per-device fan-out internally with `Promise.allSettled` so a slow provider
+// can't stall delivery to a user's other devices. Kept as its own queue so
+// concurrency can be tuned independently of the heavier import jobs.
+export type PushJobData = {
+  kind: 'send-to-user'
+  userId: string
+  payload: {
+    type: string
+    title: string
+    body: string
+    url?: string
+    data?: Record<string, unknown>
+  }
+}
+
+export const pushQueue = new Queue<PushJobData>('push-jobs', {
+  connection: redisConnectionOptions,
+  defaultJobOptions: {
+    attempts: 4,
+    backoff: { type: 'exponential', delay: 5_000 },
+    removeOnComplete: { count: 200 },
+    removeOnFail: { count: 100 },
+  },
+})
+
+export const pushQueueEvents = new QueueEvents('push-jobs', {
+  connection: redisConnectionOptions,
+})

--- a/packages/backend/src/infrastructure/queue/workers/import.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/import.worker.ts
@@ -17,6 +17,7 @@ import { grantMonthlyStreakFreezes } from './streak-freeze-grant-logic.js'
 import { scanReactivationCandidates } from './reactivation-scan-logic.js'
 import { evaluateAccountAgeMilestones } from './milestone-account-age-logic.js'
 import { grantMonthlyLeaderboardPayout } from './leaderboard-payout-logic.js'
+import { prunePushSubscriptions } from './prune-push-subscriptions-logic.js'
 
 const log = queueLogger
 
@@ -390,6 +391,17 @@ export const importWorker = new Worker<JobData, JobResult>(
         }
 
         log.info({ jobId: id, result }, 'milestone-account-age job completed')
+        return jobResult
+      }
+
+      if (name === 'prune-push-subscriptions') {
+        const result = await prunePushSubscriptions()
+
+        const jobResult: JobResult = {
+          message: result.message,
+        }
+
+        log.info({ jobId: id, deleted: result.deleted }, 'prune-push-subscriptions job completed')
         return jobResult
       }
 

--- a/packages/backend/src/infrastructure/queue/workers/prune-push-subscriptions-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/prune-push-subscriptions-logic.ts
@@ -1,0 +1,22 @@
+import { pushSubscriptionRepository } from '../../repositories/push-subscription.repository.js'
+import { queueLogger } from '../../logger/logger.js'
+
+const log = queueLogger.child({ worker: 'prune-push-subscriptions' })
+
+// Hard-delete subscriptions that the push provider declared dead (410/404,
+// flipped to is_active=false by the fan-out worker) and that haven't seen a
+// successful send in `STALE_AFTER_MS`. Without this, the table grows
+// monotonically with churned browsers / reinstalls.
+const STALE_AFTER_MS = 30 * 24 * 60 * 60_000 // 30 days
+
+export interface PruneResult {
+  deleted: number
+  message: string
+}
+
+export async function prunePushSubscriptions(): Promise<PruneResult> {
+  const deleted = await pushSubscriptionRepository.pruneStale(STALE_AFTER_MS)
+  const message = `pruned ${deleted} stale push subscription(s) (>${STALE_AFTER_MS / 86_400_000}d inactive)`
+  log.info({ deleted }, message)
+  return { deleted, message }
+}

--- a/packages/backend/src/infrastructure/queue/workers/push-fanout-logic.test.ts
+++ b/packages/backend/src/infrastructure/queue/workers/push-fanout-logic.test.ts
@@ -1,0 +1,221 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createFanOut,
+  type FanOutDeps,
+  type FanOutSubscription,
+} from './push-fanout-logic.js'
+import type { PushJobData } from '../queues.js'
+import type { SendResult } from '../../push/push-sender.js'
+
+// ---- Fakes -----------------------------------------------------------------
+
+type SendBehavior = SendResult | (() => SendResult | Promise<SendResult>)
+
+interface FakeState {
+  configured: boolean
+  subs: FanOutSubscription[]
+  // Map of endpoint → SendResult (or a thunk for async / dynamic results).
+  sendBehavior: Map<string, SendBehavior>
+  // Optional per-endpoint markFailure error injection.
+  markFailureShouldThrow: Set<string>
+  successes: string[]
+  failures: Array<{ endpoint: string; userId: string; status: number; deactivate: boolean }>
+}
+
+function makeDeps(state: FakeState): FanOutDeps {
+  return {
+    isPushConfigured: () => state.configured,
+    listActiveForUser: async () => state.subs,
+    markSuccess: async (endpoint, _userId) => {
+      state.successes.push(endpoint)
+    },
+    markFailure: async (endpoint, userId, status, deactivate) => {
+      if (state.markFailureShouldThrow.has(endpoint)) {
+        throw new Error('synthetic mark failure error')
+      }
+      state.failures.push({ endpoint, userId, status, deactivate })
+    },
+    sendPush: async (target) => {
+      const behavior = state.sendBehavior.get(target.endpoint)
+      if (!behavior) {
+        return { success: true, statusCode: 201, gone: false, retryable: false }
+      }
+      if (typeof behavior === 'function') return behavior()
+      return behavior
+    },
+    log: { info: () => {}, warn: () => {} },
+  }
+}
+
+const PAYLOAD: PushJobData = {
+  kind: 'send-to-user',
+  userId: 'user-1',
+  payload: { type: 'daily_challenge_ready', title: 'hi', body: 'go' },
+}
+
+function sub(n: number): FanOutSubscription {
+  return {
+    endpoint: `https://fcm.googleapis.com/fcm/send/token-${n}`,
+    user_id: 'user-1',
+    p256dh: `p256dh-${n}`,
+    auth: `auth-${n}`,
+  }
+}
+
+function freshState(overrides: Partial<FakeState> = {}): FakeState {
+  return {
+    configured: true,
+    subs: [],
+    sendBehavior: new Map(),
+    markFailureShouldThrow: new Set(),
+    successes: [],
+    failures: [],
+    ...overrides,
+  }
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+describe('createFanOut', () => {
+  it('short-circuits when push is not configured', async () => {
+    const state = freshState({ configured: false, subs: [sub(1)] })
+    const fanOut = createFanOut(makeDeps(state))
+    const result = await fanOut(PAYLOAD)
+    assert.deepEqual(result, { attempted: 0, succeeded: 0, pruned: 0, retryable: 0 })
+    assert.equal(state.successes.length, 0)
+    assert.equal(state.failures.length, 0)
+  })
+
+  it('returns zeros when the user has no active subscriptions', async () => {
+    const state = freshState({ subs: [] })
+    const fanOut = createFanOut(makeDeps(state))
+    const result = await fanOut(PAYLOAD)
+    assert.deepEqual(result, { attempted: 0, succeeded: 0, pruned: 0, retryable: 0 })
+  })
+
+  it('counts a single success and calls markSuccess scoped by user_id', async () => {
+    const state = freshState({ subs: [sub(1)] })
+    state.sendBehavior.set(sub(1).endpoint, {
+      success: true,
+      statusCode: 201,
+      gone: false,
+      retryable: false,
+    })
+    const fanOut = createFanOut(makeDeps(state))
+    const result = await fanOut(PAYLOAD)
+    assert.equal(result.attempted, 1)
+    assert.equal(result.succeeded, 1)
+    assert.equal(result.pruned, 0)
+    assert.equal(result.retryable, 0)
+    assert.deepEqual(state.successes, [sub(1).endpoint])
+  })
+
+  it('classifies a 410 as pruned and forwards deactivate=true to markFailure', async () => {
+    const state = freshState({ subs: [sub(1)] })
+    state.sendBehavior.set(sub(1).endpoint, {
+      success: false,
+      statusCode: 410,
+      gone: true,
+      retryable: false,
+    })
+    const fanOut = createFanOut(makeDeps(state))
+    const result = await fanOut(PAYLOAD)
+    assert.equal(result.pruned, 1)
+    assert.equal(result.succeeded, 0)
+    assert.equal(result.retryable, 0)
+    assert.deepEqual(state.failures, [
+      { endpoint: sub(1).endpoint, userId: 'user-1', status: 410, deactivate: true },
+    ])
+  })
+
+  it('classifies a 500 as retryable and does NOT deactivate', async () => {
+    const state = freshState({ subs: [sub(1)] })
+    state.sendBehavior.set(sub(1).endpoint, {
+      success: false,
+      statusCode: 500,
+      gone: false,
+      retryable: true,
+    })
+    const fanOut = createFanOut(makeDeps(state))
+    const result = await fanOut(PAYLOAD)
+    assert.equal(result.retryable, 1)
+    assert.equal(result.pruned, 0)
+    assert.equal(state.failures[0]?.deactivate, false)
+  })
+
+  it('classifies a 400 as permanent (not retryable, not pruned)', async () => {
+    const state = freshState({ subs: [sub(1)] })
+    state.sendBehavior.set(sub(1).endpoint, {
+      success: false,
+      statusCode: 400,
+      gone: false,
+      retryable: false,
+    })
+    const fanOut = createFanOut(makeDeps(state))
+    const result = await fanOut(PAYLOAD)
+    assert.equal(result.retryable, 0)
+    assert.equal(result.pruned, 0)
+    assert.equal(result.succeeded, 0)
+    assert.equal(state.failures.length, 1)
+  })
+
+  it('isolates per-device failures with Promise.allSettled (one slow device does not poison the batch)', async () => {
+    const state = freshState({ subs: [sub(1), sub(2), sub(3)] })
+    state.sendBehavior.set(sub(1).endpoint, {
+      success: true,
+      statusCode: 201,
+      gone: false,
+      retryable: false,
+    })
+    state.sendBehavior.set(sub(2).endpoint, {
+      success: false,
+      statusCode: 410,
+      gone: true,
+      retryable: false,
+    })
+    state.sendBehavior.set(sub(3).endpoint, {
+      success: true,
+      statusCode: 201,
+      gone: false,
+      retryable: false,
+    })
+    const fanOut = createFanOut(makeDeps(state))
+    const result = await fanOut(PAYLOAD)
+    assert.equal(result.attempted, 3)
+    assert.equal(result.succeeded, 2)
+    assert.equal(result.pruned, 1)
+    assert.equal(result.retryable, 0)
+  })
+
+  it('treats a thrown markFailure as retryable (idempotent retry on DB blip)', async () => {
+    const state = freshState({ subs: [sub(1)] })
+    state.sendBehavior.set(sub(1).endpoint, {
+      success: false,
+      statusCode: 500,
+      gone: false,
+      retryable: true,
+    })
+    state.markFailureShouldThrow.add(sub(1).endpoint)
+    const fanOut = createFanOut(makeDeps(state))
+    const result = await fanOut(PAYLOAD)
+    assert.equal(result.retryable, 1)
+    assert.equal(result.succeeded, 0)
+  })
+
+  it('mixes success + retryable + pruned + permanent across many devices in one fan-out', async () => {
+    const state = freshState({ subs: [sub(1), sub(2), sub(3), sub(4)] })
+    state.sendBehavior.set(sub(1).endpoint, { success: true, statusCode: 201, gone: false, retryable: false })
+    state.sendBehavior.set(sub(2).endpoint, { success: false, statusCode: 503, gone: false, retryable: true })
+    state.sendBehavior.set(sub(3).endpoint, { success: false, statusCode: 410, gone: true, retryable: false })
+    state.sendBehavior.set(sub(4).endpoint, { success: false, statusCode: 400, gone: false, retryable: false })
+    const fanOut = createFanOut(makeDeps(state))
+    const result = await fanOut(PAYLOAD)
+    assert.equal(result.attempted, 4)
+    assert.equal(result.succeeded, 1)
+    assert.equal(result.retryable, 1)
+    assert.equal(result.pruned, 1)
+    // permanent is not surfaced in the result counters but markFailure was still called for it
+    assert.equal(state.failures.length, 3)
+  })
+})

--- a/packages/backend/src/infrastructure/queue/workers/push-fanout-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/push-fanout-logic.ts
@@ -1,0 +1,79 @@
+import { pushSubscriptionRepository } from '../../repositories/push-subscription.repository.js'
+import { sendPush, isPushConfigured } from '../../push/push-sender.js'
+import type { PushJobData } from '../queues.js'
+import { queueLogger } from '../../logger/logger.js'
+
+const log = queueLogger.child({ worker: 'push-fanout' })
+
+export interface FanOutResult {
+  attempted: number
+  succeeded: number
+  pruned: number
+  retryable: number
+}
+
+// Per-user fan-out. Each device send is isolated with `Promise.allSettled`
+// so one stuck provider doesn't poison the batch, and the result tells the
+// BullMQ worker whether to fail (retry) or succeed.
+export async function fanOutPush(data: PushJobData): Promise<FanOutResult> {
+  if (!isPushConfigured()) {
+    log.warn({ userId: data.userId, type: data.payload.type }, 'push not configured; dropping job')
+    return { attempted: 0, succeeded: 0, pruned: 0, retryable: 0 }
+  }
+
+  const subs = await pushSubscriptionRepository.listActiveForUser(data.userId)
+  if (subs.length === 0) {
+    return { attempted: 0, succeeded: 0, pruned: 0, retryable: 0 }
+  }
+
+  const outcomes = await Promise.allSettled(
+    subs.map(async (sub) => {
+      const result = await sendPush(
+        { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+        data.payload,
+      )
+      if (result.success) {
+        await pushSubscriptionRepository.markSuccess(sub.endpoint, sub.user_id)
+        return { kind: 'success' as const }
+      }
+      await pushSubscriptionRepository.markFailure(
+        sub.endpoint,
+        sub.user_id,
+        result.statusCode ?? 0,
+        result.gone,
+      )
+      if (result.gone) return { kind: 'pruned' as const }
+      if (result.retryable) return { kind: 'retryable' as const }
+      return { kind: 'permanent' as const }
+    }),
+  )
+
+  let succeeded = 0
+  let pruned = 0
+  let retryable = 0
+  for (const o of outcomes) {
+    if (o.status !== 'fulfilled') {
+      // The send branch threw before classifying (DB error in mark*). Treat
+      // as retryable so BullMQ re-runs the job — it's idempotent.
+      retryable += 1
+      continue
+    }
+    if (o.value.kind === 'success') succeeded += 1
+    else if (o.value.kind === 'pruned') pruned += 1
+    else if (o.value.kind === 'retryable') retryable += 1
+  }
+
+  log.info(
+    {
+      userId: data.userId,
+      type: data.payload.type,
+      attempted: subs.length,
+      succeeded,
+      pruned,
+      retryable,
+    },
+    'push fan-out complete',
+  )
+
+  return { attempted: subs.length, succeeded, pruned, retryable }
+}

--- a/packages/backend/src/infrastructure/queue/workers/push-fanout-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/push-fanout-logic.ts
@@ -1,9 +1,12 @@
+import type { PushPayload } from '@the-box/types'
 import { pushSubscriptionRepository } from '../../repositories/push-subscription.repository.js'
-import { sendPush, isPushConfigured } from '../../push/push-sender.js'
+import {
+  isPushConfigured,
+  sendPush,
+  type SendResult,
+} from '../../push/push-sender.js'
 import type { PushJobData } from '../queues.js'
 import { queueLogger } from '../../logger/logger.js'
-
-const log = queueLogger.child({ worker: 'push-fanout' })
 
 export interface FanOutResult {
   attempted: number
@@ -12,68 +15,120 @@ export interface FanOutResult {
   retryable: number
 }
 
+// Minimal subscription shape the fan-out needs. Decoupled from the full DB
+// row so the unit tests don't have to fabricate every column.
+export interface FanOutSubscription {
+  endpoint: string
+  user_id: string
+  p256dh: string
+  auth: string
+}
+
+// Ports for the fan-out worker. Concrete adapters wire these to the
+// repository and web-push at the composition root in queues/workers.ts;
+// tests pass fakes via `createFanOut(deps)`.
+export interface FanOutDeps {
+  isPushConfigured: () => boolean
+  listActiveForUser: (userId: string) => Promise<FanOutSubscription[]>
+  markSuccess: (endpoint: string, userId: string) => Promise<void>
+  markFailure: (
+    endpoint: string,
+    userId: string,
+    status: number,
+    deactivate: boolean,
+  ) => Promise<void>
+  sendPush: (
+    target: { endpoint: string; keys: { p256dh: string; auth: string } },
+    payload: PushPayload,
+  ) => Promise<SendResult>
+  log?: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void }
+}
+
+const defaultLog = queueLogger.child({ worker: 'push-fanout' })
+
+const productionDeps: FanOutDeps = {
+  isPushConfigured,
+  listActiveForUser: (userId) => pushSubscriptionRepository.listActiveForUser(userId),
+  markSuccess: (endpoint, userId) =>
+    pushSubscriptionRepository.markSuccess(endpoint, userId),
+  markFailure: (endpoint, userId, status, deactivate) =>
+    pushSubscriptionRepository.markFailure(endpoint, userId, status, deactivate),
+  sendPush,
+  log: defaultLog,
+}
+
 // Per-user fan-out. Each device send is isolated with `Promise.allSettled`
 // so one stuck provider doesn't poison the batch, and the result tells the
 // BullMQ worker whether to fail (retry) or succeed.
-export async function fanOutPush(data: PushJobData): Promise<FanOutResult> {
-  if (!isPushConfigured()) {
-    log.warn({ userId: data.userId, type: data.payload.type }, 'push not configured; dropping job')
-    return { attempted: 0, succeeded: 0, pruned: 0, retryable: 0 }
-  }
+export function createFanOut(deps: FanOutDeps = productionDeps) {
+  const log = deps.log ?? { info: () => {}, warn: () => {} }
 
-  const subs = await pushSubscriptionRepository.listActiveForUser(data.userId)
-  if (subs.length === 0) {
-    return { attempted: 0, succeeded: 0, pruned: 0, retryable: 0 }
-  }
-
-  const outcomes = await Promise.allSettled(
-    subs.map(async (sub) => {
-      const result = await sendPush(
-        { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
-        data.payload,
+  return async function fanOutPush(data: PushJobData): Promise<FanOutResult> {
+    if (!deps.isPushConfigured()) {
+      log.warn(
+        { userId: data.userId, type: data.payload.type },
+        'push not configured; dropping job',
       )
-      if (result.success) {
-        await pushSubscriptionRepository.markSuccess(sub.endpoint, sub.user_id)
-        return { kind: 'success' as const }
-      }
-      await pushSubscriptionRepository.markFailure(
-        sub.endpoint,
-        sub.user_id,
-        result.statusCode ?? 0,
-        result.gone,
-      )
-      if (result.gone) return { kind: 'pruned' as const }
-      if (result.retryable) return { kind: 'retryable' as const }
-      return { kind: 'permanent' as const }
-    }),
-  )
-
-  let succeeded = 0
-  let pruned = 0
-  let retryable = 0
-  for (const o of outcomes) {
-    if (o.status !== 'fulfilled') {
-      // The send branch threw before classifying (DB error in mark*). Treat
-      // as retryable so BullMQ re-runs the job — it's idempotent.
-      retryable += 1
-      continue
+      return { attempted: 0, succeeded: 0, pruned: 0, retryable: 0 }
     }
-    if (o.value.kind === 'success') succeeded += 1
-    else if (o.value.kind === 'pruned') pruned += 1
-    else if (o.value.kind === 'retryable') retryable += 1
+
+    const subs = await deps.listActiveForUser(data.userId)
+    if (subs.length === 0) {
+      return { attempted: 0, succeeded: 0, pruned: 0, retryable: 0 }
+    }
+
+    const outcomes = await Promise.allSettled(
+      subs.map(async (sub) => {
+        const result = await deps.sendPush(
+          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+          data.payload,
+        )
+        if (result.success) {
+          await deps.markSuccess(sub.endpoint, sub.user_id)
+          return { kind: 'success' as const }
+        }
+        await deps.markFailure(
+          sub.endpoint,
+          sub.user_id,
+          result.statusCode ?? 0,
+          result.gone,
+        )
+        if (result.gone) return { kind: 'pruned' as const }
+        if (result.retryable) return { kind: 'retryable' as const }
+        return { kind: 'permanent' as const }
+      }),
+    )
+
+    let succeeded = 0
+    let pruned = 0
+    let retryable = 0
+    for (const o of outcomes) {
+      if (o.status !== 'fulfilled') {
+        // The send branch threw before classifying (DB error in mark*).
+        // Treat as retryable so BullMQ re-runs the job — it's idempotent.
+        retryable += 1
+        continue
+      }
+      if (o.value.kind === 'success') succeeded += 1
+      else if (o.value.kind === 'pruned') pruned += 1
+      else if (o.value.kind === 'retryable') retryable += 1
+    }
+
+    log.info(
+      {
+        userId: data.userId,
+        type: data.payload.type,
+        attempted: subs.length,
+        succeeded,
+        pruned,
+        retryable,
+      },
+      'push fan-out complete',
+    )
+
+    return { attempted: subs.length, succeeded, pruned, retryable }
   }
-
-  log.info(
-    {
-      userId: data.userId,
-      type: data.payload.type,
-      attempted: subs.length,
-      succeeded,
-      pruned,
-      retryable,
-    },
-    'push fan-out complete',
-  )
-
-  return { attempted: subs.length, succeeded, pruned, retryable }
 }
+
+// Default export wired with concrete adapters; the BullMQ worker calls this.
+export const fanOutPush = createFanOut()

--- a/packages/backend/src/infrastructure/queue/workers/push.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/push.worker.ts
@@ -1,0 +1,50 @@
+import { Worker, Job as BullJob } from 'bullmq'
+import { redisConnectionOptions } from '../connection.js'
+import { queueLogger } from '../../logger/logger.js'
+import type { PushJobData } from '../queues.js'
+import { fanOutPush } from './push-fanout-logic.js'
+
+const log = queueLogger.child({ worker: 'push' })
+
+// Push worker. Concurrency is intentionally higher than the import worker
+// because each send is small, the bottleneck is the push provider's edge,
+// and `Promise.allSettled` inside fanOutPush keeps a single slow device
+// from blocking siblings. A throw here marks the BullMQ job as failed and
+// triggers the retry policy in queues.ts (4 attempts, exponential backoff).
+export const pushWorker = new Worker<PushJobData>(
+  'push-jobs',
+  async (job: BullJob<PushJobData>) => {
+    if (job.data.kind !== 'send-to-user') {
+      throw new Error(`unknown push job kind: ${(job.data as { kind: string }).kind}`)
+    }
+    const result = await fanOutPush(job.data)
+    if (result.attempted > 0 && result.succeeded === 0 && result.retryable > 0) {
+      // Every device failed transiently — let BullMQ retry. If the user has
+      // mixed retryable + permanent failures we still consider the job done
+      // (permanent errors won't get any better on retry).
+      throw new Error(
+        `push fan-out had ${result.retryable} retryable failures and 0 successes`,
+      )
+    }
+    return result
+  },
+  {
+    connection: redisConnectionOptions,
+    concurrency: 10,
+    lockDuration: 30_000,
+    stalledInterval: 30_000,
+  },
+)
+
+pushWorker.on('failed', (job, error) => {
+  log.warn(
+    { jobId: job?.id, attemptsMade: job?.attemptsMade, error: String(error) },
+    'push job failed',
+  )
+})
+
+pushWorker.on('error', (error) => {
+  log.error({ error: String(error) }, 'push worker error')
+})
+
+log.info('push worker initialized')

--- a/packages/backend/src/infrastructure/repositories/push-subscription.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/push-subscription.repository.ts
@@ -61,6 +61,27 @@ export const pushSubscriptionRepository = {
       .select<PushSubscriptionRow[]>('*')
   },
 
+  // Used by the subscribe route to enforce a per-user device cap. Counted at
+  // the repository layer rather than the route so the same SQL/index hits
+  // the partial index on (user_id, is_active).
+  async countActiveForUser(userId: string): Promise<number> {
+    const result = await db('push_subscriptions')
+      .where({ user_id: userId, is_active: true })
+      .count<{ count: string }[]>('* as count')
+    const first = result[0]
+    return first ? Number(first.count) : 0
+  },
+
+  // Used by the subscribe route to decide whether a new endpoint counts
+  // toward the per-user cap. If a row already exists, upsert will replace
+  // it (re-bind to the user) so the cap doesn't apply.
+  async findByEndpoint(endpoint: string): Promise<PushSubscriptionRow | null> {
+    const row = await db('push_subscriptions')
+      .where({ endpoint })
+      .first<PushSubscriptionRow | undefined>('*')
+    return row ?? null
+  },
+
   // Endpoint is globally unique, so this either deletes one row or zero. We
   // hard-delete on explicit unsubscribe (vs. is_active=false) because the
   // user has signaled intent to revoke; keeping the row would just clutter.
@@ -92,6 +113,19 @@ export const pushSubscriptionRepository = {
         last_failure_status: status,
         ...(deactivate ? { is_active: false } : {}),
       })
+  },
+
+  // Hard-delete deactivated rows that haven't seen a successful send in a
+  // long time. Run from the daily prune cron so the table doesn't grow
+  // monotonically with churned browsers / reinstalls.
+  async pruneStale(deactivatedBeforeMs: number): Promise<number> {
+    const cutoff = new Date(Date.now() - deactivatedBeforeMs)
+    return db('push_subscriptions')
+      .where('is_active', false)
+      .andWhere((qb) =>
+        qb.where('last_failure_at', '<', cutoff).orWhereNull('last_failure_at'),
+      )
+      .del()
   },
 }
 

--- a/packages/backend/src/infrastructure/repositories/push-subscription.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/push-subscription.repository.ts
@@ -64,22 +64,29 @@ export const pushSubscriptionRepository = {
   // Endpoint is globally unique, so this either deletes one row or zero. We
   // hard-delete on explicit unsubscribe (vs. is_active=false) because the
   // user has signaled intent to revoke; keeping the row would just clutter.
-  async deleteByEndpoint(endpoint: string): Promise<boolean> {
-    const deleted = await db('push_subscriptions').where({ endpoint }).del()
+  // Scoped by user_id to prevent any authenticated caller from unsubscribing
+  // someone else's device by guessing or learning their endpoint URL.
+  async deleteByEndpoint(endpoint: string, userId: string): Promise<boolean> {
+    const deleted = await db('push_subscriptions').where({ endpoint, user_id: userId }).del()
     return deleted > 0
   },
 
-  async markSuccess(endpoint: string): Promise<void> {
+  async markSuccess(endpoint: string, userId: string): Promise<void> {
     await db('push_subscriptions')
-      .where({ endpoint })
+      .where({ endpoint, user_id: userId })
       .update({ last_success_at: db.fn.now(), last_failure_at: null, last_failure_status: null })
   },
 
   // 4xx/5xx response. Service decides whether to flip is_active based on
   // status (410/404 → terminally gone → flip).
-  async markFailure(endpoint: string, status: number, deactivate: boolean): Promise<void> {
+  async markFailure(
+    endpoint: string,
+    userId: string,
+    status: number,
+    deactivate: boolean,
+  ): Promise<void> {
     await db('push_subscriptions')
-      .where({ endpoint })
+      .where({ endpoint, user_id: userId })
       .update({
         last_failure_at: db.fn.now(),
         last_failure_status: status,

--- a/packages/backend/src/presentation/routes/push.routes.ts
+++ b/packages/backend/src/presentation/routes/push.routes.ts
@@ -23,8 +23,40 @@ router.get('/vapid-public-key', (_req, res) => {
   res.json({ success: true, data: { publicKey: env.VAPID_PUBLIC_KEY } })
 })
 
+// Hostnames operated by the major browser push providers. We restrict
+// `endpoint` to these so an attacker who has a valid session can't register
+// arbitrary URLs (e.g. attacker-controlled hosts) that would turn the
+// fan-out worker into an authenticated outbound webhook generator. The list
+// reflects the public push services as of 2026; new browsers/providers go
+// here when they ship.
+const ALLOWED_PUSH_HOSTS = [
+  /^fcm\.googleapis\.com$/,
+  /^updates\.push\.services\.mozilla\.com$/,
+  /^updates-autopush\.stage\.mozaws\.net$/,
+  /\.notify\.windows\.com$/,
+  /\.push\.apple\.com$/,
+  /^web\.push\.apple\.com$/,
+]
+
+function isAllowedPushEndpoint(value: string): boolean {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return false
+  }
+  if (url.protocol !== 'https:') return false
+  return ALLOWED_PUSH_HOSTS.some((pattern) => pattern.test(url.hostname))
+}
+
 const subscribeBodySchema = z.object({
-  endpoint: z.string().url().max(2000),
+  endpoint: z
+    .string()
+    .url()
+    .max(2000)
+    .refine(isAllowedPushEndpoint, {
+      message: 'endpoint host is not an allowed push provider',
+    }),
   keys: z.object({
     p256dh: z.string().min(1).max(200),
     auth: z.string().min(1).max(50),
@@ -59,8 +91,9 @@ const unsubscribeBodySchema = z.object({
 // log via access logs that capture the request line.
 router.delete('/subscribe', authMiddleware, validateBody(unsubscribeBodySchema), async (req, res, next) => {
   try {
+    const userId = req.userId!
     const body = req.body as z.infer<typeof unsubscribeBodySchema>
-    const removed = await pushSubscriptionRepository.deleteByEndpoint(body.endpoint)
+    const removed = await pushSubscriptionRepository.deleteByEndpoint(body.endpoint, userId)
     res.json({ success: true, data: { removed } })
   } catch (err) {
     next(err)

--- a/packages/backend/src/presentation/routes/push.routes.ts
+++ b/packages/backend/src/presentation/routes/push.routes.ts
@@ -1,12 +1,27 @@
 import { Router } from 'express'
+import type { Request } from 'express'
 import { z } from 'zod'
 import { env } from '../../config/env.js'
 import { pushSubscriptionRepository } from '../../infrastructure/repositories/index.js'
 import { pushService } from '../../domain/services/push.service.js'
 import { authMiddleware } from '../middleware/auth.middleware.js'
 import { validateBody } from '../middleware/validation.middleware.js'
+import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
 
 const router = Router()
+
+// Maximum active push subscriptions per user. A typical user has 1–3 (phone +
+// laptop ± work browser); the cap is generous enough not to bother real
+// users while preventing a session-authed attacker from bloating the table
+// with bogus endpoints to amplify fan-out load.
+const MAX_ACTIVE_DEVICES_PER_USER = 20
+
+// Per-session rate limit on the write endpoints. Keyed by user when an
+// authenticated session is present (cheaper than IP for legit users behind
+// shared NAT), falling back to IP for the public vapid-public-key route.
+const userKey = (req: Request): string => req.userId ?? req.ip ?? 'unknown'
+const subscribeLimiter = createRateLimiter({ windowMs: 60_000, max: 10, key: userKey })
+const unsubscribeLimiter = createRateLimiter({ windowMs: 60_000, max: 30, key: userKey })
 
 // Public: the frontend needs the VAPID public key to call
 // PushManager.subscribe(applicationServerKey: ...). Returns 503 when push is
@@ -64,22 +79,46 @@ const subscribeBodySchema = z.object({
   userAgent: z.string().max(500).optional(),
 })
 
-router.post('/subscribe', authMiddleware, validateBody(subscribeBodySchema), async (req, res, next) => {
-  try {
-    const userId = req.userId!
-    const body = req.body as z.infer<typeof subscribeBodySchema>
-    const row = await pushSubscriptionRepository.upsert({
-      userId,
-      endpoint: body.endpoint,
-      p256dh: body.keys.p256dh,
-      auth: body.keys.auth,
-      userAgent: body.userAgent,
-    })
-    res.json({ success: true, data: { id: row.id, isActive: row.is_active } })
-  } catch (err) {
-    next(err)
-  }
-})
+router.post(
+  '/subscribe',
+  authMiddleware,
+  subscribeLimiter,
+  validateBody(subscribeBodySchema),
+  async (req, res, next) => {
+    try {
+      const userId = req.userId!
+      const body = req.body as z.infer<typeof subscribeBodySchema>
+      // Cap check only applies to genuinely-new endpoints. An existing row
+      // (same browser re-subscribing, or the same endpoint moving between
+      // accounts on this device) goes through the upsert path and replaces
+      // in place, so it doesn't count toward the cap.
+      const existing = await pushSubscriptionRepository.findByEndpoint(body.endpoint)
+      if (!existing) {
+        const activeCount = await pushSubscriptionRepository.countActiveForUser(userId)
+        if (activeCount >= MAX_ACTIVE_DEVICES_PER_USER) {
+          res.status(429).json({
+            success: false,
+            error: {
+              code: 'PUSH_DEVICE_CAP_REACHED',
+              message: `at most ${MAX_ACTIVE_DEVICES_PER_USER} active devices per user`,
+            },
+          })
+          return
+        }
+      }
+      const row = await pushSubscriptionRepository.upsert({
+        userId,
+        endpoint: body.endpoint,
+        p256dh: body.keys.p256dh,
+        auth: body.keys.auth,
+        userAgent: body.userAgent,
+      })
+      res.json({ success: true, data: { id: row.id, isActive: row.is_active } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
 
 const unsubscribeBodySchema = z.object({
   endpoint: z.string().url().max(2000),
@@ -89,15 +128,21 @@ const unsubscribeBodySchema = z.object({
 // We accept the endpoint in the body rather than a query param because the
 // endpoint URL can be long and contains a per-device token we'd rather not
 // log via access logs that capture the request line.
-router.delete('/subscribe', authMiddleware, validateBody(unsubscribeBodySchema), async (req, res, next) => {
-  try {
-    const userId = req.userId!
-    const body = req.body as z.infer<typeof unsubscribeBodySchema>
-    const removed = await pushSubscriptionRepository.deleteByEndpoint(body.endpoint, userId)
-    res.json({ success: true, data: { removed } })
-  } catch (err) {
-    next(err)
-  }
-})
+router.delete(
+  '/subscribe',
+  authMiddleware,
+  unsubscribeLimiter,
+  validateBody(unsubscribeBodySchema),
+  async (req, res, next) => {
+    try {
+      const userId = req.userId!
+      const body = req.body as z.infer<typeof unsubscribeBodySchema>
+      const removed = await pushSubscriptionRepository.deleteByEndpoint(body.endpoint, userId)
+      res.json({ success: true, data: { removed } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
 
 export default router

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1583,7 +1583,13 @@
     "optedOut": "Notifications disabled on this device.",
     "permissionDenied": "You blocked notifications in your browser.",
     "permissionDeniedHint": "Notifications are blocked at the browser level. Allow them in your site settings, then come back here.",
-    "updateError": "Couldn't update notifications. Try again later."
+    "updateError": "Couldn't update notifications. Try again later.",
+    "serverUnavailable": "Notifications are temporarily unavailable. Try again later.",
+    "networkError": "Couldn't reach our servers. Check your connection.",
+    "deviceLimitReached": "You've reached the maximum number of devices for notifications.",
+    "iosInstallHint": "Add The Box to your home screen to enable push notifications on iOS.",
+    "updating": "Updating…",
+    "fallbackBody": "You have a new notification."
   },
   "personalBests": {
     "title": "Personal Bests",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1583,7 +1583,13 @@
     "optedOut": "Notifications désactivées sur cet appareil.",
     "permissionDenied": "Vous avez refusé les notifications dans votre navigateur.",
     "permissionDeniedHint": "Les notifications sont bloquées au niveau du navigateur. Autorisez-les dans les paramètres du site, puis revenez ici.",
-    "updateError": "Impossible de modifier les notifications. Réessayez plus tard."
+    "updateError": "Impossible de modifier les notifications. Réessayez plus tard.",
+    "serverUnavailable": "Les notifications sont temporairement indisponibles. Réessayez plus tard.",
+    "networkError": "Impossible de joindre nos serveurs. Vérifiez votre connexion.",
+    "deviceLimitReached": "Vous avez atteint le nombre maximum d'appareils pour les notifications.",
+    "iosInstallHint": "Ajoutez The Box à votre écran d'accueil pour activer les notifications push sur iOS.",
+    "updating": "Mise à jour…",
+    "fallbackBody": "Vous avez une nouvelle notification."
   },
   "personalBests": {
     "title": "Meilleurs Scores",

--- a/packages/frontend/src/components/profile/PushNotificationCard.tsx
+++ b/packages/frontend/src/components/profile/PushNotificationCard.tsx
@@ -1,13 +1,45 @@
+import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Bell, Loader2 } from 'lucide-react'
 import { useWebPush } from '@/hooks/useWebPush'
+import { PushApiError } from '@/lib/api/push'
 import { toast } from '@/lib/toast'
+
+// Map the typed PushApiError codes (and the DOM exception name browsers
+// throw on permission denial) to localized toast keys. Keep this exhaustive
+// so the user always sees something more specific than "try again later".
+function toastKeyForError(err: unknown): string {
+  if (err instanceof PushApiError) {
+    switch (err.code) {
+      case 'PERMISSION_DENIED':
+        return 'pushNotifications.permissionDenied'
+      case 'PUSH_DEVICE_CAP_REACHED':
+        return 'pushNotifications.deviceLimitReached'
+      case 'SERVER_UNAVAILABLE':
+      case 'PUSH_NOT_CONFIGURED':
+        return 'pushNotifications.serverUnavailable'
+      case 'NETWORK_ERROR':
+        return 'pushNotifications.networkError'
+      case 'RATE_LIMITED':
+        return 'pushNotifications.updateError'
+      default:
+        return 'pushNotifications.updateError'
+    }
+  }
+  if (err instanceof Error && err.name === 'NotAllowedError') {
+    return 'pushNotifications.permissionDenied'
+  }
+  return 'pushNotifications.updateError'
+}
 
 export function PushNotificationCard() {
   const { t } = useTranslation()
+  const descId = useId()
+  const labelId = useId()
   const {
     isSupported,
+    requiresPwaInstall,
     isServerConfigured,
     permission,
     isSubscribed,
@@ -16,33 +48,49 @@ export function PushNotificationCard() {
     unsubscribe,
   } = useWebPush()
 
+  // iOS Safari outside an installed PWA: show a static hint instead of a
+  // toggle that would just throw on click.
+  if (requiresPwaInstall) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Bell className="h-5 w-5" />
+            {t('pushNotifications.title')}
+          </CardTitle>
+          <CardDescription>{t('pushNotifications.description')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">{t('pushNotifications.iosInstallHint')}</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
   // Don't render the card at all if there's nothing the user can do here:
   // unsupported browser (Firefox on iOS, etc.) or server lacks VAPID keys.
-  if (!isSupported || isServerConfigured === false) return null
+  // `isServerConfigured === null` means we're still probing — also hide so
+  // we don't flicker the toggle in then out as the probe completes.
+  if (!isSupported || isServerConfigured !== true) return null
 
   const handleToggle = async (next: boolean) => {
     try {
       if (next) {
         await subscribe()
-        if (Notification.permission === 'granted') {
-          toast.success(t('pushNotifications.optedIn'))
-        } else if (Notification.permission === 'denied') {
-          toast.error(t('pushNotifications.permissionDenied'))
-        }
+        toast.success(t('pushNotifications.optedIn'))
       } else {
         await unsubscribe()
         toast.success(t('pushNotifications.optedOut'))
       }
     } catch (err) {
-      toast.error(t('pushNotifications.updateError'))
-      console.error('Failed to update push subscription:', err)
+      toast.error(t(toastKeyForError(err)))
     }
   }
 
   // The browser blocked us at OS/site level — flipping the toggle won't help,
   // the user has to clear the block in browser settings. Show a read-only
-  // hint instead of an interactive control.
-  const isPermanentlyDenied = permission === 'denied' && !isSubscribed
+  // hint regardless of whether a stale subscription is still on file.
+  const isPermanentlyDenied = permission === 'denied'
 
   return (
     <Card>
@@ -51,17 +99,20 @@ export function PushNotificationCard() {
           <Bell className="h-5 w-5" />
           {t('pushNotifications.title')}
         </CardTitle>
-        <CardDescription>{t('pushNotifications.description')}</CardDescription>
+        <CardDescription id={descId}>{t('pushNotifications.description')}</CardDescription>
       </CardHeader>
       <CardContent>
         {isPermanentlyDenied ? (
           <p className="text-sm text-muted-foreground">{t('pushNotifications.permissionDeniedHint')}</p>
         ) : (
-          <label className="flex items-start gap-3 cursor-pointer select-none group">
+          <label className="flex items-start gap-3 cursor-pointer select-none group" htmlFor={labelId}>
             <input
+              id={labelId}
               type="checkbox"
               checked={isSubscribed}
-              disabled={isLoading || isServerConfigured === null}
+              disabled={isLoading}
+              aria-busy={isLoading}
+              aria-describedby={descId}
               onChange={(e) => void handleToggle(e.target.checked)}
               className="mt-0.5 h-4 w-4 shrink-0 rounded border-white/20 bg-background/50 accent-neon-purple cursor-pointer disabled:cursor-wait"
             />
@@ -69,9 +120,12 @@ export function PushNotificationCard() {
               <span className="block text-sm text-foreground/90 group-hover:text-foreground transition-colors">
                 {t('pushNotifications.label')}
               </span>
-              <span className="flex items-center gap-2 text-xs text-muted-foreground">
-                {isLoading && <Loader2 className="h-3 w-3 animate-spin" />}
-              </span>
+              {isLoading && (
+                <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                  <span className="sr-only">{t('pushNotifications.updating')}</span>
+                </span>
+              )}
             </span>
           </label>
         )}

--- a/packages/frontend/src/components/pwa/PWAUpdatePrompt.tsx
+++ b/packages/frontend/src/components/pwa/PWAUpdatePrompt.tsx
@@ -4,7 +4,7 @@ import { useRegisterSW } from 'virtual:pwa-register/react'
 import { toast } from 'sonner'
 
 export function PWAUpdatePrompt() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const offlineToastShown = useRef(false)
 
   const {
@@ -12,6 +12,23 @@ export function PWAUpdatePrompt() {
     offlineReady: [offlineReady, setOfflineReady],
     updateServiceWorker,
   } = useRegisterSW()
+
+  // Push the active i18n language down to the service worker so the push
+  // fallback notification (shown when the server delivers a malformed or
+  // empty payload) matches the user's UI language. Re-fired on language
+  // switch so the SW always has the current value cached.
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return
+    const send = (locale: string): void => {
+      navigator.serviceWorker.controller?.postMessage({ type: 'SET_LOCALE', locale })
+    }
+    send(i18n.language)
+    const onLangChange = (lang: string): void => send(lang)
+    i18n.on('languageChanged', onLangChange)
+    return () => {
+      i18n.off('languageChanged', onLangChange)
+    }
+  }, [i18n])
 
   useEffect(() => {
     if (offlineReady && !offlineToastShown.current) {

--- a/packages/frontend/src/hooks/useWebPush.ts
+++ b/packages/frontend/src/hooks/useWebPush.ts
@@ -1,13 +1,17 @@
-import { useCallback, useEffect, useState } from 'react'
-import { pushApi } from '@/lib/api/push'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { pushApi, PushApiError } from '@/lib/api/push'
 
 export type PushPermissionStatus = 'default' | 'granted' | 'denied'
 
 export interface UseWebPushState {
   // Browser supports the full Notifications + Push + ServiceWorker stack.
-  // iOS Safari requires the user to install the PWA first; Notification.permission
-  // exists in the page but PushManager only inside the SW registration.
+  // iOS Safari requires the user to install the PWA first; before that,
+  // PushManager exists but `pushManager.subscribe` will reject.
   isSupported: boolean
+  // True iff we're on iOS Safari outside an installed PWA. The card shows
+  // an install hint instead of a non-functional toggle in this case. Also
+  // implies `isSupported: false` so callers don't have to combine flags.
+  requiresPwaInstall: boolean
   // The server has VAPID keys configured. When false the toggle should be
   // hidden — there's nothing the user can do about it.
   isServerConfigured: boolean | null
@@ -16,18 +20,36 @@ export interface UseWebPushState {
   // the live ServiceWorkerRegistration so it stays accurate across tabs.
   isSubscribed: boolean
   isLoading: boolean
-  // Async operations the UI can call.
+  // Async operations the UI can call. Both throw `PushApiError` with a
+  // stable `.code` so the card can render the right localized toast.
   subscribe: () => Promise<void>
   unsubscribe: () => Promise<void>
 }
 
+function isIos(): boolean {
+  if (typeof navigator === 'undefined') return false
+  return /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window)
+}
+
+function isStandalonePwa(): boolean {
+  if (typeof window === 'undefined') return false
+  // iOS exposes navigator.standalone; the cross-platform check is the
+  // display-mode media query, which Chrome/Edge also honor.
+  const iosStandalone = (navigator as { standalone?: boolean }).standalone === true
+  const matchesStandalone = window.matchMedia?.('(display-mode: standalone)').matches ?? false
+  return iosStandalone || matchesStandalone
+}
+
 function detectSupport(): boolean {
-  return (
-    typeof window !== 'undefined' &&
-    'serviceWorker' in navigator &&
-    'PushManager' in window &&
-    'Notification' in window
-  )
+  if (typeof window === 'undefined') return false
+  const hasStack =
+    'serviceWorker' in navigator && 'PushManager' in window && 'Notification' in window
+  if (!hasStack) return false
+  // iOS only allows push from an installed PWA; treat the in-tab case as
+  // unsupported so the card shows the install hint rather than a toggle that
+  // will throw when the user clicks it.
+  if (isIos() && !isStandalonePwa()) return false
+  return true
 }
 
 // Convert a base64url-encoded VAPID key into the Uint8Array shape that
@@ -50,19 +72,35 @@ function arrayBufferToBase64(buffer: ArrayBuffer | null): string {
 }
 
 async function readExistingSubscription(): Promise<PushSubscription | null> {
-  if (!detectSupport()) return null
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return null
   const reg = await navigator.serviceWorker.ready
   return reg.pushManager.getSubscription()
 }
 
 export function useWebPush(): UseWebPushState {
   const isSupported = detectSupport()
+  const requiresPwaInstall = isIos() && !isStandalonePwa()
   const [isServerConfigured, setIsServerConfigured] = useState<boolean | null>(null)
   const [permission, setPermission] = useState<PushPermissionStatus>(
-    isSupported ? (Notification.permission as PushPermissionStatus) : 'default',
+    typeof Notification !== 'undefined'
+      ? (Notification.permission as PushPermissionStatus)
+      : 'default',
   )
   const [isSubscribed, setIsSubscribed] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  // Synchronous re-entry guard. setIsLoading goes through React's state
+  // queue, so a fast double-click can fire two subscribe() calls before the
+  // disabled flag has rendered. The ref flips immediately.
+  const inFlightRef = useRef(false)
+
+  const refreshSubscription = useCallback(async () => {
+    try {
+      const sub = await readExistingSubscription()
+      setIsSubscribed(sub !== null)
+    } catch {
+      setIsSubscribed(false)
+    }
+  }, [])
 
   // Probe both the server config and the current subscription state on mount.
   // Failures are non-fatal — the UI just stays in "not subscribed".
@@ -77,33 +115,87 @@ export function useWebPush(): UseWebPushState {
         const key = await pushApi.getVapidPublicKey()
         if (cancelled) return
         setIsServerConfigured(key !== null)
-      } catch {
-        if (!cancelled) setIsServerConfigured(false)
+      } catch (err) {
+        if (cancelled) return
+        // Distinguish "server explicitly says not configured" (handled above
+        // via null return) from a network error. On NETWORK_ERROR we leave
+        // isServerConfigured as null so the card stays in "loading" rather
+        // than vanishing — the next mount will retry.
+        if (err instanceof PushApiError && err.code === 'NETWORK_ERROR') {
+          setIsServerConfigured(null)
+        } else {
+          setIsServerConfigured(false)
+        }
       }
-      try {
-        const sub = await readExistingSubscription()
-        if (!cancelled) setIsSubscribed(sub !== null)
-      } catch {
-        if (!cancelled) setIsSubscribed(false)
-      }
+      if (!cancelled) await refreshSubscription()
     })()
     return () => {
       cancelled = true
     }
-  }, [isSupported])
+  }, [isSupported, refreshSubscription])
+
+  // Cross-tab and post-permission-change sync. If the user grants/blocks in
+  // another tab, or subscribes/unsubscribes from a different tab, we want
+  // this card to reflect reality without a hard refresh.
+  useEffect(() => {
+    if (!isSupported) return
+    let cancelled = false
+
+    const syncPermission = (): void => {
+      if (cancelled) return
+      setPermission(Notification.permission as PushPermissionStatus)
+    }
+    const syncAll = (): void => {
+      syncPermission()
+      void refreshSubscription()
+    }
+
+    window.addEventListener('visibilitychange', syncAll)
+    window.addEventListener('focus', syncAll)
+
+    let permissionStatus: PermissionStatus | null = null
+    void (async () => {
+      try {
+        if (!('permissions' in navigator)) return
+        permissionStatus = await navigator.permissions.query({
+          name: 'notifications' as PermissionName,
+        })
+        if (cancelled) return
+        permissionStatus.addEventListener('change', syncPermission)
+      } catch {
+        // Some browsers (older Firefox) reject the query for 'notifications';
+        // visibilitychange + focus are still wired up so we're not blind.
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      window.removeEventListener('visibilitychange', syncAll)
+      window.removeEventListener('focus', syncAll)
+      permissionStatus?.removeEventListener('change', syncPermission)
+    }
+  }, [isSupported, refreshSubscription])
 
   const subscribe = useCallback(async () => {
-    if (!isSupported) throw new Error('push not supported')
+    if (!isSupported) {
+      throw new PushApiError('NOT_SUPPORTED', 'Push notifications not supported in this browser')
+    }
+    if (inFlightRef.current) return
+    inFlightRef.current = true
     setIsLoading(true)
     try {
       const publicKey = await pushApi.getVapidPublicKey()
-      if (!publicKey) throw new Error('server not configured')
+      if (!publicKey) {
+        throw new PushApiError('SERVER_UNAVAILABLE', 'Push service is not configured')
+      }
 
-      // Asking for permission must be tied to the user gesture; this hook
+      // Permission prompt must be tied to the user gesture; this hook
       // expects to be called from a click handler.
       const next = (await Notification.requestPermission()) as PushPermissionStatus
       setPermission(next)
-      if (next !== 'granted') return
+      if (next !== 'granted') {
+        throw new PushApiError('PERMISSION_DENIED', 'User denied notification permission')
+      }
 
       const reg = await navigator.serviceWorker.ready
       const subscription = await reg.pushManager.subscribe({
@@ -118,19 +210,34 @@ export function useWebPush(): UseWebPushState {
         json.keys?.p256dh ?? arrayBufferToBase64(subscription.getKey('p256dh'))
       const auth = json.keys?.auth ?? arrayBufferToBase64(subscription.getKey('auth'))
 
-      await pushApi.subscribe({
-        endpoint: subscription.endpoint,
-        keys: { p256dh, auth },
-        userAgent: navigator.userAgent,
-      })
+      try {
+        await pushApi.subscribe({
+          endpoint: subscription.endpoint,
+          keys: { p256dh, auth },
+          userAgent: navigator.userAgent,
+        })
+      } catch (err) {
+        // Server rejected (cap reached, rate-limited, etc.). Roll the
+        // browser-side subscription back so the user can try again later
+        // without us holding a useless endpoint.
+        try {
+          await subscription.unsubscribe()
+        } catch {
+          // best-effort
+        }
+        throw err
+      }
       setIsSubscribed(true)
     } finally {
+      inFlightRef.current = false
       setIsLoading(false)
     }
   }, [isSupported])
 
   const unsubscribe = useCallback(async () => {
     if (!isSupported) return
+    if (inFlightRef.current) return
+    inFlightRef.current = true
     setIsLoading(true)
     try {
       const sub = await readExistingSubscription()
@@ -140,19 +247,23 @@ export function useWebPush(): UseWebPushState {
         // with a 410'd endpoint.
         try {
           await pushApi.unsubscribe(sub.endpoint)
-        } catch {
-          // Swallow — the unsubscribe below is what the user actually wanted.
+        } catch (err) {
+          if (typeof console !== 'undefined') {
+            console.warn('push: server unsubscribe failed; continuing with browser-side', err)
+          }
         }
         await sub.unsubscribe()
       }
       setIsSubscribed(false)
     } finally {
+      inFlightRef.current = false
       setIsLoading(false)
     }
   }, [isSupported])
 
   return {
     isSupported,
+    requiresPwaInstall,
     isServerConfigured,
     permission,
     isSubscribed,

--- a/packages/frontend/src/lib/api/push.ts
+++ b/packages/frontend/src/lib/api/push.ts
@@ -4,10 +4,21 @@ interface ApiResponse<T> {
   error?: { code: string; message: string }
 }
 
-export class PushApiError extends Error {
-  code: string
+// Stable error codes the UI can branch on. The hook and the card both read
+// `code` to pick the right localized toast — never compare error.message.
+export type PushApiErrorCode =
+  | 'NETWORK_ERROR'
+  | 'SERVER_UNAVAILABLE'
+  | 'PUSH_DEVICE_CAP_REACHED'
+  | 'RATE_LIMITED'
+  | 'PUSH_NOT_CONFIGURED'
+  | 'UNKNOWN_ERROR'
+  | string
 
-  constructor(code: string, message: string) {
+export class PushApiError extends Error {
+  code: PushApiErrorCode
+
+  constructor(code: PushApiErrorCode, message: string) {
     super(message)
     this.code = code
     this.name = 'PushApiError'
@@ -15,7 +26,18 @@ export class PushApiError extends Error {
 }
 
 async function handleResponse<T>(response: Response): Promise<T> {
-  const json = (await response.json()) as ApiResponse<T>
+  if (response.status === 503) {
+    throw new PushApiError('SERVER_UNAVAILABLE', 'Push service is not configured')
+  }
+  if (response.status === 429) {
+    throw new PushApiError('RATE_LIMITED', 'Too many requests; try again shortly')
+  }
+  let json: ApiResponse<T>
+  try {
+    json = (await response.json()) as ApiResponse<T>
+  } catch {
+    throw new PushApiError('UNKNOWN_ERROR', `Unexpected response (HTTP ${response.status})`)
+  }
   if (!json.success || json.data === undefined) {
     throw new PushApiError(
       json.error?.code || 'UNKNOWN_ERROR',
@@ -23,6 +45,19 @@ async function handleResponse<T>(response: Response): Promise<T> {
     )
   }
   return json.data
+}
+
+// fetch() throws TypeError on network failure / DNS / offline. Wrap so the
+// caller sees a stable PushApiError code instead of having to sniff for it.
+async function safeFetch(input: string, init?: RequestInit): Promise<Response> {
+  try {
+    return await fetch(input, init)
+  } catch (err) {
+    throw new PushApiError(
+      'NETWORK_ERROR',
+      err instanceof Error ? err.message : 'Network request failed',
+    )
+  }
 }
 
 export interface SubscribePayload {
@@ -36,14 +71,14 @@ export const pushApi = {
   // PUSH_NOT_CONFIGURED). The caller should hide the opt-in UI in that case
   // rather than treat it as a hard error.
   async getVapidPublicKey(): Promise<string | null> {
-    const response = await fetch('/api/push/vapid-public-key', { credentials: 'include' })
+    const response = await safeFetch('/api/push/vapid-public-key', { credentials: 'include' })
     if (response.status === 503) return null
     const data = await handleResponse<{ publicKey: string }>(response)
     return data.publicKey
   },
 
   async subscribe(payload: SubscribePayload): Promise<{ id: number; isActive: boolean }> {
-    const response = await fetch('/api/push/subscribe', {
+    const response = await safeFetch('/api/push/subscribe', {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
@@ -53,7 +88,7 @@ export const pushApi = {
   },
 
   async unsubscribe(endpoint: string): Promise<{ removed: boolean }> {
-    const response = await fetch('/api/push/subscribe', {
+    const response = await safeFetch('/api/push/subscribe', {
       method: 'DELETE',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },

--- a/packages/frontend/src/sw.ts
+++ b/packages/frontend/src/sw.ts
@@ -134,10 +134,24 @@ self.addEventListener('push', (event: PushEvent) => {
   event.waitUntil(self.registration.showNotification(payload.title, options))
 })
 
+// Restrict click navigation to same-origin URLs: the payload arrives over
+// the network and a compromised or spoofed sender could otherwise deliver
+// an off-origin URL that lands the user on a phishing page styled as The
+// Box. Anything off-origin (or unparseable) falls back to the app root.
+function resolveSameOriginTarget(raw: string): string {
+  try {
+    const resolved = new URL(raw, self.location.origin)
+    if (resolved.origin !== self.location.origin) return '/'
+    return resolved.pathname + resolved.search + resolved.hash
+  } catch {
+    return '/'
+  }
+}
+
 self.addEventListener('notificationclick', (event: NotificationEvent) => {
   event.notification.close()
   const data = (event.notification.data ?? {}) as { url?: string }
-  const target = data.url ?? '/'
+  const target = resolveSameOriginTarget(data.url ?? '/')
   event.waitUntil(
     (async () => {
       const allClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true })

--- a/packages/frontend/src/sw.ts
+++ b/packages/frontend/src/sw.ts
@@ -87,10 +87,53 @@ interface PushPayload {
   data?: Record<string, unknown>
 }
 
+// Locale-aware fallback strings. The page persists the active i18n language
+// via `SET_LOCALE` postMessage; when the SW is woken cold by a push event
+// the module-level cache is gone so we fall back to the Cache API entry.
+// French is the project default and the last-resort fallback.
+const FALLBACK_BODY: Record<string, string> = {
+  fr: 'Vous avez une nouvelle notification.',
+  en: 'You have a new notification.',
+}
+const LOCALE_CACHE = 'app-state'
+const LOCALE_KEY = '/__locale'
+let cachedLocale: string | null = null
+
+async function readPersistedLocale(): Promise<string> {
+  if (cachedLocale) return cachedLocale
+  try {
+    const cache = await caches.open(LOCALE_CACHE)
+    const res = await cache.match(LOCALE_KEY)
+    if (res) {
+      const text = (await res.text()).trim().slice(0, 8)
+      if (text) {
+        cachedLocale = text
+        return text
+      }
+    }
+  } catch {
+    // ignore — Cache API can fail in private mode, fall through to default
+  }
+  return 'fr'
+}
+
+async function writePersistedLocale(locale: string): Promise<void> {
+  cachedLocale = locale
+  try {
+    const cache = await caches.open(LOCALE_CACHE)
+    await cache.put(
+      LOCALE_KEY,
+      new Response(locale, { headers: { 'Content-Type': 'text/plain' } }),
+    )
+  } catch {
+    // best-effort
+  }
+}
+
 // Best-effort payload parse: even if the server sends a malformed payload (or
 // none at all, which Apple does for VoIP-style "wake up" pushes), we still
 // surface a generic notification so the user knows something happened.
-function parsePushPayload(event: PushEvent): PushPayload {
+async function parsePushPayload(event: PushEvent): Promise<PushPayload> {
   if (!event.data) return fallbackPayload()
   try {
     const parsed = event.data.json() as Partial<PushPayload>
@@ -109,29 +152,124 @@ function parsePushPayload(event: PushEvent): PushPayload {
   return fallbackPayload()
 }
 
-function fallbackPayload(): PushPayload {
+async function fallbackPayload(): Promise<PushPayload> {
+  const locale = await readPersistedLocale()
   return {
     type: 'generic',
     title: 'The Box',
-    body: 'Vous avez une notification.',
+    body: FALLBACK_BODY[locale] ?? FALLBACK_BODY.fr ?? 'You have a new notification.',
   }
 }
 
+// Pick a notification tag that coalesces correctly. Distinct events must NOT
+// share a tag (the second one would silently replace the first); per-type
+// coalescing is right when the server intends it (e.g. multiple
+// 'streak_at_risk' nudges for the same day). When the payload carries a
+// stable id in `data.id` we honor it; otherwise we fall back to the type.
+function tagFor(payload: PushPayload): string {
+  const id = (payload.data?.id ?? payload.data?.notificationId) as unknown
+  if (typeof id === 'string' && id.length > 0) return `${payload.type}:${id}`
+  if (typeof id === 'number') return `${payload.type}:${id}`
+  return payload.type
+}
+
 self.addEventListener('push', (event: PushEvent) => {
-  const payload = parsePushPayload(event)
-  // Coalesce: a second push with the same `tag` replaces the first instead
-  // of stacking, which avoids a notification queue if the user hasn't opened
-  // the app in a few days. `renotify` is widely supported in browsers but
-  // missing from the lib.dom.d.ts NotificationOptions type, hence the cast.
-  const options = {
-    body: payload.body,
-    icon: '/pwa-192x192.png',
-    badge: '/pwa-64x64.png',
-    tag: payload.type,
-    renotify: true,
-    data: { url: payload.url ?? '/', ...(payload.data ?? {}) },
-  } as NotificationOptions
-  event.waitUntil(self.registration.showNotification(payload.title, options))
+  event.waitUntil(
+    (async () => {
+      const payload = await parsePushPayload(event)
+      // Coalesce: a second push with the same `tag` replaces the first instead
+      // of stacking. `renotify` re-alerts the user even when an existing
+      // notification with the same tag is being replaced — supported by
+      // Chrome/Edge/Firefox but missing from the lib.dom.d.ts type, hence
+      // the cast.
+      const options = {
+        body: payload.body,
+        icon: '/pwa-192x192.png',
+        badge: '/pwa-64x64.png',
+        tag: tagFor(payload),
+        renotify: true,
+        data: { url: payload.url ?? '/', ...(payload.data ?? {}) },
+      } as NotificationOptions
+      await self.registration.showNotification(payload.title, options)
+    })(),
+  )
+})
+
+// Browsers re-issue endpoints on their own schedule (Chrome rotates FCM
+// tokens, Firefox refreshes after long offline periods). When that happens
+// the SW gets a `pushsubscriptionchange` event — we re-subscribe with the
+// stored VAPID key and tell the server about the new endpoint so the user
+// keeps receiving pushes without having to toggle the card off and on.
+interface PushSubscriptionChangeEvent extends ExtendableEvent {
+  readonly newSubscription: PushSubscription | null
+  readonly oldSubscription: PushSubscription | null
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const raw = atob(base64)
+  const out = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i += 1) out[i] = raw.charCodeAt(i)
+  return out
+}
+
+async function reSubscribe(): Promise<PushSubscription | null> {
+  try {
+    const res = await fetch('/api/push/vapid-public-key', { credentials: 'include' })
+    if (!res.ok) return null
+    const json = (await res.json()) as { data?: { publicKey?: string } }
+    const key = json.data?.publicKey
+    if (!key) return null
+    return await self.registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(key) as unknown as ArrayBuffer,
+    })
+  } catch {
+    return null
+  }
+}
+
+self.addEventListener('pushsubscriptionchange', (rawEvent) => {
+  const event = rawEvent as PushSubscriptionChangeEvent
+  event.waitUntil(
+    (async () => {
+      const newSub = event.newSubscription ?? (await reSubscribe())
+      const oldSub = event.oldSubscription
+      if (newSub) {
+        const json = newSub.toJSON()
+        const p256dh = json.keys?.p256dh
+        const auth = json.keys?.auth
+        if (p256dh && auth) {
+          try {
+            await fetch('/api/push/subscribe', {
+              method: 'POST',
+              credentials: 'include',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                endpoint: newSub.endpoint,
+                keys: { p256dh, auth },
+              }),
+            })
+          } catch {
+            // best-effort — the next page mount will reconcile via the hook
+          }
+        }
+      }
+      if (oldSub && (!newSub || oldSub.endpoint !== newSub.endpoint)) {
+        try {
+          await fetch('/api/push/subscribe', {
+            method: 'DELETE',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ endpoint: oldSub.endpoint }),
+          })
+        } catch {
+          // best-effort
+        }
+      }
+    })(),
+  )
 })
 
 // Restrict click navigation to same-origin URLs: the payload arrives over
@@ -178,8 +316,16 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
 
 // Allow the page to trigger an immediate activation when the user clicks the
 // PWAUpdatePrompt "refresh" toast — registerType: 'prompt' relies on this.
+// Also accept SET_LOCALE from the page so push fallback notifications match
+// the user's i18n setting; see PWAUpdatePrompt.tsx for the sender side.
 self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
+  const data = event.data as { type?: string; locale?: string } | null
+  if (!data) return
+  if (data.type === 'SKIP_WAITING') {
     void self.skipWaiting()
+    return
+  }
+  if (data.type === 'SET_LOCALE' && typeof data.locale === 'string' && data.locale) {
+    void writePersistedLocale(data.locale)
   }
 })

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1369,3 +1369,51 @@ export interface AdvancedStats {
     longest: number
   }
 }
+
+// ============================================
+// Web Push Notifications
+// ============================================
+
+// Wire payload the backend ships to the service worker via web-push. The SW
+// renders a notification using `title`/`body` and stores `url` + `data` for
+// the click handler. `type` is a free-form discriminator the SW also uses to
+// pick a notification tag (so e.g. successive 'streak_at_risk' nudges
+// coalesce instead of stacking).
+export interface PushPayload {
+  type: string
+  title: string
+  body: string
+  url?: string
+  data?: Record<string, unknown>
+}
+
+// POST /api/push/subscribe body. The browser hands us all four fields; the
+// backend rejects `endpoint` if its host is not on the push-provider
+// allowlist (FCM, Mozilla autopush, Apple, Windows).
+export interface PushSubscribeRequest {
+  endpoint: string
+  keys: { p256dh: string; auth: string }
+  userAgent?: string
+}
+
+// DELETE /api/push/subscribe body.
+export interface PushUnsubscribeRequest {
+  endpoint: string
+}
+
+// GET /api/push/subscribe / POST /api/push/subscribe success body.
+export interface PushSubscribeResponse {
+  id: number
+  isActive: boolean
+}
+
+// Per-device summary returned by the (planned) GET /api/push/subscriptions
+// endpoint. Intentionally omits the endpoint URL itself — the client doesn't
+// need the per-device token, only enough to identify the row in a list.
+export interface PushSubscriptionSummary {
+  id: number
+  userAgent: string | null
+  createdAt: string
+  lastSuccessAt: string | null
+  isActive: boolean
+}


### PR DESCRIPTION
Block-merge fixes from the multi-persona review of the web push
subscription feature:

- Migration 20260519 adds the missing FK on push_subscriptions.user_id
  with ON DELETE CASCADE (cleans orphan rows first), matching the
  pattern of every other user-owned table. Account deletion now sweeps
  the rows instead of leaving them to 410 forever.
- Repository deleteByEndpoint / markSuccess / markFailure now require
  userId so a session-authed caller can no longer unsubscribe or mutate
  a row they don't own by guessing/learning the endpoint URL.
- Subscribe route refines `endpoint` against an allowlist of known push
  provider hosts (FCM, Mozilla autopush, Apple, Windows) so the fan-out
  worker can't be turned into an authenticated outbound webhook.
- Service worker notificationclick now resolves the payload `url`
  against self.origin and falls back to '/' for off-origin targets,
  closing a phishing pivot via spoofed payloads.