### PR TITLE
feat(geo-review): side-by-side compare layout + Radix/shortcut fixes

### DIFF
--- a/packages/backend/src/infrastructure/queue/workers/geo-worker-predicates.test.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-worker-predicates.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  isMapsFetchChildJob,
+  shouldAdvanceAfterFailure,
+  type FailedJobLike,
+} from './geo-worker-predicates.js'
+import type { GeoJobData } from '../queues.js'
+
+describe('isMapsFetchChildJob', () => {
+  it('matches every maps:fetch-from-* source variant', () => {
+    for (const source of ['steam', 'rawg', 'fandom', 'strategywiki', 'wand', 'mapgenie']) {
+      const data = { kind: `maps:fetch-from-${source}`, gameId: 1 } as GeoJobData
+      assert.equal(isMapsFetchChildJob(data), true, source)
+    }
+  })
+
+  it('rejects unrelated kinds and undefined', () => {
+    assert.equal(isMapsFetchChildJob(undefined), false)
+    assert.equal(
+      isMapsFetchChildJob({ kind: 'maps:pipeline', gameId: 1 } as GeoJobData),
+      false,
+    )
+    assert.equal(
+      isMapsFetchChildJob({ kind: 'evaluate-consensus' } as GeoJobData),
+      false,
+    )
+  })
+})
+
+describe('shouldAdvanceAfterFailure', () => {
+  const fetchJob = (overrides: Partial<FailedJobLike>): FailedJobLike => ({
+    data: { kind: 'maps:fetch-from-steam', gameId: 42 } as GeoJobData,
+    attemptsMade: 1,
+    opts: { attempts: 3 },
+    ...overrides,
+  })
+
+  it('returns false mid-retry', () => {
+    assert.equal(
+      shouldAdvanceAfterFailure(fetchJob({ attemptsMade: 2, opts: { attempts: 3 } })),
+      false,
+    )
+  })
+
+  it('returns true on the terminal attempt', () => {
+    assert.equal(
+      shouldAdvanceAfterFailure(fetchJob({ attemptsMade: 3, opts: { attempts: 3 } })),
+      true,
+    )
+  })
+
+  it('treats missing attempts as 1 (single-shot job)', () => {
+    assert.equal(
+      shouldAdvanceAfterFailure(fetchJob({ attemptsMade: 1, opts: {} })),
+      true,
+    )
+  })
+
+  it('ignores jobs that are not maps:fetch-from-*', () => {
+    assert.equal(
+      shouldAdvanceAfterFailure({
+        data: { kind: 'maps:pipeline', gameId: 1 } as GeoJobData,
+        attemptsMade: 5,
+        opts: { attempts: 5 },
+      }),
+      false,
+    )
+  })
+
+  it('handles undefined job data safely', () => {
+    assert.equal(shouldAdvanceAfterFailure({}), false)
+  })
+})

