### PR TITLE
Add SEO infrastructure with dynamic meta tags and sitemap

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -16,19 +16,23 @@
   <meta name="description" content="Daily video game guessing challenges. Identify games from panoramic screenshots, climb live leaderboards, unlock achievements. Play instantly as a guest — no account needed." />
   <link rel="canonical" href="https://the-box.battistella.ovh/" />
 
+  <link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr" />
+  <link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en" />
+  <link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr" />
+
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="The Box" />
   <meta property="og:title" content="The Box — Daily Video Game Guessing Challenge" />
   <meta property="og:description" content="Identify games from panoramic screenshots. New daily challenge, live leaderboards, achievements. Play instantly as a guest." />
   <meta property="og:url" content="https://the-box.battistella.ovh/" />
-  <meta property="og:image" content="https://the-box.battistella.ovh/logo.svg" />
-  <meta property="og:locale" content="en_US" />
-  <meta property="og:locale:alternate" content="fr_FR" />
+  <meta property="og:image" content="https://the-box.battistella.ovh/api/og/daily.svg" />
+  <meta property="og:locale" content="fr_FR" />
+  <meta property="og:locale:alternate" content="en_US" />
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="The Box — Daily Video Game Guessing Challenge" />
   <meta name="twitter:description" content="Identify games from panoramic screenshots. New daily challenge, live leaderboards, achievements. Play as a guest — no account needed." />
-  <meta name="twitter:image" content="https://the-box.battistella.ovh/logo.svg" />
+  <meta name="twitter:image" content="https://the-box.battistella.ovh/api/og/daily.svg" />
 </head>
 
 <body>

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2137,5 +2137,83 @@
       "later": "Later",
       "dismiss": "Dismiss"
     }
+  },
+  "seo": {
+    "home": {
+      "title": "The Box — Daily Video Game Guessing Challenge",
+      "description": "Identify games from panoramic screenshots. New daily challenge, live leaderboards, achievements. Play instantly as a guest — no account needed."
+    },
+    "play": {
+      "title": "Daily Challenge — The Box",
+      "description": "Spot today's mystery game from 10 screenshots. Faster guesses score more. Compete on the daily leaderboard."
+    },
+    "leaderboard": {
+      "title": "Leaderboard — The Box",
+      "description": "Daily and monthly rankings of the top video game guessers. Live updates as players finish today's challenge."
+    },
+    "history": {
+      "title": "Game History — The Box",
+      "description": "Replay past challenges, resume what's in progress, and review every guess from your last sessions."
+    },
+    "profile": {
+      "title": "Your Profile — The Box",
+      "description": "Your stats, achievements, daily streak and game history on The Box."
+    },
+    "publicProfile": {
+      "title": "{{username}} on The Box",
+      "description": "{{username}}'s stats, achievements and best scores on The Box daily video game challenge."
+    },
+    "premium": {
+      "title": "Premium — The Box",
+      "description": "Unlock the full challenge archive, unlimited catch-up hints and Premium badges. Support the game."
+    },
+    "faq": {
+      "title": "FAQ — The Box",
+      "description": "Answers about scoring, hints, leaderboards, daily streaks and Premium on The Box."
+    },
+    "contact": {
+      "title": "Contact — The Box",
+      "description": "Get in touch with The Box team."
+    },
+    "terms": {
+      "title": "Terms of Service — The Box",
+      "description": "The terms that govern your use of The Box."
+    },
+    "privacy": {
+      "title": "Privacy Policy — The Box",
+      "description": "How The Box handles your data."
+    },
+    "cookies": {
+      "title": "Cookie Policy — The Box",
+      "description": "How The Box uses cookies and similar storage."
+    },
+    "login": {
+      "title": "Sign In — The Box",
+      "description": "Sign in to save your scores, streaks and achievements on The Box."
+    },
+    "register": {
+      "title": "Create an Account — The Box",
+      "description": "Create a free account to track your scores, achievements and daily streak on The Box."
+    },
+    "forgotPassword": {
+      "title": "Reset Password — The Box",
+      "description": "Receive a password reset link by email."
+    },
+    "resetPassword": {
+      "title": "Choose a New Password — The Box",
+      "description": "Set a new password for your The Box account."
+    },
+    "results": {
+      "title": "Results — The Box",
+      "description": "How you did on the latest challenge."
+    },
+    "geo": {
+      "title": "Geo Mode — The Box",
+      "description": "Identify games from in-game locations on a map. New challenges every day."
+    },
+    "geoContribute": {
+      "title": "Contribute to Geo Mode — The Box",
+      "description": "Help curate and verify Geo Mode challenges."
+    }
   }
 }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2137,5 +2137,83 @@
       "later": "Plus tard",
       "dismiss": "Fermer"
     }
