### PR TITLE
feat(billing): scope portal sessions to this app's Stripe configuration

### DIFF
--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -47,6 +47,12 @@ export const env = {
   STRIPE_CHECKOUT_SUCCESS_URL: process.env['STRIPE_CHECKOUT_SUCCESS_URL'] || 'http://localhost:5173/fr/premium?checkout=success',
   STRIPE_CHECKOUT_CANCEL_URL: process.env['STRIPE_CHECKOUT_CANCEL_URL'] || 'http://localhost:5173/fr/premium?checkout=cancel',
   STRIPE_PORTAL_RETURN_URL: process.env['STRIPE_PORTAL_RETURN_URL'] || 'http://localhost:5173/fr/profile',
+  // Stripe Billing Portal configuration ID (bpc_…). When set, portal
+  // sessions are created with this configuration so the customer can
+  // only switch between The Box Premium prices, not toward products of
+  // other apps sharing the same Stripe account. Empty falls back to
+  // the account's default configuration.
+  STRIPE_PORTAL_CONFIG_ID: process.env['STRIPE_PORTAL_CONFIG_ID'] || '',
 
   // Koe support widget — identity verification secret shared with the
   // self-hosted Koe service. When set, /api/koe/identity returns an

--- a/packages/backend/src/presentation/routes/billing.routes.ts
+++ b/packages/backend/src/presentation/routes/billing.routes.ts
@@ -150,6 +150,12 @@ router.post('/portal', authMiddleware, async (req, res, next) => {
     const session = await stripe.billingPortal.sessions.create({
       customer: customerId,
       return_url: env.STRIPE_PORTAL_RETURN_URL,
+      // Restricts the portal to The Box Premium products. The four apps
+      // share one Stripe account, so without a config a customer would
+      // see WAWPTN / Tokō / CoproPilot prices in the "switch plan" picker.
+      ...(env.STRIPE_PORTAL_CONFIG_ID
+        ? { configuration: env.STRIPE_PORTAL_CONFIG_ID }
+        : {}),
     })
 
     res.json({ success: true, data: { url: session.url } })


### PR DESCRIPTION
## Context

The four apps (Tokō, WAWPTN, The Box, CoproPilot) share a single Stripe account. Before this PR, `stripe.billingPortal.sessions.create()` was called without a `configuration` parameter, so the portal fell back to the account default — which lists every active product on the account. A logged-in customer could open "Manage subscription" and see prices for the three other apps in the "switch plan" picker.

Worst case: a WAWPTN customer (3€/mo) accidentally switches to CoproPilot Entreprise (749€/year), the webhook receives a `customer.subscription.updated` for an unrelated product, and the user state in DB ends up inconsistent.

## What this PR does

- Adds a `STRIPE_PORTAL_CONFIG_ID` env var.
- When set, it is passed as the `configuration` argument to every `billingPortal.sessions.create()` call → the portal only lists this app's products.
- When empty, behaviour is unchanged (falls back to the account default), so the change is back-compat safe.

## Stripe-side state

The four portal configurations have already been provisioned in Stripe live via the API and are pinned to each app's products only. The matching `bpc_…` IDs are already set in the prod `.env` of each app.

## Test plan

- [ ] Verify backend builds and existing tests still pass
- [ ] After deploy: open Manage Subscription as a customer, confirm only this app's prices appear in the picker
- [ ] Confirm cancellation / payment method update still work
- [ ] Confirm no regression for customers that have no active subscription (route still 400s cleanly)