### PR TITLE
Add Koe support widget identity verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,10 +90,15 @@ VITE_API_URL=http://localhost:3000
 VITE_USE_MOCK_API=false
 
 # Koe support widget (https://github.com/Wifsimster/koe)
-# Both vars must be set for the widget to mount. It renders only for
+# Both VITE_ vars must be set for the widget to mount. It renders only for
 # authenticated users, alongside the header user menu.
+# KOE_IDENTITY_SECRET (backend, optional) is the shared secret used to sign
+# user IDs with HMAC-SHA256 so Koe can verify requests. Leave empty to run
+# the widget in unverified mode. Must match the secret configured on the
+# Koe service for the matching projectKey.
 VITE_KOE_PROJECT_KEY=the-box
 VITE_KOE_API_URL=https://koe.example.com
+KOE_IDENTITY_SECRET=
 
 # ============================================
 # BACKEND CONFIGURATION

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -48,6 +48,13 @@ export const env = {
   STRIPE_CHECKOUT_CANCEL_URL: process.env['STRIPE_CHECKOUT_CANCEL_URL'] || 'http://localhost:5173/fr/premium?checkout=cancel',
   STRIPE_PORTAL_RETURN_URL: process.env['STRIPE_PORTAL_RETURN_URL'] || 'http://localhost:5173/fr/profile',
 
+  // Koe support widget — identity verification secret shared with the
+  // self-hosted Koe service. When set, /api/koe/identity returns an
+  // HMAC-SHA256(userId) hex digest so the widget can prove the signed-in
+  // user is who they claim to be. Leave empty to disable verified mode
+  // (the widget still works, but submissions are treated as unverified).
+  KOE_IDENTITY_SECRET: process.env['KOE_IDENTITY_SECRET'] || '',
+
   // Web Push (VAPID). Required to send notifications. Generate a keypair
   // with `npm run vapid:generate -w @the-box/backend`. Without all three
   // values present, the push.service refuses to send and routes return 503.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -27,6 +27,7 @@ import screenshotReportRoutes from './presentation/routes/screenshot-report.rout
 import pushRoutes from './presentation/routes/push.routes.js'
 import billingRoutes from './presentation/routes/billing.routes.js'
 import billingWebhookRoutes from './presentation/routes/billing-webhook.routes.js'
+import koeRoutes from './presentation/routes/koe.routes.js'
 import { testRedisConnection } from './infrastructure/queue/connection.js'
 import { importQueue, geoQueue } from './infrastructure/queue/queues.js'
 import './infrastructure/queue/workers/import.worker.js'
@@ -226,6 +227,7 @@ app.use('/api/geo', geoRoutes)
 app.use('/api/screenshot-reports', screenshotReportRoutes)
 app.use('/api/push', pushRoutes)
 app.use('/api/billing', billingRoutes)
+app.use('/api/koe', koeRoutes)
 
 // Serve frontend static files (after API routes)
 const frontendPath = path.resolve(__dirname, '..', '..', '..', 'packages', 'frontend', 'dist')

--- a/packages/backend/src/presentation/routes/koe.routes.ts
+++ b/packages/backend/src/presentation/routes/koe.routes.ts
@@ -1,0 +1,35 @@
+import { Router } from 'express'
+import { createHmac } from 'node:crypto'
+import { env } from '../../config/env.js'
+import { authMiddleware } from '../middleware/auth.middleware.js'
+
+const router = Router()
+
+/**
+ * GET /api/koe/identity
+ *
+ * Returns the HMAC-SHA256(userId) hex digest used by the Koe widget for
+ * identity verification. Without KOE_IDENTITY_SECRET configured the
+ * endpoint returns 204 so the widget falls back to unverified mode.
+ */
+router.get('/identity', authMiddleware, (req, res, next) => {
+    try {
+        if (!env.KOE_IDENTITY_SECRET) {
+            res.status(204).end()
+            return
+        }
+
+        const userHash = createHmac('sha256', env.KOE_IDENTITY_SECRET)
+            .update(req.userId!)
+            .digest('hex')
+
+        res.json({
+            success: true,
+            data: { userHash },
+        })
+    } catch (error) {
+        next(error)
+    }
+})
+
+export default router

--- a/packages/frontend/src/components/layout/KoeSupportWidget.tsx
+++ b/packages/frontend/src/components/layout/KoeSupportWidget.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useState } from 'react'
 import { KoeWidget } from '@wifsimster/koe'
 import '@wifsimster/koe/style.css'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '@/hooks/useAuth'
