### PR TITLE
fix(leaderboard): restore mobile padding on player answers dialog

### DIFF
--- a/packages/frontend/src/pages/LeaderboardPage.tsx
+++ b/packages/frontend/src/pages/LeaderboardPage.tsx
@@ -560,18 +560,20 @@ export default function LeaderboardPage() {
 
         {/* Player Answers Dialog */}
         <Dialog open={!!selectedPlayer} onOpenChange={(open) => !open && handleCloseDialog()}>
-          <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-2xl max-h-[80vh]">
             <DialogHeader>
-              <DialogTitle className="flex items-center gap-3">
+              <DialogTitle className="flex items-center gap-3 min-w-0 pr-8">
                 {selectedPlayer && (
                   <>
-                    <Avatar className="w-8 h-8">
+                    <Avatar className="w-8 h-8 shrink-0">
                       <AvatarImage src={selectedPlayer.avatarUrl} alt={selectedPlayer.displayName} />
                       <AvatarFallback className="bg-linear-to-br from-neon-purple to-neon-pink text-sm font-bold">
                         {selectedPlayer.displayName[0]}
                       </AvatarFallback>
                     </Avatar>
-                    {t('leaderboard.playerAnswers', { name: selectedPlayer.displayName })}
+                    <span className="truncate">
+                      {t('leaderboard.playerAnswers', { name: selectedPlayer.displayName })}
+                    </span>
                   </>
                 )}
               </DialogTitle>


### PR DESCRIPTION
The override max-w-2xl on DialogContent was replacing the base
max-w-[calc(100%-2rem)] via tailwind-merge, making the dialog touch
the screen edges on mobile and causing horizontal overflow when a
guess title wrapped. Switch to max-w-[calc(100vw-2rem)] sm:max-w-2xl
(matching the admin dialogs) so the dialog keeps its 1rem edge
margin on mobile and expands on >=sm. Also guard the title against
long display names by truncating the username and pinning the avatar.