### PR TITLE
feat(ui): add ResponsiveDialog + migrate player-facing modals

### DIFF
--- a/docs/oxygen-design-system.md
+++ b/docs/oxygen-design-system.md
@@ -100,6 +100,35 @@ Chez nous :
 
 Deux solutions également valables au même problème valent moins qu'une seule solution légèrement imparfaite mais partagée. Avant d'ajouter un composant, vérifiez qu'une primitive Radix/shadcn dans `src/components/ui/` ne couvre pas déjà le cas. Avant d'ajouter une variante, vérifiez que les variantes existantes de `Card`, `Alert`, `Button` n'expriment pas déjà l'intention.
 
+### 2.7 Mobile-first — Dialog ou bottom sheet
+
+The Box est jouée majoritairement au téléphone. Une modale centrée sur un écran < 768 px est un anti-pattern : elle se découpe avec le clavier virtuel, ignore les safe-area iOS, et oblige la cible tactile « fermer » à voyager loin du pouce. Règle :
+
+> **Toute modale présentée à un joueur utilise `ResponsiveDialog` (`src/components/ui/responsive-dialog.tsx`), pas `Dialog` directement.** Sur mobile (`< 768px`), `ResponsiveDialog` rend une bottom sheet plein-écran-bas ; sur desktop, une modale centrée. L'API est identique à `Dialog` — `ResponsiveDialogContent / Header / Footer / Title / Description`.
+
+Spécifications de la bottom sheet :
+
+- **Hauteur** : `max-h-[85dvh]` (jamais 100 — laissez voir l'origine de la sheet derrière l'overlay).
+- **Coins** : `rounded-t-2xl` en haut uniquement.
+- **Drag handle** : barrette `h-1.5 w-12 bg-border/60` centrée en haut, affordance visuelle uniquement (pas de gesture handler — Radix gère la fermeture via overlay-tap et Escape).
+- **Safe-area** : `pb-[max(env(safe-area-inset-bottom),1rem)]` pour ne pas écraser les actions sous la home-indicator iOS.
+- **Animations** : `slide-in-from-bottom` / `slide-out-to-bottom`, soumises à `motion-safe:` pour respecter `prefers-reduced-motion`.
+- **Footer** : `flex-col-reverse` sur mobile (action primaire au-dessus = à portée du pouce), `sm:flex-row sm:justify-end` sur desktop. Le composant `ResponsiveDialogFooter` applique déjà ce comportement.
+- **Cible tactile « fermer »** : 44×44 minimum, déjà fourni par `ResponsiveDialogContent`.
+
+Exceptions documentées :
+
+- **Confirmations destructives ultra-courtes** (`DeleteConfirmDialog` admin) : restent en `Dialog` centré, car la modale doit interrompre — un slide-up depuis le bas est trop discret pour une action destructrice.
+- **Sheets latérales (drawers)** : `Sheet side="right"` reste légitime quand le contenu est une *navigation* ou un *panel persistant* (header menu mobile, `GameMapsDrawer` admin), pas une décision ponctuelle. La règle « bottom sheet pour les décisions » distingue **modale de décision** vs **panneau de navigation**.
+- **Admin** : non couvert par la règle (faible trafic mobile). Les dialogues admin peuvent rester en `Dialog`.
+
+Arbre de décision rapide :
+
+- Décision/action à valider, joueur, sur n'importe quel device → **`ResponsiveDialog`**
+- Navigation ou panneau latéral persistant → **`Sheet side="right"` (ou `left`)**
+- Confirmation destructive courte → **`Dialog` centré** (exception §2.5)
+- Choix dans une liste avec recherche → **`ResponsiveDialog`** (sheet plein-écran mobile, dialogue desktop)
+
 ---
 
 ## 3. Principes → fichiers
@@ -110,6 +139,7 @@ Deux solutions également valables au même problème valent moins qu'une seule 
 | Hiérarchie d'actions | `packages/frontend/src/components/ui/button.tsx` (`buttonVariants`) |
 | Hiérarchie de cartes | `packages/frontend/src/components/ui/card.tsx` (variantes CVA) |
 | Hiérarchie d'alertes | `packages/frontend/src/components/ui/alert.tsx` |