+import { koeApi } from '@/lib/api'
 
 const KOE_PROJECT_KEY = import.meta.env.VITE_KOE_PROJECT_KEY as string | undefined
 const KOE_API_URL = import.meta.env.VITE_KOE_API_URL as string | undefined
@@ -10,10 +12,33 @@ const KOE_API_URL = import.meta.env.VITE_KOE_API_URL as string | undefined
  * Koe support widget mounted alongside the user menu.
  * Only renders for authenticated users when the Koe env vars are configured,
  * so the launcher appears in-context with the rest of the account controls.
+ *
+ * The userHash is fetched from /api/koe/identity (HMAC-SHA256 of user.id
+ * with KOE_IDENTITY_SECRET) so the Koe backend can verify the requesting
+ * user. If the backend hasn't been configured with the secret it returns
+ * 204 and the widget falls back to unverified mode.
  */
 export function KoeSupportWidget() {
   const { user, isAuthenticated } = useAuth()
   const { i18n } = useTranslation()
+  const [userHash, setUserHash] = useState<string | null>(null)
+
+  const userId = user?.id
+  useEffect(() => {
+    if (!userId) return
+    let cancelled = false
+    koeApi
+      .getIdentity()
+      .then((hash) => {
+        if (!cancelled) setUserHash(hash)
+      })
+      .catch(() => {
+        if (!cancelled) setUserHash(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [userId])
 
   if (!KOE_PROJECT_KEY || !KOE_API_URL) return null
   if (!isAuthenticated || !user?.id) return null
@@ -31,6 +56,7 @@ export function KoeSupportWidget() {
           locale: i18n.language,
         },
       }}
+      userHash={userHash ?? undefined}
       position="bottom-right"
       theme={{ mode: 'dark' }}
     />

--- a/packages/frontend/src/lib/api/index.ts
+++ b/packages/frontend/src/lib/api/index.ts
@@ -4,6 +4,7 @@ export { dailyLoginApi, DailyLoginApiError } from './daily-login'
 export { geoApi, GeoApiError } from './geo'
 export type { GeoContributorMe, GeoContributorUnlock } from './geo'
 export { geoFetchApi } from './geo-fetch'
+export { koeApi } from './koe'
 export type {
   GeoFetchStage,
   GeoFetchStatus,

--- a/packages/frontend/src/lib/api/koe.ts
+++ b/packages/frontend/src/lib/api/koe.ts
@@ -1,0 +1,19 @@
+export const koeApi = {
+    /**
+     * Fetch the HMAC identity hash for the signed-in user, used by the
+     * Koe widget to prove the caller is who they claim to be. Returns null
+     * when the backend hasn't been configured with KOE_IDENTITY_SECRET
+     * (HTTP 204) — the widget then runs in unverified mode.
+     */
+    async getIdentity(): Promise<string | null> {
+        const response = await fetch('/api/koe/identity', {
+            credentials: 'include',
+        })
+
+        if (response.status === 204) return null
+        if (!response.ok) return null
+
+        const json = await response.json()
+        return json?.data?.userHash ?? null
+    },
+}


### PR DESCRIPTION
## Summary
Adds backend and frontend support for identity verification in the Koe support widget. The backend now provides an endpoint that returns an HMAC-SHA256 hash of the user ID, allowing the Koe service to verify that requests come from authenticated users.

## Key Changes
- **Backend**: Added `/api/koe/identity` endpoint that returns an HMAC-SHA256 hash of the user ID when `KOE_IDENTITY_SECRET` is configured, or HTTP 204 if not configured (allowing unverified mode fallback)
- **Frontend**: Updated `KoeSupportWidget` to fetch the user identity hash on mount and pass it to the Koe widget component
- **Configuration**: Added `KOE_IDENTITY_SECRET` environment variable to backend config with documentation explaining its purpose and optional nature
- **API Client**: Created `koeApi` module with `getIdentity()` method to handle fetching the identity hash with proper error handling
- **Documentation**: Updated `.env.example` with clarification about the new optional backend secret and its relationship to the frontend Koe configuration

## Implementation Details
- The identity hash is fetched only when a user is authenticated and has an ID
- The fetch includes credentials to maintain the authenticated session
- HTTP 204 responses are treated as "unverified mode enabled" (secret not configured)
- The component properly handles cleanup of async operations to prevent state updates on unmounted components
- The endpoint is protected by `authMiddleware` to ensure only authenticated users can access it

https://claude.ai/code/session_016fkwB9Tjmu8QfnxYjTbiYn