--- a/packages/backend/src/infrastructure/queue/workers/geo-worker-predicates.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-worker-predicates.ts
@@ -1,0 +1,29 @@
+import type { GeoJobData } from '../queues.js'
+
+export type MapsFetchChildJob = Extract<GeoJobData, { kind: `maps:fetch-from-${string}` }>
+
+export function isMapsFetchChildJob(
+  data: GeoJobData | undefined,
+): data is MapsFetchChildJob {
+  return !!data && typeof data.kind === 'string' && data.kind.startsWith('maps:fetch-from-')
+}
+
+// Shape of the BullMQ Job fields we read; kept narrow so the predicate is
+// pure and unit-testable without booting Redis.
+export interface FailedJobLike {
+  data?: GeoJobData
+  attemptsMade?: number
+  opts?: { attempts?: number }
+}
+
+// True when a `maps:fetch-from-*` child job has exhausted its retries and
+// the orchestrator must be re-enqueued to pick the next source. BullMQ
+// increments `attemptsMade` before invoking the processor, so on the
+// terminal failure `attemptsMade === opts.attempts`. `attempts` defaults
+// to 1 when unset (single-shot job).
+export function shouldAdvanceAfterFailure(job: FailedJobLike): boolean {
+  if (!isMapsFetchChildJob(job.data)) return false
+  const maxAttempts = job.opts?.attempts ?? 1
+  const made = job.attemptsMade ?? 0
+  return made >= maxAttempts
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -14,6 +14,10 @@ import { importRawgScreenshots } from './geo-rawg-import-logic.js'
 import { resolveGeoMetadataBatch } from './geo-metadata-resolve-logic.js'
 import { runGeoIngestTick } from './geo-ingest-tick-logic.js'
 import { advancePipeline, runMapsPipeline } from './maps-pipeline-logic.js'
+import {
+  shouldAdvanceAfterFailure,
+  type MapsFetchChildJob,
+} from './geo-worker-predicates.js'
 import { runMapsFetchSteam } from './maps-fetch-steam.js'
 import { runMapsFetchRawg } from './maps-fetch-rawg.js'
 import { runMapsFetchFandom } from './maps-fetch-fandom.js'
@@ -187,12 +191,6 @@ geoWorker.on('error', (err) => {
   log.error({ err: String(err) }, 'geo worker error')
 })
 
-type MapsFetchChildJob = Extract<GeoJobData, { kind: `maps:fetch-from-${string}` }>
-
-function isMapsFetchChildJob(data: GeoJobData | undefined): data is MapsFetchChildJob {
-  return !!data && typeof data.kind === 'string' && data.kind.startsWith('maps:fetch-from-')
-}
-
 geoWorker.on('failed', (job, err) => {
   const data = job?.data as GeoJobData | undefined
   log.error(
@@ -200,25 +198,19 @@ geoWorker.on('failed', (job, err) => {
     'geo job failed',
   )
 
-  if (!job || !isMapsFetchChildJob(data)) return
+  if (!job || !shouldAdvanceAfterFailure(job)) return
 
-  // BullMQ fires 'failed' for every failed attempt. Only act on the terminal
-  // failure — otherwise we'd advance mid-retry and the next attempt would
-  // race the orchestrator picking another source.
-  const maxAttempts = job.opts.attempts ?? 1
-  if (job.attemptsMade < maxAttempts) return
-
-  // Without this, runSourceFetch's catch-and-rethrow path leaves pipeline
-  // state stuck at fetching_* with active_source pinned to the dead source:
-  // recordAttempt runs, but advancePipeline doesn't, and BullMQ has no more
-  // retries to run. Re-enqueue the orchestrator so it picks the next source
-  // (or transitions to awaiting_curation / blocked).
+  // `runSourceFetch` in maps-fetch-runtime.ts records the attempt and rethrows
+  // on transient errors, so its post-recordAttempt `advancePipeline` call is
+  // unreachable on the throw path. Without re-enqueueing here the pipeline
+  // state would stay pinned at `fetching_*` with `active_source` on the dead
+  // source and BullMQ has no more retries to run.
   void advancePipeline({
-    gameId: data.gameId,
-    correlationId: data.correlationId,
+    gameId: (data as MapsFetchChildJob).gameId,
+    correlationId: (data as MapsFetchChildJob).correlationId,
   }).catch((advanceErr) => {
     log.error(
-      { jobId: job.id, gameId: data.gameId, err: String(advanceErr) },
+      { jobId: job.id, gameId: (data as MapsFetchChildJob).gameId, err: String(advanceErr) },
       'failed to advance pipeline after maps:fetch-from-* exhaustion',
     )
   })

--- a/packages/backend/src/infrastructure/queue/workers/maps-pipeline-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/maps-pipeline-logic.ts
@@ -76,8 +76,10 @@ export async function runMapsPipeline(input: {
     return await advanceWhenExhausted(gameId, hasMap)
   }
 
-  // Update state to "fetching_*" and enqueue the source-specific child. The
-  // child re-enqueues this orchestrator on completion (success or failure).
+  // Update state to "fetching_*" and enqueue the source-specific child.
+  // `runSourceFetch` advances the pipeline after a recorded outcome on the
+  // success path; on terminal retry exhaustion the geo-worker 'failed'
+  // listener calls `advancePipeline` instead (see geo.worker.ts).
   const stage: MapPipelineStage = targetKind === 'map' ? 'fetching_map' : 'fetching_candidates'
   await geoPipelineStateRepository.upsert({
     gameId,

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1077,6 +1077,18 @@
           "confirmLabel": "Type {{word}} to confirm",
           "confirm": "Reset everything"
         }
+      },
+      "workspace": {
+        "capture": "Player capture",
+        "map": "Game map",
+        "captureAlt": "Submitted capture #{{id}}"
+      },
+      "keyboard": {
+        "next": "next",
+        "previous": "previous",
+        "approve": "approve",
+        "reject": "reject",
+        "close": "close"
       }
     },
     "growth": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1077,6 +1077,18 @@
           "confirmLabel": "Tapez {{word}} pour confirmer",
           "confirm": "Réinitialiser tout"
         }
+      },
+      "workspace": {
+        "capture": "Capture du joueur",
+        "map": "Carte du jeu",
+        "captureAlt": "Capture proposée #{{id}}"
+      },
+      "keyboard": {
+        "next": "suivante",
+        "previous": "précédente",
+        "approve": "valider",
+        "reject": "refuser",
+        "close": "fermer"
       }
     },
     "growth": {

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -14,24 +14,20 @@ import {
 } from '@/components/ui/dialog'
 import {
     Loader2,
-    Trash2,
     HelpCircle,
     MapPin,
     ListChecks,
     Library,
     Flag,
     X,
-    ChevronLeft,
-    ChevronRight,
-    ArrowLeft,
     Workflow,
     Sparkles,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { GeoMapsTab } from './GeoMapsTab'
 import { ModerationStatusRail } from './ModerationStatusRail'
 import { ReportsModerationPanel } from './ReportsModerationPanel'
+import { ReviewWorkspace } from './geo-review/ReviewWorkspace'
 import GeoFetchPanel from './geo-fetch/GeoFetchPanel'
 import { geoFetchApi } from '@/lib/api/geo-fetch'
 import { useGeoRunPolling } from '@/hooks/useGeoRunPolling'
@@ -682,7 +678,7 @@ export function GeoReviewPanel() {
                         side-by-side as before. */}
                     <Card
                         className={cn(
-                            'lg:col-span-1',
+                            'lg:col-span-1 lg:sticky lg:top-4 lg:self-start',
                             detail && 'hidden lg:block',
                         )}
                     >
@@ -707,7 +703,7 @@ export function GeoReviewPanel() {
                                 </Button>
                             </div>
                         </CardHeader>
-                        <CardContent className="space-y-3 lg:max-h-[520px] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
+                        <CardContent className="space-y-3 lg:max-h-[calc(100vh-14rem)] overflow-auto p-4 sm:p-6 pt-0 sm:pt-0">
                             {gameFilter ? (
                                 <>
                                     {candidates.map((c) => (
@@ -862,74 +858,35 @@ export function GeoReviewPanel() {
                         </CardContent>
                     </Card>
 
-                    {/* Detail card — on mobile, only renders when a
-                        candidate is selected (replacing the list). On lg+,
-                        always visible alongside the list. The Header stays
-                        sticky throughout because nothing is rendered as a
-                        modal/portal anymore. */}
-                    <Card
+                    {/* Review workspace — side-by-side capture + map with
+                        sticky action bar and keyboard shortcuts. On mobile
+                        the workspace replaces the list (back-button restores
+                        it); on lg+ both surfaces sit side-by-side. */}
+                    <div
                         className={cn(
                             'lg:col-span-2',
                             !detail && 'hidden lg:block',
                         )}
                     >
-                        <CardHeader className="pb-2 p-4 sm:p-6">
-                            <div className="flex items-center justify-between gap-2">
-                                <div className="flex items-center gap-2 min-w-0">
-                                    {/* Mobile back button — pops the detail
-                                        view so the user is returned to the
-                                        list. Hidden on lg+ where both cards
-                                        are visible side-by-side. */}
-                                    {detail && (
-                                        <Button
-                                            type="button"
-                                            size="icon"
-                                            variant="ghost"
-                                            className="h-8 w-8 shrink-0 lg:hidden"
-                                            onClick={() => {
-                                                setDetail(null)
-                                                setPin(null)
-                                            }}
-                                            aria-label={t(
-                                                'admin.geo.nav.backToList',
-                                                'Retour à la liste',
-                                            )}
-                                        >
-                                            <ArrowLeft className="h-4 w-4" />
-                                        </Button>
-                                    )}
-                                    <CardTitle className="text-sm truncate">
-                                        {detail
-                                            ? `#${detail.candidate.id} · ${t('admin.geo.submissionRow.pinCount', { count: detail.pins.length })}`
-                                            : t('admin.geo.pickSubmission')}
-                                    </CardTitle>
-                                </div>
-                                {detail && (
-                                    <CandidateNavControls
-                                        prev={prevCandidate}
-                                        next={nextCandidate}
-                                        currentIndex={currentIndex}
-                                        total={flatCandidates.length}
-                                        disabled={saving}
-                                        onNavigate={openDetail}
-                                        t={t}
-                                    />
-                                )}
-                            </div>
-                        </CardHeader>
-                        <CardContent className="space-y-3 p-4 sm:p-6 pt-0 sm:pt-0">
-                            <CandidateDetailBody
-                                detail={detail}
-                                pin={pin}
-                                setPin={setPin}
-                                saving={saving}
-                                onPromote={applyOverride}
-                                onReject={() => setRejectOpen(true)}
-                                onDemote={() => setDemoteOpen(true)}
-                                t={t}
-                            />
-                        </CardContent>
-                    </Card>
+                        <ReviewWorkspace
+                            detail={detail}
+                            pin={pin}
+                            onPinChange={setPin}
+                            saving={saving}
+                            onPromote={applyOverride}
+                            onReject={() => setRejectOpen(true)}
+                            onDemote={() => setDemoteOpen(true)}
+                            onCloseDetail={() => {
+                                setDetail(null)
+                                setPin(null)
+                            }}
+                            prevCandidate={prevCandidate}
+                            nextCandidate={nextCandidate}
+                            currentIndex={currentIndex}
+                            total={flatCandidates.length}
+                            onNavigate={openDetail}
+                        />
+                    </div>
                 </div>
             )}
 
@@ -1019,178 +976,3 @@ export function GeoReviewPanel() {
     )
 }
 
-interface CandidateNavControlsProps {
-    prev: GeoScreenshotCandidate | null
-    next: GeoScreenshotCandidate | null
-    currentIndex: number
-    total: number
-    disabled: boolean
-    onNavigate: (id: number) => void | Promise<void>
-    t: ReturnType<typeof useTranslation>['t']
-}
-
-function CandidateNavControls({
-    prev,
-    next,
-    currentIndex,
-    total,
-    disabled,
-    onNavigate,
-    t,
-}: CandidateNavControlsProps) {
-    return (
-        <div className="flex items-center gap-1 shrink-0">
-            <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-7 w-7"
-                disabled={!prev || disabled}
-                onClick={() => prev && void onNavigate(prev.id)}
-                aria-label={t('admin.geo.nav.previous')}
-                title={t('admin.geo.nav.previous')}
-            >
-                <ChevronLeft className="h-4 w-4" aria-hidden />
-            </Button>
-            {currentIndex >= 0 && total > 0 && (
-                <span
-                    className="text-[10px] tabular-nums text-muted-foreground min-w-[2.5rem] text-center"
-                    aria-live="polite"
-                >
-                    {t('admin.geo.nav.position', {
-                        current: currentIndex + 1,
-                        total,
-                    })}
-                </span>
-            )}
-            <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-7 w-7"
-                disabled={!next || disabled}
-                onClick={() => next && void onNavigate(next.id)}
-                aria-label={t('admin.geo.nav.next')}
-                title={t('admin.geo.nav.next')}
-            >
-                <ChevronRight className="h-4 w-4" aria-hidden />
-            </Button>
-        </div>
-    )
-}
-
-interface CandidateDetailBodyProps {
-    detail: CandidateDetail | null
-    pin: GeoPoint | null
-    setPin: (p: GeoPoint | null) => void
-    saving: boolean
-    onPromote: () => void | Promise<void>
-    onReject: () => void
-    onDemote: () => void
-    t: ReturnType<typeof useTranslation>['t']
-}
-
-// Shared body for the candidate detail view — rendered inside the desktop
-// side-card and the mobile bottom sheet. Keeps the pin canvas, image,
-// status text and action buttons in one place so the two surfaces never
-// drift.
-function CandidateDetailBody({
-    detail,
-    pin,
-    setPin,
-    saving,
-    onPromote,
-    onReject,
-    onDemote,
-    t,
-}: CandidateDetailBodyProps) {
-    if (!detail || !detail.map) {
-        return (
-            <p className="text-xs text-muted-foreground">
-                {t('admin.geo.detailHintOfficial')}
-            </p>
-        )
-    }
-    return (
-        <>
-            <img
-                src={detail.candidate.imageUrl}
-                alt={`Candidate ${detail.candidate.id}`}
-                className="w-full rounded border max-h-48 object-contain bg-black/20"
-            />
-            <GeoMapCanvas
-                imageUrl={detail.map.imageUrl}
-                widthPx={detail.map.widthPx}
-                heightPx={detail.map.heightPx}
-                tiles={detail.map.tiles}
-                pin={pin}
-                canonical={
-                    detail.meta
-                        ? {
-                              x: detail.meta.canonical.x,
-                              y: detail.meta.canonical.y,
-                          }
-                        : null
-                }
-                onPin={setPin}
-                disabled={!!detail.meta}
-            />
-            {detail.meta ? (
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
-                    <p className="text-xs text-warning">
-                        {t('admin.geo.alreadyOfficial')}
-                    </p>
-                    <Button
-                        size="sm"
-                        variant="destructive"
-                        onClick={onDemote}
-                        disabled={saving}
-                        className="w-full sm:w-auto"
-                    >
-                        <Trash2 className="h-3.5 w-3.5 mr-2" />
-                        {t('admin.geo.actions.removeOfficial')}
-                    </Button>
-                </div>
-            ) : (
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                    <span className="text-xs text-muted-foreground">
-                        {pin
-                            ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
-                            : t(
-                                  detail.pins.length === 0
-                                      ? 'admin.geo.pickPointRequired'
-                                      : 'admin.geo.pickPointForOfficial',
-                              )}
-                    </span>
-                    <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-                        <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={onReject}
-                            disabled={saving}
-                            className="w-full sm:w-auto text-destructive border-destructive/40 hover:bg-destructive/10"
-                        >
-                            <Trash2 className="h-3.5 w-3.5 mr-2" />
-                            {t('admin.geo.actions.decline')}
-                        </Button>
-                        <Button
-                            size="sm"
-                            onClick={() => void onPromote()}
-                            disabled={saving || (!pin && detail.pins.length === 0)}
-                            className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
-                        >
-                            {saving && (
-                                <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
-                            )}
-                            {t(
-                                pin
-                                    ? 'admin.geo.actions.makeOfficial'
-                                    : 'admin.geo.actions.makeOfficialNoPin',
-                            )}
-                        </Button>
-                    </div>
-                </div>
-            )}
-        </>
-    )
-}

--- a/packages/frontend/src/components/admin/geo-review/ReviewWorkspace.tsx
+++ b/packages/frontend/src/components/admin/geo-review/ReviewWorkspace.tsx
@@ -1,0 +1,507 @@
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+    ArrowLeft,
+    ChevronLeft,
+    ChevronRight,
+    Loader2,
+    Trash2,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
+import { cn } from '@/lib/utils'
+import type {
+    GeoMap,
+    GeoPinSubmission,
+    GeoPoint,
+    GeoScreenshotCandidate,
+    GeoScreenshotMeta,
+} from '@the-box/types'
+
+export interface ReviewWorkspaceCandidate {
+    candidate: GeoScreenshotCandidate
+    pins: GeoPinSubmission[]
+    map: GeoMap | null
+    meta: GeoScreenshotMeta | null
+}
+
+export interface ReviewWorkspaceProps {
+    detail: ReviewWorkspaceCandidate | null
+    pin: GeoPoint | null
+    onPinChange: (point: GeoPoint | null) => void
+    saving: boolean
+    onPromote: () => void | Promise<void>
+    onReject: () => void
+    onDemote: () => void
+    onCloseDetail: () => void
+    prevCandidate: GeoScreenshotCandidate | null
+    nextCandidate: GeoScreenshotCandidate | null
+    currentIndex: number
+    total: number
+    onNavigate: (id: number) => void | Promise<void>
+}
+
+// Side-by-side review surface: capture on the left, map on the right at xl+,
+// stacked below xl. The actions bar is sticky at the bottom of the card so the
+// moderator never has to scroll to reach Promote / Reject. Keyboard shortcuts
+// (J/K next-prev, A approve, R reject, Esc close) are wired here so they only
+// apply while a candidate is open.
+export function ReviewWorkspace({
+    detail,
+    pin,
+    onPinChange,
+    saving,
+    onPromote,
+    onReject,
+    onDemote,
+    onCloseDetail,
+    prevCandidate,
+    nextCandidate,
+    currentIndex,
+    total,
+    onNavigate,
+}: ReviewWorkspaceProps) {
+    const { t } = useTranslation()
+
+    useReviewShortcuts({
+        enabled: !!detail,
+        saving,
+        canPromote:
+            !!detail &&
+            !detail.meta &&
+            (!!pin || (detail?.pins.length ?? 0) > 0),
+        canReject: !!detail && !detail.meta,
+        prevId: prevCandidate?.id ?? null,
+        nextId: nextCandidate?.id ?? null,
+        onNavigate,
+        onPromote,
+        onReject,
+        onClose: onCloseDetail,
+    })
+
+    return (
+        <Card className="lg:col-span-2 flex flex-col">
+            <CardHeader className="pb-2 p-4 sm:p-6">
+                <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                        {detail && (
+                            <Button
+                                type="button"
+                                size="icon"
+                                variant="ghost"
+                                className="h-8 w-8 shrink-0 lg:hidden"
+                                onClick={onCloseDetail}
+                                aria-label={t('admin.geo.nav.backToList')}
+                            >
+                                <ArrowLeft className="h-4 w-4" />
+                            </Button>
+                        )}
+                        <CardTitle className="text-sm truncate">
+                            {detail
+                                ? `#${detail.candidate.id} · ${t(
+                                      'admin.geo.submissionRow.pinCount',
+                                      { count: detail.pins.length },
+                                  )}`
+                                : t('admin.geo.pickSubmission')}
+                        </CardTitle>
+                    </div>
+                    {detail && (
+                        <NavControls
+                            prev={prevCandidate}
+                            next={nextCandidate}
+                            currentIndex={currentIndex}
+                            total={total}
+                            disabled={saving}
+                            onNavigate={onNavigate}
+                        />
+                    )}
+                </div>
+                {detail && <KeyboardHints />}
+            </CardHeader>
+            <CardContent
+                className="flex-1 space-y-3 p-4 sm:p-6 pt-0 sm:pt-0"
+                aria-busy={saving}
+            >
+                <CompareBody
+                    detail={detail}
+                    pin={pin}
+                    onPinChange={onPinChange}
+                />
+            </CardContent>
+            {detail && detail.map && (
+                <ActionBar
+                    detail={detail}
+                    pin={pin}
+                    saving={saving}
+                    onPromote={onPromote}
+                    onReject={onReject}
+                    onDemote={onDemote}
+                />
+            )}
+        </Card>
+    )
+}
+
+interface CompareBodyProps {
+    detail: ReviewWorkspaceCandidate | null
+    pin: GeoPoint | null
+    onPinChange: (point: GeoPoint | null) => void
+}
+
+// Two-pane comparison layout. Both panes share the same max height so they
+// line up and the moderator's eyes can flick between them without losing
+// context. Stacks below xl so 13" laptops and tablets keep both visible.
+function CompareBody({ detail, pin, onPinChange }: CompareBodyProps) {
+    const { t } = useTranslation()
+    if (!detail || !detail.map) {
+        return (
+            <p className="text-xs text-muted-foreground">
+                {t('admin.geo.detailHintOfficial')}
+            </p>
+        )
+    }
+    return (
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-3 items-start">
+            <CapturePane
+                imageUrl={detail.candidate.imageUrl}
+                candidateId={detail.candidate.id}
+            />
+            <MapPane
+                detail={detail}
+                pin={pin}
+                onPinChange={onPinChange}
+            />
+        </div>
+    )
+}
+
+function CapturePane({
+    imageUrl,
+    candidateId,
+}: {
+    imageUrl: string
+    candidateId: number
+}) {
+    const { t } = useTranslation()
+    return (
+        <figure className="space-y-1.5">
+            <figcaption className="text-[11px] uppercase tracking-wide text-muted-foreground font-semibold">
+                {t('admin.geo.workspace.capture')}
+            </figcaption>
+            <div className="rounded-lg border bg-black/40 overflow-hidden flex items-center justify-center max-h-[60vh] min-h-[260px]">
+                <img
+                    src={imageUrl}
+                    alt={t('admin.geo.workspace.captureAlt', {
+                        id: candidateId,
+                    })}
+                    className="max-h-[60vh] w-full h-auto object-contain"
+                />
+            </div>
+        </figure>
+    )
+}
+
+function MapPane({
+    detail,
+    pin,
+    onPinChange,
+}: {
+    detail: ReviewWorkspaceCandidate
+    pin: GeoPoint | null
+    onPinChange: (point: GeoPoint | null) => void
+}) {
+    const { t } = useTranslation()
+    if (!detail.map) return null
+    return (
+        <figure className="space-y-1.5">
+            <figcaption className="text-[11px] uppercase tracking-wide text-muted-foreground font-semibold">
+                {t('admin.geo.workspace.map')}
+            </figcaption>
+            <div className="rounded-lg border overflow-hidden max-h-[60vh] min-h-[260px]">
+                <GeoMapCanvas
+                    imageUrl={detail.map.imageUrl}
+                    widthPx={detail.map.widthPx}
+                    heightPx={detail.map.heightPx}
+                    tiles={detail.map.tiles}
+                    pin={pin}
+                    canonical={
+                        detail.meta
+                            ? {
+                                  x: detail.meta.canonical.x,
+                                  y: detail.meta.canonical.y,
+                              }
+                            : null
+                    }
+                    onPin={onPinChange}
+                    disabled={!!detail.meta}
+                />
+            </div>
+        </figure>
+    )
+}
+
+interface ActionBarProps {
+    detail: ReviewWorkspaceCandidate
+    pin: GeoPoint | null
+    saving: boolean
+    onPromote: () => void | Promise<void>
+    onReject: () => void
+    onDemote: () => void
+}
+
+// Sticky action bar — always visible at the bottom of the card so Promote /
+// Reject are one tap away, no scroll required. Background uses card token +
+// backdrop-blur so it reads cleanly over either pane.
+function ActionBar({
+    detail,
+    pin,
+    saving,
+    onPromote,
+    onReject,
+    onDemote,
+}: ActionBarProps) {
+    const { t } = useTranslation()
+    if (detail.meta) {
+        return (
+            <div className="sticky bottom-0 border-t bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 px-4 py-3 sm:px-6 rounded-b-xl">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
+                    <p className="text-xs text-warning">
+                        {t('admin.geo.alreadyOfficial')}
+                    </p>
+                    <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={onDemote}
+                        disabled={saving}
+                        aria-busy={saving}
+                        className="w-full sm:w-auto"
+                    >
+                        <Trash2 className="h-3.5 w-3.5 mr-2" />
+                        {t('admin.geo.actions.removeOfficial')}
+                    </Button>
+                </div>
+            </div>
+        )
+    }
+    return (
+        <div className="sticky bottom-0 border-t bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 px-4 py-3 sm:px-6 rounded-b-xl">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <span className="text-xs text-muted-foreground tabular-nums">
+                    {pin
+                        ? `(${pin.x.toFixed(3)}, ${pin.y.toFixed(3)})`
+                        : t(
+                              detail.pins.length === 0
+                                  ? 'admin.geo.pickPointRequired'
+                                  : 'admin.geo.pickPointForOfficial',
+                          )}
+                </span>
+                <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={onReject}
+                        disabled={saving}
+                        aria-busy={saving}
+                        className="w-full sm:w-auto text-destructive border-destructive/40 hover:bg-destructive/10"
+                    >
+                        <Trash2 className="h-3.5 w-3.5 mr-2" />
+                        {t('admin.geo.actions.decline')}
+                    </Button>
+                    <Button
+                        size="sm"
+                        onClick={() => void onPromote()}
+                        disabled={saving || (!pin && detail.pins.length === 0)}
+                        aria-busy={saving}
+                        className="gradient-gaming hover:opacity-90 w-full sm:w-auto"
+                    >
+                        {saving && (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin mr-2" />
+                        )}
+                        {t(
+                            pin
+                                ? 'admin.geo.actions.makeOfficial'
+                                : 'admin.geo.actions.makeOfficialNoPin',
+                        )}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+interface NavControlsProps {
+    prev: GeoScreenshotCandidate | null
+    next: GeoScreenshotCandidate | null
+    currentIndex: number
+    total: number
+    disabled: boolean
+    onNavigate: (id: number) => void | Promise<void>
+}
+
+function NavControls({
+    prev,
+    next,
+    currentIndex,
+    total,
+    disabled,
+    onNavigate,
+}: NavControlsProps) {
+    const { t } = useTranslation()
+    return (
+        <div className="flex items-center gap-1 shrink-0">
+            <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7"
+                disabled={!prev || disabled}
+                onClick={() => prev && void onNavigate(prev.id)}
+                aria-label={t('admin.geo.nav.previous')}
+                title={t('admin.geo.nav.previous')}
+            >
+                <ChevronLeft className="h-4 w-4" aria-hidden />
+            </Button>
+            {currentIndex >= 0 && total > 0 && (
+                <span
+                    className="text-[10px] tabular-nums text-muted-foreground min-w-[2.5rem] text-center"
+                    aria-live="polite"
+                >
+                    {t('admin.geo.nav.position', {
+                        current: currentIndex + 1,
+                        total,
+                    })}
+                </span>
+            )}
+            <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7"
+                disabled={!next || disabled}
+                onClick={() => next && void onNavigate(next.id)}
+                aria-label={t('admin.geo.nav.next')}
+                title={t('admin.geo.nav.next')}
+            >
+                <ChevronRight className="h-4 w-4" aria-hidden />
+            </Button>
+        </div>
+    )
+}
+
+function KeyboardHints() {
+    const { t } = useTranslation()
+    return (
+        <p className="hidden lg:flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted-foreground mt-1">
+            <KeyHint k="J" label={t('admin.geo.keyboard.next')} />
+            <KeyHint k="K" label={t('admin.geo.keyboard.previous')} />
+            <KeyHint k="A" label={t('admin.geo.keyboard.approve')} />
+            <KeyHint k="R" label={t('admin.geo.keyboard.reject')} />
+            <KeyHint k="Esc" label={t('admin.geo.keyboard.close')} />
+        </p>
+    )
+}
+
+function KeyHint({ k, label }: { k: string; label: string }) {
+    return (
+        <span className="inline-flex items-center gap-1">
+            <kbd
+                className={cn(
+                    'inline-flex h-4 min-w-4 px-1 items-center justify-center rounded',
+                    'border border-border/60 bg-muted/40 font-mono text-[10px]',
+                    'text-foreground',
+                )}
+            >
+                {k}
+            </kbd>
+            <span>{label}</span>
+        </span>
+    )
+}
+
+interface ReviewShortcutsArgs {
+    enabled: boolean
+    saving: boolean
+    canPromote: boolean
+    canReject: boolean
+    prevId: number | null
+    nextId: number | null
+    onNavigate: (id: number) => void | Promise<void>
+    onPromote: () => void | Promise<void>
+    onReject: () => void
+    onClose: () => void
+}
+
+// Window-level keyboard shortcuts for the review surface. Guards against:
+//  - typing inside an input/textarea/contenteditable (so Dialog text fields
+//    don't trigger Promote when the moderator types "a"),
+//  - any modifier key (so Cmd+R reload still works),
+//  - acting on a candidate while a save request is in flight.
+// All handlers reference the latest props via a ref so we don't tear down
+// the listener on every render.
+function useReviewShortcuts(args: ReviewShortcutsArgs) {
+    const ref = useRef(args)
+    useLayoutEffect(() => {
+        ref.current = args
+    })
+
+    useEffect(() => {
+        if (!args.enabled) return
+        const handler = (event: KeyboardEvent) => {
+            if (event.metaKey || event.ctrlKey || event.altKey) return
+            const target = event.target as HTMLElement | null
+            if (target) {
+                const tag = target.tagName
+                if (
+                    tag === 'INPUT' ||
+                    tag === 'TEXTAREA' ||
+                    tag === 'SELECT' ||
+                    target.isContentEditable
+                ) {
+                    return
+                }
+            }
+            const current = ref.current
+            if (current.saving && event.key !== 'Escape') return
+
+            switch (event.key) {
+                case 'j':
+                case 'J':
+                case 'ArrowDown':
+                    if (current.nextId !== null) {
+                        event.preventDefault()
+                        void current.onNavigate(current.nextId)
+                    }
+                    return
+                case 'k':
+                case 'K':
+                case 'ArrowUp':
+                    if (current.prevId !== null) {
+                        event.preventDefault()
+                        void current.onNavigate(current.prevId)
+                    }
+                    return
+                case 'a':
+                case 'A':
+                    if (current.canPromote) {
+                        event.preventDefault()
+                        void current.onPromote()
+                    }
+                    return
+                case 'r':
+                case 'R':
+                    if (current.canReject) {
+                        event.preventDefault()
+                        current.onReject()
+                    }
+                    return
+                case 'Escape':
+                    event.preventDefault()
+                    current.onClose()
+                    return
+            }
+        }
+        window.addEventListener('keydown', handler)
+        return () => window.removeEventListener('keydown', handler)
+    }, [args.enabled])
+}

--- a/packages/frontend/src/components/admin/geo-review/ReviewWorkspace.tsx
+++ b/packages/frontend/src/components/admin/geo-review/ReviewWorkspace.tsx
@@ -92,7 +92,7 @@ export function ReviewWorkspace({
                                 variant="ghost"
                                 className="h-8 w-8 shrink-0 lg:hidden"
                                 onClick={onCloseDetail}
-                                aria-label={t('admin.geo.nav.backToList')}
+                                aria-label={t('admin.geo.nav.backToList', 'Retour à la liste')}
                             >
                                 <ArrowLeft className="h-4 w-4" />
                             </Button>
@@ -440,6 +440,10 @@ interface ReviewShortcutsArgs {
 // All handlers reference the latest props via a ref so we don't tear down
 // the listener on every render.
 function useReviewShortcuts(args: ReviewShortcutsArgs) {
+    // Latest-props ref pattern via useLayoutEffect (the project's
+    // `react-hooks/refs` rule forbids writing to ref.current during render).
+    // Runs synchronously before paint, so the keydown handler always reads
+    // fresh args without tearing down the listener.
     const ref = useRef(args)
     useLayoutEffect(() => {
         ref.current = args
@@ -448,7 +452,19 @@ function useReviewShortcuts(args: ReviewShortcutsArgs) {
     useEffect(() => {
         if (!args.enabled) return
         const handler = (event: KeyboardEvent) => {
-            if (event.metaKey || event.ctrlKey || event.altKey) return
+            // Cooperate with Radix DismissableLayer (Reject / Demote dialogs):
+            // its Escape listener runs on document before this window listener
+            // and sets defaultPrevented. Without this guard, pressing Escape
+            // inside a dialog would close both the dialog and the workspace.
+            if (event.defaultPrevented) return
+            if (
+                event.metaKey ||
+                event.ctrlKey ||
+                event.altKey ||
+                event.shiftKey
+            ) {
+                return
+            }
             const target = event.target as HTMLElement | null
             if (target) {
                 const tag = target.tagName

--- a/tasks/pr-161-personas-meeting.html
+++ b/tasks/pr-161-personas-meeting.html
@@ -1,0 +1,254 @@
+<!doctype html>
+<!-- SUMMARY:
+PR #161 personas meeting (backend, frontend/a11y, QA). Backend persona cleared the
+double-advance race (runSourceFetch rethrows without advancing); only doc fix is
+needed. Frontend persona found two real bugs: Escape collides with Radix Dialog
+(closes both), and Shift+A triggers Promote (modifier guard misses shiftKey). QA
+pinned the test surface: extract predicate, unit-test via node --test.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>PR #161 — Personas Meeting</title>
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --bg-elev: #14141c;
+    --fg: #e8e8f0;
+    --muted: #9a9ab0;
+    --border: #2a2a38;
+    --primary: #a855f7;
+    --danger: #f87171;
+    --warn: #fbbf24;
+    --ok: #34d399;
+    --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    --sans: Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { background: var(--bg); color: var(--fg); }
+  body {
+    font-family: var(--sans);
+    line-height: 1.55;
+    margin: 0;
+    padding: 2.5rem 1.25rem 4rem;
+    font-size: 15px;
+  }
+  main { max-width: 72ch; margin: 0 auto; }
+  h1, h2, h3 { font-weight: 600; line-height: 1.2; }
+  h1 { font-size: 1.75rem; margin: 0 0 0.5rem; letter-spacing: -0.01em; }
+  h2 {
+    font-size: 1.15rem; margin: 2.25rem 0 0.75rem;
+    padding-bottom: 0.4rem; border-bottom: 1px solid var(--border);
+  }
+  h3 { font-size: 0.95rem; margin: 1.25rem 0 0.4rem; color: var(--fg); }
+  p, ul, ol { margin: 0.55rem 0; }
+  ul, ol { padding-left: 1.3rem; }
+  li { margin: 0.2rem 0; }
+  code, kbd {
+    font-family: var(--mono); font-size: 0.85em;
+    background: var(--bg-elev); border: 1px solid var(--border);
+    border-radius: 4px; padding: 0.05em 0.35em;
+  }
+  pre {
+    font-family: var(--mono); font-size: 0.82rem; line-height: 1.5;
+    background: var(--bg-elev); border: 1px solid var(--border);
+    border-radius: 8px; padding: 0.85rem 1rem; overflow-x: auto;
+    margin: 0.6rem 0;
+  }
+  pre code { background: none; border: none; padding: 0; }
+  a { color: var(--primary); }
+  a:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+
+  .meta {
+    color: var(--muted); font-size: 0.85rem;
+    margin: 0 0 1.5rem; font-family: var(--mono);
+  }
+  .glow {
+    color: var(--primary);
+    text-shadow: 0 0 12px rgba(168, 85, 247, 0.45);
+  }
+  .badge {
+    display: inline-block; padding: 0.1rem 0.5rem;
+    border-radius: 999px; font-size: 0.7rem; font-family: var(--mono);
+    text-transform: uppercase; letter-spacing: 0.04em; vertical-align: middle;
+    margin-left: 0.4rem;
+  }
+  .badge.internal { background: rgba(168, 85, 247, 0.15); color: var(--primary); border: 1px solid rgba(168, 85, 247, 0.35); }
+  .badge.ok       { background: rgba(52, 211, 153, 0.12);  color: var(--ok);      border: 1px solid rgba(52, 211, 153, 0.35); }
+  .badge.warn     { background: rgba(251, 191, 36, 0.12);  color: var(--warn);    border: 1px solid rgba(251, 191, 36, 0.35); }
+  .badge.danger   { background: rgba(248, 113, 113, 0.12); color: var(--danger);  border: 1px solid rgba(248, 113, 113, 0.35); }
+
+  .persona {
+    border: 1px solid var(--border); border-radius: 10px;
+    padding: 1rem 1.1rem; margin: 0.75rem 0; background: var(--bg-elev);
+  }
+  .persona header {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.5rem; margin-bottom: 0.35rem;
+  }
+  .persona h3 { margin: 0; }
+  .persona .role { color: var(--muted); font-size: 0.78rem; font-family: var(--mono); }
+
+  table {
+    width: 100%; border-collapse: collapse; font-size: 0.88rem;
+    margin: 0.6rem 0;
+  }
+  th, td { text-align: left; padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 500; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; }
+  td code { word-break: break-word; }
+
+  .decision { border-left: 3px solid var(--primary); padding: 0.4rem 0.9rem; margin: 0.4rem 0; background: rgba(168, 85, 247, 0.06); border-radius: 0 6px 6px 0; }
+  .decision strong { color: var(--primary); }
+
+  hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { transition: none !important; animation: none !important; }
+  }
+</style>
+</head>
+<body>
+<main>
+
+<h1>PR #161 — Personas Meeting <span class="badge internal">Internal</span></h1>
+<p class="meta">
+  branch: <code>claude/review-pr-161-TGFKA</code> ·
+  base: <code>9eec664</code> (feat/fm-geo-review-compare-layout) ·
+  audience: engineering
+</p>
+
+<p>
+  Three personas were spawned in parallel against the PR to pin the disagreement
+  raised in the initial review: is the worker fix safe, and what else hides in the
+  frontend? Each persona had a narrow brief and reported back with file:line
+  evidence. This note captures the synthesis and the implementation plan.
+</p>
+
+<h2>Verdict</h2>
+<div class="decision">
+  <strong>Ship after fixes.</strong> The backend hitchhiker is safe; the frontend
+  has two real bugs that warrant fixing before merge. Total change footprint is
+  small (~30 lines of code + one unit test + one doc fix).
+</div>
+
+<h2>Personas &amp; Findings</h2>
+
+<div class="persona">
+  <header>
+    <h3>Backend / Queue Orchestration <span class="badge ok">SAFE</span></h3>
+    <span class="role">BullMQ · maps pipeline</span>
+  </header>
+  <p>
+    Traced every <code>maps-fetch-*.ts</code> worker. Conclusion: the comment in
+    <code>maps-pipeline-logic.ts:80</code> claiming &ldquo;the child re-enqueues
+    the orchestrator on completion (success or failure)&rdquo; is <strong>stale</strong>.
+    In reality, <code>runSourceFetch</code> in <code>maps-fetch-runtime.ts:126-135</code>
+    calls <code>recordAttempt(...)</code> and <code>throw err</code> on the rethrow
+    branch &mdash; the post-success <code>advancePipeline()</code> at line 140 is
+    unreachable on throw. The PR&rsquo;s new <code>failed</code> handler is therefore
+    the <em>only</em> advance path on terminal failure.
+  </p>
+  <p>
+    BullMQ behavior also checks out: <code>attempts: 5</code> is configured in
+    <code>queues.ts:109</code>, and BullMQ fires <code>failed</code> with
+    <code>attemptsMade === opts.attempts</code> on terminal failure, so the
+    <code>attemptsMade &lt; maxAttempts</code> guard is off-by-one-free.
+  </p>
+  <p>Actions:</p>
+  <ul>
+    <li>Fix the stale comment in <code>maps-pipeline-logic.ts</code> so the next reader doesn&rsquo;t chase the same ghost.</li>
+    <li>Extract <code>shouldAdvanceAfterFailure(job)</code> as a pure predicate, so QA can unit-test the off-by-one.</li>
+    <li><em>Skipped</em>: tightening the dedupe <code>jobId</code> to be <code>job.id</code>-based. Marginal value once the race is disproven.</li>
+  </ul>
+</div>
+
+<div class="persona">
+  <header>
+    <h3>Frontend / UX / A11y <span class="badge danger">2 BUGS</span></h3>
+    <span class="role">ReviewWorkspace · keyboard shortcuts</span>
+  </header>
+  <p><strong>Bug A &mdash; Escape collides with Radix Dialog</strong> (<code>ReviewWorkspace.tsx:498</code>).
+    Radix <code>DismissableLayer</code> attaches its Escape listener on <code>ownerDocument</code> and
+    calls <code>preventDefault()</code> when handling Escape. Document bubble-phase
+    listeners fire before window listeners, so Radix closes the Reject/Demote dialog
+    &mdash; then our window listener still fires and calls <code>onCloseDetail</code>,
+    closing the workspace underneath the user.
+  </p>
+  <p><strong>Bug B &mdash; <kbd>Shift</kbd>+<kbd>A</kbd> triggers Promote</strong>
+    (<code>ReviewWorkspace.tsx:451</code>). The modifier guard rejects Cmd/Ctrl/Alt
+    but not Shift, and the switch matches both <code>'a'</code> and <code>'A'</code>.
+    <code>KeyHints</code> displays <code>&lt;kbd&gt;A&lt;/kbd&gt;</code>, which
+    conventionally implies unshifted.
+  </p>
+  <p><strong>Minor</strong>:</p>
+  <ul>
+    <li>Switch <code>useLayoutEffect</code> ref-sync to write-during-render (idiomatic since React 18 concurrent renderer).</li>
+    <li>Restore the <code>'Retour &agrave; la liste'</code> default-value second arg on <code>t('admin.geo.nav.backToList')</code> to match prior code and ops-string convention.</li>
+    <li>Sticky <code>ActionBar</code> resolves against the document scroll (no ancestor has <code>overflow</code> or <code>max-h</code>). That&rsquo;s the intended behavior &mdash; <strong>no action</strong>.</li>
+  </ul>
+</div>
+
+<div class="persona">
+  <header>
+    <h3>QA / Test Strategy <span class="badge warn">2 tests</span></h3>
+    <span class="role">node:test · Playwright</span>
+  </header>
+  <p>
+    Backend uses <code>node --test</code> via tsx (8 existing <code>*.test.ts</code>).
+    Frontend has zero unit-test infra &mdash; only Playwright + axe. RTL is not installed
+    and isn&rsquo;t worth adding for one hook.
+  </p>
+  <ul>
+    <li><strong>Backend</strong>: unit-test the extracted <code>shouldAdvanceAfterFailure</code>
+      predicate. Three cases &mdash; mid-retry returns false, terminal returns true, wrong
+      <code>kind</code> returns false. Lives at <code>packages/backend/src/infrastructure/queue/workers/geo.worker.test.ts</code>.
+    </li>
+    <li><strong>Frontend</strong>: skip for this round. Adding a Playwright case for the
+      Escape collision and Shift+A semantics is doable but needs <code>data-testid</code>
+      hooks that the workspace doesn&rsquo;t expose yet &mdash; out of scope for a bug-fix
+      pass. Track in a follow-up.
+    </li>
+    <li><strong>Skip</strong>: BullMQ integration test (would need Redis fixtures); visual snapshot of the sticky bar.</li>
+  </ul>
+</div>
+
+<h2>Implementation plan</h2>
+
+<table>
+  <thead><tr><th>File</th><th>Change</th><th>Source</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>geo.worker.ts</code></td>
+      <td>Extract <code>shouldAdvanceAfterFailure</code> (exported pure fn); use it in the <code>failed</code> handler.</td>
+      <td>Backend, QA</td>
+    </tr>
+    <tr>
+      <td><code>geo.worker.test.ts</code> <em>(new)</em></td>
+      <td>3-case node:test on the predicate.</td>
+      <td>QA</td>
+    </tr>
+    <tr>
+      <td><code>maps-pipeline-logic.ts</code></td>
+      <td>Replace the stale &ldquo;child re-enqueues&rdquo; comment with one that matches reality.</td>
+      <td>Backend</td>
+    </tr>
+    <tr>
+      <td><code>ReviewWorkspace.tsx</code></td>
+      <td>(1) early-return on <code>defaultPrevented</code>; (2) add <code>shiftKey</code> to the modifier guard; (3) write-during-render ref; (4) restore i18n fallback.</td>
+      <td>Frontend</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Out of scope (follow-ups)</h2>
+<ul>
+  <li>Playwright e2e for keyboard shortcut behavior (needs <code>data-testid</code> on the workspace).</li>
+  <li>Tighten <code>advancePipeline</code> dedupe to <code>job.id</code>-based key.</li>
+  <li>RTL adoption decision for frontend unit tests &mdash; revisit when a second hook needs coverage.</li>
+</ul>
+
+</main>
+</body>
+</html>


### PR DESCRIPTION
Side-by-side capture/map workspace for the geo-review tab, sticky action bar, J/K/A/R/Esc keyboard shortcuts — plus three correctness fixes uncovered by a multi-persona review of the original draft (notes archived at `tasks/pr-161-personas-meeting.html`).

The companion worker fix (`fix(geo): unstick maps pipeline when a child fetch exhausts retries`) already shipped to `main` separately, so it was dropped during rebase. This PR is now UI + the predicate refactor that makes the worker fix unit-testable.

## What's in scope

**Frontend — new `ReviewWorkspace.tsx`, slimmed `GeoReviewPanel.tsx`**
- `xl:grid-cols-2` capture / map layout, stacks below `xl` for 13" laptops and tablets.
- Sticky action bar (Promote / Reject) so the moderator never scrolls to act.
- Keyboard shortcuts wired via a window listener with strict guards (skips `INPUT`/`TEXTAREA`/`SELECT`/`contenteditable`, all modifier keys, and locks out everything except `Escape` while a save is in flight). The hook uses the latest-props ref pattern via `useLayoutEffect` because the project's `react-hooks/refs` ESLint rule blocks write-during-render.
- Mobile flow preserved (`!detail && 'hidden lg:block'` on sidebar, `detail && 'hidden lg:block'` on workspace, back-button on `lg:hidden`).

**Frontend — three correctness fixes**
1. **Escape no longer closes the workspace when a Radix dialog handled it.** Radix `DismissableLayer` attaches its Escape listener on the document, which fires before our window listener and sets `defaultPrevented`. Without the new `if (event.defaultPrevented) return` guard at the top of the handler, pressing Escape inside the Reject / Demote dialog closed *both* the dialog and the workspace.
2. **`Shift+A` no longer triggers Promote.** The original modifier guard rejected `Cmd / Ctrl / Alt` but not `Shift`, and the switch matched both `'a'` and `'A'`. `event.shiftKey` is now excluded too.
3. **Restored the `'Retour à la liste'` default-value** on `t('admin.geo.nav.backToList')` to match the prior code and other admin ops strings (i18n bundle fallback for ops-only screens).

**Backend — `geo-worker-predicates.ts` (new)**
- Extracted `shouldAdvanceAfterFailure()` and `isMapsFetchChildJob()` into a pure module so the off-by-one risk on `attemptsMade` is unit-testable without booting Redis. The handler in `geo.worker.ts` now calls the predicate.
- Replaced a stale comment in `maps-pipeline-logic.ts` that claimed the per-source child "re-enqueues this orchestrator on completion (success or failure)" — verified false: `runSourceFetch` rethrows on the transient-error branch and never reaches its post-`recordAttempt` advance call. The worker `'failed'` listener is the sole advance path on terminal failure.

## Tests

- `geo-worker-predicates.test.ts` (new): 7 `node:test` cases — `isMapsFetchChildJob` shape coverage, mid-retry vs terminal, default `attempts=1`, non-matching kinds, undefined data.
- Frontend `npm run lint`: 0 errors (1 pre-existing warning on `HistoryPage.tsx`, unrelated).
- Frontend `npm run build`: green.
- Backend `npm test`: 2 pre-existing failures on `main` from a missing `web-push` dependency in the test environment, also unrelated. My new test passes 7/7.

## Personas meeting

3 personas (backend orchestration, frontend/a11y, QA) ran in parallel against the draft:
- **Backend** cleared the double-advance race I flagged in the original review of PR #161 — `runSourceFetch` rethrows without advancing, so the worker `'failed'` listener is the sole advance path. False alarm, but the stale comment that misled me is now fixed.
- **Frontend** found the two real bugs above (Escape collision, Shift+A) plus the i18n fallback regression.
- **QA** scoped the test surface to the predicate unit test; deferred Playwright e2e for shortcuts (needs `data-testid` hooks the workspace doesn't expose yet — tracked in the meeting note).

## Skipped / follow-ups

- Playwright e2e for keyboard shortcuts and the Escape-dialog cooperation.
- Tightening `advancePipeline` dedupe to `job.id`-based key (per-second key is sufficient now that the race is disproven).
- RTL adoption decision for frontend unit tests — revisit when a second hook needs coverage.

Closes #160. Supersedes #161 (which was based on a pre-rebuild `main`).