### PR TITLE
Track and display all guess attempts per position

### DIFF
--- a/packages/backend/src/domain/services/user.service.ts
+++ b/packages/backend/src/domain/services/user.service.ts
@@ -2,6 +2,7 @@ import type {
   GameHistoryResponse,
   GameSessionDetailsResponse,
   Game,
+  GuessAttempt,
   Screenshot,
   MissedChallenge,
 } from '@the-box/types'
@@ -83,6 +84,12 @@ export function createUserService(deps: UserServiceDeps): UserService {
         // Get the first guess (for userGuess display)
         const firstGuess = positionGuesses[0]!
 
+        // All attempts the user made for this position, in order.
+        const attempts: GuessAttempt[] = positionGuesses.map(g => ({
+          guess: g.guessedText ?? '',
+          isCorrect: g.isCorrect,
+        }))
+
         if (correctGuess) {
           // Calculate hint penalty (20% of score if hint was used)
           let hintPenalty: number | undefined
@@ -118,6 +125,7 @@ export function createUserService(deps: UserServiceDeps): UserService {
             hintPenalty,
             tryNumber: correctGuess.tryNumber,
             screenshot: screenshotMap.get(position)!,
+            attempts,
           }
         } else {
           // No correct guess - use the last guess for display
@@ -147,6 +155,7 @@ export function createUserService(deps: UserServiceDeps): UserService {
             wrongGuessPenalty: WRONG_GUESS_PENALTY,
             tryNumber: lastGuess.tryNumber,
             screenshot: screenshotMap.get(position)!,
+            attempts,
           }
         }
       })

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -256,6 +256,12 @@
       "activationFailed": "Could not activate the second chance right now."
     },
     "notFound": "Not Found",
+    "attempts": {
+      "label": "Attempts",
+      "count_one": "{{count}} attempt",
+      "count_other": "{{count}} attempts",
+      "noneRecorded": "No attempts"
+    },
     "completionChoice": {
       "title": "Nice Work!",
       "description": "You've visited all positions and found a game. Would you like to continue or see your results?",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -256,6 +256,12 @@
       "activationFailed": "Impossible d'activer la seconde chance pour l'instant."
     },
     "notFound": "Jeu Introuvable",