+  },
+  "seo": {
+    "home": {
+      "title": "The Box — Le défi quotidien de jeux vidéo",
+      "description": "Reconnaissez des jeux vidéo à partir de leurs screenshots. Défi quotidien, classements en direct, succès à débloquer. Jouez instantanément en invité — aucun compte requis."
+    },
+    "play": {
+      "title": "Défi du jour — The Box",
+      "description": "Devinez le jeu mystère du jour à partir de 10 screenshots. Plus vous répondez vite, plus vous marquez. Affrontez le classement quotidien."
+    },
+    "leaderboard": {
+      "title": "Classement — The Box",
+      "description": "Classements quotidiens et mensuels des meilleurs joueurs. Mises à jour en direct dès qu'un défi est terminé."
+    },
+    "history": {
+      "title": "Historique — The Box",
+      "description": "Rejouez les défis passés, reprenez ceux en cours et passez en revue chaque réponse de vos dernières parties."
+    },
+    "profile": {
+      "title": "Votre profil — The Box",
+      "description": "Vos stats, succès, série quotidienne et historique de parties sur The Box."
+    },
+    "publicProfile": {
+      "title": "{{username}} sur The Box",
+      "description": "Stats, succès et meilleurs scores de {{username}} sur The Box, le défi quotidien de jeux vidéo."
+    },
+    "premium": {
+      "title": "Premium — The Box",
+      "description": "Débloquez l'archive complète des défis, des indices illimités en rattrapage et un badge Premium. Soutenez le jeu."
+    },
+    "faq": {
+      "title": "FAQ — The Box",
+      "description": "Réponses sur le score, les indices, les classements, les séries quotidiennes et Premium sur The Box."
+    },
+    "contact": {
+      "title": "Contact — The Box",
+      "description": "Contactez l'équipe de The Box."
+    },
+    "terms": {
+      "title": "Conditions d'utilisation — The Box",
+      "description": "Les conditions qui régissent votre utilisation de The Box."
+    },
+    "privacy": {
+      "title": "Politique de confidentialité — The Box",
+      "description": "Comment The Box gère vos données."
+    },
+    "cookies": {
+      "title": "Politique de cookies — The Box",
+      "description": "Comment The Box utilise les cookies et stockages similaires."
+    },
+    "login": {
+      "title": "Connexion — The Box",
+      "description": "Connectez-vous pour sauvegarder vos scores, séries et succès sur The Box."
+    },
+    "register": {
+      "title": "Créer un compte — The Box",
+      "description": "Créez un compte gratuit pour suivre vos scores, succès et série quotidienne sur The Box."
+    },
+    "forgotPassword": {
+      "title": "Réinitialiser le mot de passe — The Box",
+      "description": "Recevez un lien de réinitialisation par e-mail."
+    },
+    "resetPassword": {
+      "title": "Choisir un nouveau mot de passe — The Box",
+      "description": "Définissez un nouveau mot de passe pour votre compte The Box."
+    },
+    "results": {
+      "title": "Résultats — The Box",
+      "description": "Votre performance sur le dernier défi."
+    },
+    "geo": {
+      "title": "Mode Geo — The Box",
+      "description": "Reconnaissez des jeux à partir de leurs lieux sur une carte. Nouveaux défis chaque jour."
+    },
+    "geoContribute": {
+      "title": "Contribuer au mode Geo — The Box",
+      "description": "Aidez à curer et vérifier les défis du mode Geo."
+    }
   }
 }

--- a/packages/frontend/public/robots.txt
+++ b/packages/frontend/public/robots.txt
@@ -1,0 +1,12 @@
+User-agent: *
+Allow: /
+
+Disallow: /api/
+Disallow: /*/admin
+Disallow: /*/profile
+Disallow: /*/history
+Disallow: /*/results
+Disallow: /*/reset-password
+Disallow: /*/forgot-password
+
+Sitemap: https://the-box.battistella.ovh/sitemap.xml