+| Modales mobile-first | `packages/frontend/src/components/ui/responsive-dialog.tsx` |
 | Toasts | `packages/frontend/src/components/ui/sonner.tsx`, `packages/frontend/src/lib/toast.ts` |
 | Reduced motion | `packages/frontend/src/index.css` (`@media (prefers-reduced-motion: reduce)`) |
 | Anneaux de focus | token `--ring`, utilitaire `focus-visible:ring-ring` |
@@ -149,3 +179,10 @@ Deux solutions également valables au même problème valent moins qu'une seule 
 - [ ] Les sélecteurs de formulaire suivent l'arbre de décision §2.4
 - [ ] Pas de nouveau composant custom si une primitive `ui/*` suffit
 - [ ] Pas de nouvelle variante si une variante CVA existante exprime déjà l'intention
+
+**Mobile-first**
+
+- [ ] Toute modale joueur utilise `ResponsiveDialog`, pas `Dialog` (cf. §2.7)
+- [ ] Les bottom sheets respectent `max-h-[85dvh]`, drag handle, safe-area, footer `flex-col-reverse`
+- [ ] Les cibles tactiles font ≥ 44×44 px (fermeture, CTA, items de liste)
+- [ ] Le contenu reste accessible avec le clavier virtuel ouvert (test : focus sur un input dans la sheet)

--- a/packages/frontend/src/components/ReportCaptureDialog.tsx
+++ b/packages/frontend/src/components/ReportCaptureDialog.tsx
@@ -6,14 +6,14 @@ import { reportsApi, ReportApiError, type SubmitReportInput } from '@/lib/api/re
 import { toast } from '@/lib/toast'
 import { Button } from '@/components/ui/button'
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
-} from '@/components/ui/dialog'
+    ResponsiveDialog,
+    ResponsiveDialogContent,
+    ResponsiveDialogDescription,
+    ResponsiveDialogFooter,
+    ResponsiveDialogHeader,
+    ResponsiveDialogTitle,
+    ResponsiveDialogTrigger,
+} from '@/components/ui/responsive-dialog'
 import { Label } from '@/components/ui/label'
 import {
     Select,
@@ -110,8 +110,8 @@ export function ReportCaptureDialog({
     }
 
     return (
-        <Dialog open={open} onOpenChange={handleOpenChange}>
-            <DialogTrigger asChild>
+        <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+            <ResponsiveDialogTrigger asChild>
                 <Button
                     variant="ghost"
                     size="sm"
@@ -126,14 +126,14 @@ export function ReportCaptureDialog({
                     <Flag className={iconOnly ? 'h-4 w-4' : 'h-3.5 w-3.5 mr-1.5'} />
                     {!iconOnly && t('report.trigger')}
                 </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
-                <DialogHeader>
-                    <DialogTitle>{t('report.title')}</DialogTitle>
-                    <DialogDescription>
+            </ResponsiveDialogTrigger>
+            <ResponsiveDialogContent className="sm:max-w-md">
+                <ResponsiveDialogHeader>
+                    <ResponsiveDialogTitle>{t('report.title')}</ResponsiveDialogTitle>
+                    <ResponsiveDialogDescription>
                         {t('report.description')}
-                    </DialogDescription>
-                </DialogHeader>
+                    </ResponsiveDialogDescription>
+                </ResponsiveDialogHeader>
                 <div className="space-y-4 py-2">
                     <div className="space-y-2">
                         <Label htmlFor="report-reason">
@@ -172,7 +172,7 @@ export function ReportCaptureDialog({
                         />
                     </div>
                 </div>
-                <DialogFooter>
+                <ResponsiveDialogFooter>
                     <Button
                         type="button"
                         variant="ghost"
@@ -192,8 +192,8 @@ export function ReportCaptureDialog({
                         )}
                         {submitting ? t('report.submitting') : t('report.submit')}
                     </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
+                </ResponsiveDialogFooter>
+            </ResponsiveDialogContent>
+        </ResponsiveDialog>
     )
 }

--- a/packages/frontend/src/components/daily-login/DailyRewardModal.tsx
+++ b/packages/frontend/src/components/daily-login/DailyRewardModal.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-    DialogDescription,
-} from '@/components/ui/dialog'
+    ResponsiveDialog,
+    ResponsiveDialogContent,
+    ResponsiveDialogHeader,
+    ResponsiveDialogTitle,
+    ResponsiveDialogDescription,
+} from '@/components/ui/responsive-dialog'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { useDailyLoginStore } from '@/stores/dailyLoginStore'
@@ -73,21 +73,21 @@ export function DailyRewardModal() {
     }
 
     return (
-        <Dialog open={isModalOpen} onOpenChange={(open) => { if (!open) handleClose() }}>
-            <DialogContent className="sm:max-w-md">
-                <DialogHeader>
-                    <DialogTitle className="flex items-center gap-2 text-xl">
+        <ResponsiveDialog open={isModalOpen} onOpenChange={(open) => { if (!open) handleClose() }}>
+            <ResponsiveDialogContent className="sm:max-w-md">
+                <ResponsiveDialogHeader>
+                    <ResponsiveDialogTitle className="flex items-center gap-2 text-xl">
                         <Gift className="w-5 h-5 text-primary" />
                         {showClaimSuccess
                             ? t('dailyLogin.rewardClaimed')
                             : t('dailyLogin.dailyReward')}
-                    </DialogTitle>
-                    <DialogDescription>
+                    </ResponsiveDialogTitle>
+                    <ResponsiveDialogDescription>
                         {showClaimSuccess
                             ? t('dailyLogin.claimSuccessDescription')
                             : t('dailyLogin.claimDescription')}
-                    </DialogDescription>
-                </DialogHeader>
+                    </ResponsiveDialogDescription>
+                </ResponsiveDialogHeader>
 
                 {/* Streak Display */}
                 <div className="flex items-center justify-center gap-2 py-2">
@@ -177,7 +177,7 @@ export function DailyRewardModal() {
                         </Button>
                     )}
                 </div>
-            </DialogContent>
-        </Dialog>
+            </ResponsiveDialogContent>
+        </ResponsiveDialog>
     )
 }

--- a/packages/frontend/src/components/game/CompletionChoiceModal.tsx
+++ b/packages/frontend/src/components/game/CompletionChoiceModal.tsx
@@ -1,11 +1,11 @@
 import { useTranslation } from 'react-i18next'
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog'
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+} from '@/components/ui/responsive-dialog'
 import { Button } from '@/components/ui/button'
 import { useGameStore } from '@/stores/gameStore'
 import { Trophy, Play } from 'lucide-react'
