### PR TITLE
fix(queue): use scheduled fire time for daily-challenge cron

### DIFF
--- a/packages/backend/src/infrastructure/queue/workers/import.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/import.worker.ts
@@ -127,15 +127,20 @@ export const importWorker = new Worker<JobData, JobResult>(
       }
 
       if (name === 'create-daily-challenge') {
-        // Use the job's scheduled timestamp (cron fire time) so a restart-
-        // induced re-registration moments before midnight UTC can't cause the
-        // worker to compute "tomorrow" from Date.now().
+        // For repeatable BullMQ jobs the scheduled fire time is encoded in the
+        // job id as `repeat:<key>:<ms>`. `job.timestamp` is the queue-add time
+        // of the previous iteration, so using it would compute yesterday.
+        let referenceMs = Date.now()
+        if (typeof id === 'string' && id.startsWith('repeat:')) {
+          const parsed = Number(id.split(':').pop())
+          if (Number.isFinite(parsed)) referenceMs = parsed
+        }
         const result = await createDailyChallenge(
           (current, total) => {
             const progress = Math.round((current / total) * 100)
             job.updateProgress(progress)
           },
-          { referenceMs: job.timestamp }
+          { referenceMs }
         )
 
         const jobResult: JobResult = {


### PR DESCRIPTION
## Summary
- `job.timestamp` is the queue-add time of the previous iteration for a repeatable BullMQ job, not the current iteration's fire time. Passing it as `referenceMs` made every cron run create a challenge for **the previous day**.
- Symptom: at 02:00 Paris (00:00 UTC) on 2026-05-14 the cron fired and created a challenge dated `2026-05-13`; the UI for today showed *"Aucun défi disponible pour le 2026-05-14"*.
- Fix: parse the scheduled fire time from the BullMQ job id (`repeat:<key>:<ms>`) and fall back to `Date.now()`.

### Evidence from prod logs
```
"jobId":"repeat:1135…:1778716800000","timestamp":"2026-05-14T00:00:00.094Z","msg":"starting import job"
"challengeDate":"2026-05-13","msg":"Starting daily challenge creation"
```
Job fired at 2026-05-14T00:00 UTC but `job.timestamp` resolved to 2026-05-13T00:00 UTC (previous iteration's add time).

## Test plan
- [ ] Unit-test: stub `job.id = "repeat:abc:1778716800000"` → `referenceMs === 1778716800000` → `challengeDate === "2026-05-14"`
- [ ] Unit-test: non-repeat job id → falls back to `Date.now()`
- [ ] After deploy, verify next 02:00 Paris cron run creates a challenge for the correct date in `daily_challenges`

🤖 Generated with [Claude Code](https://claude.com/claude-code)