--- a/packages/frontend/public/sitemap.xml
+++ b/packages/frontend/public/sitemap.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://the-box.battistella.ovh/fr</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr"/>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/en</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr"/>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/fr/play</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/play"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/play"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/play"/>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/en/play</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/play"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/play"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/play"/>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/fr/leaderboard</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/leaderboard"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/leaderboard"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/leaderboard"/>
+    <changefreq>hourly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/en/leaderboard</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/leaderboard"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/leaderboard"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/leaderboard"/>
+    <changefreq>hourly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/fr/premium</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/premium"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/premium"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/premium"/>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/en/premium</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/premium"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/premium"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/premium"/>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/fr/faq</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/faq"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/faq"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/faq"/>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/en/faq</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/faq"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/faq"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/faq"/>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/fr/contact</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/contact"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/contact"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/contact"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/en/contact</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/contact"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/contact"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://the-box.battistella.ovh/fr/contact"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/fr/terms</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/terms"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/terms"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/en/terms</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/terms"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/terms"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/fr/privacy</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/privacy"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/privacy"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/en/privacy</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/privacy"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/privacy"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/fr/cookies</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/cookies"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/cookies"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://the-box.battistella.ovh/en/cookies</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr/cookies"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://the-box.battistella.ovh/en/cookies"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { Toaster } from '@/components/ui/sonner'
 import { ErrorBoundary, LazyComponentErrorBoundary } from '@/components/ErrorBoundary'
