### PR TITLE
docs(auth): correct admin-bootstrap race comment

### DIFF
--- a/packages/backend/src/infrastructure/auth/auth.ts
+++ b/packages/backend/src/infrastructure/auth/auth.ts
@@ -238,16 +238,25 @@ function createAuth() {
           before: async (user) => {
             // Closes the first-user-admin race. Two parallel sign-ups
             // on a fresh DB used to both read count=0 and both insert
-            // with role=admin. Migration 20260521 adds a partial unique
-            // index that makes two admin rows impossible at the DB
-            // level; here we additionally serialise concurrent hook
-            // calls with an advisory transaction lock so the racing
-            // user gets a clean role=user fallback instead of a
-            // unique-violation 5xx.
+            // with role=admin.
             //
-            // The key is a fixed hash so every node holding this lock
-            // serialises on the same Postgres row regardless of how
-            // many app replicas are running.
+            // The actual defense is migration 20260521's partial unique
+            // index `one_admin_role_idx`, which makes two admin rows
+            // impossible at the database level — the second writer in
+            // the race trips a unique-violation and its sign-up fails.
+            //
+            // The advisory transaction lock here narrows but does NOT
+            // close the SELECT→INSERT window: pg_advisory_xact_lock is
+            // released at COMMIT, before Better Auth performs its
+            // INSERT in a separate session, so a tight race can still
+            // surface as a 5xx for the loser. It serialises the role
+            // check across hook invocations so most racing signups see
+            // the committed admin row and degrade to role=user
+            // cleanly — a one-shot cold-start UX wart, not a security
+            // gap (the unique index has that covered).
+            //
+            // The fixed hash key serialises every replica on the same
+            // Postgres row regardless of how many app instances exist.
             const client = await pool.connect();
             try {
               await client.query('BEGIN');


### PR DESCRIPTION
## Summary

Reviewing #153 surfaced a mismatch between the code and its comment in `packages/backend/src/infrastructure/auth/auth.ts`. The comment claimed the advisory lock gives a racing signup "a clean role=user fallback instead of a unique-violation 5xx" — it doesn't. `pg_advisory_xact_lock` is released at `COMMIT`, which happens **before** Better Auth performs its INSERT in a separate session, so the SELECT→INSERT window stays open.

The actual defense against two `role='admin'` rows is migration `20260521_one_admin_partial_unique.ts`. The lock only narrows the race window.

This PR rewrites the comment to describe what the code does. No runtime behaviour changes.

## Why not "fix the lock"

To actually deliver the commented behaviour, the lock would need to span the INSERT (session-level `pg_advisory_lock` held across `before` + `after` hooks with a per-signup client map, plus failure cleanup). That's fragile, and the security invariant is already enforced by the unique index. A 5xx for the loser of a millisecond-window race on a cold-start admin-bootstrap path is an acceptable UX wart, not a vulnerability.

## Outstanding from #153

The integration test asked for in the issue's "Test plan" still requires a real-DB harness (testcontainers or similar) that doesn't exist in `packages/backend`. That's a separate PR.

Closes part of #153 (comment accuracy). Leaves #153 open for the harness + race test.

## Test plan

- [x] Comment-only change to a single file — no runtime impact
- [x] Pre-existing `npm run build` / `npm test` failures in this repo confirmed to be unrelated (reproduce on `main`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDkM2wQUyXvfDLfUduwboW)_