### PR TITLE
Add i18n support for achievements and daily login rewards

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -80,7 +80,177 @@
       "progress": "Progress"
     },
     "unlocked": "Achievement Unlocked!",
-    "unlockedWithName": "Achievement Unlocked: {{name}}"
+    "unlockedWithName": "Achievement Unlocked: {{name}}",
+    "items": {
+      "speed_demon": {
+        "name": "Speed Demon",
+        "description": "Get 3 perfect speed guesses in a row (under 3 seconds each)"
+      },
+      "lightning_reflexes": {
+        "name": "Lightning Reflexes",
+        "description": "Answer 10 screenshots in under 3 seconds"
+      },
+      "quick_draw": {
+        "name": "Quick Draw",
+        "description": "Answer any screenshot in under 2 seconds"
+      },
+      "no_hints_needed": {
+        "name": "No Hints Needed",
+        "description": "Complete a daily challenge without using any hints"
+      },
+      "hint_free_master": {
+        "name": "Hint-Free Master",
+        "description": "Complete 10 daily challenges without using hints"
+      },
+      "sharp_eye": {
+        "name": "Sharp Eye",
+        "description": "Get 10 correct guesses in a row with no wrong answers"
+      },
+      "perfect_run": {
+        "name": "Perfect Run",
+        "description": "Score exactly 2000 points in a single challenge"
+      },
+      "high_roller": {
+        "name": "High Roller",
+        "description": "Score over 1800 points in a single challenge"
+      },
+      "dedicated_player": {
+        "name": "Dedicated Player",
+        "description": "Maintain a 3-day play streak"
+      },
+      "weekly_warrior": {
+        "name": "Weekly Warrior",
+        "description": "Maintain a 7-day play streak"
+      },
+      "month_master": {
+        "name": "Month Master",
+        "description": "Maintain a 30-day play streak"
+      },
+      "rpg_expert": {
+        "name": "RPG Expert",
+        "description": "Correctly identify 10 RPG games"
+      },
+      "action_hero": {
+        "name": "Action Hero",
+        "description": "Correctly identify 10 Action games"
+      },
+      "strategy_savant": {
+        "name": "Strategy Savant",
+        "description": "Correctly identify 10 Strategy games"
+      },
+      "first_win": {
+        "name": "First Win",
+        "description": "Complete your first daily challenge"
+      },
+      "century_club": {
+        "name": "Century Club",
+        "description": "Complete 100 daily challenges"
+      },
+      "top_ten": {
+        "name": "Top 10",
+        "description": "Rank in the top 10 on any daily challenge"
+      },
+      "podium_finish": {
+        "name": "Podium Finish",
+        "description": "Rank in the top 3 on any daily challenge"
+      },
+      "champion": {
+        "name": "Champion",
+        "description": "Achieve 1st place on any daily challenge"
+      },
+      "welcome_player": {
+        "name": "Welcome!",
+        "description": "Start your first daily challenge"
+      },
+      "first_guess": {
+        "name": "First Try",
+        "description": "Make your first guess"
+      },
+      "first_correct": {
+        "name": "Eagle Eye",
+        "description": "Find your first correct answer"
+      },
+      "getting_warmed_up": {
+        "name": "Warming Up",
+        "description": "Find 3 screenshots in a single challenge"
+      },
+      "halfway_there": {
+        "name": "Halfway There",
+        "description": "Find 5 screenshots in a single challenge"
+      },
+      "almost_perfect": {
+        "name": "Almost Perfect",
+        "description": "Find 8 screenshots in a single challenge"
+      },
+      "score_500": {
+        "name": "Rising Star",
+        "description": "Score 500+ points in a single challenge"
+      },
+      "score_1000": {
+        "name": "In Top Form",
+        "description": "Score 1000+ points in a single challenge"
+      },
+      "score_1500": {
+        "name": "Pro Player",
+        "description": "Score 1500+ points in a single challenge"
+      },
+      "regular_player": {
+        "name": "Regular Player",
+        "description": "Complete 5 daily challenges"
+      },
+      "committed_gamer": {
+        "name": "Committed Gamer",
+        "description": "Complete 10 daily challenges"
+      },
+      "veteran_player": {
+        "name": "Veteran Player",
+        "description": "Complete 25 daily challenges"
+      },
+      "dedicated_fan": {
+        "name": "Dedicated Fan",
+        "description": "Complete 50 daily challenges"
+      },
+      "game_collector_10": {
+        "name": "Collector",
+        "description": "Correctly identify 10 different games"
+      },
+      "game_collector_50": {
+        "name": "Game Expert",
+        "description": "Correctly identify 50 different games"
+      },
+      "game_collector_100": {
+        "name": "Walking Encyclopedia",
+        "description": "Correctly identify 100 different games"
+      },
+      "comeback_kid": {
+        "name": "Back Again",
+        "description": "Play 2 days in a row"
+      },
+      "five_day_streak": {
+        "name": "On a Roll",
+        "description": "Play 5 days in a row"
+      },
+      "two_week_warrior": {
+        "name": "Two-Week Warrior",
+        "description": "Play 14 days in a row"
+      },
+      "fast_fingers": {
+        "name": "Fast Fingers",
+        "description": "Answer in under 5 seconds"
+      },
+      "speed_collector": {
+        "name": "Speed Collector",
+        "description": "Get 5 quick answers (under 5 seconds)"
+      },
+      "persistent_guesser": {
+        "name": "Persistent",
+        "description": "Make 100 guesses in total"
+      },
+      "guessing_machine": {
+        "name": "Guessing Machine",
+        "description": "Make 500 guesses in total"
+      }
+    }
   },
   "game": {
     "progressDots": {
@@ -1837,7 +2007,37 @@
     "hintGenre": "Genre Hint",
     "streakFreeze": "Streak freeze",
     "secondChance": "Second chance",
-    "points": "points"
+    "points": "points",
+    "rewards": {
+      "day1": {
+        "name": "Year Hint",
+        "description": "Get a hint about the game's release year"
+      },
+      "day2": {
+        "name": "Publisher Hint",
+        "description": "Get a hint about the game's publisher"
+      },
+      "day3": {
+        "name": "100 Points",
+        "description": "100 bonus points added to your score"
+      },
+      "day4": {
+        "name": "2x Year Hint",
+        "description": "Get two hints about the release year"
+      },
+      "day5": {
+        "name": "2x Publisher Hint",
+        "description": "Get two hints about the publisher"
+      },
+      "day6": {
+        "name": "250 Points",
+        "description": "Big 250-point bonus"
+      },
+      "day7": {
+        "name": "Legendary Chest",
+        "description": "The ultimate chest: 2x each hint + 500 points!"
+      }
+    }
   },
   "onboarding": {
     "welcomeTitle": "Welcome to The Box!",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -80,7 +80,177 @@
       "progress": "Progression"
     },
     "unlocked": "Succès Débloqué !",
-    "unlockedWithName": "Succès Débloqué : {{name}}"
+    "unlockedWithName": "Succès Débloqué : {{name}}",
+    "items": {
+      "speed_demon": {
+        "name": "Démon de la Vitesse",
+        "description": "Obtenez 3 réponses parfaites de suite (moins de 3 secondes chacune)"
+      },
+      "lightning_reflexes": {
+        "name": "Réflexes Éclair",
+        "description": "Répondez à 10 captures en moins de 3 secondes"
+      },
+      "quick_draw": {
+        "name": "Dégaineur",
+        "description": "Répondez à une capture en moins de 2 secondes"
+      },
+      "no_hints_needed": {
+        "name": "Sans Indices",
+        "description": "Complétez un défi quotidien sans utiliser d'indices"
+      },
+      "hint_free_master": {
+        "name": "Maître Sans Indices",
+        "description": "Complétez 10 défis quotidiens sans utiliser d'indices"
+      },
+      "sharp_eye": {
+        "name": "Regard Perçant",
+        "description": "Obtenez 10 bonnes réponses de suite sans erreur"
+      },
+      "perfect_run": {
+        "name": "Partie Parfaite",
+        "description": "Obtenez exactement 2000 points dans un seul défi"
+      },
+      "high_roller": {
+        "name": "Gros Joueur",
+        "description": "Obtenez plus de 1800 points dans un seul défi"
+      },
+      "dedicated_player": {
+        "name": "Joueur Dévoué",
+        "description": "Maintenez une série de 3 jours"
+      },
+      "weekly_warrior": {
+        "name": "Guerrier Hebdomadaire",
+        "description": "Maintenez une série de 7 jours"
+      },
+      "month_master": {
+        "name": "Maître du Mois",
+        "description": "Maintenez une série de 30 jours"
+      },
+      "rpg_expert": {
+        "name": "Expert RPG",
+        "description": "Identifiez correctement 10 jeux RPG"
+      },
+      "action_hero": {
+        "name": "Héros d'Action",
+        "description": "Identifiez correctement 10 jeux d'Action"
+      },
+      "strategy_savant": {
+        "name": "Stratège Érudit",
+        "description": "Identifiez correctement 10 jeux de Stratégie"
+      },
+      "first_win": {
+        "name": "Première Victoire",
+        "description": "Complétez votre premier défi quotidien"
+      },
+      "century_club": {
+        "name": "Club des Cent",
+        "description": "Complétez 100 défis quotidiens"
+      },
+      "top_ten": {
+        "name": "Top 10",
+        "description": "Classez-vous dans le top 10 d'un défi quotidien"
+      },
+      "podium_finish": {
+        "name": "Sur le Podium",
+        "description": "Classez-vous dans le top 3 d'un défi quotidien"
+      },
+      "champion": {
+        "name": "Champion",
+        "description": "Obtenez la 1ère place d'un défi quotidien"
+      },
+      "welcome_player": {
+        "name": "Bienvenue !",
+        "description": "Lancez votre premier défi quotidien"
+      },
+      "first_guess": {
+        "name": "Premier Essai",
+        "description": "Faites votre première proposition"
+      },
+      "first_correct": {
+        "name": "Œil de Lynx",
+        "description": "Trouvez votre première bonne réponse"
+      },
+      "getting_warmed_up": {
+        "name": "Échauffement",
+        "description": "Trouvez 3 captures dans un seul défi"
+      },
+      "halfway_there": {
+        "name": "À Mi-Chemin",
+        "description": "Trouvez 5 captures dans un seul défi"
+      },
+      "almost_perfect": {
+        "name": "Presque Parfait",
+        "description": "Trouvez 8 captures dans un seul défi"
+      },
+      "score_500": {
+        "name": "Étoile Montante",
+        "description": "Obtenez 500+ points dans un seul défi"
+      },
+      "score_1000": {
+        "name": "En Pleine Forme",
+        "description": "Obtenez 1000+ points dans un seul défi"
+      },
+      "score_1500": {
+        "name": "Joueur Pro",
+        "description": "Obtenez 1500+ points dans un seul défi"
+      },
+      "regular_player": {
+        "name": "Joueur Régulier",
+        "description": "Complétez 5 défis quotidiens"
+      },
+      "committed_gamer": {
+        "name": "Gamer Assidu",
+        "description": "Complétez 10 défis quotidiens"
+      },
+      "veteran_player": {
+        "name": "Joueur Vétéran",
+        "description": "Complétez 25 défis quotidiens"
+      },
+      "dedicated_fan": {
+        "name": "Fan Dévoué",
+        "description": "Complétez 50 défis quotidiens"
+      },
+      "game_collector_10": {
+        "name": "Collectionneur",
+        "description": "Identifiez correctement 10 jeux différents"
+      },
+      "game_collector_50": {
+        "name": "Expert en Jeux",
+        "description": "Identifiez correctement 50 jeux différents"
+      },
+      "game_collector_100": {
+        "name": "Encyclopédie Vivante",
+        "description": "Identifiez correctement 100 jeux différents"
+      },
+      "comeback_kid": {
+        "name": "De Retour",
+        "description": "Jouez 2 jours de suite"
+      },
+      "five_day_streak": {
+        "name": "Sur une Lancée",
+        "description": "Jouez 5 jours de suite"
+      },
+      "two_week_warrior": {
+        "name": "Guerrier des Deux Semaines",
+        "description": "Jouez 14 jours de suite"
+      },
+      "fast_fingers": {
+        "name": "Doigts Rapides",
+        "description": "Répondez en moins de 5 secondes"
+      },
+      "speed_collector": {
+        "name": "Collectionneur de Vitesse",
+        "description": "Obtenez 5 réponses rapides (moins de 5 secondes)"
+      },
+      "persistent_guesser": {
+        "name": "Persévérant",
+        "description": "Faites 100 propositions au total"
+      },
+      "guessing_machine": {
+        "name": "Machine à Deviner",
+        "description": "Faites 500 propositions au total"
+      }
+    }
   },
   "game": {
     "progressDots": {
@@ -1837,7 +2007,37 @@
     "hintGenre": "Indice Genre",
     "streakFreeze": "Protection de série",
     "secondChance": "Seconde chance",
-    "points": "points"
+    "points": "points",
+    "rewards": {
+      "day1": {
+        "name": "Indice Année",
+        "description": "Obtenez un indice sur l'année de sortie du jeu"
+      },
+      "day2": {
+        "name": "Indice Éditeur",
+        "description": "Obtenez un indice sur l'éditeur du jeu"
+      },
+      "day3": {
+        "name": "100 Points",
+        "description": "Bonus de 100 points ajoutés à votre score"
+      },
+      "day4": {
+        "name": "2x Indice Année",
+        "description": "Obtenez deux indices sur l'année de sortie"
+      },
+      "day5": {
+        "name": "2x Indice Éditeur",
+        "description": "Obtenez deux indices sur l'éditeur"
+      },
+      "day6": {
+        "name": "250 Points",
+        "description": "Gros bonus de 250 points"
+      },
+      "day7": {
+        "name": "Coffre Légendaire",
+        "description": "Le coffre ultime : 2x chaque indice + 500 points !"
+      }
+    }
   },
   "onboarding": {
     "welcomeTitle": "Bienvenue dans The Box !",

--- a/packages/frontend/src/components/achievement/AchievementCard.tsx
+++ b/packages/frontend/src/components/achievement/AchievementCard.tsx
@@ -46,6 +46,12 @@ export function AchievementCard({ achievement, size = 'medium', className }: Ach
 
     const lockedLabel = t('achievements.status.locked')
     const earnedLabel = t('achievements.status.earned')
+    const localizedName = t(`achievements.items.${achievement.key}.name`, {
+        defaultValue: achievement.name,
+    })
+    const localizedDescription = t(`achievements.items.${achievement.key}.description`, {
+        defaultValue: achievement.description,
+    })
     // A non-color status hint that screen readers can use ("locked" /
     // "earned"). We render the same cue visually as a Lock icon so users
     // who can't perceive the purple-vs-grey delta still get the signal.
@@ -66,10 +72,10 @@ export function AchievementCard({ achievement, size = 'medium', className }: Ach
                 <div className="text-3xl">{isLocked ? <Lock className="w-8 h-8" aria-hidden="true" /> : achievement.iconUrl}</div>
                 <div className="flex-1 min-w-0">
                     <div className="font-semibold text-sm truncate">
-                        {isLocked ? '???' : achievement.name}
+                        {isLocked ? '???' : localizedName}
                     </div>
                     <div className="text-xs text-muted-foreground truncate">
-                        {isLocked ? t('achievements.status.hidden') : achievement.description}
+                        {isLocked ? t('achievements.status.hidden') : localizedDescription}
                     </div>
                     {hasProgress && !isComplete && (
                         <Progress value={(achievement.progress / achievement.progressMax!) * 100} className="mt-1 h-1" />
@@ -131,10 +137,10 @@ export function AchievementCard({ achievement, size = 'medium', className }: Ach
                     </div>
                     <div className="flex-1 min-w-0">
                         <CardTitle className="text-lg">
-                            {isLocked ? '???' : achievement.name}
+                            {isLocked ? '???' : localizedName}
                         </CardTitle>
                         <CardDescription className="mt-1">
-                            {isLocked ? t('achievements.status.hiddenDescription') : achievement.description}
+                            {isLocked ? t('achievements.status.hiddenDescription') : localizedDescription}
                         </CardDescription>
                     </div>
                 </div>

--- a/packages/frontend/src/components/achievement/AchievementNotification.tsx
+++ b/packages/frontend/src/components/achievement/AchievementNotification.tsx
@@ -1,6 +1,7 @@
 import type { NewlyEarnedAchievement } from '@the-box/types'
 import { motion } from 'framer-motion'
 import { toast as sonner } from 'sonner'
+import { useTranslation } from 'react-i18next'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -23,7 +24,17 @@ const tierColors = {
  * reuse inside `sonner.toast.custom(...)` — see `showAchievementToast`.
  */
 export function AchievementToastBody({ achievement, toastId }: AchievementToastBodyProps) {
+    const { t } = useTranslation()
     const tierGradient = tierColors[achievement.tier as keyof typeof tierColors] || tierColors[1]
+    const localizedName = t(`achievements.items.${achievement.key}.name`, {
+        defaultValue: achievement.name,
+    })
+    const localizedDescription = t(`achievements.items.${achievement.key}.description`, {
+        defaultValue: achievement.description,
+    })
+    const localizedCategory = t(`achievements.categories.${achievement.category}`, {
+        defaultValue: achievement.category,
+    })
 
     return (
         <Card className={`relative overflow-hidden border-2 bg-linear-to-br ${tierGradient} shadow-2xl w-full max-w-md`}>
@@ -51,7 +62,7 @@ export function AchievementToastBody({ achievement, toastId }: AchievementToastB
                     </motion.div>
                     <span className="text-sm font-semibold text-warning flex items-center gap-1">
                         <Sparkles className="h-4 w-4" />
-                        Achievement Unlocked!
+                        {t('achievements.unlocked')}
                     </span>
                 </div>
 
@@ -67,9 +78,9 @@ export function AchievementToastBody({ achievement, toastId }: AchievementToastB
                         {achievement.iconUrl || '🏆'}
                     </motion.div>
                     <div className="flex-1">
-                        <CardTitle className="text-xl">{achievement.name}</CardTitle>
+                        <CardTitle className="text-xl">{localizedName}</CardTitle>
                         <CardDescription className="mt-1 text-muted-foreground">
-                            {achievement.description}
+                            {localizedDescription}
                         </CardDescription>
                     </div>
                 </div>
@@ -78,10 +89,10 @@ export function AchievementToastBody({ achievement, toastId }: AchievementToastB
             <CardContent className="pt-0 relative">
                 <div className="flex items-center gap-2">
                     <Badge variant="secondary" className="text-xs">
-                        +{achievement.points} points
+                        +{achievement.points} {t('dailyLogin.points')}
                     </Badge>
                     <Badge variant="outline" className="text-xs capitalize">
-                        {achievement.category}
+                        {localizedCategory}
                     </Badge>
                 </div>
             </CardContent>

--- a/packages/frontend/src/components/daily-login/DailyRewardModal.tsx
+++ b/packages/frontend/src/components/daily-login/DailyRewardModal.tsx
@@ -121,9 +121,15 @@ export function DailyRewardModal() {
                         )}
 
                         <span className="text-4xl mb-2">{reward.iconUrl}</span>
-                        <h3 className="font-bold text-lg text-center">{reward.displayName}</h3>
+                        <h3 className="font-bold text-lg text-center">
+                            {t(`dailyLogin.rewards.day${reward.dayNumber}.name`, {
+                                defaultValue: reward.displayName,
+                            })}
+                        </h3>
                         <p className="text-sm text-muted-foreground text-center mt-1">
-                            {reward.description}
+                            {t(`dailyLogin.rewards.day${reward.dayNumber}.description`, {
+                                defaultValue: reward.description ?? '',
+                            })}
                         </p>
 
                         {/* Reward details */}

--- a/packages/frontend/src/components/home/HomeAchievementTeaser.tsx
+++ b/packages/frontend/src/components/home/HomeAchievementTeaser.tsx
@@ -46,10 +46,17 @@ interface TeaserCardProps {
 }
 
 function TeaserCard({ achievement, lockedLabel }: TeaserCardProps) {
+  const { t } = useTranslation()
+  const localizedName = t(`achievements.items.${achievement.key}.name`, {
+    defaultValue: achievement.name,
+  })
+  const localizedDescription = t(`achievements.items.${achievement.key}.description`, {
+    defaultValue: achievement.description,
+  })
   return (
     <div
       className="group relative h-full overflow-hidden rounded-xl border border-neon-purple/30 bg-card/60 backdrop-blur-sm transition-colors hover:border-neon-pink/60"
-      aria-label={`${achievement.name} — ${lockedLabel}`}
+      aria-label={`${localizedName} — ${lockedLabel}`}
     >
       <div
         aria-hidden="true"
@@ -74,10 +81,10 @@ function TeaserCard({ achievement, lockedLabel }: TeaserCardProps) {
           </span>
         </div>
         <h3 className="text-sm sm:text-base font-semibold leading-tight text-foreground">
-          {achievement.name}
+          {localizedName}
         </h3>
         <p className="text-xs sm:text-sm text-muted-foreground line-clamp-3">
-          {achievement.description}
+          {localizedDescription}
         </p>
         <Badge
           variant="outline"


### PR DESCRIPTION
## Summary
This PR adds comprehensive internationalization (i18n) support for achievements and daily login rewards by introducing localized strings in the translation files and updating components to use the translation system.

## Key Changes

- **Translation Files** (`en/translation.json`, `fr/translation.json`):
  - Added `achievements.items` object with 40 achievement definitions (name + description) for both English and French
  - Added `dailyLogin.rewards` object with 7 daily reward definitions (day1–day7) for both English and French

- **Achievement Components**:
  - `AchievementNotification.tsx`: Updated to fetch localized achievement name, description, and category using `useTranslation()` hook with fallback to original values
  - `AchievementCard.tsx`: Updated to display localized achievement name and description, with fallback for locked achievements
  - `HomeAchievementTeaser.tsx`: Updated to use localized name and description in teaser cards and aria-labels

- **Daily Login Component**:
  - `DailyRewardModal.tsx`: Updated to fetch localized reward name and description using the translation key pattern `dailyLogin.rewards.day${dayNumber}` with fallback to original values

## Implementation Details

- All components use the `useTranslation()` hook from `react-i18next` to access translations
- Translation keys follow the pattern: `achievements.items.${achievement.key}.name|description` and `dailyLogin.rewards.day${dayNumber}.name|description`
- All translations include `defaultValue` fallback to maintain backward compatibility if translation keys are missing
- Localized category names are also fetched for achievements using `achievements.categories.${category}` pattern
- No changes to component logic or structure—only display values are now localized

https://claude.ai/code/session_016zkMbEFvRaRM6TMAaoxawu