### PR TITLE
Update support menu label to "Bug & feedback"

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -33,7 +33,7 @@
     "create": "Create",
     "history": "History",
     "profile": "Profile",
-    "support": "Support",
+    "support": "Bug & feedback",
     "unknown": "Unknown",
     "backTo": "Back to",
     "filters": "Filters",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -33,7 +33,7 @@
     "create": "Créer",
     "history": "Historique",
     "profile": "Profil",
-    "support": "Support",
+    "support": "Bug & suggestions",
     "unknown": "Inconnu",
     "backTo": "Retour à",
     "filters": "Filtres",


### PR DESCRIPTION
## Summary
Updated the "Support" menu label to more accurately reflect its purpose as a channel for bug reports and user feedback.

## Changes
- **English**: Changed "Support" → "Bug & feedback"
- **French**: Changed "Support" → "Bug & suggestions"

## Details
This change clarifies the menu item's function by explicitly indicating it's for reporting bugs and providing feedback/suggestions, rather than general support. The translations maintain consistency across both supported languages while using culturally appropriate terminology ("feedback" in English, "suggestions" in French).

https://claude.ai/code/session_01FmdScMAxGVPTZPeEjSXdxd