### PR TITLE
Fix z-index layering of top-right overlay above topBar

### DIFF
--- a/packages/frontend/src/components/geo/ImmersiveLayout.tsx
+++ b/packages/frontend/src/components/geo/ImmersiveLayout.tsx
@@ -57,10 +57,16 @@ export function ImmersiveLayout({
             )}
             data-immersive={isImmersive ? 'true' : 'false'}
         >
-            {/* Top-right overlay (fullscreen toggle, etc.) */}
+            {/* Top-right overlay (fullscreen toggle, etc.). Needs to sit above
+                the `topBar` strip — both used to share `z-30`, but the topBar's
+                `backdrop-filter` makes z-index apply to it as a non-positioned
+                element, so equal z-index would let the later sibling (topBar)
+                intercept clicks over this overlay. Bumped to z-40 so the Home
+                and fullscreen buttons stay clickable across the topBar's
+                right padding. */}
             {topRight && (
                 <div
-                    className="absolute right-3 top-3 z-30 flex items-center gap-2"
+                    className="absolute right-3 top-3 z-40 flex items-center gap-2"
                     style={{
                         paddingTop: 'env(safe-area-inset-top, 0px)',
                         paddingRight: 'env(safe-area-inset-right, 0px)',


### PR DESCRIPTION
## Summary
Increased the z-index of the top-right overlay (containing fullscreen toggle and Home button) from `z-30` to `z-40` to ensure it remains clickable and sits above the topBar strip.

## Changes
- Bumped z-index of top-right overlay container from `z-30` to `z-40`
- Updated comment to explain the z-index layering issue and solution

## Details
The topBar and top-right overlay were both using `z-30`, but the topBar's `backdrop-filter` CSS property causes z-index to apply to it as a non-positioned element. This meant that the later sibling (topBar) would intercept clicks intended for the overlay buttons, making them unclickable across the topBar's right padding area.

By bumping the overlay to `z-40`, the Home and fullscreen buttons now remain properly clickable and visually sit above the topBar as intended.

https://claude.ai/code/session_015XkWJiBgQMnQSufLwMXVVL