### PR TITLE
fix(game): skip round-timer stamp on prefetched screenshots

### DIFF
--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -113,7 +113,12 @@ export interface GameServiceDeps {
 export interface GameService {
   getTodayChallenge(userId?: string, date?: string): Promise<TodayChallengeResponse>
   startChallenge(challengeId: number, userId: string, isPremium?: boolean): Promise<StartChallengeResponse>
-  getScreenshot(sessionId: string, position: number, userId: string): Promise<ScreenshotResponse>
+  getScreenshot(
+    sessionId: string,
+    position: number,
+    userId: string,
+    prefetch?: boolean
+  ): Promise<ScreenshotResponse>
   submitGuess(data: {
     tierSessionId: string
     screenshotId: number
@@ -404,7 +409,8 @@ export function createGameService(deps: GameServiceDeps): GameService {
   async getScreenshot(
     sessionId: string,
     position: number,
-    userId: string
+    userId: string,
+    prefetch: boolean = false
   ): Promise<ScreenshotResponse> {
     const session = await sessionRepository.findGameSessionById(sessionId, userId)
     if (!session) {
@@ -429,6 +435,14 @@ export function createGameService(deps: GameServiceDeps): GameService {
     // path swallowed the error and let submitGuess fall back to the
     // client-supplied timer, which re-enabled the original
     // `{ roundTimeTakenMs: 1 }` cheat any time the DB blipped.
+    //
+    // Prefetch calls (carousel prev/next warming, full-batch warming on
+    // session resume) skip the stamp: stamping here would clobber
+    // `round_position` to the prefetched slot and the user's next
+    // submitGuess on the *current* position would 409 with
+    // ROUND_NOT_STARTED. The client cannot weaponise prefetch=1 — the
+    // stamp is the only way to enable scoring, so a malicious caller
+    // that always passes prefetch=1 simply locks itself out.
     const latestTier = await sessionRepository.findLatestTierSession(session.id)
     if (!latestTier) {
       throw new GameError(
@@ -437,7 +451,9 @@ export function createGameService(deps: GameServiceDeps): GameService {
         409
       )
     }
-    await sessionRepository.markRoundStarted(latestTier.id, position)
+    if (!prefetch) {
+      await sessionRepository.markRoundStarted(latestTier.id, position)
+    }
 
     // Use proxy URL to hide the actual file path (which contains game slug)
     const proxyImageUrl = `/api/game/image/${tierScreenshot.screenshot_id}`

--- a/packages/backend/src/presentation/routes/game.routes.ts
+++ b/packages/backend/src/presentation/routes/game.routes.ts
@@ -232,7 +232,7 @@ router.post('/start/:challengeId', authMiddleware, async (req, res, next) => {
 // Get current screenshot
 router.get('/screenshot', authMiddleware, async (req, res, next) => {
   try {
-    const { sessionId, position } = req.query
+    const { sessionId, position, prefetch } = req.query
 
     if (!sessionId || !position) {
       res.status(400).json({
@@ -242,10 +242,15 @@ router.get('/screenshot', authMiddleware, async (req, res, next) => {
       return
     }
 
+    // Carousel/background warming uses prefetch=1 so the round-timer
+    // stamp stays on the position the user is actually playing.
+    const isPrefetch = prefetch === '1' || prefetch === 'true'
+
     const data = await gameService.getScreenshot(
       sessionId as string,
       parseInt(position as string, 10),
-      req.userId!
+      req.userId!,
+      isPrefetch
     )
 
     res.json({

--- a/packages/frontend/src/components/game/ScreenshotViewer.tsx
+++ b/packages/frontend/src/components/game/ScreenshotViewer.tsx
@@ -81,7 +81,7 @@ export function ScreenshotViewer({
     // Load adjacent screenshots
     if (sessionId && gamePhase === 'playing') {
       if (findPreviousPosition) {
-        gameApi.getScreenshot(sessionId, findPreviousPosition)
+        gameApi.getScreenshot(sessionId, findPreviousPosition, { prefetch: true })
           .then((data) => {
             setImages((prev) => {
               const updated = [...prev]
@@ -100,7 +100,7 @@ export function ScreenshotViewer({
       }
 
       if (findNextPosition) {
-        gameApi.getScreenshot(sessionId, findNextPosition)
+        gameApi.getScreenshot(sessionId, findNextPosition, { prefetch: true })
           .then((data) => {
             setImages((prev) => {
               const updated = [...prev]

--- a/packages/frontend/src/lib/api/game.ts
+++ b/packages/frontend/src/lib/api/game.ts
@@ -67,13 +67,25 @@ export const gameApi = {
   },
 
   /**
-   * Get screenshot for current position
+   * Get screenshot for a position.
+   *
+   * Pass `prefetch: true` for carousel warming / background preloading.
+   * The server otherwise stamps the round timer onto this position, and
+   * a subsequent submitGuess on a different position will 409 with
+   * `ROUND_NOT_STARTED`.
    */
-  async getScreenshot(sessionId: string, position: number): Promise<ScreenshotResponse> {
+  async getScreenshot(
+    sessionId: string,
+    position: number,
+    options: { prefetch?: boolean } = {}
+  ): Promise<ScreenshotResponse> {
     const params = new URLSearchParams({
       sessionId,
       position: position.toString(),
     })
+    if (options.prefetch) {
+      params.set('prefetch', '1')
+    }
     const response = await fetch(`/api/game/screenshot?${params}`, {
       credentials: 'include',
     })

--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -106,7 +106,7 @@ export default function GamePage() {
       await Promise.allSettled(
         batch.map(async (position) => {
           try {
-            const data = await gameApi.getScreenshot(sid, position)
+            const data = await gameApi.getScreenshot(sid, position, { prefetch: true })
             // Preload the image in browser cache
             const img = new Image()
             img.src = data.imageUrl
@@ -282,7 +282,7 @@ export default function GamePage() {
     // Pre-fetch next screenshot
     if (nextPos) {
       try {
-        const nextData = await gameApi.getScreenshot(sid, nextPos)
+        const nextData = await gameApi.getScreenshot(sid, nextPos, { prefetch: true })
         // Preload the image in browser cache
         const img = new Image()
         img.src = nextData.imageUrl
@@ -294,7 +294,7 @@ export default function GamePage() {
     // Pre-fetch previous screenshot
     if (prevPos) {
       try {
-        const prevData = await gameApi.getScreenshot(sid, prevPos)
+        const prevData = await gameApi.getScreenshot(sid, prevPos, { prefetch: true })
         // Preload the image in browser cache
         const img = new Image()
         img.src = prevData.imageUrl


### PR DESCRIPTION
## Summary
- Production was returning `409 ROUND_NOT_STARTED` ("No active round timer for this position. Reload the screenshot and retry.") to legitimate players on the daily challenge.
- Root cause: after [#207 / `1fa7df2`](https://github.com/Wifsimster/the-box/commit/1fa7df2) made `submitGuess` reject when `tier_session.round_position !== data.position`, both `ScreenshotViewer` (carousel prev/next) and `GamePage` (full-batch + adjacent prefetch) kept calling `GET /api/game/screenshot` for off-screen positions. Each call ran through `markRoundStarted`, clobbering the stamp away from the position the user was actually playing. By the time the user submitted, the server's `round_position` was whatever prefetch resolved last.
- Fix: opt-in `?prefetch=1` query param. The 5 prefetch call sites now pass it and the server skips `markRoundStarted` for those; the real fetch for the active position (`fetchScreenshot`, session-restore path) still stamps. Cheat-resistant: `prefetch=1` never enables scoring, so a malicious caller who always passes it just locks itself out.

## Files
- `backend/src/domain/services/game.service.ts` — `getScreenshot` takes `prefetch?: boolean`, guards `markRoundStarted`.
- `backend/src/presentation/routes/game.routes.ts` — parses `?prefetch=1` / `?prefetch=true`.
- `frontend/src/lib/api/game.ts` — `getScreenshot(sessionId, position, { prefetch })`.
- `frontend/src/pages/GamePage.tsx` — `prefetchAllScreenshots` + `prefetchAdjacentScreenshots` (3 sites) pass `prefetch: true`.
- `frontend/src/components/game/ScreenshotViewer.tsx` — carousel prev/next preloads pass `prefetch: true`.

## Test plan
- [x] `npm test` — 96/96 unit tests passing (covered by pre-commit hook).
- [x] `tsc --noEmit` clean on backend and frontend.
- [ ] Manual on staging: start a daily challenge, advance to position 2+, submit a correct guess → no 409.
- [ ] Manual on staging: confirm prev/next carousel preloads still warm the browser cache (`/api/game/image/:id` requests fire).
- [ ] Manual: refresh mid-session, submit again — round timer re-stamps via the non-prefetch fetch, submit succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)