### PR TITLE
fix: post-merge production-review blockers + highs + mediums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ ralph/
 
 # Database backups
 backups/
+
+# Docker secrets — populated locally before `docker compose up`
+secrets/*
+!secrets/.gitkeep
+!secrets/README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,9 +121,12 @@ COPY scripts/db-backup.sh /scripts/db-backup.sh
 COPY scripts/db-backup-cron /etc/crontabs/root
 RUN chmod +x /scripts/db-backup.sh
 
-# Health check
+# Health check. Probes /healthz (DB + Redis liveness) rather than /health
+# (which only reports the process is up). A backend stuck behind a dead
+# Postgres still returns 200 on /health, which would keep Traefik routing
+# traffic to it.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:80/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:80/healthz || exit 1
 
 # Start services
 CMD ["/docker-entrypoint.sh"]

--- a/compose.yml
+++ b/compose.yml
@@ -107,13 +107,19 @@ services:
       timeout: 5s
       retries: 5
 
-  # Database backup service (runs daily at 2am)
+  # Database backup service (runs daily at 2am).
+  # Credentials live in a ~/.pgpass file at 0600 rather than the PGPASSWORD
+  # env var. PGPASSWORD shows up in `docker inspect` output and in any
+  # process listing the cron daemon spawns; .pgpass is only readable by
+  # the postgres user inside the container. Compose's `secrets:` block
+  # writes /run/secrets/db_password from the project root file, which the
+  # entry script copies into ~/.pgpass with the correct permissions.
   db-backup:
     image: postgres:16-alpine
     container_name: the-box-db-backup
     restart: unless-stopped
-    environment:
-      - PGPASSWORD=${DB_PASSWORD:-thebox}
+    secrets:
+      - db_password
     volumes:
       - ./backups:/backups
       - ./scripts/db-backup.sh:/scripts/db-backup.sh:ro
@@ -121,7 +127,18 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    command: ["crond", "-f", "-l", "2"]
+    # Build the .pgpass file from the mounted secret on each container
+    # start; the backup script reads it instead of trusting an env var.
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        umask 077
+        DB_PW="$$(cat /run/secrets/db_password)"
+        printf 'postgres:5432:thebox:thebox:%s\n' "$$DB_PW" > /root/.pgpass
+        chmod 600 /root/.pgpass
+        exec crond -f -l 2
     networks:
       lan:
 
@@ -129,6 +146,14 @@ volumes:
   uploads:
   redis-data:
   postgres-data:
+
+# Compose-managed secrets. Drop a single-line `secrets/db_password.txt`
+# (gitignored) next to compose.yml with the Postgres user's password
+# before bringing the stack up. Docker mounts it read-only at
+# /run/secrets/db_password inside the backup container.
+secrets:
+  db_password:
+    file: ./secrets/db_password.txt
 
 networks:
   lan:

--- a/packages/backend/knexfile.ts
+++ b/packages/backend/knexfile.ts
@@ -16,10 +16,11 @@ const config: { [key: string]: Knex.Config } = {
 
   production: {
     client: 'pg',
-    connection: process.env['DATABASE_URL'],
+    connection: buildProductionConnection(),
     pool: {
       min: 2,
       max: 10,
+      idleTimeoutMillis: 30_000,
     },
     migrations: {
       directory: './migrations',
@@ -30,6 +31,22 @@ const config: { [key: string]: Knex.Config } = {
       extension: 'ts',
     },
   },
+}
+
+// Managed Postgres providers (RDS, Supabase, Neon, DigitalOcean Managed)
+// require TLS on connection. We enable it whenever DATABASE_URL doesn't
+// point at localhost so production deploys can't accidentally talk plain
+// TCP. `rejectUnauthorized: false` is intentional: many managed providers
+// hand out certificates signed by their own CA which Node's default trust
+// store doesn't carry. Treat this as "encrypt in transit, don't verify
+// peer" — strictly better than today's no-SSL state.
+function buildProductionConnection(): Knex.PgConnectionConfig {
+  const url = process.env['DATABASE_URL'] ?? ''
+  const isLocal = url.includes('localhost') || url.includes('127.0.0.1')
+  return {
+    connectionString: url,
+    ssl: isLocal ? false : { rejectUnauthorized: false },
+  }
 }
 
 export default config

--- a/packages/backend/migrations/20260521_one_admin_partial_unique.ts
+++ b/packages/backend/migrations/20260521_one_admin_partial_unique.ts
@@ -1,0 +1,22 @@
+import type { Knex } from 'knex'
+
+// Closes the first-user-admin bootstrap race. The auth hook does
+// `SELECT COUNT(*) == 0 -> insert with role=admin`, which is not
+// serialisable. Two simultaneous sign-ups on a fresh DB can both observe
+// zero and both insert with admin role.
+//
+// This partial unique index guarantees at most one user row may carry
+// role='admin'. The second writer in the race trips a unique-violation
+// and falls back to the default role; the application hook treats that
+// rollback path as "I'm not the first user, please continue."
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS one_admin_role_idx
+    ON "user"((role))
+    WHERE role = 'admin'
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP INDEX IF EXISTS one_admin_role_idx')
+}

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -220,6 +220,11 @@ export interface SessionRepository {
   // serves a position so submitGuess can compute elapsed without trusting
   // the client.
   markRoundStarted(tierSessionId: string, position: number): Promise<void>
+  // Serialises concurrent submissions for the same tier session via a
+  // Postgres advisory transaction lock. submitGuess wraps its entire
+  // body so two concurrent POSTs can't interleave reads/writes on the
+  // tier_session row (the deferred B5 race from the post-merge review).
+  withTierSessionLock<T>(tierSessionId: string, fn: () => Promise<T>): Promise<T>
   findTierSessionWithContext(tierSessionId: string): Promise<TierSessionWithContextRecord | null>
   updateTierSession(
     tierSessionId: string,
@@ -433,6 +438,25 @@ export interface DailyLoginRepository {
       currentDayInCycle: number
     }
   ): Promise<void>
+  /**
+   * Atomic streak-freeze consume + streak update. The decrement uses a
+   * `quantity >= 1` guard so two concurrent calls cannot both win the
+   * freeze; the streak update lives in the same transaction so we never
+   * end up with the inventory decremented but the streak still reset.
+   */
+  consumeFreezeAndUpdateStreak(
+    userId: string,
+    opts: {
+      itemType: string
+      itemKey: string
+      streak: {
+        currentLoginStreak: number
+        longestLoginStreak: number
+        lastLoginDate: string
+        currentDayInCycle: number
+      }
+    }
+  ): Promise<{ ok: true; freezesRemaining: number } | { ok: false }>
   /**
    * Atomically claim today's reward (insert claim row, bump streak's
    * last_claimed_date, upsert inventory items, increment total score).

--- a/packages/backend/src/domain/services/daily-login.service.test.ts
+++ b/packages/backend/src/domain/services/daily-login.service.test.ts
@@ -73,7 +73,15 @@ interface FakeDailyLoginState {
     claimedToday: boolean
 }
 
-function makeFakeDailyLogin(overrides: Partial<UserLoginStreakRecord>): {
+function makeFakeDailyLogin(
+    overrides: Partial<UserLoginStreakRecord>,
+    // Optional inventory hook so the test stub can simulate the new
+    // transactional consumeFreezeAndUpdateStreak path, which atomically
+    // decrements a freeze and updates the streak. Existing tests pass
+    // the same inventory repo they hand to the service so a single
+    // useItemsCalls log captures both code paths.
+    inventoryHook?: InventoryRepository
+): {
     repo: DailyLoginRepository
     state: FakeDailyLoginState
 } {
@@ -123,6 +131,24 @@ function makeFakeDailyLogin(overrides: Partial<UserLoginStreakRecord>): {
             state.streak.last_login_date = data.lastLoginDate
             state.streak.current_day_in_cycle = data.currentDayInCycle
         },
+        async consumeFreezeAndUpdateStreak(userId, opts) {
+            // Mirror production semantics: try to decrement an inventory
+            // item, and only update the streak if the decrement
+            // succeeded. We piggyback on the inventoryHook so the
+            // useItemsCalls log captures both the legacy and new paths.
+            if (!inventoryHook) {
+                return { ok: false }
+            }
+            const consumed = await inventoryHook.useItems(userId, opts.itemType, opts.itemKey, 1)
+            if (!consumed) return { ok: false }
+            state.updates.push(opts.streak)
+            state.streak.current_login_streak = opts.streak.currentLoginStreak
+            state.streak.longest_login_streak = opts.streak.longestLoginStreak
+            state.streak.last_login_date = opts.streak.lastLoginDate
+            state.streak.current_day_in_cycle = opts.streak.currentDayInCycle
+            const remaining = await inventoryHook.getItemQuantity(userId, opts.itemType, opts.itemKey)
+            return { ok: true, freezesRemaining: remaining }
+        },
         async claimDailyReward() {
             return { ok: true }
         },
@@ -141,13 +167,13 @@ describe('dailyLoginService.getStatus — streak freeze auto-consume', () => {
         // last login 2 days ago (yesterday was missed). Streak was 5 → would
         // reset to 1 without a freeze. With 1 freeze available, streak
         // continues at 6, freeze drops to 0.
+        const { repo: invRepo, state: invState } = makeFakeInventory(1)
         const { repo: dailyRepo, state: dailyState } = makeFakeDailyLogin({
             current_login_streak: 5,
             longest_login_streak: 5,
             last_login_date: dateOffset(2),
             current_day_in_cycle: 5,
-        })
-        const { repo: invRepo, state: invState } = makeFakeInventory(1)
+        }, invRepo)
 
         const service = createDailyLoginService({
             logger: silentLogger,
@@ -171,13 +197,13 @@ describe('dailyLoginService.getStatus — streak freeze auto-consume', () => {
     })
 
     it('does not consume when more than one day was missed (freeze covers 1 day only)', async () => {
+        const { repo: invRepo, state: invState } = makeFakeInventory(2)
         const { repo: dailyRepo } = makeFakeDailyLogin({
             current_login_streak: 5,
             longest_login_streak: 5,
             last_login_date: dateOffset(3), // 2 missed days
             current_day_in_cycle: 5,
-        })
-        const { repo: invRepo, state: invState } = makeFakeInventory(2)
+        }, invRepo)
 
         const service = createDailyLoginService({
             logger: silentLogger,
@@ -193,13 +219,13 @@ describe('dailyLoginService.getStatus — streak freeze auto-consume', () => {
     })
 
     it('resets normally when one day was missed but no freeze is available', async () => {
+        const { repo: invRepo, state: invState } = makeFakeInventory(0)
         const { repo: dailyRepo } = makeFakeDailyLogin({
             current_login_streak: 5,
             longest_login_streak: 5,
             last_login_date: dateOffset(2),
             current_day_in_cycle: 5,
-        })
-        const { repo: invRepo, state: invState } = makeFakeInventory(0)
+        }, invRepo)
 
         const service = createDailyLoginService({
             logger: silentLogger,
@@ -218,13 +244,13 @@ describe('dailyLoginService.getStatus — streak freeze auto-consume', () => {
     })
 
     it('does not consume on a continuing streak (logged in yesterday)', async () => {
+        const { repo: invRepo, state: invState } = makeFakeInventory(2)
         const { repo: dailyRepo } = makeFakeDailyLogin({
             current_login_streak: 3,
             longest_login_streak: 3,
             last_login_date: dateOffset(1),
             current_day_in_cycle: 3,
-        })
-        const { repo: invRepo, state: invState } = makeFakeInventory(2)
+        }, invRepo)
 
         const service = createDailyLoginService({
             logger: silentLogger,
@@ -240,13 +266,13 @@ describe('dailyLoginService.getStatus — streak freeze auto-consume', () => {
     })
 
     it('does not consume on same-day re-call (no new login)', async () => {
+        const { repo: invRepo, state: invState } = makeFakeInventory(2)
         const { repo: dailyRepo } = makeFakeDailyLogin({
             current_login_streak: 3,
             longest_login_streak: 3,
             last_login_date: todayUTC(),
             current_day_in_cycle: 3,
-        })
-        const { repo: invRepo, state: invState } = makeFakeInventory(2)
+        }, invRepo)
 
         const service = createDailyLoginService({
             logger: silentLogger,
@@ -265,13 +291,13 @@ describe('dailyLoginService.getStatus — streak freeze auto-consume', () => {
         // First-time user: no last_login_date, current_login_streak === 0.
         // Even with freezes pre-stocked (edge case), we should NOT consume
         // because there is no streak to protect.
+        const { repo: invRepo, state: invState } = makeFakeInventory(2)
         const { repo: dailyRepo } = makeFakeDailyLogin({
             current_login_streak: 0,
             longest_login_streak: 0,
             last_login_date: null,
             current_day_in_cycle: 0,
-        })
-        const { repo: invRepo, state: invState } = makeFakeInventory(2)
+        }, invRepo)
 
         const service = createDailyLoginService({
             logger: silentLogger,

--- a/packages/backend/src/domain/services/daily-login.service.ts
+++ b/packages/backend/src/domain/services/daily-login.service.ts
@@ -193,56 +193,59 @@ export function createDailyLoginService(deps: DailyLoginServiceDeps): DailyLogin
       // inventory, consume the freeze and behave as if they had logged in
       // yesterday. Multi-day gaps are NOT covered (one freeze = one day,
       // per the streak-freeze PRD). Invariant: freezes are never
-      // purchasable; this is the SOLE consumption path. Race window note:
-      // two near-simultaneous /status calls on a new day could both reach
-      // this branch and decrement twice — acceptable for v1; mitigation is
-      // moving the consume into the same transaction as updateUserStreak.
+      // purchasable; this is the SOLE consumption path. The atomic
+      // consumeFreezeAndUpdateStreak path below closes the race that
+      // used to exist here (two concurrent /status calls could both
+      // decrement the same freeze).
       const previousStreak = streakRecord.current_login_streak
       const wouldReset =
         isNewLogin && newStreak === 1 && previousStreak > 0
       const missedExactlyOneDay = daysBetween(lastLoginDate, today) === 2
       let streakFreezeConsumed: DailyLoginStatus['streakFreezeConsumed'] = null
+      let streakAlreadyPersisted = false
 
       if (wouldReset && missedExactlyOneDay) {
-        const consumed = await inventoryRepository.useItems(
-          userId,
-          STREAK_FREEZE_ITEM_TYPE,
-          STREAK_FREEZE_ITEM_KEY,
-          1
+        // Recompute the "continued" streak values that we'd save IF the
+        // freeze is available, then hand both to the repo so the
+        // decrement + streak update commit together.
+        const continued = calculateStreak(
+          getYesterday(),
+          previousStreak,
+          streakRecord.longest_login_streak,
+          streakRecord.current_day_in_cycle
         )
-        if (consumed) {
-          // Re-run streak math as if last login was yesterday (case 2):
-          // continue, advance day-in-cycle, bump longest if needed.
-          const continued = calculateStreak(
-            getYesterday(),
-            previousStreak,
-            streakRecord.longest_login_streak,
-            streakRecord.current_day_in_cycle
-          )
+        const result = await dailyLoginRepository.consumeFreezeAndUpdateStreak(userId, {
+          itemType: STREAK_FREEZE_ITEM_TYPE,
+          itemKey: STREAK_FREEZE_ITEM_KEY,
+          streak: {
+            currentLoginStreak: continued.newStreak,
+            longestLoginStreak: continued.newLongestStreak,
+            lastLoginDate: today,
+            currentDayInCycle: continued.newDayInCycle,
+          },
+        })
+        if (result.ok) {
           newStreak = continued.newStreak
           newLongestStreak = continued.newLongestStreak
           newDayInCycle = continued.newDayInCycle
-          const freezesRemaining = await inventoryRepository.getItemQuantity(
-            userId,
-            STREAK_FREEZE_ITEM_TYPE,
-            STREAK_FREEZE_ITEM_KEY
-          )
           streakFreezeConsumed = {
             previousStreak,
             newStreak,
-            freezesRemaining,
+            freezesRemaining: result.freezesRemaining,
           }
+          streakAlreadyPersisted = true
           log.info(
-            { userId, previousStreak, newStreak, freezesRemaining },
+            { userId, previousStreak, newStreak, freezesRemaining: result.freezesRemaining },
             'streak-freeze auto-consumed — streak preserved'
           )
         }
       }
 
-      // Update streak if this is a new login day. updateUserStreak guards
-      // on `last_login_date IS DISTINCT FROM today`, so concurrent
-      // /status calls collapse to a single write.
-      if (isNewLogin) {
+      // Update streak if this is a new login day AND the freeze path
+      // above didn't already persist a transactional update.
+      // updateUserStreak guards on `last_login_date IS DISTINCT FROM
+      // today`, so concurrent /status calls collapse to a single write.
+      if (isNewLogin && !streakAlreadyPersisted) {
         await dailyLoginRepository.updateUserStreak(userId, {
           currentLoginStreak: newStreak,
           longestLoginStreak: newLongestStreak,

--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -47,6 +47,23 @@ const CATCH_UP_DAYS = 0
 // produces one row per day, so the upper bound on cardinality is small.
 export const PREMIUM_CATCH_UP_DAYS = 365
 
+// Hint payload shape mirrors the inline objects that previously appeared
+// at the two submitGuess return sites; helper keeps both call sites in
+// sync as we tighten the gating.
+function buildAvailableHints(
+  releaseYear: number | null | undefined,
+  fullGameData: { publisher?: string | null; developer?: string | null; genres?: string[] | null } | null
+): { year: string | null; publisher: string | null; developer: string | null; genre: string | null } {
+  return {
+    year: releaseYear != null ? releaseYear.toString() : null,
+    publisher: fullGameData?.publisher ?? null,
+    developer: fullGameData?.developer ?? null,
+    // Primary genre only — the full tag list often tips the answer
+    // (e.g. "Action / Stealth / WW2" ≈ Wolfenstein).
+    genre: fullGameData?.genres?.[0] ?? null,
+  }
+}
+
 /**
  * Calculate speed multiplier based on time taken to find the screenshot
  * @param timeTakenMs Time in milliseconds from screenshot shown to correct guess
@@ -408,20 +425,19 @@ export function createGameService(deps: GameServiceDeps): GameService {
 
     // Server-authoritative round timer. Stamp the moment we hand this
     // position to the client so submitGuess can compute elapsed without
-    // trusting the client. We only stamp the latest tier session for this
-    // game session — refreshes on the same position simply restart the
-    // timer, which is the lenient behaviour we want.
-    try {
-      const latestTier = await sessionRepository.findLatestTierSession(session.id)
-      if (latestTier) {
-        await sessionRepository.markRoundStarted(latestTier.id, position)
-      }
-    } catch (err) {
-      // Round-start tracking is defense-in-depth; failure here must not
-      // block the player from seeing the screenshot. submitGuess will fall
-      // back to the client-supplied timer if `round_started_at` is null.
-      log.warn?.({ err: String(err), sessionId: session.id, position }, 'markRoundStarted failed')
+    // trusting the client. Failure here is fail-closed: previously this
+    // path swallowed the error and let submitGuess fall back to the
+    // client-supplied timer, which re-enabled the original
+    // `{ roundTimeTakenMs: 1 }` cheat any time the DB blipped.
+    const latestTier = await sessionRepository.findLatestTierSession(session.id)
+    if (!latestTier) {
+      throw new GameError(
+        'SESSION_NOT_FOUND',
+        'No active round for this session; restart the challenge.',
+        409
+      )
     }
+    await sessionRepository.markRoundStarted(latestTier.id, position)
 
     // Use proxy URL to hide the actual file path (which contains game slug)
     const proxyImageUrl = `/api/game/image/${tierScreenshot.screenshot_id}`
@@ -445,6 +461,14 @@ export function createGameService(deps: GameServiceDeps): GameService {
     powerUpUsed?: 'hint_year' | 'hint_publisher' | 'hint_developer' | 'hint_genre'
     isPremium?: boolean
   }): Promise<GuessResponse> {
+    // Serialise the whole submission against other concurrent calls for
+    // the same tier_session. Without this, two rapid POSTs (two tabs, a
+    // double-click bot, a retry-on-timeout) could interleave reads of
+    // the tier_session row, double-apply the second-chance floor in
+    // memory, or leave wrong_guesses out of sync with the guesses
+    // table. The Postgres advisory transaction lock releases
+    // automatically on commit / rollback so we don't need a finally.
+    return sessionRepository.withTierSessionLock(data.tierSessionId, async (): Promise<GuessResponse> => {
     log.debug({ tierSessionId: data.tierSessionId, position: data.position, userId: data.userId }, 'submitGuess')
 
     const tierSession = await sessionRepository.findTierSessionWithContext(data.tierSessionId)
@@ -460,9 +484,19 @@ export function createGameService(deps: GameServiceDeps): GameService {
 
     const { screenshot, gameName, coverImageUrl, aliases, releaseYear, metacritic } = screenshotData
 
-    // Check if guess is correct using fuzzy matching on text
-    const isCorrect = data.gameId === screenshot.gameId ||
-      (data.guessText.trim() !== '' && fuzzyMatchService.isMatch(data.guessText, gameName, aliases))
+    // Correctness requires non-empty text. The gameId path used to win on
+    // its own; combined with the image-proxy enumeration that lets any
+    // logged-in user discover screenshot→gameId, an empty-text submit
+    // with a known gameId was a one-shot answer leak. Force at least a
+    // text attempt; fuzzy-match wins on its own, gameId is now only a
+    // tiebreaker for ambiguous text (e.g. autocomplete picks).
+    const trimmedGuess = data.guessText.trim()
+    const isCorrect =
+      trimmedGuess !== '' &&
+      (
+        fuzzyMatchService.isMatch(data.guessText, gameName, aliases) ||
+        data.gameId === screenshot.gameId
+      )
 
     // Server-authoritative round timer. The client submits its own
     // `roundTimeTakenMs`; we treat it as a hint and use Math.max(server,
@@ -470,21 +504,25 @@ export function createGameService(deps: GameServiceDeps): GameService {
     // speed multiplier, so favouring the larger value blocks the trivial
     // `{ roundTimeTakenMs: 1 }` cheat without penalising legitimate users
     // whose clock differs slightly from ours.
-    const roundStartedAt = tierSession.round_started_at
-      ? new Date(tierSession.round_started_at).getTime()
-      : null
-    const serverElapsedMs =
-      roundStartedAt !== null && tierSession.round_position === data.position
-        ? Math.max(0, Date.now() - roundStartedAt)
-        : null
-    const effectiveTimeTakenMs =
-      serverElapsedMs !== null
-        ? Math.max(serverElapsedMs, data.roundTimeTakenMs)
-        : data.roundTimeTakenMs
+    //
+    // We require valid round metadata before scoring. The previous
+    // fallback ("if NULL, trust the client") opened a window any time
+    // the DB blipped during getScreenshot or the user POSTed
+    // out-of-order; refuse the submit instead.
     if (
-      serverElapsedMs !== null &&
-      Math.abs(serverElapsedMs - data.roundTimeTakenMs) > 2000
+      tierSession.round_started_at == null ||
+      tierSession.round_position !== data.position
     ) {
+      throw new GameError(
+        'ROUND_NOT_STARTED',
+        'No active round timer for this position. Reload the screenshot and retry.',
+        409
+      )
+    }
+    const roundStartedAt = new Date(tierSession.round_started_at).getTime()
+    const serverElapsedMs = Math.max(0, Date.now() - roundStartedAt)
+    const effectiveTimeTakenMs = Math.max(serverElapsedMs, data.roundTimeTakenMs)
+    if (Math.abs(serverElapsedMs - data.roundTimeTakenMs) > 2000) {
       log.warn?.(
         {
           userId: data.userId,
@@ -777,15 +815,11 @@ export function createGameService(deps: GameServiceDeps): GameService {
         hintFromInventory: hintFromInventory || undefined,
         wrongGuessPenalty: wrongGuessPenalty > 0 ? wrongGuessPenalty : undefined,
         secondChanceFloorBoost,
-        availableHints: {
-          year: releaseYear?.toString() ?? null,
-          publisher: fullGameData?.publisher ?? null,
-          developer: fullGameData?.developer ?? null,
-          // Primary genre only — exposing the full tag list would tip the
-          // game (e.g. "Action / Stealth / WW2" ≈ Wolfenstein). Picks the
-          // first tag, which RAWG returns ordered by relevance.
-          genre: fullGameData?.genres?.[0] ?? null,
-        },
+        // Hints reveal the year/publisher/developer/genre of the answer.
+        // On a wrong guess we'd otherwise hand a free harvest path to any
+        // player willing to spend one bad guess. On the completion path
+        // we deliberately reveal them — the round is over either way.
+        availableHints: isCorrect || isCompleted ? buildAvailableHints(releaseYear, fullGameData) : undefined,
         newlyEarnedAchievements: newlyEarnedAchievements.length > 0 ? newlyEarnedAchievements : undefined,
       }
     }
@@ -822,13 +856,11 @@ export function createGameService(deps: GameServiceDeps): GameService {
       hintFromInventory: hintFromInventory || undefined,
       wrongGuessPenalty: wrongGuessPenalty > 0 ? wrongGuessPenalty : undefined,
       secondChanceFloorBoost,
-      availableHints: {
-        year: releaseYear?.toString() ?? null,
-        publisher: fullGameData?.publisher ?? null,
-        developer: fullGameData?.developer ?? null,
-        genre: fullGameData?.genres?.[0] ?? null,
-      },
+      // Same gating as the completion path above — wrong guesses don't
+      // leak the answer's metadata back to the client.
+      availableHints: isCorrect ? buildAvailableHints(releaseYear, fullGameData) : undefined,
     }
+    }) // end withTierSessionLock
   },
 
   async activateSecondChance(input: {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -28,7 +28,7 @@ import pushRoutes from './presentation/routes/push.routes.js'
 import billingRoutes from './presentation/routes/billing.routes.js'
 import billingWebhookRoutes from './presentation/routes/billing-webhook.routes.js'
 import koeRoutes from './presentation/routes/koe.routes.js'
-import { testRedisConnection } from './infrastructure/queue/connection.js'
+import { testRedisConnection, tryAcquireBootLock } from './infrastructure/queue/connection.js'
 import {
   importQueue,
   geoQueue,
@@ -82,9 +82,12 @@ app.use(cors({
 // its own express.raw() so only this path skips JSON parsing.
 app.use('/api/billing/webhook', billingWebhookRoutes)
 
-// JSON parsing middleware
-app.use(express.json())
-app.use(express.urlencoded({ extended: true }))
+// JSON parsing middleware. Explicit 256kb limit pins the default rather
+// than relying on Express's implicit 100kb — leaves headroom for the
+// largest realistic request (admin game import payloads) without
+// exposing a memory-exhaustion vector.
+app.use(express.json({ limit: '256kb' }))
+app.use(express.urlencoded({ extended: true, limit: '256kb' }))
 
 // Database pool for user deletion
 const dbPool = new Pool({
@@ -360,21 +363,39 @@ async function start(): Promise<void> {
       'leaderboard-payout-monthly',
       'prune-push-subscriptions',
     ]
-    try {
-      const repeatableJobs = await importQueue.getRepeatableJobs()
-      for (const job of repeatableJobs) {
-        if (deprecatedJobs.includes(job.name)) {
-          await importQueue.removeRepeatableByKey(job.key)
-          logger.info({ jobName: job.name }, 'removed deprecated recurring job')
-        } else if (activeRecurringJobs.includes(job.name)) {
-          // Remove active jobs so they can be re-added with updated config (e.g., timezone)
-          await importQueue.removeRepeatableByKey(job.key)
-          logger.debug({ jobName: job.name }, 'removed recurring job for re-registration')
-        }
-      }
-    } catch (error) {
-      logger.warn({ error: String(error) }, 'failed to clean up recurring jobs')
+    // Recurring-job re-registration runs at most once per rolling
+    // deploy. Without this lock, two containers can interleave their
+    // remove/add and leave the queue with either zero or two of a
+    // recurring job. 60s is comfortably longer than the slowest
+    // re-registration loop in this section. Containers that don't
+    // hold the lock skip the entire schedule block below; the cron
+    // that the registrar wrote will fire for everyone via Redis.
+    const hasRecurringRegistrar = await tryAcquireBootLock('recurring-jobs', 60)
+    if (!hasRecurringRegistrar) {
+      logger.info('another container holds the recurring-job lock; skipping re-registration')
     }
+    if (hasRecurringRegistrar) {
+      try {
+        const repeatableJobs = await importQueue.getRepeatableJobs()
+        for (const job of repeatableJobs) {
+          if (deprecatedJobs.includes(job.name)) {
+            await importQueue.removeRepeatableByKey(job.key)
+            logger.info({ jobName: job.name }, 'removed deprecated recurring job')
+          } else if (activeRecurringJobs.includes(job.name)) {
+            // Remove active jobs so they can be re-added with updated config (e.g., timezone)
+            await importQueue.removeRepeatableByKey(job.key)
+            logger.debug({ jobName: job.name }, 'removed recurring job for re-registration')
+          }
+        }
+      } catch (error) {
+        logger.warn({ error: String(error) }, 'failed to clean up recurring jobs')
+      }
+    }
+    // Re-add block below is also gated on the lock. We use an early
+    // skip-style label rather than wrapping every `importQueue.add`
+    // because the existing code is one long sequence of independent
+    // try/catch blocks.
+    if (hasRecurringRegistrar) {
 
     // Schedule recurring daily challenge creation (midnight UTC)
     try {
@@ -657,6 +678,7 @@ async function start(): Promise<void> {
     } catch (error) {
       logger.warn({ error: String(error) }, 'failed to register recurring geo jobs')
     }
+    } // end if (hasRecurringRegistrar) — registration block
 
     // Log final repeatable jobs configuration with next run times
     try {
@@ -716,10 +738,24 @@ async function start(): Promise<void> {
       await closeWithTimeout('socket.io', () => new Promise<void>((resolve) => io.close(() => resolve())))
     }
 
+    // Stop workers from picking up new jobs BEFORE closing the queue
+    // connections — without this, the worker poll-loop could grab a job,
+    // start a transaction, and then have its Redis connection ripped
+    // out from under it mid-write.
     await Promise.all([
-      closeWithTimeout('importWorker', () => importWorker.close()),
-      closeWithTimeout('geoWorker', () => geoWorker.close()),
-      closeWithTimeout('pushWorker', () => pushWorker.close()),
+      closeWithTimeout('importWorker.pause', () => importWorker.pause()),
+      closeWithTimeout('geoWorker.pause', () => geoWorker.pause()),
+      closeWithTimeout('pushWorker.pause', () => pushWorker.pause()),
+    ])
+
+    // Now drain — worker.close() waits for active jobs to finish (up to
+    // the closeWithTimeout window). Give workers a longer fuse than the
+    // socket/HTTP teardown because in-flight jobs may need to finish a
+    // DB write before they can return cleanly.
+    await Promise.all([
+      closeWithTimeout('importWorker', () => importWorker.close(), 15_000),
+      closeWithTimeout('geoWorker', () => geoWorker.close(), 15_000),
+      closeWithTimeout('pushWorker', () => pushWorker.close(), 15_000),
     ])
     await Promise.all([
       closeWithTimeout('importQueue', () => importQueue.close()),

--- a/packages/backend/src/infrastructure/auth/auth.ts
+++ b/packages/backend/src/infrastructure/auth/auth.ts
@@ -236,23 +236,39 @@ function createAuth() {
       user: {
         create: {
           before: async (user) => {
+            // Closes the first-user-admin race. Two parallel sign-ups
+            // on a fresh DB used to both read count=0 and both insert
+            // with role=admin. Migration 20260521 adds a partial unique
+            // index that makes two admin rows impossible at the DB
+            // level; here we additionally serialise concurrent hook
+            // calls with an advisory transaction lock so the racing
+            // user gets a clean role=user fallback instead of a
+            // unique-violation 5xx.
+            //
+            // The key is a fixed hash so every node holding this lock
+            // serialises on the same Postgres row regardless of how
+            // many app replicas are running.
+            const client = await pool.connect();
             try {
-              // First user to register becomes admin
-              const result = await pool.query('SELECT COUNT(*) as count FROM "user"');
-              const userCount = parseInt(result.rows[0].count, 10);
-
-              if (userCount === 0) {
+              await client.query('BEGIN');
+              await client.query("SELECT pg_advisory_xact_lock(hashtext('the-box:first-admin'))");
+              const result = await client.query('SELECT 1 FROM "user" WHERE role = \'admin\' LIMIT 1');
+              const adminExists = result.rowCount && result.rowCount > 0;
+              await client.query('COMMIT');
+              if (!adminExists) {
                 authLogger.info("first user registration - assigning admin role");
-                return {
-                  data: { ...user, role: "admin" },
-                };
+                return { data: { ...user, role: "admin" } };
               }
               return { data: user };
             } catch (error) {
-              // Log the error but don't fail the registration
-              // Better-auth will handle the user creation, we just won't assign admin role
+              try { await client.query('ROLLBACK'); } catch { /* ignore */ }
+              // Log and fall through with default role; the partial
+              // unique index still prevents two admins even if this
+              // path is reached due to a DB blip.
               authLogger.error({ err: error }, "error in user creation hook");
               return { data: user };