+import { RouteSeo } from '@/components/RouteSeo'
 import {
   PWAUpdatePrompt,
   OfflineIndicator,
@@ -122,6 +123,7 @@ function LanguageLayout() {
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
+      <RouteSeo />
       {!isFullscreen && <Header />}
       <main className="flex-1">
         <LazyComponentErrorBoundary>

--- a/packages/frontend/src/components/RouteSeo.tsx
+++ b/packages/frontend/src/components/RouteSeo.tsx
@@ -1,0 +1,137 @@
+import { useLocation } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { Seo } from './Seo'
+import { SITE_NAME, SITE_URL, stripLangPrefix } from '@/lib/seo'
+
+type RouteDef = {
+  /** Match against the language-stripped path (e.g. `/play`, `/u/foo`). */
+  match: (path: string) => null | Record<string, string>
+  /** i18n key under `seo.*`. */
+  key: string
+  noindex?: boolean
+  ogType?: 'website' | 'profile' | 'article'
+  /** Build JSON-LD for this route. */
+  jsonLd?: (lang: string) => Record<string, unknown> | Record<string, unknown>[] | undefined
+}
+
+const homeJsonLd = (lang: string): Record<string, unknown>[] => [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: SITE_NAME,
+    url: `${SITE_URL}/${lang}`,
+    inLanguage: lang,
+    applicationCategory: 'GameApplication',
+    operatingSystem: 'Web',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'EUR',
+    },
+    description:
+      lang === 'fr'
+        ? 'Devinez des jeux vidéo à partir de screenshots. Défi quotidien, classements en direct, succès.'
+        : 'Guess video games from screenshots. Daily challenge, live leaderboards, achievements.',
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: SITE_NAME,
+    url: SITE_URL,
+    logo: `${SITE_URL}/logo.svg`,
+  },
+]
+
+const breadcrumbLd = (lang: string, items: Array<{ name: string; path: string }>) => ({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: items.map((item, idx) => ({
+    '@type': 'ListItem',
+    position: idx + 1,
+    name: item.name,
+    item: `${SITE_URL}/${lang}${item.path}`,
+  })),
+})
+
+function exact(suffix: string) {
+  const re = new RegExp(`^${suffix.replace(/\//g, '\\/')}\\/?$`)
+  return (path: string) => (re.test(path) ? {} : null)
+}
+
+function paramMatch(template: string, paramName: string) {
+  const re = new RegExp(`^${template.replace(/:[a-z]+/gi, '([^/]+)').replace(/\//g, '\\/')}\\/?$`)
+  return (path: string) => {
+    const m = path.match(re)
+    return m ? { [paramName]: m[1]! } : null
+  }
+}
+
+const ROUTES: RouteDef[] = [
+  {
+    match: exact('/'),
+    key: 'home',
+    jsonLd: homeJsonLd,
+  },
+  { match: exact('/play'), key: 'play' },
+  {
+    match: exact('/leaderboard'),
+    key: 'leaderboard',
+    jsonLd: (lang) =>
+      breadcrumbLd(lang, [
+        { name: SITE_NAME, path: '' },
+        { name: lang === 'fr' ? 'Classement' : 'Leaderboard', path: '/leaderboard' },
+      ]),
+  },
+  { match: exact('/results'), key: 'results', noindex: true },
+  { match: exact('/login'), key: 'login', noindex: true },
+  { match: exact('/register'), key: 'register', noindex: true },
+  { match: exact('/forgot-password'), key: 'forgotPassword', noindex: true },
+  { match: exact('/reset-password'), key: 'resetPassword', noindex: true },
+  { match: exact('/terms'), key: 'terms' },
+  { match: exact('/privacy'), key: 'privacy' },
+  { match: exact('/cookies'), key: 'cookies' },
+  { match: exact('/faq'), key: 'faq' },
+  { match: exact('/contact'), key: 'contact' },
+  { match: exact('/premium'), key: 'premium' },
+  { match: exact('/abonnement'), key: 'premium' },
+  { match: exact('/geo'), key: 'geo' },
+  { match: exact('/geo/play'), key: 'geo' },
+  { match: exact('/geo/contribute'), key: 'geoContribute' },
+  { match: paramMatch('/u/:username', 'username'), key: 'publicProfile', ogType: 'profile' },
+  // Private / volatile surfaces — we still want a sensible title but block indexing.
+  { match: exact('/profile'), key: 'profile', noindex: true },
+  { match: (p) => (p.startsWith('/history') ? {} : null), key: 'history', noindex: true },
+  { match: (p) => (p.startsWith('/admin') ? {} : null), key: 'home', noindex: true },
+]
+
+export function RouteSeo() {
+  const { pathname } = useLocation()
+  const { t, i18n } = useTranslation()
+
+  const suffix = stripLangPrefix(pathname) || '/'
+  const matched = ROUTES.find((r) => r.match(suffix) !== null)
+  if (!matched) {
+    return (
+      <Seo
+        title={t('seo.home.title')}
+        description={t('seo.home.description')}
+        pathSuffix={suffix}
+      />
+    )
+  }
+  const params = matched.match(suffix) ?? {}
+  const title = t(`seo.${matched.key}.title`, params)
+  const description = t(`seo.${matched.key}.description`, params)
+  const jsonLd = matched.jsonLd?.(i18n.language)
+
+  return (
+    <Seo
+      title={title}
+      description={description}
+      pathSuffix={suffix}
+      noindex={matched.noindex}
+      ogType={matched.ogType}
+      jsonLd={jsonLd}
+    />
+  )
+}

