### PR TITLE
Add tour replay functionality to user menu

### DIFF
--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -18,7 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin, Sparkles, Play, LifeBuoy } from 'lucide-react'
+import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin, Sparkles, Play, LifeBuoy, Compass } from 'lucide-react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
 import { DailyRewardBadge } from '@/components/daily-login'
@@ -27,6 +27,7 @@ import { useDailyLoginStore } from '@/stores/dailyLoginStore'
 import { useBillingStore } from '@/stores/billingStore'
 import { KoeSupportWidget } from '@/components/layout/KoeSupportWidget'
 import { InstallPromptButton } from '@/components/pwa'
+import { requestTourReplay } from '@/components/onboarding/tour-storage'
 import { cn } from '@/lib/utils'
 
 interface NavigationLinksProps {
@@ -118,9 +119,15 @@ function openKoeSupport() {
 export function Header() {
   const { t } = useTranslation()
   const { localizedPath } = useLocalizedPath()
+  const navigate = useNavigate()
   const { session, isPending, signOut } = useAuth()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [isScrolled, setIsScrolled] = useState(false)
+
+  const handleReplayTour = () => {
+    requestTourReplay()
+    navigate(localizedPath('/'))
+  }
   const isRewardModalOpen = useDailyLoginStore((state) => state.isModalOpen)
   const closeRewardModal = useDailyLoginStore((state) => state.closeModal)
   const billingEntitlement = useBillingStore((state) => state.entitlement)
@@ -261,6 +268,18 @@ export function Header() {
                             </Link>
                           </Button>
                         )}
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setMobileMenuOpen(false)
+                            handleReplayTour()
+                          }}
+                          className="w-full justify-start"
+                        >
+                          <Compass className="w-4 h-4 mr-2" />
+                          {t('tour.replayCta')}
+                        </Button>
                         <Button variant="ghost" size="sm" onClick={() => {
                           signOut()
                           setMobileMenuOpen(false)
@@ -380,6 +399,10 @@ export function Header() {
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleReplayTour} className="flex items-center gap-2 cursor-pointer">
+                  <Compass className="w-4 h-4" />
+                  {t('tour.replayCta')}
+                </DropdownMenuItem>
                 <DropdownMenuItem onClick={signOut} className="cursor-pointer">
                   <LogOut className="w-4 h-4" />
                   {t('common.logout')}

--- a/packages/frontend/src/components/onboarding/tour-storage.ts
+++ b/packages/frontend/src/components/onboarding/tour-storage.ts
@@ -1,6 +1,8 @@
 const TOUR_DONE_FLAG = 'theBox.homeTourCompleted'
 const TOUR_PENDING_FLAG = 'theBox.homeTourPending'
 
+export const TOUR_REPLAY_EVENT = 'theBox:tourReplay'
+
 export function hasCompletedTour(): boolean {
   try {
     return localStorage.getItem(TOUR_DONE_FLAG) === '1'
@@ -41,5 +43,15 @@ export function consumeTourPending(): boolean {
     return pending
   } catch {
     return false
+  }
+}
+
+// Trigger a replay from anywhere in the app. The pending flag covers the
+// case where HomePage is about to mount (navigated in from another route);
+// the event covers the case where HomePage is already mounted.
+export function requestTourReplay(): void {
+  markTourPending()
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(TOUR_REPLAY_EVENT))
   }
 }

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -13,7 +13,7 @@ import { gameApi } from '@/lib/api/game'
 import { useNextDailyCountdown } from '@/hooks/useNextDailyCountdown'
 import { WelcomeModal } from '@/components/onboarding/WelcomeModal'
 import { TourGuide } from '@/components/onboarding/TourGuide'
-import { consumeTourPending, hasCompletedTour } from '@/components/onboarding/tour-storage'
+import { consumeTourPending, hasCompletedTour, TOUR_REPLAY_EVENT } from '@/components/onboarding/tour-storage'
 import { StreakRiskBanner } from '@/components/daily-login/StreakRiskBanner'
 import { HomeAchievementTeaser } from '@/components/home/HomeAchievementTeaser'
 import { useBillingStore } from '@/stores/billingStore'
@@ -83,6 +83,14 @@ export default function HomePage() {
       }
     }, 600)
     return () => window.clearTimeout(id)
+  }, [])
+
+  // Replay from the user menu while already on this page — the mount-time
+  // effect above won't re-run, so listen for the explicit replay event.
+  useEffect(() => {
+    const handler = () => setTourOpen(true)
+    window.addEventListener(TOUR_REPLAY_EVENT, handler)
+    return () => window.removeEventListener(TOUR_REPLAY_EVENT, handler)
   }, [])
 
   // Helper: drop `initial`/`animate`/`transition` when reduced motion is


### PR DESCRIPTION
## Summary
This PR adds the ability for users to replay the onboarding tour from the user menu, accessible both on mobile and desktop views.

## Key Changes
- **Header Component**: Added "Replay Tour" button to both mobile menu and desktop dropdown menu with a Compass icon
- **Tour Storage**: Introduced `requestTourReplay()` function and `TOUR_REPLAY_EVENT` constant to handle tour replay requests from anywhere in the app
- **HomePage**: Added event listener for `TOUR_REPLAY_EVENT` to support replaying the tour while already on the home page
- **Navigation**: Integrated `useNavigate` hook to redirect users to home page when replaying tour from other routes

## Implementation Details
- The replay mechanism uses two approaches to cover different scenarios:
  - `markTourPending()` flag for cases where HomePage is about to mount after navigation
  - `TOUR_REPLAY_EVENT` custom event for cases where HomePage is already mounted
- The tour replay button closes the mobile menu before triggering the replay
- Uses existing translation key `tour.replayCta` for the button label
- Maintains consistent UI patterns with existing menu items (ghost button variant, icon + text layout)

https://claude.ai/code/session_01RaDPkoWJgzwbW3tyffH2fi