### PR TITLE
Add GoatCounter analytics tracking

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -38,6 +38,9 @@
   <meta name="twitter:description" content="Identify games from panoramic screenshots. New daily challenge, live leaderboards, achievements. Play as a guest — no account needed." />
   <meta name="twitter:image" content="https://the-box.battistella.ovh/api/og/daily.png" />
   <meta name="twitter:image:alt" content="The Box — daily video game screenshot guessing challenge" />
+
+  <script data-goatcounter="https://the-box-stats.battistella.ovh/count"
+          async src="//the-box-stats.battistella.ovh/count.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
This PR adds GoatCounter analytics tracking to the frontend application by integrating the GoatCounter tracking script into the HTML head.

## Changes
- Added GoatCounter tracking script to `packages/frontend/index.html`
  - Configured to point to `https://the-box-stats.battistella.ovh/count`
  - Script loads asynchronously to avoid blocking page rendering

## Implementation Details
The GoatCounter script is loaded via an async script tag, which ensures that analytics collection doesn't impact page load performance. The tracking endpoint is configured to use the dedicated stats subdomain for the application.

https://claude.ai/code/session_014dbRCwKccn9JPuGaZn7GcH