@@ -42,21 +42,21 @@ export function CompletionChoiceModal() {
   }
 
   return (
-    <Dialog open={showCompletionChoice}>
-      <DialogContent
+    <ResponsiveDialog open={showCompletionChoice}>
+      <ResponsiveDialogContent
         className="sm:max-w-md"
         onPointerDownOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 text-xl">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle className="flex items-center gap-2 text-xl">
             <Trophy className="w-5 h-5 text-primary" />
             {t('game.completionChoice.title')}
-          </DialogTitle>
-          <DialogDescription>
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
             {t('game.completionChoice.description', { count: remainingGames })}
-          </DialogDescription>
-        </DialogHeader>
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
 
         {/* Remaining games info */}
         <div className="flex flex-col items-center py-4">
@@ -87,7 +87,7 @@ export function CompletionChoiceModal() {
             {t('game.completionChoice.seeResults')}
           </Button>
         </div>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   )
 }

--- a/packages/frontend/src/components/game/EndGameButton.tsx
+++ b/packages/frontend/src/components/game/EndGameButton.tsx
@@ -4,12 +4,12 @@ import { useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from '@/components/ui/responsive-dialog'
 import { useGameStore } from '@/stores/gameStore'
 import { Loader2, Trophy, CheckCircle2 } from 'lucide-react'
 import { toast } from '@/lib/toast'
@@ -80,14 +80,14 @@ export function EndGameButton() {
         )}
       </AnimatePresence>
 