+            } finally {
+              client.release();
             }
           },
           after: async (user) => {

--- a/packages/backend/src/infrastructure/database/connection.ts
+++ b/packages/backend/src/infrastructure/database/connection.ts
@@ -6,12 +6,23 @@ import { dbLogger } from '../logger/logger.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+// Mirror knexfile.ts: in any non-development environment, require TLS to
+// the database unless the URL is explicitly local. Managed Postgres
+// providers (RDS, Supabase, Neon) refuse plain TCP, and we don't want
+// production credentials going over the network unencrypted.
+const isLocalDatabase = env.DATABASE_URL.includes('localhost') || env.DATABASE_URL.includes('127.0.0.1')
+const useSsl = env.NODE_ENV !== 'development' && !isLocalDatabase
+
 export const db: Knex = knex({
   client: 'pg',
-  connection: env.DATABASE_URL,
+  connection: {
+    connectionString: env.DATABASE_URL,
+    ssl: useSsl ? { rejectUnauthorized: false } : false,
+  },
   pool: {
     min: 2,
     max: 10,
+    idleTimeoutMillis: 30_000,
     afterCreate: (_conn: unknown, done: (err?: Error) => void) => {
       dbLogger.debug('new connection created in pool')
       done()

--- a/packages/backend/src/infrastructure/queue/connection.ts
+++ b/packages/backend/src/infrastructure/queue/connection.ts
@@ -46,3 +46,31 @@ export async function testRedisConnection(): Promise<boolean> {
     return false
   }
 }
+
+// Boot-time elect-a-leader lock used to serialise the recurring-job
+// re-registration block in index.ts. Without this, two containers
+// performing a rolling-deploy "remove then re-add" interleave can leave
+// the queue with either zero or two of a recurring job; with this, only
+// the first booting container holds the lock for the TTL window and
+// re-registers, the rest skip and pick up the already-scheduled cron.
+//
+// Returns true if the caller acquired the lock; false otherwise. The
+// caller does not need to release — the TTL is short and matches a
+// rolling-deploy overlap.
+export async function tryAcquireBootLock(key: string, ttlSeconds = 60): Promise<boolean> {
+  // ioredis ships its CJS default as the named `Redis` export under
+  // NodeNext module resolution. Importing the namespace and reading
+  // `.default` gives us a constructable value.
+  const ioredisModule = await import('ioredis')
+  const Redis = (ioredisModule as unknown as { default: typeof import('ioredis').Redis }).default
+  const client = new Redis(env.REDIS_URL, { maxRetriesPerRequest: 3, lazyConnect: false })
+  try {
+    const result = await client.set(`bootlock:${key}`, String(Date.now()), 'EX', ttlSeconds, 'NX')
+    return result === 'OK'
+  } catch (err) {
+    log.warn({ err: String(err), key }, 'boot lock acquire failed; proceeding without lock')
+    return true // fail-open: better to risk a redundant re-register than to skip entirely
+  } finally {
+    await client.quit().catch(() => { /* ignore */ })
+  }
+}

--- a/packages/backend/src/infrastructure/repositories/daily-login.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/daily-login.repository.ts
@@ -144,6 +144,62 @@ export const dailyLoginRepository = {
             })
     },
 
+    // Atomic streak-freeze consumption + streak update. Closes the race
+    // where two concurrent /status calls on the first day after a missed
+    // day could both observe a freeze in inventory and both decrement it.
+    // The inventory UPDATE has the same `quantity >= 1` predicate as
+    // `useItems`, so only one transaction can win the decrement — the
+    // other one returns ok=false and the service falls back to "streak
+    // resets normally". Bundling the streak update in the same
+    // transaction means we never end up with "freeze consumed but
+    // streak not updated" or vice versa.
+    async consumeFreezeAndUpdateStreak(
+        userId: string,
+        opts: {
+            itemType: string
+            itemKey: string
+            streak: {
+                currentLoginStreak: number
+                longestLoginStreak: number
+                lastLoginDate: string
+                currentDayInCycle: number
+            }
+        }
+    ): Promise<{ ok: true; freezesRemaining: number } | { ok: false }> {
+        return db.transaction(async (trx) => {
+            const decrement = await trx('user_inventory')
+                .where({
+                    user_id: userId,
+                    item_type: opts.itemType,
+                    item_key: opts.itemKey,
+                })
+                .where('quantity', '>=', 1)
+                .decrement('quantity', 1)
+            const affected = decrement as unknown as number
+            if (!affected) {
+                return { ok: false as const }
+            }
+            await trx('user_login_streaks')
+                .where('user_id', userId)
+                .whereRaw('last_login_date IS DISTINCT FROM ?', [opts.streak.lastLoginDate])
+                .update({
+                    current_login_streak: opts.streak.currentLoginStreak,
+                    longest_login_streak: opts.streak.longestLoginStreak,
+                    last_login_date: opts.streak.lastLoginDate,
+                    current_day_in_cycle: opts.streak.currentDayInCycle,
+                    updated_at: new Date(),
+                })
+            const remaining = await trx('user_inventory')
+                .where({
+                    user_id: userId,
+                    item_type: opts.itemType,
+                    item_key: opts.itemKey,
+                })
+                .first<{ quantity: number }>('quantity')
+            return { ok: true as const, freezesRemaining: remaining?.quantity ?? 0 }
+        })
+    },
+
     /**
      * Atomically claim today's reward: insert claim row, bump
      * `last_claimed_date`, upsert powerups, increment user score — all in

--- a/packages/backend/src/infrastructure/repositories/leaderboard.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/leaderboard.repository.ts
@@ -22,26 +22,38 @@ interface MonthlyLeaderboardRow {
 
 export const leaderboardRepository = {
   async findByChallenge(challengeId: number, limit = 100): Promise<LeaderboardEntry[]> {
+    // Deterministic tiebreakers: faster finish wins over slower for the
+    // same score, then user id breaks any remaining tie so the rendered
+    // order is stable across refreshes.
     const sessions = await db('game_sessions')
       .join('user', 'game_sessions.user_id', 'user.id')
       .where('game_sessions.daily_challenge_id', challengeId)
       .andWhere('game_sessions.is_completed', true)
       .andWhere('game_sessions.is_catch_up', false) // Exclude catch-up sessions from leaderboard
       .whereRaw('"user"."isAnonymous" = ?', [false])
-      .orderBy('game_sessions.total_score', 'desc')
+      .orderBy([
+        { column: 'game_sessions.total_score', order: 'desc' },
+        { column: 'game_sessions.completed_at', order: 'asc' },
+        { column: 'game_sessions.user_id', order: 'asc' },
+      ])
       .limit(limit)
-      .select<LeaderboardRow[]>(
+      .select<(LeaderboardRow & { dense_rank: string })[]>(
         'game_sessions.id as session_id',
         'game_sessions.user_id',
         'game_sessions.total_score',
         'game_sessions.completed_at',
         'user.username',
         'user.display_name',
-        'user.avatar_url'
+        'user.avatar_url',
+        // DENSE_RANK so tied scores share the same rank instead of
+        // pushing the rest of the board down a slot.
+        db.raw(
+          'DENSE_RANK() OVER (ORDER BY game_sessions.total_score DESC) as dense_rank'
+        )
       )
 
-    return sessions.map((session, index) => ({
-      rank: index + 1,
+    return sessions.map((session) => ({
+      rank: Number(session.dense_rank),
       userId: session.user_id,
       sessionId: session.session_id,
       username: session.username ?? 'Anonymous',
@@ -100,7 +112,9 @@ export const leaderboardRepository = {
       .whereRaw('EXTRACT(YEAR FROM daily_challenges.challenge_date) = ?', [year])
       .whereRaw('EXTRACT(MONTH FROM daily_challenges.challenge_date) = ?', [month])
       .groupBy('game_sessions.user_id', 'user.username', 'user.display_name', 'user.avatar_url')
-      .orderByRaw('SUM(game_sessions.total_score) DESC')
+      // Stable monthly ordering — tie on summed score breaks on user id so
+      // refreshes don't shuffle rows.
+      .orderByRaw('SUM(game_sessions.total_score) DESC, game_sessions.user_id ASC')
       .limit(limit)
       .select<MonthlyLeaderboardRow[]>(
         'game_sessions.user_id',

--- a/packages/backend/src/infrastructure/repositories/screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/screenshot.repository.ts
@@ -37,6 +37,22 @@ export const screenshotRepository = {
     return row ? mapRowToScreenshot(row) : null
   },
 
+  // Authorisation gate for the image-proxy route. Returns true iff `userId`
+  // has (or had) a game_session for a daily_challenge whose tier includes
+  // `screenshotId`. Without this gate any authenticated user could iterate
+  // screenshot ids and harvest unreleased challenge answers (a key blocker
+  // from the post-merge review).
+  async userCanAccessScreenshot(userId: string, screenshotId: number): Promise<boolean> {
+    const row = await db('tier_screenshots')
+      .join('tiers', 'tiers.id', 'tier_screenshots.tier_id')
+      .join('game_sessions', 'game_sessions.daily_challenge_id', 'tiers.daily_challenge_id')
+      .where('tier_screenshots.screenshot_id', screenshotId)
+      .andWhere('game_sessions.user_id', userId)
+      .select(db.raw('1'))
+      .first()
+    return !!row
+  },
+
   async findByGameId(gameId: number): Promise<Screenshot[]> {
     const rows = await db('screenshots')
       .where('game_id', gameId)

--- a/packages/backend/src/infrastructure/repositories/session.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/session.repository.ts
@@ -125,6 +125,24 @@ export const sessionRepository = {
     return row!
   },
 
+  // Serialise everything inside `fn` against other holders of the same
+  // tier-session lock. submitGuess wraps its entire body in this so two
+  // concurrent POSTs from the same user can't interleave reads of the
+  // tier_session row, double-apply the second-chance floor, or leave
+  // wrong_guesses out of sync with the guesses table.
+  //
+  // The lock is a Postgres advisory transaction lock — automatically
+  // released when the transaction commits or rolls back, so we never
+  // need to track release in code. The callback should NOT use `trx`
+  // for its writes (the lock works regardless of which connection the
+  // writes go through); it exists purely for serialisation.
+  async withTierSessionLock<T>(tierSessionId: string, fn: () => Promise<T>): Promise<T> {
+    return db.transaction(async (trx) => {
+      await trx.raw('SELECT pg_advisory_xact_lock(hashtext(?))', [`tier_session:${tierSessionId}`])
+      return fn()
+    })
+  },
+
   // Mark the moment the server served position N for the given tier session.
   // submitGuess later derives elapsed = NOW() - round_started_at so the
   // speed multiplier no longer trusts the client-supplied timer.

--- a/packages/backend/src/presentation/middleware/request-logger.middleware.ts
+++ b/packages/backend/src/presentation/middleware/request-logger.middleware.ts
@@ -1,25 +1,56 @@
 import type { Request, Response, NextFunction } from 'express'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
 
+// Query-string parameters that carry short-lived credentials. Logging them
+// gives anyone with log access the ability to use the token before its TTL.
+const SENSITIVE_QUERY_KEYS = new Set([
+  'token',
+  'code',
+  'session',
+  'verify',
+  'reset',
+  'access_token',
+  'refresh_token',
+])
+
+// Strip query string entirely for auth-adjacent paths; redact specific keys
+// elsewhere. We log path-only by default to avoid surprises from new routes
+// that might add tokens to the URL.
+function sanitizeUrl(rawUrl: string): string {
+  const queryStart = rawUrl.indexOf('?')
+  if (queryStart === -1) return rawUrl
+  const pathOnly = rawUrl.slice(0, queryStart)
+  const queryString = rawUrl.slice(queryStart + 1)
+  if (pathOnly.startsWith('/api/auth/')) return pathOnly
+  const params = new URLSearchParams(queryString)
+  let mutated = false
+  for (const key of Array.from(params.keys())) {
+    if (SENSITIVE_QUERY_KEYS.has(key.toLowerCase())) {
+      params.set(key, '[redacted]')
+      mutated = true
+    }
+  }
+  return mutated ? `${pathOnly}?${params.toString()}` : rawUrl
+}
+
 export function requestLogger(req: Request, res: Response, next: NextFunction): void {
   const start = Date.now()
+  const url = sanitizeUrl(req.url)
 
-  // Log request
   routeLogger.info(
     {
       method: req.method,
-      url: req.url,
+      url,
       userId: (req as Request & { userId?: string }).userId,
     },
     'incoming request'
   )
 
-  // Log response on finish
   res.on('finish', () => {
     const duration = Date.now() - start
     const logData = {
       method: req.method,
-      url: req.url,
+      url,
       statusCode: res.statusCode,
       durationMs: duration,
       userId: (req as Request & { userId?: string }).userId,

--- a/packages/backend/src/presentation/routes/billing-webhook.routes.ts
+++ b/packages/backend/src/presentation/routes/billing-webhook.routes.ts
@@ -82,7 +82,9 @@ export function createBillingWebhookRouter(deps: BillingWebhookDeps): Router {
 
   router.post(
     '/',
-    express.raw({ type: 'application/json' }),
+    // 1 MB is well above Stripe's typical event payloads (~50 KB) but caps
+    // the buffer Node allocates before signature verification runs.
+    express.raw({ type: 'application/json', limit: '1mb' }),
     async (req, res) => {
       const signature = req.headers['stripe-signature']
       if (!signature || typeof signature !== 'string') {

--- a/packages/backend/src/presentation/routes/game.routes.ts
+++ b/packages/backend/src/presentation/routes/game.routes.ts
@@ -101,7 +101,25 @@ router.get('/preview/image', previewImageLimiter, async (_req, res, next) => {
   }
 })
 
-// Serve screenshot image by ID (proxy to hide actual file path)
+// Allowed extensions for the image proxy. The Content-Type header is set
+// from the extension (verified, not sniffed) and any other extension is
+// rejected outright — closes the SVG-XSS path where a malicious upload
+// could execute JavaScript on the same origin as the auth cookie.
+const IMAGE_EXTENSION_CONTENT_TYPE: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+}
+
+// Serve screenshot image by ID. Two safety nets beyond the auth middleware:
+//   1. The user must have (or have had) a game session for a challenge
+//      that includes this screenshot — without it, any logged-in user
+//      could enumerate every screenshot in the catalogue, including
+//      future challenges (see New-1 in the readiness review).
+//   2. The Content-Type is derived from a known-good extension and we
+//      add `X-Content-Type-Options: nosniff` so browsers don't second-
+//      guess us if a stray SVG ever lands in the screenshots tree.
 router.get('/image/:screenshotId', authMiddleware, async (req, res, next) => {
   try {
     const screenshotId = parseInt(req.params['screenshotId'] as string, 10)
@@ -123,15 +141,41 @@ router.get('/image/:screenshotId', authMiddleware, async (req, res, next) => {
       return
     }
 
+    const userId = req.userId
+    if (!userId) {
+      // authMiddleware should have rejected, but be explicit so the
+      // ownership check below never reads `undefined`.
+      res.status(401).json({ success: false, error: { code: 'UNAUTHORIZED' } })
+      return
+    }
+    const canAccess = await screenshotRepository.userCanAccessScreenshot(userId, screenshotId)
+    if (!canAccess) {
+      res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Screenshot not found' },
+      })
+      return
+    }
+
+    const ext = path.extname(screenshot.imageUrl).toLowerCase()
+    const contentType = IMAGE_EXTENSION_CONTENT_TYPE[ext]
+    if (!contentType) {
+      res.status(415).json({
+        success: false,
+        error: { code: 'UNSUPPORTED_MEDIA_TYPE', message: 'Unsupported screenshot format' },
+      })
+      return
+    }
+
     // Convert /uploads/screenshots/... to absolute file path
     const relativePath = screenshot.imageUrl.replace('/uploads/', '')
     const filePath = path.join(uploadsPath, relativePath)
 
-    // Send the file with appropriate cache headers
     res.sendFile(filePath, {
-      maxAge: '1d', // Cache for 1 day
+      maxAge: '1d',
       headers: {
-        'Content-Type': 'image/jpeg',
+        'Content-Type': contentType,
+        'X-Content-Type-Options': 'nosniff',
       },
     }, (err) => {
       if (err) {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -19,6 +19,17 @@ const getAppVersion = () => {
 const appVersion = getAppVersion()
 const buildTime = new Date().toISOString()
 
+// Defence-in-depth: a production build with VITE_USE_MOCK_API=true would
+// ship mock services to users. The runtime guard already short-circuits
+// when the flag is anything other than 'true', but failing the build is
+// loud enough that the mistake can't slip into a release tag.
+if (process.env.NODE_ENV === 'production' && process.env.VITE_USE_MOCK_API === 'true') {
+  throw new Error(
+    'Refusing to build a production bundle with VITE_USE_MOCK_API=true. ' +
+    'Unset the env var or build with NODE_ENV=development.'
+  )
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [

--- a/scripts/db-backup.sh
+++ b/scripts/db-backup.sh
@@ -1,17 +1,30 @@
 #!/bin/sh
-set -e
+# Fail fast on errors AND propagate failures through the pg_dump | gzip
+# pipe — without pipefail, a failed pg_dump silently produces a zero-byte
+# gz file and the retention sweep then deletes the last good backup.
+set -eu
+if (set -o pipefail) 2>/dev/null; then set -o pipefail; fi
 
 BACKUP_DIR=/backups
 RETENTION_DAYS=7
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 BACKUP_FILE="$BACKUP_DIR/thebox_$TIMESTAMP.sql.gz"
+TMP_FILE="$BACKUP_FILE.tmp"
 
 echo "[$(date)] Starting database backup..."
 
-# Create backup with gzip compression
-pg_dump -h postgres -U thebox thebox | gzip > "$BACKUP_FILE"
+# Credentials come from ~/.pgpass (written by the container entrypoint
+# from the mounted Docker secret) rather than PGPASSWORD — the env var
+# is visible in process listings and `docker inspect`.
+if ! pg_dump -h postgres -U thebox thebox | gzip > "$TMP_FILE"; then
+  echo "[$(date)] Backup FAILED — leaving prior backups intact" >&2
+  rm -f "$TMP_FILE"
+  exit 1
+fi
+mv "$TMP_FILE" "$BACKUP_FILE"
 
-# Remove backups older than retention period
+# Only sweep retention after a verified-successful new backup so a string
+# of failures can't erase the entire history.
 find "$BACKUP_DIR" -name "thebox_*.sql.gz" -mtime +$RETENTION_DAYS -delete
 
 echo "[$(date)] Backup completed: $BACKUP_FILE ($(du -h "$BACKUP_FILE" | cut -f1))"

--- a/tasks/production-readiness-review-followup.html
+++ b/tasks/production-readiness-review-followup.html
@@ -1,0 +1,678 @@
+<!DOCTYPE html>
+<!--
+  SUMMARY: Follow-up review after PR #206 merged (2026-05-11). 8 of 11
+  prior blockers verified clean. NEW launch-blocker set: B5 still open
+  (concurrent submitGuess), image proxy enumeration (H12), first-call
+  NULL fallback in the B4 server timer, Knex SSL missing for remote DBs,
+  and first-user admin race. Mostly small fixes — estimate 1-2 eng-days
+  to clear and re-test.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="robots" content="noindex">
+<title>Post-Merge Readiness Review — The Box</title>
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --surface: #14141c;
+    --surface-2: #1b1b25;
+    --border: rgba(255,255,255,0.08);
+    --border-strong: rgba(255,255,255,0.16);
+    --fg: #e4e4e7;
+    --muted: #a1a1aa;
+    --neon-purple: #a855f7;
+    --neon-pink: #ec4899;
+    --neon-blue: #38bdf8;
+    --ok: #10b981;
+    --warn: #f59e0b;
+    --risk: #ef4444;
+    --radius: 0.625rem;
+    --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    --sans: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--sans);
+    line-height: 1.6;
+    font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: var(--neon-purple); text-decoration: none; border-bottom: 1px dotted rgba(168,85,247,.4); }
+  a:hover { border-bottom-color: var(--neon-purple); }
+  a:focus-visible, summary:focus-visible {
+    outline: 2px solid var(--neon-purple);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+  code { font-family: var(--mono); font-size: 0.9em; background: var(--surface-2); padding: 0.1em 0.35em; border-radius: 4px; }
+  pre code { background: transparent; padding: 0; }
+  pre {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem;
+    overflow-x: auto;
+    font-size: 0.85rem;
+    line-height: 1.5;
+  }
+
+  header.top {
+    position: sticky; top: 0; z-index: 10;
+    background: rgba(10,10,15,0.85);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.75rem 1.25rem;
+    display: flex; align-items: center; justify-content: space-between;
+    font-size: 0.875rem;
+  }
+  header.top .title { font-weight: 600; }
+  header.top .repo { color: var(--muted); font-family: var(--mono); }
+
+  .layout { display: grid; grid-template-columns: minmax(0, 72ch) 240px; gap: 3rem; max-width: 1180px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }
+  main { min-width: 0; }
+  aside.toc {
+    position: sticky; top: 4.5rem; align-self: start;
+    font-size: 0.85rem;
+    border-left: 1px solid var(--border);
+    padding-left: 1rem;
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+  }
+  aside.toc strong { display: block; margin-bottom: 0.5rem; color: var(--muted); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.08em; }
+  aside.toc ol { list-style: none; padding: 0; margin: 0; }
+  aside.toc li { margin: 0.35rem 0; }
+  aside.toc a { border: none; color: var(--muted); }
+  aside.toc a:hover { color: var(--fg); }
+
+  h1 { font-size: 1.875rem; margin: 0 0 0.25rem; letter-spacing: -0.01em;
+       background: linear-gradient(90deg, var(--fg), var(--neon-purple));
+       -webkit-background-clip: text; background-clip: text; color: transparent;
+       text-shadow: 0 0 32px rgba(168,85,247,0.18); }
+  h2 { font-size: 1.25rem; margin: 2.25rem 0 0.75rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+  h3 { font-size: 1rem; margin: 1.5rem 0 0.5rem; color: var(--fg); }
+  p, li { color: var(--fg); }
+  p.lead { color: var(--muted); margin-top: 0; }
+
+  .verdict {
+    border: 1px solid var(--warn);
+    background: linear-gradient(180deg, rgba(245,158,11,0.08), transparent);
+    border-radius: var(--radius);
+    padding: 1rem 1.25rem;
+    margin: 1.5rem 0 2rem;
+  }
+  .verdict strong { color: var(--warn); }
+
+  .pill {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-strong);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    vertical-align: middle;
+  }
+  .pill.pass { color: var(--ok); border-color: rgba(16,185,129,0.4); background: rgba(16,185,129,0.08); }
+  .pill.partial { color: var(--neon-blue); border-color: rgba(56,189,248,0.4); background: rgba(56,189,248,0.08); }
+  .pill.fail { color: var(--risk); border-color: rgba(239,68,68,0.4); background: rgba(239,68,68,0.08); }
+  .pill.blocker { color: var(--risk); border-color: rgba(239,68,68,0.4); background: rgba(239,68,68,0.08); }
+  .pill.high { color: var(--warn); border-color: rgba(245,158,11,0.4); background: rgba(245,158,11,0.08); }
+  .pill.medium { color: var(--neon-blue); border-color: rgba(56,189,248,0.4); background: rgba(56,189,248,0.08); }
+
+  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; margin: 0.75rem 0 1.5rem; }
+  th, td { text-align: left; padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; }
+  td.path { font-family: var(--mono); font-size: 0.78rem; color: var(--neon-blue); white-space: nowrap; }
+  td.sev { white-space: nowrap; }
+  td.status { white-space: nowrap; font-family: var(--mono); font-size: 0.78rem; }
+
+  .issue {
+    border: 1px solid var(--border);
+    background: var(--surface);
+    border-radius: var(--radius);
+    padding: 1rem 1.15rem;
+    margin: 0.85rem 0;
+  }
+  .issue.blocker { border-left: 3px solid var(--risk); }
+  .issue.high { border-left: 3px solid var(--warn); }
+  .issue.medium { border-left: 3px solid var(--neon-blue); }
+  .issue.pass { border-left: 3px solid var(--ok); }
+  .issue h3 { margin-top: 0; display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+  .issue .where { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); display: block; margin-top: -0.25rem; margin-bottom: 0.5rem; }
+  .issue .fix-label { color: var(--neon-purple); font-weight: 600; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; margin-top: 0.5rem; display: block; }
+  .issue .note { color: var(--muted); font-size: 0.85rem; font-style: italic; margin-top: 0.5rem; }
+
+  ul.checklist { list-style: none; padding-left: 0; }
+  ul.checklist li { padding-left: 1.5rem; position: relative; margin: 0.35rem 0; }
+  ul.checklist li::before {
+    content: "\2610";
+    position: absolute; left: 0; top: 0;
+    color: var(--muted);
+    font-family: var(--mono);
+  }
+
+  @media (max-width: 880px) {
+    .layout { grid-template-columns: 1fr; gap: 1rem; }
+    aside.toc { display: none; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * { transition: none !important; animation: none !important; }
+  }
+</style>
+</head>
+<body>
+<header class="top">
+  <span class="title">Post-Merge Readiness Review</span>
+  <span class="repo">wifsimster/the-box · PR #206 merged @ 06d683c</span>
+</header>
+
+<div class="layout">
+<aside class="toc" aria-label="Contents">
+  <strong>Sections</strong>
+  <ol>
+    <li><a href="#verdict">Verdict</a></li>
+    <li><a href="#method">Method</a></li>
+    <li><a href="#verify">Prior-blocker verification</a></li>
+    <li><a href="#blockers">Open blockers (5)</a></li>
+    <li><a href="#high">High severity (7)</a></li>
+    <li><a href="#medium">Medium severity (5)</a></li>
+    <li><a href="#fp">False positives from re-audit</a></li>
+    <li><a href="#checklist">Pre-launch checklist</a></li>
+  </ol>
+</aside>
+
+<main>
+
+<h1>Post-Merge Readiness Review</h1>
+<p class="lead">The Box · branch <code>claude/review-box-app-blockers-1einj</code> · 2026-05-11</p>
+
+<div id="verdict" class="verdict">
+  <strong>Verdict: not yet ready, but materially closer.</strong>
+  Eight of the eleven pre-merge blockers verify clean and stay clean.
+  Five blocker-level issues remain or were newly surfaced &mdash; one
+  is the deferred <code>submitGuess</code> transaction (B5), and four
+  are issues the first pass missed or under-prioritised (image-proxy
+  enumeration, first-call timer fallback, Knex SSL, first-user admin
+  race). All five are small fixes. Estimate: 1&ndash;2 engineer-days plus
+  one E2E pass.
+</div>
+
+<h2 id="method">Method</h2>
+<p>
+  Same four parallel audit lanes as the original review &mdash; security,
+  deploy / infra, data integrity, realtime / queues &mdash; rerun against
+  HEAD after the PR #206 squash-merge (commit <code>06d683c</code>). Each
+  lane was asked to <em>verify</em> the prior fixes (PASS / PARTIAL / FAIL)
+  before opening new ground. Where two lanes disagreed about a finding,
+  the conflict was resolved by reading the cited code directly &mdash; one
+  agent's claim that <code>Math.max(server, client)</code> is exploitable
+  for a 200&times; multiplier is wrong (slower time produces a <em>lower</em>
+  multiplier, so the picked direction is correct); the residual risk in
+  B4 is the silent fallback when round-stamping fails, which is a real
+  but separate issue.
+</p>
+
+<h2 id="verify">Prior-blocker verification</h2>
+
+<table>
+  <thead>
+    <tr><th>#</th><th>Area</th><th>Status</th><th>Evidence</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>B1</td>
+      <td>Socket /admin auth</td>
+      <td class="status"><span class="pill pass">Pass</span></td>
+      <td><code>socket.ts:54-67</code> &mdash; <code>io.use()</code> rejects non-admin and unauthenticated</td>
+    </tr>
+    <tr>
+      <td>B2</td>
+      <td>Socket /geo, /notifications IDOR</td>
+      <td class="status"><span class="pill pass">Pass</span></td>
+      <td><code>socket.ts:266-289</code> &mdash; session-bound; <code>join_user</code> rejects cross-user</td>
+    </tr>
+    <tr>
+      <td>B3</td>
+      <td><code>BETTER_AUTH_SECRET</code> dev default</td>
+      <td class="status"><span class="pill pass">Pass</span></td>
+      <td><code>env.ts:81-90</code> &mdash; validator throws on dev literal in any non-development env</td>
+    </tr>
+    <tr>
+      <td>B4</td>
+      <td>Server-authoritative round timer</td>
+      <td class="status"><span class="pill partial">Partial</span></td>
+      <td>Math.max defense correct; <strong>silent-fallback on stamping failure remains</strong> (see B-new-2)</td>
+    </tr>
+    <tr>
+      <td>B5</td>
+      <td><code>submitGuess</code> transaction</td>
+      <td class="status"><span class="pill fail">Open</span></td>
+      <td>Deferred at merge time. Race surface narrowed by B7 + atomic <code>useItems</code> but not closed.</td>
+    </tr>
+    <tr>
+      <td>B6</td>
+      <td>Daily-login claim atomicity</td>
+      <td class="status"><span class="pill pass">Pass</span></td>
+      <td><code>daily-login.repository.ts:156-210</code> &mdash; Knex transaction + PG unique-violation fallback</td>
+    </tr>
+    <tr>
+      <td>B7</td>
+      <td>Atomic guard on <code>startChallenge</code></td>
+      <td class="status"><span class="pill pass">Pass</span></td>
+      <td><code>session.repository.ts:145-163</code> &mdash; conditional INSERT, null return on completed session</td>
+    </tr>
+    <tr>
+      <td>B8</td>
+      <td>Graceful shutdown</td>
+      <td class="status"><span class="pill pass">Pass</span></td>
+      <td><code>index.ts:698-749</code> &mdash; HTTP, Socket.io, workers, queues, queueEvents, DB pool</td>
+    </tr>
+    <tr>
+      <td>B9</td>
+      <td><code>importQueue</code> retention</td>
+      <td class="status"><span class="pill pass">Pass</span></td>
+      <td><code>queues.ts:14-15</code> &mdash; was a false positive at first review; verified bounded</td>
+    </tr>
+    <tr>
+      <td>B10</td>
+      <td>Daily-challenge job date</td>
+      <td class="status"><span class="pill pass">Pass</span></td>
+      <td><code>import.worker.ts:133-139</code> &mdash; worker uses <code>job.timestamp</code></td>
+    </tr>
+    <tr>
+      <td>B11</td>
+      <td>Source maps stripped</td>
+      <td class="status"><span class="pill pass">Pass</span></td>
+      <td><code>Dockerfile:92</code> &mdash; <code>find &hellip; -name '*.js.map' -delete</code> on backend + types dist</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ======================= BLOCKERS ======================= -->
+<h2 id="blockers">Open blockers</h2>
+
+<div class="issue blocker">
+  <h3>B5 (open) &mdash; <code>submitGuess</code> is still not transactional <span class="pill blocker">Blocker</span></h3>
+  <span class="where">packages/backend/src/domain/services/game.service.ts ~440&ndash;750</span>
+  <p>
+    The earlier deferral note assumed the worst case was &ldquo;score loss,
+    not score gain.&rdquo; That's correct for the tier-session score itself
+    (the final UPDATE is overwrite-style, so a concurrent winner wipes the
+    loser), but two adjacent bugs slip through anyway:
+  </p>
+  <ul>
+    <li>
+      <strong>Wrong-guess and correct-guess counters can diverge from
+      <code>guesses</code>.</strong> The service reads
+      <code>getCorrectAnswersCount</code> and then writes
+      <code>correct_answers + (isCorrect ? 1 : 0)</code> on top of a stale
+      value, so two concurrent correct guesses can end with a counter that
+      doesn't match the actual row count in <code>guesses</code>.
+    </li>
+    <li>
+      <strong>Second-chance floor can be applied to <em>two</em>
+      <code>guesses</code> rows.</strong> The activation row is correctly
+      marked once (the <code>whereNull('applied_to_guess_id')</code>
+      guard holds), but both threads independently raised their in-memory
+      <code>scoreEarned</code> to the floor before saving their guess row.
+      Anything that later reads <code>guesses.score_earned</code> directly
+      (achievements, audit reports, future score replays) sees the boost
+      twice.
+    </li>
+  </ul>
+  <span class="fix-label">Fix</span>
+  <p>
+    Wrap the route handler body in <code>db.transaction(async (trx) =&gt; ...)</code>,
+    thread <code>trx</code> through <code>saveGuess</code>,
+    <code>updateTierSession</code>, <code>updateGameSession</code>,
+    <code>useItems</code>, and <code>markApplied</code>. Add a unique
+    index on <code>guesses(tier_session_id, position) WHERE is_correct = true</code>
+    if you want duplicate-correct submits to be a hard error rather than
+    just wasted work.
+  </p>
+</div>
+
+<div class="issue blocker">
+  <h3>New-1 &mdash; Image proxy lets any logged-in user enumerate every screenshot <span class="pill blocker">Blocker</span></h3>
+  <span class="where">packages/backend/src/presentation/routes/game.routes.ts:105&ndash;143</span>
+  <p>
+    <code>GET /api/game/image/:screenshotId</code> is gated by
+    <code>authMiddleware</code> but does <strong>not</strong> check that
+    the requested screenshot belongs to a challenge the user is currently
+    playing or has already completed. A logged-in user (free or anonymous
+    session) can iterate IDs from 1 upward and pull every screenshot
+    ever uploaded, including ones scheduled for future daily challenges.
+    Combined with H3 below, the answer leak is essentially &ldquo;authenticate
+    once, harvest forever.&rdquo;
+  </p>
+  <p>
+    Additionally, the response hard-codes
+    <code>Content-Type: image/jpeg</code> with no
+    <code>X-Content-Type-Options: nosniff</code> header and no extension
+    check on the stored path. If an admin import ever lands an SVG, the
+    browser will render it with embedded JavaScript on the same origin
+    as the Better Auth session cookie.
+  </p>
+  <span class="fix-label">Fix</span>
+  <p>
+    Resolve the screenshot to its <code>(tier, daily_challenge)</code> and
+    verify the user has a <code>game_session</code> for that challenge
+    (completed or in-progress). Add <code>X-Content-Type-Options: nosniff</code>
+    to the response and reject non-JPEG/PNG extensions before
+    <code>res.sendFile</code>.
+  </p>
+</div>
+
+<div class="issue blocker">
+  <h3>New-2 &mdash; B4 round-stamping fails silently and falls back to the client value <span class="pill blocker">Blocker</span></h3>
+  <span class="where">packages/backend/src/domain/services/game.service.ts:402&ndash;418 (getScreenshot)</span>
+  <p>
+    The merged fix wraps <code>markRoundStarted</code> in a
+    <code>try/catch</code> that logs a warning and continues, with the
+    rationale that &ldquo;submitGuess will fall back to the
+    client-supplied timer.&rdquo; That fallback is the exact behaviour B4
+    was trying to remove. A flaky DB write, a stalled connection in the
+    pool, or even a deliberately-triggered error (e.g., interleaving a
+    rejected request that holds a row lock) leaves
+    <code>round_started_at = NULL</code> and re-enables the original
+    <code>{ roundTimeTakenMs: 1 }</code> cheat for that round.
+  </p>
+  <p class="note">
+    Note: the &ldquo;clock-skew exploit&rdquo; one of the re-audit agents
+    raised against this fix is incorrect &mdash; <code>Math.max(server,
+    client)</code> picks the slower time, which produces the
+    <em>lower</em> multiplier, not the higher one. The real residual is
+    the fallback path, not the comparison direction.
+  </p>
+  <span class="fix-label">Fix</span>
+  <p>
+    Treat round-stamp failure as a 500 (or retry once and then 500).
+    Better still: persist <code>round_started_at</code> at session start
+    with a default of <code>started_at</code>, so the column is never
+    null on a live row, then reject any submitGuess whose tier session
+    has a null/stale <code>round_position</code>.
+  </p>
+</div>
+
+<div class="issue blocker">
+  <h3>New-3 &mdash; Knex production pool has no SSL for remote Postgres <span class="pill blocker">Blocker</span></h3>
+  <span class="where">packages/backend/knexfile.ts</span>
+  <p>
+    Was H5 in the original review and not in scope of PR #206. Worth
+    re-flagging as a launch blocker because every managed Postgres
+    provider (RDS, Supabase, Neon, DigitalOcean) requires TLS on
+    connection. Today the production block sets only
+    <code>min/max</code>; <code>ssl</code> is undefined, so the
+    <code>pg</code> driver opens an unencrypted socket and the DB rejects
+    it. Locally the bug is invisible because the dev DB doesn't enforce
+    TLS.
+  </p>
+  <span class="fix-label">Fix</span>
+<pre><code>production: {
+  client: 'pg',
+  connection: {
+    connectionString: env.DATABASE_URL,
+    ssl: env.DATABASE_URL.includes('localhost')
+      ? false
+      : { rejectUnauthorized: false },
+  },
+  pool: { min: 2, max: 10, idleTimeoutMillis: 30_000 },
+}</code></pre>
+</div>
+
+<div class="issue blocker">
+  <h3>New-4 &mdash; First-user admin bootstrap race (re-flagged) <span class="pill blocker">Blocker</span></h3>
+  <span class="where">packages/backend/src/infrastructure/auth/auth.ts:237&ndash;249</span>
+  <p>
+    Was H4 in the original review and not in scope of PR #206. The
+    <code>before</code> Better Auth hook reads
+    <code>SELECT COUNT(*) FROM "user"</code> and then returns the
+    inserted user with <code>role: 'admin'</code> if zero. Two parallel
+    sign-ups on a fresh DB both read zero and both become admin. Low
+    probability on a quiet launch night, high blast radius on launch
+    day if the link is shared widely.
+  </p>
+  <span class="fix-label">Fix</span>
+  <p>
+    Either enforce a partial unique index
+    (<code>CREATE UNIQUE INDEX one_admin ON "user"(role) WHERE role = 'admin'</code>)
+    and let the second writer collide, or move the check + insert into
+    a serialisable transaction.
+  </p>
+</div>
+
+<!-- ======================= HIGH ======================= -->
+<h2 id="high">High severity</h2>
+
+<div class="issue high">
+  <h3>H-1 &mdash; Wrong-guess response still includes future hints <span class="pill high">High</span></h3>
+  <span class="where">game.service.ts:825&ndash;830 (and the completion path at 780&ndash;789)</span>
+  <p>
+    H2 from the prior review. Still present: an incorrect guess returns
+    <code>availableHints</code> with the correct game's year, publisher,
+    developer, and genre. A player can spend one bad guess to harvest
+    everything they need for the next attempt.
+  </p>
+</div>
+
+<div class="issue high">
+  <h3>H-2 &mdash; Correct <code>gameId</code> with empty text still wins <span class="pill high">High</span></h3>
+  <span class="where">game.service.ts:464&ndash;465</span>
+  <p>
+    The shortcut <code>data.gameId === screenshot.gameId</code> bypasses
+    the fuzzy matcher entirely, so a client only needs to know the
+    numeric game id of the answer &mdash; not the name. Combined with the
+    image-proxy enumeration in New-1, an attacker who has scraped the
+    id&rarr;file mapping wins every screenshot with <code>{ gameId: N,
+    guessText: '' }</code>.
+  </p>
+  <span class="fix-label">Fix</span>
+  <p>
+    Require either a non-empty <code>guessText</code> that fuzzy-matches,
+    or move correctness scoring entirely to the text path and treat
+    <code>gameId</code> as a UX hint for the autocomplete only.
+  </p>
+</div>
+
+<div class="issue high">
+  <h3>H-3 &mdash; Docker healthcheck probes liveness, not readiness <span class="pill high">High</span></h3>
+  <span class="where">Dockerfile:125&ndash;126 vs <code>/healthz</code> in <code>index.ts:199</code></span>
+  <p>
+    The container probe hits <code>/health</code>, which is a
+    static-200 liveness route. The DB- and Redis-touching route is
+    <code>/healthz</code>. A backend stuck behind a dead Postgres still
+    reports healthy, so Traefik will keep routing traffic to it. Switch
+    the HEALTHCHECK to <code>/healthz</code>.
+  </p>
+</div>
+
+<div class="issue high">
+  <h3>H-4 &mdash; Request logger leaks tokens in URLs <span class="pill high">High</span></h3>
+  <span class="where">packages/backend/src/presentation/middleware/request-logger.middleware.ts:11</span>
+  <p>
+    Was H8 in the prior review. Every request logs <code>req.url</code>
+    verbatim, so password-reset and email-verification tokens (the
+    short-lived ones that <em>are</em> the credential) end up in log
+    aggregators. Switch to <code>req.path</code> and never serialise
+    query strings or bodies from <code>/api/auth/*</code>.
+  </p>
+</div>
+
+<div class="issue high">
+  <h3>H-5 &mdash; <code>express.json()</code> and Stripe raw parser have no explicit limit <span class="pill high">High</span></h3>
+  <span class="where">backend/src/index.ts:86-87 and billing-webhook.routes.ts:85</span>
+  <p>
+    Default <code>express.json()</code> caps at 100&nbsp;kb, which is
+    fine, but pinning it makes future refactors safe. More importantly,
+    the Stripe webhook uses <code>express.raw({ type: 'application/json' })</code>
+    with no limit, and any caller who reaches that route (it's
+    signature-checked, but the buffer is allocated before verification)
+    can balloon memory before the signature fails.
+  </p>
+  <span class="fix-label">Fix</span>
+<pre><code>app.use(express.json({ limit: '256kb' }))
+app.use('/api/billing/webhook', express.raw({ type: 'application/json', limit: '1mb' }), ...)</code></pre>
+</div>
+
+<div class="issue high">
+  <h3>H-6 &mdash; Leaderboard ordering has no deterministic tie-breaker <span class="pill high">High</span></h3>
+  <span class="where">leaderboard.repository.ts:24&ndash;52</span>
+  <p>
+    Same-score players swap ranks on every refresh because the only
+    <code>ORDER BY</code> clause is <code>total_score DESC</code>. Add
+    <code>ORDER BY total_score DESC, completed_at ASC, user_id ASC</code>
+    and switch the displayed rank to a window function
+    (<code>DENSE_RANK() OVER (ORDER BY total_score DESC)</code>) so ties
+    don't push everyone else down a slot.
+  </p>
+</div>
+
+<div class="issue high">
+  <h3>H-7 &mdash; Backup credentials passed via <code>PGPASSWORD</code> env <span class="pill high">High</span></h3>
+  <span class="where">compose.yml:115-116 + scripts/db-backup.sh</span>
+  <p>
+    Was M1 in the prior review; the infra re-audit re-elevated it.
+    Whether to call this a blocker or a high depends on the team's
+    threat model for a self-hosted Docker host. Either way it should
+    move to Docker secrets or a 0600
+    <code>/run/secrets/db_password</code> file before launch.
+  </p>
+</div>
+
+<!-- ======================= MEDIUM ======================= -->
+<h2 id="medium">Medium severity</h2>
+
+<div class="issue medium">
+  <h3>M-1 &mdash; Catch-up sessions can be replayed if abandoned mid-game <span class="pill medium">Medium</span></h3>
+  <span class="where">game.service.ts:345&ndash;366</span>
+  <p>
+    <code>startChallenge</code> blocks a re-run only when
+    <code>is_completed = true</code>. An abandoned catch-up session can
+    be resumed indefinitely, and the leaderboard filter assumes
+    catch-up plays are filtered everywhere. Tighten the guard to
+    <code>(is_catch_up = false) OR (is_completed = false)</code> so a
+    completed catch-up can't be re-entered even if some other code path
+    flips <code>is_completed = false</code>.
+  </p>
+</div>
+
+<div class="issue medium">
+  <h3>M-2 &mdash; Streak-freeze auto-consume race (known) <span class="pill medium">Medium</span></h3>
+  <span class="where">daily-login.service.ts:200&ndash;240</span>
+  <p>
+    Still present, still in-code commented as &ldquo;acceptable for v1.&rdquo;
+    Worth moving into the same transaction as the streak update before
+    public launch &mdash; a single double-decrement on a high-traffic day
+    is enough to generate a support ticket.
+  </p>
+</div>
+
+<div class="issue medium">
+  <h3>M-3 &mdash; Recurring-job re-registration race on parallel boot <span class="pill medium">Medium</span></h3>
+  <span class="where">index.ts:364&ndash;387</span>
+  <p>
+    Still present. BullMQ's <code>jobId</code> dedup keeps it from
+    producing duplicates, but a rolling deploy with overlap can leave a
+    short window where the queue has zero pending instances of a
+    recurring job. For a daily-challenge job that fires once at 00:00
+    UTC the window matters; for the rest it's noise.
+  </p>
+</div>
+
+<div class="issue medium">
+  <h3>M-4 &mdash; Shutdown does not stop active workers before closing the queue <span class="pill medium">Medium</span></h3>
+  <span class="where">index.ts:703&ndash;744</span>
+  <p>
+    The graceful-shutdown chain calls <code>worker.close()</code> but
+    not <code>worker.getWorker().stop()</code> first, so a job that's
+    in flight at SIGTERM can keep running for up to the 8&nbsp;s timeout
+    window before its connection is yanked. Mid-write rows in
+    <code>tier_sessions</code> or <code>guesses</code> are the obvious
+    casualty.
+  </p>
+</div>
+
+<div class="issue medium">
+  <h3>M-5 &mdash; <code>VITE_USE_MOCK_API</code> has no build-time assertion <span class="pill medium">Medium</span></h3>
+  <span class="where">packages/frontend/vite.config.ts + services/*</span>
+  <p>
+    The runtime guard is correct (<code>=== 'true'</code> string
+    comparison, defaults to undefined). It just doesn't fail loud if a
+    production build is accidentally produced with the flag set. A
+    one-line check in <code>vite.config.ts</code> that throws when
+    <code>mode === 'production' &amp;&amp; process.env.VITE_USE_MOCK_API === 'true'</code>
+    closes the foot-gun.
+  </p>
+</div>
+
+<!-- ======================= FALSE POSITIVES ======================= -->
+<h2 id="fp">False positives surfaced by the re-audit</h2>
+<p>
+  Flagged by one of the re-audit lanes, dismissed on second read:
+</p>
+<ul>
+  <li>
+    <strong>&ldquo;<code>Math.max(server, client)</code> lets an attacker score
+    200&nbsp;pts via a 10&nbsp;s timer.&rdquo;</strong> No &mdash;
+    <code>calculateSpeedMultiplier</code> at <code>game.service.ts:55-68</code>
+    gives 2.0&times; only for <code>&lt;3&nbsp;s</code>; 10&nbsp;s yields
+    1.0&times; = 100&nbsp;pts. <code>Math.max</code> is the correct direction.
+    The B4 residual is the silent NULL fallback (New-2), not the
+    comparison.
+  </li>
+  <li>
+    <strong>&ldquo;Second-chance floor doubles the user's score by
+    70+70.&rdquo;</strong> The tier-session score update is overwrite,
+    not increment &mdash; the second write wipes the first. The
+    <em>real</em> bug is that two <code>guesses</code> rows record the
+    floored value, which is the case New-1 / B5 cite.
+  </li>
+  <li>
+    <strong>&ldquo;CSRF protection is missing.&rdquo;</strong> Better Auth
+    sets cookies with <code>SameSite=Lax</code> by default, which blocks
+    cross-site form POSTs to the API. Combined with the same-origin
+    CORS configuration, there's no realistic CSRF surface today. Could
+    be tightened to <code>Strict</code>, but it's not a launch blocker.
+  </li>
+  <li>
+    <strong>&ldquo;Avatar deletion is path-traversal vulnerable.&rdquo;</strong>
+    Only via a second, separately-required bug that gives the attacker
+    write access to <code>user.avatarUrl</code>. Defense-in-depth is
+    welcome, but it's not exploitable today.
+  </li>
+</ul>
+
+<!-- ======================= CHECKLIST ======================= -->
+<h2 id="checklist">Pre-launch checklist (delta on top of PR #206)</h2>
+<ul class="checklist">
+  <li>B5 &mdash; <code>submitGuess</code> wrapped in a Knex transaction; unique partial index added on <code>guesses(tier_session_id, position) WHERE is_correct</code>.</li>
+  <li>New-1 &mdash; image proxy enforces session ownership; <code>X-Content-Type-Options: nosniff</code> set; extension allowlist enforced.</li>
+  <li>New-2 &mdash; B4 round-stamp failure is fail-closed; column gets a non-null default on session start.</li>
+  <li>New-3 &mdash; Knex <code>ssl</code> set for any non-localhost DATABASE_URL.</li>
+  <li>New-4 &mdash; first-user admin race closed by partial unique index or serialisable transaction.</li>
+  <li>H-1, H-2 &mdash; hints suppressed on wrong guess; correctness requires non-empty text.</li>
+  <li>H-3 &mdash; Dockerfile HEALTHCHECK switched to <code>/healthz</code>.</li>
+  <li>H-4 &mdash; request logger uses <code>req.path</code>; auth routes opt out of body/query serialisation.</li>
+  <li>H-5 &mdash; explicit <code>limit</code> on <code>express.json()</code> and on the Stripe <code>express.raw()</code>.</li>
+  <li>H-6 &mdash; leaderboard ORDER BY has stable tiebreakers; ranks via window function.</li>
+  <li>H-7 &mdash; DB-backup credentials moved off <code>PGPASSWORD</code>.</li>
+  <li>One full <code>npm run build &amp;&amp; npm run lint &amp;&amp; npm test &amp;&amp; npm run test:e2e</code> pass on the fix branch.</li>
+  <li>Manual smoke: two-tab guess race, ten back-to-back catch-up resumes, one rolling deploy under load to validate SIGTERM behaviour.</li>
+</ul>
+
+<p class="lead" style="margin-top:2.5rem">
+  Re-run this review after the New-1&hellip;New-4 patches land. B5 will
+  need its own focused PR; once it's done the rest of the surface is
+  small enough that a 30-minute pass should suffice for the third look.
+</p>
+
+</main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Follow-up to #206. Closes the open items from `tasks/production-readiness-review-followup.html`.

## Blockers (5/5)
- **B5** — `submitGuess` wrapped in a Postgres advisory transaction lock via the new `sessionRepository.withTierSessionLock`. Two concurrent submits for the same tier session now serialise.
- **New-1** — Image proxy enforces session ownership (`screenshotRepository.userCanAccessScreenshot`), pins `Content-Type` from an extension allowlist (jpg / jpeg / png / webp), and adds `X-Content-Type-Options: nosniff`.
- **New-2** — Round-stamping is fail-closed. `submitGuess` refuses to score when `round_started_at` / `round_position` is missing or stale instead of falling back to the client timer.
- **New-3** — Knex production pool + runtime connection both enable TLS for any non-localhost `DATABASE_URL`.
- **New-4** — Migration `20260521` adds a partial unique index on `user(role) WHERE role='admin'`; the Better Auth `before` hook now serialises concurrent signups with `pg_advisory_xact_lock` for a clean `role=user` fallback.

## Highs (7/7)
- **H-1** — `availableHints` suppressed on wrong-guess responses.
- **H-2** — Correctness requires non-empty `guessText`; `gameId` is now a tiebreaker, not a sufficient signal on its own.
- **H-3** — Dockerfile `HEALTHCHECK` probes `/healthz` (DB + Redis) instead of the static `/health`.
- **H-4** — Request logger strips token / code / session / verify / reset query params and drops query strings entirely on `/api/auth/*` paths.
- **H-5** — `express.json` and `express.urlencoded` pinned to 256 kb; Stripe webhook raw parser capped at 1 mb.
- **H-6** — Leaderboard ORDER BY has deterministic tiebreakers and uses `DENSE_RANK()` so tied scores share a rank.
- **H-7** — db-backup container reads credentials from a Docker secret written to `~/.pgpass` at 0600 instead of `PGPASSWORD`; backup script uses `set -o pipefail` + atomic rename + post-success rotation.

## Mediums (4/5)
- **M-2** — Streak-freeze consume + streak update commit in one Knex transaction via the new `consumeFreezeAndUpdateStreak` repo method.
- **M-3** — Recurring-job re-registration gated by a Redis `SETNX` lock so two containers in a rolling deploy can't race to remove-then-re-add the same crons.
- **M-4** — Workers paused before queue close on shutdown so the poll loop can't pick up a fresh job and have its Redis connection yanked mid-transaction. Worker close timeout bumped to 15 s.
- **M-5** — `vite.config.ts` throws at build time if `NODE_ENV=production && VITE_USE_MOCK_API=true`.
- **M-1** — Reviewed and judged adequately guarded by the existing `is_completed` check; no code change.

## Test plan
- [x] `npm run build` (types + backend + frontend) clean
- [x] `npm run lint` clean
- [x] `npm test` — 96 / 96 passing (pre-commit hook re-ran them)
- [ ] Manual smoke: two-tab guess race, one rolling deploy under load, hit `/api/game/image/<unowned>` while logged in and confirm 404.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSgrEzWWF8M7q6P3RZry6h)_