--- a/packages/frontend/src/components/Seo.tsx
+++ b/packages/frontend/src/components/Seo.tsx
@@ -1,0 +1,147 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import {
+  DEFAULT_OG_IMAGE,
+  LOCALE_BY_LANG,
+  SITE_NAME,
+  SITE_URL,
+  buildHreflangAlternates,
+  buildLocalizedUrl,
+  stripLangPrefix,
+} from '@/lib/seo'
+import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '@/lib/i18n'
+
+type SeoProps = {
+  title: string
+  description: string
+  /**
+   * Path suffix without the language prefix (e.g. `/leaderboard`). Defaults to
+   * the current location's suffix so canonical and hreflang stay in sync.
+   */
+  pathSuffix?: string
+  image?: string
+  /** Discourage indexing (used for auth flows, admin, history detail, results). */
+  noindex?: boolean
+  /** Structured data (Schema.org). Rendered as a JSON-LD `<script>`. */
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[]
+  ogType?: 'website' | 'article' | 'profile'
+}
+
+// Marker attribute so we only remove tags this component owns on cleanup.
+const MARKER = 'data-seo'
+
+function upsertMeta(selector: string, attrs: Record<string, string>): HTMLElement {
+  let el = document.head.querySelector<HTMLElement>(selector)
+  if (!el) {
+    el = document.createElement('meta')
+    el.setAttribute(MARKER, 'managed')
+    document.head.appendChild(el)
+  }
+  for (const [k, v] of Object.entries(attrs)) {
+    el.setAttribute(k, v)
+  }
+  return el
+}
+
+function clearManaged(name: string) {
+  document.head.querySelectorAll(`[${MARKER}="${name}"]`).forEach((el) => el.remove())
+}
+
+export function Seo({
+  title,
+  description,
+  pathSuffix,
+  image = DEFAULT_OG_IMAGE,
+  noindex = false,
+  jsonLd,
+  ogType = 'website',
+}: SeoProps) {
+  const location = useLocation()
+  const { i18n } = useTranslation()
+
+  useEffect(() => {
+    const lang = (SUPPORTED_LANGUAGES.includes(i18n.language as SupportedLanguage)
+      ? i18n.language
+      : 'fr') as SupportedLanguage
+    const suffix = pathSuffix ?? stripLangPrefix(location.pathname)
+    const canonical = buildLocalizedUrl(lang, suffix)
+
+    document.title = title
+
+    upsertMeta('meta[name="description"]', { name: 'description', content: description })
+
+    // Canonical
+    let canonicalEl = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+    if (!canonicalEl) {
+      canonicalEl = document.createElement('link')
+      canonicalEl.setAttribute('rel', 'canonical')
+      document.head.appendChild(canonicalEl)
+    }
+    canonicalEl.setAttribute('href', canonical)
+
+    // hreflang alternates (always managed by this component).
+    clearManaged('hreflang')
+    for (const alt of buildHreflangAlternates(suffix)) {
+      const link = document.createElement('link')
+      link.setAttribute('rel', 'alternate')
+      link.setAttribute('hreflang', alt.hreflang)
+      link.setAttribute('href', alt.href)
+      link.setAttribute(MARKER, 'hreflang')
+      document.head.appendChild(link)
+    }
+
+    // Open Graph + Twitter
+    upsertMeta('meta[property="og:type"]', { property: 'og:type', content: ogType })
+    upsertMeta('meta[property="og:site_name"]', { property: 'og:site_name', content: SITE_NAME })
+    upsertMeta('meta[property="og:title"]', { property: 'og:title', content: title })
+    upsertMeta('meta[property="og:description"]', { property: 'og:description', content: description })
+    upsertMeta('meta[property="og:url"]', { property: 'og:url', content: canonical })
+    upsertMeta('meta[property="og:image"]', {
+      property: 'og:image',
+      content: image.startsWith('http') ? image : `${SITE_URL}${image}`,
+    })
+    upsertMeta('meta[property="og:locale"]', {
+      property: 'og:locale',
+      content: LOCALE_BY_LANG[lang],
+    })
+
+    upsertMeta('meta[name="twitter:card"]', { name: 'twitter:card', content: 'summary_large_image' })
+    upsertMeta('meta[name="twitter:title"]', { name: 'twitter:title', content: title })
+    upsertMeta('meta[name="twitter:description"]', { name: 'twitter:description', content: description })
+    upsertMeta('meta[name="twitter:image"]', {
+      name: 'twitter:image',
+      content: image.startsWith('http') ? image : `${SITE_URL}${image}`,
+    })
+
+    // robots
+    if (noindex) {
+      upsertMeta('meta[name="robots"]', { name: 'robots', content: 'noindex, nofollow' })
+    } else {
+      const existing = document.head.querySelector('meta[name="robots"]')
+      if (existing) existing.remove()
+    }
+
+    // JSON-LD
+    clearManaged('jsonld')
+    if (jsonLd) {
+      const items = Array.isArray(jsonLd) ? jsonLd : [jsonLd]
+      for (const item of items) {
+        const script = document.createElement('script')
+        script.setAttribute('type', 'application/ld+json')
+        script.setAttribute(MARKER, 'jsonld')
+        script.text = JSON.stringify(item)
+        document.head.appendChild(script)
+      }
+    }
+
+    return () => {
+      // Only the per-page extras get cleaned; canonical/og stay set so the next
+      // page can overwrite them without a missing-tag flash.
+      clearManaged('hreflang')
+      clearManaged('jsonld')
+    }
+  }, [title, description, pathSuffix, image, noindex, jsonLd, ogType, location.pathname, i18n.language])
+
+  return null
+}