-      <Dialog open={showConfirm} onOpenChange={setShowConfirm}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader className="text-center sm:text-center">
+      <ResponsiveDialog open={showConfirm} onOpenChange={setShowConfirm}>
+        <ResponsiveDialogContent className="sm:max-w-md">
+          <ResponsiveDialogHeader className="text-center sm:text-center">
             <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-linear-to-br from-primary/20 to-neon-purple/20 ring-2 ring-primary/30">
               <Trophy className="h-8 w-8 text-primary" />
             </div>
-            <DialogTitle className="text-xl">{t('game.endGame.confirmTitle')}</DialogTitle>
-          </DialogHeader>
+            <ResponsiveDialogTitle className="text-xl">{t('game.endGame.confirmTitle')}</ResponsiveDialogTitle>
+          </ResponsiveDialogHeader>
 
           <div className="py-4 text-center">
             <p className="text-muted-foreground text-base italic">
@@ -95,7 +95,7 @@ export function EndGameButton() {
             </p>
           </div>
 
-          <DialogFooter className="flex-col gap-2 sm:flex-col">
+          <ResponsiveDialogFooter className="flex-col gap-2 sm:flex-col">
             <Button
               variant="gaming"
               onClick={handleEndGame}
@@ -117,9 +117,9 @@ export function EndGameButton() {
             >
               {t('common.cancel')}
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </ResponsiveDialogFooter>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
     </>
   )
 }

--- a/packages/frontend/src/components/game/SecondChanceModal.tsx
+++ b/packages/frontend/src/components/game/SecondChanceModal.tsx
@@ -2,13 +2,13 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Heart } from 'lucide-react'
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-} from '@/components/ui/dialog'
+    ResponsiveDialog,
+    ResponsiveDialogContent,
+    ResponsiveDialogDescription,
+    ResponsiveDialogFooter,
+    ResponsiveDialogHeader,
+    ResponsiveDialogTitle,
+} from '@/components/ui/responsive-dialog'
 import { Button } from '@/components/ui/button'
 import { useGameStore } from '@/stores/gameStore'
 import { useDailyLoginStore } from '@/stores/dailyLoginStore'
@@ -60,18 +60,18 @@ export function SecondChanceModal() {
     }
 
     return (
-        <Dialog open={open} onOpenChange={(o) => { if (!o) handleDismiss() }}>
-            <DialogContent className="sm:max-w-md">
-                <DialogHeader>
-                    <DialogTitle className="flex items-center gap-2">
+        <ResponsiveDialog open={open} onOpenChange={(o) => { if (!o) handleDismiss() }}>
+            <ResponsiveDialogContent className="sm:max-w-md">
+                <ResponsiveDialogHeader>
+                    <ResponsiveDialogTitle className="flex items-center gap-2">
                         <Heart className="h-5 w-5 text-neon-pink" />
                         {t('game.secondChance.title')}
-                    </DialogTitle>
-                    <DialogDescription>
+                    </ResponsiveDialogTitle>
+                    <ResponsiveDialogDescription>
                         {t('game.secondChance.description')}
-                    </DialogDescription>
-                </DialogHeader>
-                <DialogFooter className="gap-2 sm:gap-2">
+                    </ResponsiveDialogDescription>
+                </ResponsiveDialogHeader>
+                <ResponsiveDialogFooter>
                     <Button
                         variant="outline"
                         onClick={handleDismiss}
@@ -88,8 +88,8 @@ export function SecondChanceModal() {
                             ? t('game.secondChance.activating')
                             : t('game.secondChance.accept')}
                     </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
+                </ResponsiveDialogFooter>
+            </ResponsiveDialogContent>
+        </ResponsiveDialog>
     )
 }

--- a/packages/frontend/src/components/onboarding/GuestGateModal.tsx
+++ b/packages/frontend/src/components/onboarding/GuestGateModal.tsx
@@ -1,11 +1,11 @@
 import { useTranslation } from 'react-i18next'
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog'
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+} from '@/components/ui/responsive-dialog'
 import { Button } from '@/components/ui/button'
 import { Trophy, Flame, Gift } from 'lucide-react'
 