+    "attempts": {
+      "label": "Tentatives",
+      "count_one": "{{count}} tentative",
+      "count_other": "{{count}} tentatives",
+      "noneRecorded": "Aucune tentative"
+    },
     "completionChoice": {
       "title": "Bien joué !",
       "description": "Vous avez visité toutes les positions et trouvé un jeu. Voulez-vous continuer ou voir vos résultats ?",

--- a/packages/frontend/src/components/game/GuessAttemptsList.tsx
+++ b/packages/frontend/src/components/game/GuessAttemptsList.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next'
+import { CheckCircle2, XCircle } from 'lucide-react'
+import type { GuessAttempt } from '@the-box/types'
+
+interface GuessAttemptsListProps {
+  attempts: GuessAttempt[]
+  /** Smaller variant used inside mobile result rows. */
+  compact?: boolean
+}
+
+export function GuessAttemptsList({ attempts, compact = false }: GuessAttemptsListProps) {
+  const { t } = useTranslation()
+
+  if (!attempts || attempts.length === 0) {
+    return null
+  }
+
+  const textSize = compact ? 'text-[10px]' : 'text-xs'
+  const padding = compact ? 'px-1.5 py-0.5' : 'px-2 py-0.5'
+  const iconSize = compact ? 'w-2.5 h-2.5' : 'w-3 h-3'
+
+  return (
+    <div className="mt-1 flex flex-wrap items-center gap-1">
+      <span className={`${textSize} text-muted-foreground mr-1`}>
+        {t('game.attempts.label')}:
+      </span>
+      {attempts.map((attempt, index) => {
+        const display = attempt.guess?.trim() || '—'
+        const isCorrect = attempt.isCorrect
+        return (
+          <span
+            key={`${index}-${display}`}
+            className={`inline-flex items-center gap-1 rounded-full border ${padding} ${textSize} font-medium ${
+              isCorrect
+                ? 'border-success/40 bg-success/10 text-success'
+                : 'border-destructive/40 bg-destructive/10 text-destructive line-through decoration-destructive/50'
+            }`}
+          >
+            {isCorrect ? (
+              <CheckCircle2 className={`${iconSize} shrink-0`} aria-hidden="true" />
+            ) : (
+              <XCircle className={`${iconSize} shrink-0`} aria-hidden="true" />
+            )}
+            <span className="max-w-[14ch] truncate">{display}</span>
+          </span>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/frontend/src/hooks/useGameGuess.ts
+++ b/packages/frontend/src/hooks/useGameGuess.ts
@@ -91,6 +91,13 @@ export function useGameGuess(submissionService: GuessSubmissionService) {
           dailyLoginStore.fetchInventory().catch(console.error)
         }
 
+        // Always record the attempt (wrong or correct) so the results
+        // page can display the full list of guesses per position.
+        store.recordAttempt(store.currentPosition, {
+          guess: game?.name || userInput,
+          isCorrect: result.isCorrect,
+        })
+
         // Update screenshots found
         store.setScreenshotsFound(result.screenshotsFound)
 
@@ -133,6 +140,7 @@ export function useGameGuess(submissionService: GuessSubmissionService) {
 
         // Record result only when advancing (to show in result screen)
         if (shouldAdvance) {
+          const attempts = store.positionAttempts[store.currentPosition] ?? []
           store.addGuessResult({
             position: store.currentPosition,
             isCorrect: result.isCorrect,
@@ -142,6 +150,7 @@ export function useGameGuess(submissionService: GuessSubmissionService) {
             scoreEarned: result.scoreEarned,
             hintPenalty: result.hintPenalty,
             wrongGuessPenalty: result.wrongGuessPenalty,
+            attempts,
           })
         }
 

--- a/packages/frontend/src/pages/GameHistoryDetailsPage.tsx
+++ b/packages/frontend/src/pages/GameHistoryDetailsPage.tsx
@@ -10,8 +10,9 @@ import { Trophy, Target, ArrowLeft, CheckCircle, XCircle, Clock, Loader2 } from 
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { gameApi } from '@/lib/api/game'
 import { getApiErrorMessage } from '@/lib/api-errors'
-import type { GameSessionDetailsResponse } from '@/types'
+import type { GameSessionDetailsResponse, GuessAttempt } from '@/types'
 import { calculateSpeedMultiplier } from '@/lib/utils'
+import { GuessAttemptsList } from '@/components/game/GuessAttemptsList'
 import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe'
 
 export default function GameHistoryDetailsPage() {
@@ -82,7 +83,11 @@ export default function GameHistoryDetailsPage() {
     wrongGuessPenalty?: number
     tryNumber: number
     screenshot?: { thumbnailUrl?: string; imageUrl: string }
-  }> = [...sessionData.guesses]
+    attempts: GuessAttempt[]
+  }> = sessionData.guesses.map(g => ({
+    ...g,
+    attempts: g.attempts ?? [],
+  }))
 
   // Add unfound games as unguessed entries
   if (sessionData.unfoundGames && sessionData.unfoundGames.length > 0) {
@@ -96,6 +101,7 @@ export default function GameHistoryDetailsPage() {
       scoreEarned: -50,
       tryNumber: 0,
       screenshot: unfound.screenshot,
+      attempts: [] as GuessAttempt[],
     }))
     allResults.push(...unfoundResults)
   }
@@ -257,15 +263,18 @@ export default function GameHistoryDetailsPage() {
                     )}
                     <div className="flex-1 min-w-0">
                       <span className="font-medium text-sm sm:text-base block truncate">{result.correctGame.name}</span>
-                      {result.userGuess && !result.isCorrect && (
-                        <span className="text-xs sm:text-sm text-muted-foreground block sm:inline sm:ml-2 mt-0.5 sm:mt-0">
-                          {t('game.userGuessed', { guess: result.userGuess })}
-                        </span>
-                      )}
-                      {isUnguessed && (
+                      {isUnguessed && result.attempts.length === 0 && (
                         <span className="text-xs sm:text-sm text-destructive block mt-0.5">
                           {t('game.notFound')}
                         </span>
+                      )}
+                      {result.attempts.length > 0 && (
+                        <>
+                          <span className="text-xs text-muted-foreground block mt-0.5">
+                            {t('game.attempts.count', { count: result.attempts.length })}
+                          </span>
+                          <GuessAttemptsList attempts={result.attempts} />
+                        </>
                       )}
                     </div>
                   </div>

--- a/packages/frontend/src/pages/ResultsPage.tsx
+++ b/packages/frontend/src/pages/ResultsPage.tsx
@@ -14,6 +14,7 @@ import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { usePercentileRank } from '@/hooks/usePercentileRank'
 import { PercentileBanner } from '@/components/game/PercentileBanner'
 import { ShareCard } from '@/components/game/ShareCard'
+import { GuessAttemptsList } from '@/components/game/GuessAttemptsList'
 import { calculateSpeedMultiplier } from '@/lib/utils'
 import { useEffect, useRef } from 'react'
 import { playAchievementSound } from '@/lib/audio'
@@ -229,15 +230,18 @@ export default function ResultsPage() {
                           )}
                           <div className="flex-1 min-w-0">
                             <span className="font-medium text-sm sm:text-base block truncate">{result.correctGame.name}</span>
-                            {result.userGuess && !result.isCorrect && (
-                              <span className="text-xs sm:text-sm text-muted-foreground block sm:inline sm:ml-2 mt-0.5 sm:mt-0">
-                                (guessed: {result.userGuess})
-                              </span>
-                            )}
-                            {isUnguessed && (
+                            {isUnguessed && (!result.attempts || result.attempts.length === 0) && (
                               <span className="text-xs sm:text-sm text-destructive block mt-0.5">
                                 {t('game.notFound') || 'Not Found'}
                               </span>
+                            )}
+                            {result.attempts && result.attempts.length > 0 && (
+                              <>
+                                <span className="text-xs text-muted-foreground block mt-0.5">
+                                  {t('game.attempts.count', { count: result.attempts.length })}
+                                </span>
+                                <GuessAttemptsList attempts={result.attempts} compact />
+                              </>
                             )}
                           </div>
                         </div>
@@ -316,15 +320,18 @@ export default function ResultsPage() {
                       )}
                       <div className="flex-1 min-w-0">
                         <span className="font-medium text-base block truncate">{result.correctGame.name}</span>
-                        {result.userGuess && !result.isCorrect && (
-                          <span className="text-sm text-muted-foreground inline ml-2">
-                            (guessed: {result.userGuess})
-                          </span>
-                        )}
-                        {isUnguessed && (
+                        {isUnguessed && (!result.attempts || result.attempts.length === 0) && (
                           <span className="text-sm text-destructive block mt-0.5">
                             {t('game.notFound') || 'Not Found'}
                           </span>
+                        )}
+                        {result.attempts && result.attempts.length > 0 && (
+                          <>
+                            <span className="text-xs text-muted-foreground block mt-0.5">
+                              {t('game.attempts.count', { count: result.attempts.length })}
+                            </span>
+                            <GuessAttemptsList attempts={result.attempts} />
+                          </>
                         )}
                       </div>
                     </div>

--- a/packages/frontend/src/stores/gameStore.ts
+++ b/packages/frontend/src/stores/gameStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { persist, devtools } from 'zustand/middleware'
 import type {
   GamePhase,
+  GuessAttempt,
   GuessResult,
   TierScreenshot,
   ScreenshotResponse,
@@ -52,6 +53,9 @@ interface GameState {
   totalScore: number
   correctAnswers: number
   guessResults: GuessResult[]
+  // All attempts the user made for each position, in chronological order.
+  // Includes wrong guesses (which never reach `guessResults`).
+  positionAttempts: Record<number, GuessAttempt[]>
 
   // Personal bests tracking
   personalBests: {
@@ -84,6 +88,7 @@ interface GameState {
   setShowCompletionChoice: (value: boolean) => void
 
   addGuessResult: (result: GuessResult) => void
+  recordAttempt: (position: number, attempt: GuessAttempt) => void
   updateScore: (totalScore: number) => void
   incrementCorrectAnswers: () => void
 
@@ -158,6 +163,7 @@ const initialState = {
   totalScore: 0,
   correctAnswers: 0,
   guessResults: [],
+  positionAttempts: {} as Record<number, GuessAttempt[]>,
   // Personal bests
   personalBests: {
     highestScore: 0,
@@ -211,6 +217,13 @@ export const useGameStore = create<GameState>()(
         addGuessResult: (result) => set((state) => ({
           guessResults: [...state.guessResults, result],
           lastResult: result,
+        })),
+
+        recordAttempt: (position, attempt) => set((state) => ({
+          positionAttempts: {
+            ...state.positionAttempts,
+            [position]: [...(state.positionAttempts[position] ?? []), attempt],
+          },
         })),
 
         updateScore: (totalScore) => set({ totalScore }),
@@ -606,7 +619,7 @@ export const useGameStore = create<GameState>()(
         },
 
         endGameAction: async () => {
-          const { sessionId, updateScore, setScreenshotsFound, setGamePhase, setIsSessionCompleted, guessResults } = get()
+          const { sessionId, updateScore, setScreenshotsFound, setGamePhase, setIsSessionCompleted, guessResults, positionAttempts } = get()
           if (!sessionId) {
             const error = new Error('No active game session')
             console.error('Failed to end game:', error)
@@ -622,15 +635,20 @@ export const useGameStore = create<GameState>()(
             // Add unfound games to guessResults as unguessed entries
             if (result.unfoundGames && result.unfoundGames.length > 0) {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Backend response shape varies
-              const unfoundResults: GuessResult[] = result.unfoundGames.map((unfound: any) => ({
-                position: unfound.position,
-                isCorrect: false,
-                correctGame: unfound.game,
-                userGuess: null,
-                timeTakenMs: 0,
-                scoreEarned: -50, // Show -50 penalty
-                screenshot: unfound.screenshot,
-              }))
+              const unfoundResults: GuessResult[] = result.unfoundGames.map((unfound: any) => {
+                const attempts = positionAttempts[unfound.position] ?? []
+                const lastWrong = attempts.length > 0 ? attempts[attempts.length - 1].guess : null
+                return {
+                  position: unfound.position,
+                  isCorrect: false,
+                  correctGame: unfound.game,
+                  userGuess: lastWrong,
+                  timeTakenMs: 0,
+                  scoreEarned: -50, // Show -50 penalty
+                  screenshot: unfound.screenshot,
+                  attempts,
+                }
+              })
 
               // Merge with existing results and sort by position
               const allResults = [...guessResults, ...unfoundResults].sort((a, b) => a.position - b.position)
@@ -658,6 +676,9 @@ export const useGameStore = create<GameState>()(
           screenshotsFound: state.screenshotsFound,
           // Persist guess results for results page display
           guessResults: state.guessResults,
+          // Persist per-position attempts so refresh on the results page
+          // still has the full list of tries.
+          positionAttempts: state.positionAttempts,
           // Persist personal bests
           personalBests: state.personalBests,
         }),

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -17,6 +17,7 @@ export type {
 
   // Game State
   GamePhase,
+  GuessAttempt,
   GuessResult,
   PositionStatus,
   PositionState,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -245,6 +245,12 @@ export type GamePhase =
   | 'bonus_round'
   | 'challenge_complete'
 
+export interface GuessAttempt {
+  /** Free-text the user entered (game name) for this attempt. */
+  guess: string
+  isCorrect: boolean
+}
+
 export interface GuessResult {
   position: number
   isCorrect: boolean
@@ -255,6 +261,8 @@ export interface GuessResult {
   hintPenalty?: number
   wrongGuessPenalty?: number
   screenshot?: Screenshot
+  /** All guesses the user made for this position, in chronological order. */
+  attempts?: GuessAttempt[]
 }
 
 // Position tracking for navigation
@@ -502,6 +510,7 @@ export interface GameSessionDetailsResponse {
     wrongGuessPenalty?: number
     tryNumber: number
     screenshot: Screenshot
+    attempts: GuessAttempt[]
   }>
   unfoundGames: Array<{
     position: number


### PR DESCRIPTION
## Summary

This PR adds comprehensive tracking of all user guess attempts (both correct and incorrect) for each position in a game session. Previously, only the final correct guess or last incorrect guess was displayed. Now the full history of attempts is recorded and shown on results pages, providing better feedback to players about their guessing process.

## Key Changes

- **New `GuessAttempt` type** (`packages/types/src/index.ts`): Defines the structure for tracking individual guess attempts with the guessed text and correctness status.

- **Game store enhancements** (`packages/frontend/src/stores/gameStore.ts`):
  - Added `positionAttempts` state to track all attempts per position in chronological order
  - New `recordAttempt()` action to record both correct and incorrect guesses
  - Updated `endGameAction()` to include attempts in unfound game results
  - Persisted `positionAttempts` to localStorage for results page refresh resilience

- **New `GuessAttemptsList` component** (`packages/frontend/src/components/game/GuessAttemptsList.tsx`):
  - Displays all attempts for a position with visual indicators (green checkmark for correct, red X for incorrect)
  - Supports compact mode for mobile result rows
  - Shows attempt count and truncates long game names
  - Fully internationalized with i18n support

- **Results page updates** (`packages/frontend/src/pages/ResultsPage.tsx`):
  - Replaced single "guessed: X" text with full `GuessAttemptsList` component
  - Shows attempt count for positions with multiple tries
  - Handles both mobile and desktop layouts

- **Game history details page** (`packages/frontend/src/pages/GameHistoryDetailsPage.tsx`):
  - Integrated `GuessAttemptsList` to display historical attempts
  - Maps backend attempts data to component props

- **Backend user service** (`packages/backend/src/domain/services/user.service.ts`):
  - Builds `attempts` array from all guesses for a position (correct and incorrect)
  - Includes attempts in both successful and unsuccessful guess results

- **Game guess hook** (`packages/frontend/src/hooks/useGameGuess.ts`):
  - Records every attempt (correct or incorrect) via `recordAttempt()`
  - Includes full attempts list when adding guess results

- **Internationalization** (`packages/frontend/public/locales/`):
  - Added `game.attempts.label`, `game.attempts.count_one`, `game.attempts.count_other`, and `game.attempts.noneRecorded` keys for both English and French

## Implementation Details

- Attempts are stored in chronological order and persisted to allow results page refreshes to maintain the full history
- The `GuessResult` type now includes an optional `attempts` field for backward compatibility
- Unfound games now display the last incorrect guess (if any) and the full attempts list
- The component gracefully handles empty attempt lists and uses Lucide icons for visual feedback

https://claude.ai/code/session_015XAYsfYWpUmdeTKsxAoA4x