### PR TITLE
Update contact information and bug report link

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1504,7 +1504,7 @@
     "contactTitle": "Contact Us",
     "contactIntro": "Have a question, suggestion, or problem? We're here to help.",
     "contactEmailTitle": "By Email",
-    "contactEmail": "contact@thebox.game",
+    "contactEmail": "battistella@proton.me",
     "contactSocialTitle": "Social Media",
     "contactSocial": "Follow us for the latest news and updates.",
     "contactBugTitle": "Report a Bug",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1504,7 +1504,7 @@
     "contactTitle": "Nous contacter",
     "contactIntro": "Une question, une suggestion ou un problème ? Nous sommes là pour vous aider.",
     "contactEmailTitle": "Par email",
-    "contactEmail": "contact@thebox.game",
+    "contactEmail": "battistella@proton.me",
     "contactSocialTitle": "Réseaux sociaux",
     "contactSocial": "Suivez-nous pour les dernières actualités et mises à jour.",
     "contactBugTitle": "Signaler un bug",

--- a/packages/frontend/src/pages/ContactPage.tsx
+++ b/packages/frontend/src/pages/ContactPage.tsx
@@ -22,8 +22,8 @@ export default function ContactPage() {
       icon: Bug,
       title: t('legal.contactBugTitle'),
       content: t('legal.contactBug'),
-      link: 'https://github.com/Wifsimster/the-box/issues',
-      linkLabel: 'GitHub Issues',
+      link: 'https://pro.battistella.ovh/',
+      linkLabel: 'pro.battistella.ovh',
     },
   ]
 


### PR DESCRIPTION
## Summary
Updated contact information across the application to reflect new contact details and bug reporting process.

## Key Changes
- Changed primary contact email from `contact@thebox.game` to `battistella@proton.me` in both English and French locales
- Updated bug report link from GitHub Issues to `https://pro.battistella.ovh/`
- Updated bug report link label from "GitHub Issues" to "pro.battistella.ovh"

## Details
These changes affect the Contact page, redirecting users to the new contact email and bug reporting endpoint. The updates are applied consistently across both language translations (English and French).

https://claude.ai/code/session_01SAmxGWBqKiEWdp8ZKEeYrs