### PR TITLE
Make Postgres TLS opt-in via DATABASE_SSL flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,13 @@ DB_NAME=thebox
 # Production: Set via DB_* variables in compose.yml
 DATABASE_URL=postgresql://thebox:thebox_secret@localhost:5432/thebox
 
+# Opt-in TLS to Postgres. Set to "true" for managed providers (RDS,
+# Supabase, Neon, DigitalOcean Managed) that require TLS. Leave unset
+# for self-hosted Postgres on a private Docker network — forcing SSL
+# on a server without it fails the boot with
+# "server does not support SSL connections".
+# DATABASE_SSL=true
+
 # ============================================
 # AUTHENTICATION (REQUIRED IN PRODUCTION)
 # ============================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-box",
-  "version": "2.91.1",
+  "version": "2.91.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-box",
-      "version": "2.91.1",
+      "version": "2.91.2",
       "workspaces": [
         "packages/*"
       ],
@@ -16965,7 +16965,7 @@
     },
     "packages/backend": {
       "name": "@the-box/backend",
-      "version": "2.91.1",
+      "version": "2.91.2",
       "dependencies": {
         "@the-box/types": "*",
         "better-auth": "^1.4.10",
@@ -17015,7 +17015,7 @@
     },
     "packages/frontend": {
       "name": "@the-box/frontend",
-      "version": "2.91.1",
+      "version": "2.91.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -17085,7 +17085,7 @@
     },
     "packages/types": {
       "name": "@the-box/types",
-      "version": "2.91.1",
+      "version": "2.91.2",
       "devDependencies": {
         "typescript": "^5.6.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-box",
-  "version": "2.91.1",
+  "version": "2.91.2",
   "private": true,
   "description": "Gaming screenshot guessing application",
   "workspaces": [

--- a/packages/backend/knexfile.ts
+++ b/packages/backend/knexfile.ts
@@ -33,19 +33,17 @@ const config: { [key: string]: Knex.Config } = {
   },
 }
 
-// Managed Postgres providers (RDS, Supabase, Neon, DigitalOcean Managed)
-// require TLS on connection. We enable it whenever DATABASE_URL doesn't
-// point at localhost so production deploys can't accidentally talk plain
-// TCP. `rejectUnauthorized: false` is intentional: many managed providers
-// hand out certificates signed by their own CA which Node's default trust
-// store doesn't carry. Treat this as "encrypt in transit, don't verify
-// peer" — strictly better than today's no-SSL state.
+// TLS is opt-in via DATABASE_SSL=true. Managed Postgres providers (RDS,
+// Supabase, Neon, DigitalOcean Managed) require it and should set the flag;
+// self-hosted Postgres reached over a private Docker network or VPN does
+// not, and forcing SSL there causes "server does not support SSL
+// connections" at boot. `rejectUnauthorized: false` is intentional: many
+// managed providers hand out certificates signed by their own CA which
+// Node's default trust store doesn't carry.
 function buildProductionConnection(): Knex.PgConnectionConfig {
-  const url = process.env['DATABASE_URL'] ?? ''
-  const isLocal = url.includes('localhost') || url.includes('127.0.0.1')
   return {
-    connectionString: url,
-    ssl: isLocal ? false : { rejectUnauthorized: false },
+    connectionString: process.env['DATABASE_URL'] ?? '',
+    ssl: process.env['DATABASE_SSL'] === 'true' ? { rejectUnauthorized: false } : false,
   }
 }
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-box/backend",
-  "version": "2.91.1",
+  "version": "2.91.2",
   "description": "Backend API for The Box game",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -7,6 +7,11 @@ export const env = {
   PORT: parseInt(process.env['PORT'] || '3000', 10),
   LOG_LEVEL: process.env['LOG_LEVEL'] || 'info',
   DATABASE_URL: process.env['DATABASE_URL'] || 'postgresql://thebox:thebox_secret@localhost:5432/thebox',
+  // Opt-in TLS for Postgres. Set to 'true' for managed providers (RDS,
+  // Supabase, Neon) that require TLS. Leave unset/false for self-hosted
+  // Postgres on a private network — forcing SSL on a server without it
+  // fails the boot with "server does not support SSL connections".
+  DATABASE_SSL: process.env['DATABASE_SSL'] || 'false',
   CORS_ORIGIN: process.env['CORS_ORIGIN'] || 'http://localhost:5173',
 
   // Better Auth. The default below is ONLY used when NODE_ENV === 'development';

--- a/packages/backend/src/infrastructure/database/connection.ts
+++ b/packages/backend/src/infrastructure/database/connection.ts
@@ -6,12 +6,11 @@ import { dbLogger } from '../logger/logger.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// Mirror knexfile.ts: in any non-development environment, require TLS to
-// the database unless the URL is explicitly local. Managed Postgres
-// providers (RDS, Supabase, Neon) refuse plain TCP, and we don't want
-// production credentials going over the network unencrypted.
-const isLocalDatabase = env.DATABASE_URL.includes('localhost') || env.DATABASE_URL.includes('127.0.0.1')
-const useSsl = env.NODE_ENV !== 'development' && !isLocalDatabase
+// Mirror knexfile.ts: TLS is opt-in via DATABASE_SSL=true. Managed
+// Postgres providers (RDS, Supabase, Neon) require it; self-hosted
+// Postgres on a private Docker network does not, and forcing SSL there
+// fails the boot with "server does not support SSL connections".
+const useSsl = env.DATABASE_SSL === 'true'
 
 export const db: Knex = knex({
   client: 'pg',

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-box/frontend",
   "private": true,
-  "version": "2.91.1",
+  "version": "2.91.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-box/types",
-  "version": "2.91.1",
+  "version": "2.91.2",
   "description": "Shared TypeScript types for The Box",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
Changes the Postgres TLS configuration from automatic (based on localhost detection) to explicit opt-in via a `DATABASE_SSL` environment variable. This fixes issues with self-hosted Postgres instances on private networks that don't support SSL.

## Key Changes
- **knexfile.ts**: Replaced localhost detection logic with explicit `DATABASE_SSL=true` flag check
- **connection.ts**: Mirrored the knexfile changes to use the same opt-in approach
- **env.ts**: Added `DATABASE_SSL` configuration variable (defaults to `'false'`)
- **.env.example**: Added documentation for the new `DATABASE_SSL` flag with usage guidance
- **Version bump**: Updated all package versions to 2.91.2

## Implementation Details
- TLS is now **disabled by default** for all environments
- Managed Postgres providers (RDS, Supabase, Neon, DigitalOcean Managed) must explicitly set `DATABASE_SSL=true`
- Self-hosted Postgres on private Docker networks no longer requires workarounds
- `rejectUnauthorized: false` remains intentional to support managed providers with custom CA certificates
- Configuration is consistent across both knexfile and runtime connection setup

https://claude.ai/code/session_01JaY9Wf9Xxtp3Hg6AgGjjY1