@@ -19,15 +19,15 @@ export function GuestGateModal({ open, onCreateAccount, onContinueAsGuest }: Gue
   const { t } = useTranslation()
 
   return (
-    <Dialog open={open} onOpenChange={(next) => { if (!next) onContinueAsGuest() }}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 text-xl">
+    <ResponsiveDialog open={open} onOpenChange={(next) => { if (!next) onContinueAsGuest() }}>
+      <ResponsiveDialogContent className="sm:max-w-md">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle className="flex items-center gap-2 text-xl">
             <Trophy className="w-5 h-5 text-neon-pink" />
             {t('guestGate.title')}
-          </DialogTitle>
-          <DialogDescription>{t('guestGate.subtitle')}</DialogDescription>
-        </DialogHeader>
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>{t('guestGate.subtitle')}</ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
 
         <ul className="grid gap-2 my-4 text-sm">
           <li className="flex items-start gap-3 p-2 rounded-lg bg-card/40 border border-white/5">
@@ -44,7 +44,7 @@ export function GuestGateModal({ open, onCreateAccount, onContinueAsGuest }: Gue
           </li>
         </ul>
 
-        <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
           <Button variant="ghost" onClick={onContinueAsGuest}>
             {t('guestGate.continueGuest')}
           </Button>
@@ -52,7 +52,7 @@ export function GuestGateModal({ open, onCreateAccount, onContinueAsGuest }: Gue
             {t('guestGate.createAccount')}
           </Button>
         </div>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   )
 }

--- a/packages/frontend/src/components/onboarding/WelcomeModal.tsx
+++ b/packages/frontend/src/components/onboarding/WelcomeModal.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog'
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+} from '@/components/ui/responsive-dialog'
 import { Button } from '@/components/ui/button'
 import { Sparkles, Camera, Gift, Trophy, ArrowRight } from 'lucide-react'
 import { consumeWelcomeFlag } from './welcome-storage'
@@ -30,19 +30,19 @@ export function WelcomeModal() {
   }
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-lg">
+    <ResponsiveDialog open={isOpen} onOpenChange={handleClose}>
+      <ResponsiveDialogContent className="sm:max-w-lg">
         {step === 0 ? (
           <>
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-xl">
+            <ResponsiveDialogHeader>
+              <ResponsiveDialogTitle className="flex items-center gap-2 text-xl">
                 <Sparkles className="w-5 h-5 text-neon-purple" />
                 {t('onboarding.welcomeTitle')}
-              </DialogTitle>
-              <DialogDescription>
+              </ResponsiveDialogTitle>
+              <ResponsiveDialogDescription>
                 {t('onboarding.welcomeSubtitle')}
-              </DialogDescription>
-            </DialogHeader>
+              </ResponsiveDialogDescription>
+            </ResponsiveDialogHeader>
 
             <div className="grid gap-3 my-4">
               <div className="flex items-start gap-3 p-3 rounded-lg bg-card/40 border border-white/5">
@@ -71,15 +71,15 @@ export function WelcomeModal() {
           </>
         ) : (
           <>
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-xl">
+            <ResponsiveDialogHeader>
+              <ResponsiveDialogTitle className="flex items-center gap-2 text-xl">
                 <Camera className="w-5 h-5 text-neon-cyan" />
                 {t('onboarding.howTitle')}
-              </DialogTitle>
-              <DialogDescription>
+              </ResponsiveDialogTitle>
+              <ResponsiveDialogDescription>
                 {t('onboarding.howSubtitle')}
-              </DialogDescription>
-            </DialogHeader>
+              </ResponsiveDialogDescription>
+            </ResponsiveDialogHeader>
 
             <ol className="space-y-3 my-4 text-sm text-foreground/90">
               <li className="flex gap-3">
@@ -103,7 +103,7 @@ export function WelcomeModal() {
             </div>
           </>
         )}
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   )
 }

--- a/packages/frontend/src/components/profile/AvatarUpload.tsx
+++ b/packages/frontend/src/components/profile/AvatarUpload.tsx
@@ -2,14 +2,14 @@ import { useState, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Camera, Upload, Trash2, Loader2 } from 'lucide-react'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogTrigger,
+} from '@/components/ui/responsive-dialog'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { userApi } from '@/lib/api/user'
@@ -124,8 +124,8 @@ export function AvatarUpload({
   const displayAvatar = preview || currentAvatarUrl
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveDialogTrigger asChild>
         <button
           type="button"
           className="relative group cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-full"
@@ -144,15 +144,15 @@ export function AvatarUpload({
             <Camera className="h-8 w-8 text-white" />
           </div>
         </button>
-      </DialogTrigger>
+      </ResponsiveDialogTrigger>
 
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>{t('profile.avatar.title')}</DialogTitle>
-          <DialogDescription>
+      <ResponsiveDialogContent className="sm:max-w-md">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>{t('profile.avatar.title')}</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
             {t('profile.avatar.description')}
-          </DialogDescription>
-        </DialogHeader>
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
 
         <div className="flex flex-col items-center gap-6 py-4">
           {/* Preview Avatar */}
@@ -199,7 +199,7 @@ export function AvatarUpload({
           </p>
         </div>
 
-        <DialogFooter className={cn('gap-2', selectedFile ? 'sm:justify-between' : '')}>
+        <ResponsiveDialogFooter className={cn(selectedFile ? 'sm:justify-between' : '')}>
           {currentAvatarUrl && !selectedFile && (
             <Button
               type="button"
@@ -243,8 +243,8 @@ export function AvatarUpload({
               </Button>
             </>
           )}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   )
 }

--- a/packages/frontend/src/components/ui/responsive-dialog.tsx
+++ b/packages/frontend/src/components/ui/responsive-dialog.tsx
@@ -1,0 +1,154 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useIsMobile } from "@/hooks/useIsMobile"
+
+const ResponsiveDialog = DialogPrimitive.Root
+
+const ResponsiveDialogTrigger = DialogPrimitive.Trigger
+
+const ResponsiveDialogPortal = DialogPrimitive.Portal
+
+const ResponsiveDialogClose = DialogPrimitive.Close
+
+function ResponsiveDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="responsive-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/80 backdrop-blur-sm motion-safe:data-[state=open]:animate-in motion-safe:data-[state=closed]:animate-out motion-safe:data-[state=closed]:fade-out-0 motion-safe:data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+type ResponsiveDialogContentProps = React.ComponentProps<
+  typeof DialogPrimitive.Content
+> & {
+  /**
+   * Hide the drag-handle affordance on the mobile bottom sheet.
+   * Default: handle is shown so users see the sheet can be dismissed.
+   */
+  hideDragHandle?: boolean
+}
+
+function ResponsiveDialogContent({
+  className,
+  children,
+  hideDragHandle,
+  style,
+  ...props
+}: ResponsiveDialogContentProps) {
+  const isMobile = useIsMobile()
+
+  return (
+    <ResponsiveDialogPortal>
+      <ResponsiveDialogOverlay />
+      <DialogPrimitive.Content
+        aria-describedby={undefined}
+        data-slot="responsive-dialog-content"
+        data-variant={isMobile ? "sheet" : "dialog"}
+        style={isMobile ? style : { translate: "-50% -50%", ...style }}
+        className={cn(
+          isMobile
+            ? "fixed inset-x-0 bottom-0 z-50 flex flex-col gap-3 max-h-[85dvh] overflow-y-auto rounded-t-2xl border-t border-border bg-card p-4 pb-[max(env(safe-area-inset-bottom),1rem)] shadow-lg motion-safe:data-[state=open]:animate-in motion-safe:data-[state=closed]:animate-out motion-safe:data-[state=open]:slide-in-from-bottom motion-safe:data-[state=closed]:slide-out-to-bottom motion-safe:data-[state=open]:duration-300 motion-safe:data-[state=closed]:duration-200"
+            : "fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] sm:max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto gap-3 sm:gap-4 rounded-lg border border-border bg-card p-4 sm:p-6 shadow-lg duration-200 motion-safe:data-[state=open]:animate-in motion-safe:data-[state=closed]:animate-out motion-safe:data-[state=closed]:fade-out-0 motion-safe:data-[state=open]:fade-in-0 motion-safe:data-[state=closed]:zoom-out-95 motion-safe:data-[state=open]:zoom-in-95 motion-safe:data-[state=closed]:slide-out-to-left-1/2 motion-safe:data-[state=closed]:slide-out-to-top-[48%] motion-safe:data-[state=open]:slide-in-from-left-1/2 motion-safe:data-[state=open]:slide-in-from-top-[48%]",
+          className,
+        )}
+        {...props}
+      >
+        {isMobile && !hideDragHandle && (
+          <div
+            aria-hidden="true"
+            className="mx-auto -mt-1 mb-1 h-1.5 w-12 shrink-0 rounded-full bg-border/60"
+          />
+        )}
+        {children}
+        <DialogPrimitive.Close className="absolute right-2 top-2 flex h-11 w-11 items-center justify-center rounded-md opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-5 w-5" aria-hidden="true" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </ResponsiveDialogPortal>
+  )
+}
+
+function ResponsiveDialogHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="responsive-dialog-header"
+      className={cn(
+        "flex flex-col space-y-1.5 text-center sm:text-left",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResponsiveDialogFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="responsive-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResponsiveDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="responsive-dialog-title"
+      className={cn(
+        "text-base sm:text-lg font-semibold leading-none tracking-tight",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResponsiveDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="responsive-dialog-description"
+      className={cn("text-sm sm:text-base text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  ResponsiveDialog,
+  ResponsiveDialogPortal,
+  ResponsiveDialogOverlay,
+  ResponsiveDialogTrigger,
+  ResponsiveDialogClose,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogFooter,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+}

--- a/packages/frontend/src/pages/LeaderboardPage.tsx
+++ b/packages/frontend/src/pages/LeaderboardPage.tsx
@@ -12,7 +12,12 @@ import { PageHero } from '@/components/layout/PageHero'
 import { DatePicker } from '@/components/ui/date-picker'
 import { MonthPicker } from '@/components/ui/month-picker'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from '@/components/ui/responsive-dialog'
 import { GuessAttemptsList } from '@/components/game/GuessAttemptsList'
 import type { GameSessionDetailsResponse } from '@the-box/types'
 
@@ -572,10 +577,10 @@ export default function LeaderboardPage() {
         </Tabs>
 
         {/* Player Answers Dialog */}
-        <Dialog open={!!selectedPlayer} onOpenChange={(open) => !open && handleCloseDialog()}>
-          <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-2xl max-h-[80vh]">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-3 min-w-0 pr-8">
+        <ResponsiveDialog open={!!selectedPlayer} onOpenChange={(open) => !open && handleCloseDialog()}>
+          <ResponsiveDialogContent className="sm:max-w-2xl">
+            <ResponsiveDialogHeader>
+              <ResponsiveDialogTitle className="flex items-center gap-3 min-w-0 pr-8">
                 {selectedPlayer && (
                   <>
                     <Avatar className="w-8 h-8 shrink-0">
@@ -589,8 +594,8 @@ export default function LeaderboardPage() {
                     </span>
                   </>
                 )}
-              </DialogTitle>
-            </DialogHeader>
+              </ResponsiveDialogTitle>
+            </ResponsiveDialogHeader>
 
             {sessionLoading && (
               <div className="flex justify-center py-8">
@@ -675,8 +680,8 @@ export default function LeaderboardPage() {
                 </div>
               </div>
             )}
-          </DialogContent>
-        </Dialog>
+          </ResponsiveDialogContent>
+        </ResponsiveDialog>
       </div>
     </PageHero>
   )


### PR DESCRIPTION
On mobile, centered Dialogs clip with the iOS keyboard, ignore safe-area
insets, and place the close target far from the thumb. Add a shared
ResponsiveDialog primitive that renders a bottom sheet on <768px (drag
handle, rounded-t-2xl, max-h-[85dvh], safe-area-aware footer) and the
existing centered Dialog on desktop. The API mirrors Dialog so call
sites only swap imports.

Migrated player-facing dialogs: DailyRewardModal, WelcomeModal,
GuestGateModal, CompletionChoiceModal, SecondChanceModal,
EndGameButton, ReportCaptureDialog, LeaderboardPage session dialog,
AvatarUpload. Admin dialogs and destructive confirmation modals stay
on the centered Dialog (documented exception).

Document the Dialog-vs-Sheet rule and the bottom-sheet spec in the
Oxygen design-system doc (new section 2.7).