### PR TITLE
Display guess attempts in leaderboard with new GuessAttemptsList component

### DIFF
--- a/packages/frontend/src/pages/LeaderboardPage.tsx
+++ b/packages/frontend/src/pages/LeaderboardPage.tsx
@@ -13,6 +13,7 @@ import { DatePicker } from '@/components/ui/date-picker'
 import { MonthPicker } from '@/components/ui/month-picker'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { GuessAttemptsList } from '@/components/game/GuessAttemptsList'
 import type { GameSessionDetailsResponse } from '@the-box/types'
 
 interface LeaderboardEntry {
@@ -631,11 +632,18 @@ export default function LeaderboardPage() {
                           </div>
                           <div className="flex-1 min-w-0">
                             <div className="font-medium truncate">{item.guess.correctGame.name}</div>
-                            {item.guess.userGuess && (
+                            {item.guess.attempts && item.guess.attempts.length > 0 ? (
+                              <>
+                                <span className="text-xs text-muted-foreground block mt-0.5">
+                                  {t('game.attempts.count', { count: item.guess.attempts.length })}
+                                </span>
+                                <GuessAttemptsList attempts={item.guess.attempts} compact />
+                              </>
+                            ) : item.guess.userGuess ? (
                               <div className="text-sm text-muted-foreground truncate">
                                 {t('game.yourGuess')}: {item.guess.userGuess}
                               </div>
-                            )}
+                            ) : null}
                           </div>
                           <div className="flex items-center gap-2 shrink-0">
                             {item.guess.isCorrect ? (


### PR DESCRIPTION
## Summary
Enhanced the leaderboard display to show detailed guess attempts when available, replacing the simple "your guess" text with a structured list of attempts and attempt count.

## Key Changes
- Imported the `GuessAttemptsList` component from `@/components/game/GuessAttemptsList`
- Updated the leaderboard entry rendering logic to prioritize displaying attempts:
  - If `item.guess.attempts` exists and has entries, display the attempt count (i18n key: `game.attempts.count`) and render the `GuessAttemptsList` component in compact mode
  - Fall back to the original `userGuess` display if no attempts are available
  - Return `null` if neither attempts nor userGuess exist
- Changed the conditional structure from a simple `&&` check to a ternary chain for clearer intent

## Implementation Details
- The `GuessAttemptsList` component is rendered with the `compact` prop to fit the leaderboard's space constraints
- Maintains backward compatibility by falling back to the existing `userGuess` display when attempts data is unavailable
- Uses existing i18n infrastructure for the attempts count label

https://claude.ai/code/session_018nHwuiocM2mhDAmwLfnhbY