### PR TITLE
Remove "panoramic" references from UI and marketing copy

### DIFF
--- a/packages/backend/src/infrastructure/queue/workers/inactive-user-reminder-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/inactive-user-reminder-logic.ts
@@ -93,7 +93,7 @@ function buildHtml(displayName: string, days: number, playUrl: string, unsubscri
     heading: `Ça fait ${days} jours, ${displayName}…`,
     paragraphs: [
       `Ton dernier passage dans la Box remonte à <strong style="color:#f0abfc;">${days} jours</strong>. Les défis du jour continuent de tomber sans toi — et on aimerait bien te revoir.`,
-      `Un nouveau panorama t'attend dès maintenant. Quelques secondes suffisent pour retrouver la main.`,
+      `Un nouveau défi t'attend dès maintenant. Quelques secondes suffisent pour retrouver la main.`,
     ],
     cta: { label: 'Relancer une partie', url: playUrl },
     tip: "Astuce : ton inventaire d'indices est toujours là, intact, prêt à servir sur le prochain défi.",

--- a/packages/backend/src/presentation/routes/og.routes.ts
+++ b/packages/backend/src/presentation/routes/og.routes.ts
@@ -44,8 +44,8 @@ function buildDailySvg(date: string, lang: 'fr' | 'en'): string {
   const readable = escapeXml(formatDate(date, locale))
   const tagline = escapeXml(
     lang === 'fr'
-      ? "Devinez le jeu à partir d'une capture panoramique."
-      : 'Guess the game from a panoramic screenshot.'
+      ? "Devinez le jeu à partir d'une capture d'écran."
+      : 'Guess the game from a screenshot.'
   )
   const brand = escapeXml('THE BOX')
   const cta = escapeXml(

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -13,7 +13,7 @@
   <meta name="apple-mobile-web-app-title" content="The Box" />
   <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
   <title>The Box — Daily Video Game Guessing Challenge</title>
-  <meta name="description" content="Daily video game guessing challenges. Identify games from panoramic screenshots, climb live leaderboards, unlock achievements. Play instantly as a guest — no account needed." />
+  <meta name="description" content="Daily video game guessing challenges. Identify games from screenshots, climb live leaderboards, unlock achievements. Play instantly as a guest — no account needed." />
   <link rel="canonical" href="https://the-box.battistella.ovh/" />
 
   <link rel="alternate" hreflang="fr" href="https://the-box.battistella.ovh/fr" />
@@ -23,7 +23,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="The Box" />
   <meta property="og:title" content="The Box — Daily Video Game Guessing Challenge" />
-  <meta property="og:description" content="Identify games from panoramic screenshots. New daily challenge, live leaderboards, achievements. Play instantly as a guest." />
+  <meta property="og:description" content="Identify games from screenshots. New daily challenge, live leaderboards, achievements. Play instantly as a guest." />
   <meta property="og:url" content="https://the-box.battistella.ovh/" />
   <meta property="og:image" content="https://the-box.battistella.ovh/api/og/daily.png" />
   <meta property="og:image:type" content="image/png" />
@@ -35,7 +35,7 @@
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="The Box — Daily Video Game Guessing Challenge" />
-  <meta name="twitter:description" content="Identify games from panoramic screenshots. New daily challenge, live leaderboards, achievements. Play as a guest — no account needed." />
+  <meta name="twitter:description" content="Identify games from screenshots. New daily challenge, live leaderboards, achievements. Play as a guest — no account needed." />
   <meta name="twitter:image" content="https://the-box.battistella.ovh/api/og/daily.png" />
   <meta name="twitter:image:alt" content="The Box — daily video game screenshot guessing challenge" />
 

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1846,7 +1846,7 @@
     "welcomeRanked": "You're on the global leaderboard from your very first challenge.",
     "howTitle": "How it works",
     "howSubtitle": "One challenge, 10 screenshots, one ranking.",
-    "step1": "Look at the 360° panoramic screenshot.",
+    "step1": "Look at the screenshot.",
     "step2": "Guess the game — the faster you are, the higher the score.",
     "step3": "Use a hint if you need to, then move to the next screenshot.",
     "skip": "Skip",
@@ -2206,7 +2206,7 @@
   "seo": {
     "home": {
       "title": "The Box — Daily Video Game Guessing Challenge",
-      "description": "Identify games from panoramic screenshots. New daily challenge, live leaderboards, achievements. Play instantly as a guest — no account needed."
+      "description": "Identify games from screenshots. New daily challenge, live leaderboards, achievements. Play instantly as a guest — no account needed."
     },
     "play": {
       "title": "Daily Challenge — The Box",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1846,7 +1846,7 @@
     "welcomeRanked": "Tu es sur le classement mondial dès ton premier défi.",
     "howTitle": "Comment ça marche",
     "howSubtitle": "Un défi, 10 captures, un classement.",
-    "step1": "Regarde la capture d'écran à 360°.",
+    "step1": "Regarde la capture d'écran.",
     "step2": "Devine le jeu — plus tu es rapide, plus le score grimpe.",
     "step3": "Utilise un indice si besoin, puis enchaîne la capture suivante.",
     "skip": "Passer",

--- a/packages/frontend/src/components/game/GuessInput.tsx
+++ b/packages/frontend/src/components/game/GuessInput.tsx
@@ -48,7 +48,7 @@ export function GuessInput() {
   } = useGameStore()
 
   // Focus input when playing.
-  // `preventScroll: true` stops Android Chrome from scrolling the panorama out
+  // `preventScroll: true` stops Android Chrome from scrolling the screenshot out
   // of view when the input becomes active.
   useEffect(() => {
     if (gamePhase === 'playing' && inputRef.current) {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
         name: 'The Box — Daily Video Game Guessing Challenge',
         short_name: 'The Box',
         description:
-          'Identify video games from 360° panoramic screenshots. New daily challenge, live leaderboards, achievements.',
+          'Identify video games from screenshots. New daily challenge, live leaderboards, achievements.',
         start_url: '/',
         scope: '/',
         display: 'standalone',


### PR DESCRIPTION
## Summary
Updated all user-facing copy and metadata to remove references to "panoramic" or "360°" screenshots. The game now presents itself as a general screenshot guessing challenge rather than specifically panoramic screenshots.

## Changes Made

- **Frontend metadata** (`index.html`): Updated meta descriptions (og:description, twitter:description) and page title meta to remove "panoramic" references
- **SEO translations** (`en/translation.json`, `fr/translation.json`): 
  - Updated home page description in SEO config
  - Changed "Look at the 360° panoramic screenshot" to "Look at the screenshot" in the how-it-works step
  - Updated French equivalent from "Regarde la capture d'écran à 360°" to "Regarde la capture d'écran"
- **Web app manifest** (`vite.config.ts`): Removed "360° panoramic" from PWA description
- **OG image tagline** (`og.routes.ts`): Updated both English and French taglines to remove panoramic reference
- **Email template** (`inactive-user-reminder-logic.ts`): Changed French email copy from "Un nouveau panorama t'attend" to "Un nouveau défi t'attend"
- **Code comment** (`GuessInput.tsx`): Updated comment to reference "screenshot" instead of "panorama"

## Implementation Details

All changes are copy/messaging updates with no functional impact. The modifications ensure consistent messaging across:
- HTML meta tags (SEO, social sharing)
- i18n translation files (user-facing UI)
- PWA manifest
- Email communications
- Code comments

This aligns the marketing and UI messaging with the actual game mechanics.

https://claude.ai/code/session_01PHpZ9Ayi6SBxUtok6pJdkP