--- a/packages/frontend/src/lib/seo.ts
+++ b/packages/frontend/src/lib/seo.ts
@@ -1,0 +1,37 @@
+import { SUPPORTED_LANGUAGES, type SupportedLanguage } from './i18n'
+
+export const SITE_URL = 'https://the-box.battistella.ovh'
+export const SITE_NAME = 'The Box'
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/api/og/daily.svg`
+
+export const LOCALE_BY_LANG: Record<SupportedLanguage, string> = {
+  fr: 'fr_FR',
+  en: 'en_US',
+}
+
+export function stripLangPrefix(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean)
+  if (segments.length > 0 && SUPPORTED_LANGUAGES.includes(segments[0] as SupportedLanguage)) {
+    return '/' + segments.slice(1).join('/')
+  }
+  return pathname
+}
+
+export function buildLocalizedUrl(lang: SupportedLanguage, suffixPath: string): string {
+  const clean = suffixPath.replace(/^\/+/, '')
+  return clean ? `${SITE_URL}/${lang}/${clean}` : `${SITE_URL}/${lang}`
+}
+
+export type HreflangAlternate = {
+  hreflang: string
+  href: string
+}
+
+export function buildHreflangAlternates(suffixPath: string): HreflangAlternate[] {
+  const alternates: HreflangAlternate[] = SUPPORTED_LANGUAGES.map((lang) => ({
+    hreflang: lang,
+    href: buildLocalizedUrl(lang, suffixPath),
+  }))
+  alternates.push({ hreflang: 'x-default', href: buildLocalizedUrl('fr', suffixPath) })
+  return alternates
+}


### PR DESCRIPTION
## Summary
Implement comprehensive SEO support for the application with dynamic meta tag management, hreflang alternates for multilingual content, structured data (JSON-LD), and static sitemap/robots.txt files.

## Key Changes

- **New `Seo` component** (`packages/frontend/src/components/Seo.tsx`): React component that dynamically manages document head meta tags including:
  - Title and description
  - Open Graph tags (og:type, og:title, og:description, og:image, og:locale, og:url)
  - Twitter Card meta tags
  - Canonical links
  - hreflang alternates for language variants
  - robots meta tag (noindex/nofollow support)
  - JSON-LD structured data injection
  - Intelligent cleanup to avoid tag duplication while preserving canonical/OG tags across page transitions

- **New `RouteSeo` component** (`packages/frontend/src/components/RouteSeo.tsx`): Route-aware wrapper that:
  - Maps application routes to SEO metadata via i18n keys
  - Supports dynamic parameters (e.g., username in public profiles)
  - Generates route-specific JSON-LD (WebApplication schema for home, BreadcrumbList for leaderboard, etc.)
  - Marks auth flows and private pages with `noindex`
  - Handles both exact and parameterized route matching

- **SEO utilities library** (`packages/frontend/src/lib/seo.ts`):
  - URL building functions for localized paths
  - hreflang alternate generation
  - Language prefix stripping from pathnames
  - Locale mapping for Open Graph

- **Multilingual SEO metadata**: Added comprehensive i18n translations for all routes in both French and English (`translation.json`)

- **Static sitemap** (`packages/frontend/public/sitemap.xml`): XML sitemap with hreflang alternates for all public routes, change frequencies, and priorities

- **robots.txt** (`packages/frontend/public/robots.txt`): Crawler directives blocking private routes (/admin, /profile, /history, /results, auth flows) while allowing public content

- **HTML head updates** (`packages/frontend/index.html`): Added hreflang alternates to the base template for default language variants

- **App integration** (`packages/frontend/src/App.tsx`): Integrated `RouteSeo` component into the main app layout

## Implementation Details

- Uses a marker attribute (`data-seo`) to track and selectively clean up managed meta tags, preventing duplicate tags while preserving canonical/OG tags across navigation
- Supports both single and array JSON-LD structures for flexibility
- Handles language detection with fallback to French
- Automatically builds canonical URLs based on current language and route
- Cleanup function only removes per-page extras (hreflang, JSON-LD) to avoid visual flashing of missing tags

https://claude.ai/code/session_01QQXH94NxSnpzvriFAUtGiw