### PR TITLE
ci: harden deploy health gate and add provenance/sbom to release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,31 @@ jobs:
       - name: Show status
         run: docker compose ps
 
+      - name: Wait for the-box to become healthy
+        # `up -d` returns as soon as containers start, not when the app is
+        # ready. Without this gate, a container restart-looping on a bad
+        # migration or boot error would still leave the workflow green.
+        # The healthcheck in compose.yml polls /health every 30s with a 30s
+        # start_period; allow ~3 minutes before declaring the deploy failed.
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 36); do
+            status=$(docker inspect --format='{{.State.Health.Status}}' the-box 2>/dev/null || echo "missing")
+            echo "[$i/36] the-box health: $status"
+            case "$status" in
+              healthy)  exit 0 ;;
+              unhealthy)
+                echo "Container reported unhealthy — dumping recent logs:"
+                docker logs --tail=200 the-box || true
+                exit 1
+                ;;
+            esac
+            sleep 5
+          done
+          echo "Timed out waiting for the-box to become healthy"
+          docker logs --tail=200 the-box || true
+          exit 1
+
       - name: Prune dangling images
         if: success()
         working-directory: /

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -205,6 +205,8 @@ jobs:
             VCS_REF=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.cache_scope }}
           cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}
+          provenance: mode=max
+          sbom: true
           outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest


### PR DESCRIPTION
- deploy.yml: poll `docker inspect` until the-box reports healthy
  (or unhealthy), so a restart-looping container can no longer leave
  a green deploy run. Times out at ~3 minutes and dumps recent logs
  on failure.
- release.yml: bump docker/build-push-action v5 → v6 and enable
  build-time provenance (mode=max) plus SBOM attestations on the
  multi-arch image.

https://claude.ai/code/session_01BrLYs6s6da8QLL3eaowPEk