### PR TITLE
Add support widget integration to user menu

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -33,6 +33,7 @@
     "create": "Create",
     "history": "History",
     "profile": "Profile",
+    "support": "Support",
     "unknown": "Unknown",
     "backTo": "Back to",
     "filters": "Filters",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -33,6 +33,7 @@
     "create": "Créer",
     "history": "Historique",
     "profile": "Profil",
+    "support": "Support",
     "unknown": "Inconnu",
     "backTo": "Retour à",
     "filters": "Filtres",

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -18,7 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin, Sparkles, Play } from 'lucide-react'
+import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin, Sparkles, Play, LifeBuoy } from 'lucide-react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
 import { DailyRewardBadge } from '@/components/daily-login'
@@ -91,6 +91,20 @@ function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick, sh
       )}
     </>
   )
+}
+
+// Koe widget owns its own launcher and panel state internally — there is no
+// imperative open API. Clicking the floating launcher button toggles the
+// panel, so we reuse that same DOM seam to open it from the user menu.
+const isKoeConfigured = Boolean(
+  import.meta.env.VITE_KOE_PROJECT_KEY && import.meta.env.VITE_KOE_API_URL,
+)
+
+function openKoeSupport() {
+  const launcher = document.querySelector<HTMLButtonElement>(
+    '.koe-root button[aria-expanded="false"]',
+  )
+  launcher?.click()
 }
 
 /**
@@ -225,6 +239,20 @@ export function Header() {
                             {billingEntitlement?.isPremium ? t('common.manageSubscription') : t('common.subscribeToPremium')}
                           </Link>
                         </Button>
+                        {isKoeConfigured && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => {
+                              setMobileMenuOpen(false)
+                              openKoeSupport()
+                            }}
+                            className="w-full justify-start"
+                          >
+                            <LifeBuoy className="w-4 h-4 mr-2" />
+                            {t('common.support')}
+                          </Button>
+                        )}
                         {session?.user?.role === 'admin' && (
                           <Button variant="ghost" size="sm" asChild className="w-full justify-start">
                             <Link to={localizedPath('/admin')} onClick={() => setMobileMenuOpen(false)}>
@@ -334,6 +362,15 @@ export function Header() {
                     {billingEntitlement?.isPremium ? t('common.manageSubscription') : t('common.subscribeToPremium')}
                   </Link>
                 </DropdownMenuItem>
+                {isKoeConfigured && (
+                  <DropdownMenuItem
+                    onClick={openKoeSupport}
+                    className="flex items-center gap-2 cursor-pointer"
+                  >
+                    <LifeBuoy className="w-4 h-4" />
+                    {t('common.support')}
+                  </DropdownMenuItem>
+                )}
                 {session?.user?.role === 'admin' && (
                   <DropdownMenuItem asChild>
                     <Link to={localizedPath('/admin')} className="flex items-center gap-2 cursor-pointer">


### PR DESCRIPTION
## Summary
Integrate Koe support widget into the application header by adding a "Support" menu item that opens the widget when clicked. The feature is conditionally displayed only when the Koe service is properly configured.

## Key Changes
- Added `LifeBuoy` icon import from lucide-react for the support menu item
- Implemented `openKoeSupport()` helper function that programmatically opens the Koe widget by clicking its launcher button
- Added configuration check (`isKoeConfigured`) that verifies both `VITE_KOE_PROJECT_KEY` and `VITE_KOE_API_URL` environment variables are set
- Added "Support" menu item to both mobile and desktop dropdown menus that:
  - Only displays when Koe is configured
  - Closes mobile menu before opening support widget (mobile only)
  - Uses the `LifeBuoy` icon for visual consistency
- Added "support" translation key to English and French locale files

## Implementation Details
The Koe widget manages its own internal state and doesn't expose an imperative API, so the implementation leverages the existing DOM structure by querying for the widget's launcher button and triggering a click to toggle the panel. This approach reuses the same interaction pattern as the widget's built-in launcher button.

https://claude.ai/code/session_01D6zRQxXEZpaEiYUrjCyEcN