### PR TITLE
Hide KoeWidget launcher button, use user menu for access

### DIFF
--- a/packages/frontend/src/components/layout/KoeSupportWidget.tsx
+++ b/packages/frontend/src/components/layout/KoeSupportWidget.tsx
@@ -44,21 +44,29 @@ export function KoeSupportWidget() {
   if (!isAuthenticated || !user?.id) return null
 
   return (
-    <KoeWidget
-      projectKey={KOE_PROJECT_KEY}
-      apiUrl={KOE_API_URL}
-      user={{
-        id: user.id,
-        name: user.name ?? undefined,
-        email: user.email ?? undefined,
-        metadata: {
-          role: user.role ?? 'user',
-          locale: i18n.language,
-        },
-      }}
-      userHash={userHash ?? undefined}
-      position="bottom-right"
-      theme={{ mode: 'dark' }}
-    />
+    <>
+      {/* Hide the floating launcher in its closed state — entry point is the
+          user-menu "Support" item, which calls .click() on the launcher
+          programmatically (display:none doesn't block synthetic clicks).
+          The open-state button (aria-expanded="true", X icon) stays visible
+          so users can still close the panel. */}
+      <style>{`.koe-root button[aria-expanded="false"]{display:none!important;}`}</style>
+      <KoeWidget
+        projectKey={KOE_PROJECT_KEY}
+        apiUrl={KOE_API_URL}
+        user={{
+          id: user.id,
+          name: user.name ?? undefined,
+          email: user.email ?? undefined,
+          metadata: {
+            role: user.role ?? 'user',
+            locale: i18n.language,
+          },
+        }}
+        userHash={userHash ?? undefined}
+        position="bottom-right"
+        theme={{ mode: 'dark' }}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
Modified the KoeSupportWidget to hide the floating launcher button and instead provide access to the support panel through the user menu. The launcher can still be opened programmatically via the user menu's "Support" item, and users can still close the panel using the X button.

## Changes
- Wrapped KoeWidget in a fragment with an injected style rule
- Added CSS rule to hide the launcher button when closed (`aria-expanded="false"`)
- Used `!important` flag to ensure the style takes precedence
- Kept the close button (X icon) visible by only hiding the closed state
- Added explanatory comment documenting the approach and rationale

## Implementation Details
The solution uses a style injection rather than relying on `display:none` in component props because synthetic clicks (triggered programmatically from the user menu) still work on hidden elements. This allows the "Support" menu item to trigger the launcher while keeping the floating button hidden from the UI.

https://claude.ai/code/session_012cCaUaDAPh4XevKCCnoMXy