### PR TITLE
Add premium subscription link to header navigation

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -17,6 +17,8 @@
     "geo": "Geo",
     "alpha": "Alpha",
     "premium": "Premium",
+    "subscribeToPremium": "Subscribe to Premium",
+    "manageSubscription": "Manage subscription",
     "settings": "Settings",
     "login": "Login",
     "register": "Register",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -17,6 +17,8 @@
     "geo": "Géo",
     "alpha": "Alpha",
     "premium": "Premium",
+    "subscribeToPremium": "Passer Premium",
+    "manageSubscription": "Gérer mon abonnement",
     "settings": "Paramètres",
     "login": "Connexion",
     "register": "Inscription",

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -215,6 +215,12 @@ export function Header() {
                             {t('common.history')}
                           </Link>
                         </Button>
+                        <Button variant="ghost" size="sm" asChild className="w-full justify-start">
+                          <Link to={localizedPath('/premium')} onClick={() => setMobileMenuOpen(false)}>
+                            <Sparkles className="w-4 h-4 mr-2 text-neon-pink" />
+                            {billingEntitlement?.isPremium ? t('common.manageSubscription') : t('common.subscribeToPremium')}
+                          </Link>
+                        </Button>
                         {session?.user?.role === 'admin' && (
                           <Button variant="ghost" size="sm" asChild className="w-full justify-start">
                             <Link to={localizedPath('/admin')} onClick={() => setMobileMenuOpen(false)}>
@@ -302,7 +308,7 @@ export function Header() {
                   <ChevronDown className="w-4 h-4 text-white" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuContent align="end" className="w-56">
                 <DropdownMenuItem asChild>
                   <Link to={localizedPath('/profile')} className="flex items-center gap-2 cursor-pointer">
                     <User className="w-4 h-4" />
@@ -313,6 +319,12 @@ export function Header() {
                   <Link to={localizedPath('/history')} className="flex items-center gap-2 cursor-pointer">
                     <History className="w-4 h-4" />
                     {t('common.history')}
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link to={localizedPath('/premium')} className="flex items-center gap-2 cursor-pointer">
+                    <Sparkles className="w-4 h-4 text-neon-pink" />
+                    {billingEntitlement?.isPremium ? t('common.manageSubscription') : t('common.subscribeToPremium')}
                   </Link>
                 </DropdownMenuItem>
                 {session?.user?.role === 'admin' && (


### PR DESCRIPTION
## Summary
Added a premium subscription management link to the header navigation, accessible from both mobile and desktop menu layouts. The link dynamically displays different text based on the user's subscription status.

## Key Changes
- **Mobile Menu**: Added a new "Subscribe to Premium" / "Manage subscription" button in the mobile navigation menu with a sparkles icon
- **Desktop Dropdown**: Added the same premium link to the user dropdown menu in the desktop header
- **Dropdown Width**: Increased the desktop dropdown menu width from `w-48` to `w-56` to accommodate the new menu item
- **Internationalization**: Added English and French translations for the new menu labels:
  - `subscribeToPremium`: "Subscribe to Premium" (EN) / "Passer Premium" (FR)
  - `manageSubscription`: "Manage subscription" (EN) / "Gérer mon abonnement" (FR)

## Implementation Details
- The premium link uses the `billingEntitlement?.isPremium` flag to conditionally display either "Subscribe to Premium" or "Manage subscription"
- Both menu implementations use consistent styling with a neon-pink sparkles icon
- The mobile menu item properly closes the menu on click via `setMobileMenuOpen(false)`
- The link routes to the `/premium` path with proper localization support

https://claude.ai/code/session_01JGuL5etpxEbdciS8VBaWDK