### PR TITLE
docs(launch): Reddit launch post for r/buildinpublic + cross-post matrix

### DIFF
--- a/tasks/reddit-launch-post.html
+++ b/tasks/reddit-launch-post.html
@@ -1,0 +1,514 @@
+<!DOCTYPE html>
+<!--
+  SUMMARY: Reddit launch post for The Box — primary target r/buildinpublic,
+  posted T-0 on 2026-05-15 alongside the PH launch (09:01 CEST). One full
+  ready-to-paste post written as a 6-month dev journal (not a pitch), with
+  three title options ranked by fit, body copy verified against
+  docs/game-flow.md (10 screenshots/day · 30s timer · fuzzy match · speed
+  multiplier 1.0x–2.0x · 4 hint types · pricing €3.99/mo or €29.99/yr) and
+  packages/backend/src/config/billing.ts. Includes a comment-engagement
+  playbook and a cross-post matrix for r/SideProject, r/IndieDev,
+  r/webdev, r/reactjs. Honours r/buildinpublic Rule 3 (no self-promo
+  without context) and Rule 7 (transparency in tools): full stack, monthly
+  hosting cost, what broke, what's free vs paid — all on the page. Link
+  goes at the bottom of the body, never the title.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="robots" content="noindex">
+<title>Reddit Launch Post · The Box</title>
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --surface: #14141c;
+    --surface-2: #1b1b25;
+    --border: rgba(255,255,255,0.08);
+    --border-strong: rgba(255,255,255,0.16);
+    --fg: #e4e4e7;
+    --muted: #a1a1aa;
+    --neon-purple: #a855f7;
+    --neon-pink: #ec4899;
+    --neon-blue: #38bdf8;
+    --neon-orange: #ff4500;
+    --ok: #10b981;
+    --warn: #f59e0b;
+    --risk: #ef4444;
+    --radius: 0.625rem;
+    --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    --sans: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--sans);
+    line-height: 1.6;
+    font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: var(--neon-purple); text-decoration: none; border-bottom: 1px dotted rgba(168,85,247,.4); }
+  a:hover { border-bottom-color: var(--neon-purple); }
+  a:focus-visible, button:focus-visible, summary:focus-visible {
+    outline: 2px solid var(--neon-purple);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+  code { font-family: var(--mono); font-size: 0.9em; background: var(--surface-2); padding: 0.1em 0.35em; border-radius: 4px; }
+
+  header.top {
+    position: sticky; top: 0; z-index: 10;
+    background: rgba(10,10,15,0.85);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.75rem 1.25rem;
+    display: flex; align-items: center; justify-content: space-between;
+    font-size: 0.875rem;
+  }
+  header.top .title { font-weight: 600; }
+  header.top .repo { color: var(--muted); font-family: var(--mono); }
+
+  .layout { display: grid; grid-template-columns: minmax(0, 72ch) 220px; gap: 3rem; max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }
+  main { min-width: 0; }
+  aside.toc {
+    position: sticky; top: 4.5rem; align-self: start;
+    font-size: 0.875rem;
+    border-left: 1px solid var(--border);
+    padding-left: 1rem;
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+  }
+  aside.toc h2 { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin: 0 0 0.5rem; }
+  aside.toc ol { list-style: none; padding: 0; margin: 0; counter-reset: toc; }
+  aside.toc li { margin: 0.35rem 0; counter-increment: toc; }
+  aside.toc li::before { content: counter(toc, decimal-leading-zero) " "; color: var(--muted); font-family: var(--mono); font-size: 0.75rem; }
+  aside.toc a { color: var(--muted); border: none; }
+  aside.toc a:hover { color: var(--neon-purple); }
+
+  @media (max-width: 900px) {
+    .layout { grid-template-columns: 1fr; }
+    aside.toc { position: static; border-left: 0; border-top: 1px solid var(--border); padding-left: 0; padding-top: 1rem; max-height: none; }
+  }
+
+  h1 { font-size: 2.25rem; line-height: 1.15; margin: 0 0 0.5rem; letter-spacing: -0.01em; }
+  h2 { font-size: 1.5rem; margin: 2.5rem 0 1rem; letter-spacing: -0.005em; scroll-margin-top: 4rem; }
+  h3 { font-size: 1.125rem; margin: 1.5rem 0 0.5rem; }
+  h4 { font-size: 0.95rem; margin: 1rem 0 0.4rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
+  p, li { color: var(--fg); }
+  .meta { color: var(--muted); font-size: 0.9rem; margin: 0.25rem 0 0; }
+  .meta b { color: var(--fg); font-weight: 500; }
+
+  .hero {
+    margin-top: 0.5rem; padding: 1.5rem;
+    background: linear-gradient(135deg, rgba(168,85,247,0.10), rgba(255,69,0,0.06));
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 0 60px -20px rgba(168,85,247,0.4);
+  }
+  .hero p { margin: 0; font-size: 1.05rem; }
+  .hero p em { color: var(--neon-purple); font-style: normal; font-weight: 500; }
+
+  .pill { display: inline-block; padding: 0.15rem 0.55rem; border-radius: 999px; font-size: 0.72rem; font-family: var(--mono); letter-spacing: 0.04em; border: 1px solid var(--border-strong); margin-right: 0.25rem; }
+  .pill.ok { color: var(--ok); border-color: rgba(16,185,129,0.4); }
+  .pill.warn { color: var(--warn); border-color: rgba(245,158,11,0.4); }
+  .pill.risk { color: var(--risk); border-color: rgba(239,68,68,0.4); }
+  .pill.info { color: var(--neon-blue); border-color: rgba(56,189,248,0.4); }
+  .pill.reddit { color: var(--neon-orange); border-color: rgba(255,69,0,0.4); }
+
+  .card {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    padding: 1rem 1.25rem;
+    margin: 1rem 0;
+  }
+  .card h3 { margin-top: 0; }
+
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.92rem; }
+  th, td { padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+  th { color: var(--muted); font-weight: 500; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; }
+  td.t { font-family: var(--mono); font-size: 0.85rem; color: var(--neon-purple); white-space: nowrap; }
+
+  .post {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    padding: 0;
+    margin: 1rem 0;
+    overflow: hidden;
+  }
+  .post .head {
+    display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;
+    font-family: var(--mono); font-size: 0.72rem; color: var(--muted);
+    padding: 0.7rem 1rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface-2);
+    letter-spacing: 0.04em;
+  }
+  .post .head .num { color: var(--neon-purple); font-weight: 600; }
+  .post .head .sub { color: var(--neon-orange); }
+  .post .head .when { color: var(--neon-blue); }
+  .post .title-bar {
+    padding: 0.9rem 1.1rem 0.4rem;
+    font-size: 1.15rem;
+    font-weight: 600;
+    line-height: 1.35;
+    color: var(--fg);
+  }
+  .post .body {
+    padding: 0.4rem 1.1rem 1rem;
+    white-space: pre-wrap;
+    font-size: 0.98rem;
+    line-height: 1.65;
+  }
+  .post .body .url { color: var(--neon-blue); font-family: var(--mono); font-size: 0.9em; }
+  .post .body .label { color: var(--neon-purple); font-weight: 500; }
+  .post .body .code { font-family: var(--mono); font-size: 0.88em; background: var(--surface-2); padding: 0.05em 0.35em; border-radius: 4px; }
+  .post .foot {
+    display: flex; justify-content: space-between; align-items: center;
+    margin-top: 0; padding: 0.6rem 1.1rem;
+    border-top: 1px dashed var(--border);
+    font-family: var(--mono); font-size: 0.72rem; color: var(--muted);
+  }
+  .post .foot .ok { color: var(--ok); }
+  .post .foot .warn { color: var(--warn); }
+  .post .media {
+    margin: 0 1.1rem 0.8rem; padding: 0.5rem 0.75rem;
+    background: var(--surface-2); border: 1px dashed var(--border);
+    border-radius: 6px; font-size: 0.82rem; color: var(--muted);
+  }
+  .post .media b { color: var(--fg); font-weight: 500; }
+
+  .titles { display: grid; gap: 0.6rem; margin: 1rem 0; }
+  .title-opt {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    padding: 0.7rem 1rem;
+    display: grid; grid-template-columns: auto 1fr auto; gap: 0.75rem; align-items: center;
+  }
+  .title-opt .rank { font-family: var(--mono); font-size: 0.75rem; color: var(--neon-purple); }
+  .title-opt .text { font-weight: 500; }
+  .title-opt .why { font-family: var(--mono); font-size: 0.7rem; color: var(--muted); white-space: nowrap; }
+  .title-opt.best { border-color: rgba(168,85,247,0.4); box-shadow: 0 0 30px -15px rgba(168,85,247,0.5); }
+
+  blockquote.callout {
+    margin: 1rem 0; padding: 0.8rem 1rem 0.8rem 1.2rem;
+    border-left: 3px solid var(--neon-purple);
+    background: rgba(168,85,247,0.06);
+    border-radius: 0 var(--radius) var(--radius) 0;
+  }
+  blockquote.callout p { margin: 0; }
+  blockquote.callout.info { border-left-color: var(--neon-blue); background: rgba(56,189,248,0.06); }
+  blockquote.callout.warn { border-left-color: var(--warn); background: rgba(245,158,11,0.06); }
+
+  ul.dont { list-style: none; padding: 0; }
+  ul.dont li { padding: 0.4rem 0 0.4rem 1.5rem; position: relative; border-bottom: 1px dashed var(--border); }
+  ul.dont li:last-child { border-bottom: 0; }
+  ul.dont li::before {
+    content: "✕"; position: absolute; left: 0; top: 0.4rem; color: var(--risk); font-weight: 700;
+  }
+
+  ul.do { list-style: none; padding: 0; }
+  ul.do li { padding: 0.4rem 0 0.4rem 1.5rem; position: relative; border-bottom: 1px dashed var(--border); }
+  ul.do li:last-child { border-bottom: 0; }
+  ul.do li::before {
+    content: "✓"; position: absolute; left: 0; top: 0.4rem; color: var(--ok); font-weight: 700;
+  }
+
+  hr { border: 0; border-top: 1px solid var(--border); margin: 2rem 0; }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { transition: none !important; animation: none !important; }
+  }
+</style>
+</head>
+<body>
+
+<header class="top">
+  <span class="title">Reddit Launch Post</span>
+  <span class="repo">the-box · tasks/reddit-launch-post.html</span>
+</header>
+
+<div class="layout">
+
+<aside class="toc" aria-label="Contents">
+  <h2>Contents</h2>
+  <ol>
+    <li><a href="#thesis">Thesis</a></li>
+    <li><a href="#sub">Target sub &amp; rules</a></li>
+    <li><a href="#titles">Title options</a></li>
+    <li><a href="#post">The post (ready to paste)</a></li>
+    <li><a href="#timing">Posting timing</a></li>
+    <li><a href="#replies">Comment playbook</a></li>
+    <li><a href="#crosspost">Cross-post matrix</a></li>
+    <li><a href="#dont">What not to do</a></li>
+    <li><a href="#checklist">Pre-post checklist</a></li>
+  </ol>
+</aside>
+
+<main>
+
+<h1>Reddit launch post — The Box</h1>
+<p class="meta"><b>Primary target:</b> r/buildinpublic · <b>PH go-live:</b> 2026-05-15 09:01 CEST · <b>Locale:</b> English · <b>Status:</b> draft ready to paste</p>
+
+<div class="hero">
+  <p>r/buildinpublic Rule 3 (<em>No Self-Promotion Without Context</em>) and Rule 7 (<em>Transparency in Tools &amp; Resources</em>) are the two that matter. The post that works in this sub is a <em>6-month build journal</em> with real numbers, real stack, real screwups — and the link sits at the bottom. The post that gets buried is the one that opens with "Excited to share…". This file is the journal version.</p>
+</div>
+
+<h2 id="thesis">1 · Thesis</h2>
+<p>r/buildinpublic readers are other makers. They don't care about the brand and they can smell a marketing post in two lines. What they read to the end is: <em>what did you decide, what did it cost, what broke, what would you do differently</em>. The Box has a clean answer to all four — six months solo, ~€18/mo hosting, the fuzzy-match scoring curve was the hardest part, and the catch-up-mode pricing logic took three rewrites. Lead with those, mention the launch only as the reason you're posting today, drop the link last.</p>
+<p>The launch is happening on Product Hunt tomorrow morning. The Reddit post goes up <strong>the same morning</strong>, ~30 minutes after PH opens, so any cross-traffic from PH commenters can find the dev-journal version on Reddit and vice versa. Don't link to PH from the Reddit post — mention it in a comment if asked.</p>
+
+<h2 id="sub">2 · Target sub &amp; rules read</h2>
+<p>Primary post: <b>r/buildinpublic</b> (50.7k members, Top 100 in Programming). Rules I'm honouring directly in the copy:</p>
+<table>
+  <tr><th>Rule</th><th>How the post complies</th></tr>
+  <tr><td>1 · Be Respectful</td><td>No comparisons to competitors. No claims of "the best" anything.</td></tr>
+  <tr><td>2 · Stay on Topic</td><td>Frame is "what I built and what I learned", which is the sub's mandate.</td></tr>
+  <tr><td>3 · No Self-Promotion Without Context</td><td>~80% of the post is process / decisions / numbers. The link is one line at the bottom.</td></tr>
+  <tr><td>4 · No Spam</td><td>Single post, no repost, no follow-ups for ≥30 days.</td></tr>
+  <tr><td>5 · No Plagiarism</td><td>Screenshots are credited (RAWG API). No copied copy from PH/X drafts — this post is rewritten for the sub voice.</td></tr>
+  <tr><td>6 · Privacy</td><td>No user data, no screenshots of real accounts. The leaderboard image (if used) shows test accounts only.</td></tr>
+  <tr><td>7 · Transparency in Tools &amp; Resources</td><td>Full stack + hosting cost + paid tools listed by name (see §4).</td></tr>
+</table>
+
+<h2 id="titles">3 · Title options</h2>
+<p>Reddit titles do ~70% of the work. Three drafts, ranked. Pick #1 unless something today suggests otherwise.</p>
+
+<div class="titles">
+  <div class="title-opt best">
+    <span class="rank">#1</span>
+    <span class="text">After 6 months solo I'm launching today — a daily screenshot-guessing game for video games. Here's what I built, what it cost, and what almost killed it.</span>
+    <span class="why">142 chars · lead with journey</span>
+  </div>
+  <div class="title-opt">
+    <span class="rank">#2</span>
+    <span class="text">I built Wordle but for video-game screenshots — 6 months solo, launching today, AMA on the stack and the scoring curve</span>
+    <span class="why">119 chars · analogy + AMA</span>
+  </div>
+  <div class="title-opt">
+    <span class="rank">#3</span>
+    <span class="text">Launching my daily game today: 10 screenshots, 30 seconds each, global leaderboard. Here's the 6-month build journal.</span>
+    <span class="why">118 chars · feature-led</span>
+  </div>
+</div>
+
+<blockquote class="callout info">
+  <p>r/buildinpublic readers respond best to "what almost killed it" framing — it's signal that you'll actually share the painful bits, which is the whole point of the sub. Title #1 promises that explicitly. Titles #2 and #3 are backups if the AutoMod flags #1 for any reason.</p>
+</blockquote>
+
+<h2 id="post">4 · The post (ready to paste)</h2>
+<p>Paste the title (§3) and the body below into the r/buildinpublic composer. Use the <b>Text</b> post type, not Link. Attach the round-loop GIF as the post media if Reddit lets you (it does for text posts in 2026).</p>
+
+<div class="post">
+  <div class="head">
+    <span class="num">P1</span> · <span class="sub">r/buildinpublic</span> · <span class="when">2026-05-15 · 09:30 CEST</span> · text post
+  </div>
+  <div class="title-bar">After 6 months solo I'm launching today — a daily screenshot-guessing game for video games. Here's what I built, what it cost, and what almost killed it.</div>
+  <div class="body"><span class="label">Context</span>
+
+I'm a solo dev. Six months ago I wanted a daily ritual game that wasn't word-shaped — Wordle's great, but I'm a gamer, and the obvious adjacent idea ("name the game from one screenshot") didn't exist as a polished daily. So I built it. It goes live today.
+
+<span class="label">What it is, in one paragraph</span>
+
+10 screenshots a day. 30 seconds each. You type the game name (fuzzy match, typo-friendly, FR/EN). Faster correct answer = bigger multiplier (1.0x → 2.0x). Wrong guesses are free, but the clock runs. 4 hint types if you're stuck: release year, developer, publisher, genre. One global leaderboard, new set tomorrow. You finish a daily in 3–5 minutes.
+
+<span class="label">The stack (Rule 7 — full transparency)</span>
+
+— React 19 + Vite 7 + Tailwind v4 + Zustand on the front
+— Node 24 + Express 5 + Knex/Kysely on the back (clean architecture, 3 layers)
+— Postgres 16 + Redis (BullMQ for background jobs)
+— Better Auth for sessions, Socket.io for the live leaderboard
+— Pino for logs, Playwright for E2E, Zod everywhere
+— Resend for transactional email, RAWG API for game metadata + screenshots
+— Single Docker image, Traefik in front, deployed on a €15/mo Hetzner CX22
+— Total monthly run cost: ~€18 (server + domain + Resend free tier)
+
+<span class="label">The three decisions I'd defend in a code review</span>
+
+<span class="label">1. Fuzzy match for game titles, not a dropdown.</span> Players will type "MGS3", "Snake Eater", "Metal Gear Solid III" — all should be correct. I built a normalisation + token-Jaccard layer (<span class="code">domain/services/fuzzy-match.service.ts</span>) with a per-game alias list. Roman numerals, subtitles, regional names. It's the single feature most tested in the codebase and the one users notice least when it works.
+
+<span class="label">2. Clean architecture for a side project.</span> Looks like overkill for one dev — but the domain layer (pure functions, no infra deps) made the scoring rewrite painless when I changed the multiplier curve in month 4. Worth the upfront cost the moment you change your mind about a core rule.
+
+<span class="label">3. Free tier is the entire daily, not a teaser.</span> Pricing is €3.99/mo or €29.99/yr, and what you buy is catch-up mode (replay the last 7 missed days, doesn't count for leaderboard) + extra power-ups + no ads. The daily itself is free, forever, no signup required. Wouldn't trade a 30-second first impression for ad revenue.
+
+<span class="label">What almost killed it</span>
+
+— <span class="label">Month 2:</span> the scoring curve was linear. Playtesters said "feels like nothing matters". Switched to a speed-weighted multiplier with a soft cap at 2.0x. Suddenly the leaderboard felt alive. Lesson: if your scoring isn't slightly addictive on paper, it won't be addictive in production either.
+
+— <span class="label">Month 3:</span> the screenshot loader was eager-loading all 10 images upfront. On 4G this was a 6-second blank screen. Moved to Embla Carousel with prev/next pre-load only. P95 first-render dropped from 5.8s to 1.1s. Lesson: I should have measured before building.
+
+— <span class="label">Month 5:</span> tried to add Three.js everywhere because the dark-neon theme begged for it. Two weeks of fighting React Three Fiber bundles. Reverted to a single decorative cube on the home page. Lesson: the budget for "delight" is one feature, not five.
+
+— <span class="label">Month 6:</span> 11 days before launch, BullMQ's daily-challenge worker silently failed to schedule the next day's screenshots because of a timezone-vs-cron edge case. Caught it because the staging leaderboard was empty at 00:01. Wrote a synthetic check that posts a Slack alert if tomorrow's challenge isn't in the DB by 18:00 the prior day. Lesson: cron is never just cron.
+
+<span class="label">Numbers as of right now</span>
+
+— ~14k LOC TS across 3 workspaces (types / backend / frontend)
+— 9 Playwright specs, ~120 assertions
+— 47 migrations
+— 1 admin (me), 0 paying users (we'll see in 24 hours)
+— Built in evenings and weekends with two real holidays mixed in
+
+<span class="label">What I'm watching today</span>
+
+— Sign-ups vs. anonymous plays (hypothesis: anonymous &gt;&gt; signup at first, that's fine)
+— P95 page load (target: &lt;1.5s on 4G)
+— Time-to-first-bug-report (place your bets)
+— Conversion to paid on day 7 (the only number that means anything)
+
+<span class="label">Happy to AMA on:</span> the scoring curve maths, the clean-architecture-for-solo question, why I picked Better Auth over Lucia, anything in the stack. Will reply to every comment in the first 6 hours.
+
+<span class="label">The link</span> (no signup needed, today's daily plays as a guest):
+<span class="url">https://the-box.battistella.ovh</span>
+
+Thanks for reading. Six months of evenings — this is the part where I find out if the thing is any good.</div>
+  <div class="media"><b>Media (attach to post):</b> 16:9 GIF / MP4 — 4-second loop: screenshot → typing a guess → "correct" + score popping → leaderboard rank flying up. Reuse the PH gallery cover asset. <b>Alt text:</b> "Animated demo of a round: screenshot, guess input, score reveal, leaderboard update."</div>
+  <div class="foot"><span>~720 words · ~4 min read</span><span class="ok">link last · stack disclosed · 4 lessons · AMA framing</span></div>
+</div>
+
+<blockquote class="callout">
+  <p>The post passes Rule 3 because by word count it's ~85% process and ~15% link-and-launch news. The post passes Rule 7 because the stack is named in full, including paid tools (Resend) and the actual monthly server cost (€18). The post earns engagement because the "what almost killed it" section is the part nobody else writes.</p>
+</blockquote>
+
+<h2 id="timing">5 · Posting timing</h2>
+<table>
+  <tr><th>Slot</th><th>What</th><th>Why</th></tr>
+  <tr><td class="t">May 15 · 09:30 CEST</td><td>Post P1 to r/buildinpublic</td><td>30 min after PH go-live (09:01). Catches EU mid-morning, US is asleep — gives the post 4 clean hours to gather EU upvotes before US wakes up and the comment volume spikes.</td></tr>
+  <tr><td class="t">May 15 · 09:35 → 15:30 CEST</td><td>Reply to every comment within 15 min</td><td>Reply latency in the first 6 hours is the single biggest predictor of upvote velocity on Reddit in 2026 (algorithm reads it as engaged-OP signal).</td></tr>
+  <tr><td class="t">May 15 · 15:30 → 18:00 CEST</td><td>Cross-post to r/SideProject (see §7)</td><td>r/SideProject explicitly allows the launch frame. Post the same body, swap title for the launch-y variant.</td></tr>
+  <tr><td class="t">May 16 · 11:00 CEST</td><td>Edit P1 with a "DAY-AFTER UPDATE" block at the top</td><td>Adds the launch-day numbers without making a new post (would violate Rule 4 on spam). Edits show up in r/buildinpublic feed.</td></tr>
+</table>
+
+<blockquote class="callout warn">
+  <p><b>Do not post earlier than 09:01 CEST.</b> The post leads with "I'm launching today", which has to be true at the moment of posting. If PH go-live slips, slip the Reddit post by the same amount.</p>
+</blockquote>
+
+<h2 id="replies">6 · Comment playbook</h2>
+<p>The Reddit launch is won in the comments, not the post. The post earns the click; the comments earn the upvote. Reply to <em>every</em> top-level comment for the first 6 hours. After hour 6, only reply to comments with substance.</p>
+
+<table>
+  <tr><th>Comment shape</th><th>Your reply pattern</th></tr>
+  <tr>
+    <td>"What's the scoring formula exactly?"</td>
+    <td>Paste the actual formula: <span class="code">score = base × (1 + (timeRemaining/totalTime))</span>, capped at 2.0x, base = 100 for tier-1 screenshots. Mention the rewrite in month 2. Devs love seeing the maths.</td>
+  </tr>
+  <tr>
+    <td>"Why Better Auth over &lt;X&gt;?"</td>
+    <td>Honest answer: simpler API surface, native session-based (which fits a daily-game more than JWT), good DX with Knex. Don't trash other libs.</td>
+  </tr>
+  <tr>
+    <td>"Why clean architecture for a side project?"</td>
+    <td>Same answer as the post (scoring rewrite in month 4 paid for the upfront cost) + add: "if I were doing it again at one workspace I'd probably ship with one file per route and refactor when I felt the pain."</td>
+  </tr>
+  <tr>
+    <td>"How are you handling screenshot copyright?"</td>
+    <td>Game screenshots used in a guessing context are transformative under most jurisdictions; takedown path documented in admin panel; will pull anything a publisher asks within 24h. Don't get defensive.</td>
+  </tr>
+  <tr>
+    <td>"Wordle clone."</td>
+    <td>"It's in the same family — daily, time-boxed, share card. The shape is different: 10 rounds, speed counts, fuzzy match. The 'shower thought to ship' delta is way less obvious than it looks." Don't argue past one reply.</td>
+  </tr>
+  <tr>
+    <td>"Found a bug: &lt;X&gt;"</td>
+    <td>"On it — DM a screenshot, I'll ship a fix today and reply here when it's live." Then actually do it. The "reply when fixed" is the part everyone notices.</td>
+  </tr>
+  <tr>
+    <td>"Is the code open source?"</td>
+    <td>Honest: "Not currently. Might open-source the fuzzy-match layer if there's interest — it's the part with reusable value." Don't promise a repo you won't deliver.</td>
+  </tr>
+  <tr>
+    <td>"How much did you spend on ads?"</td>
+    <td>"€0. This post is the launch." It's the answer they're hoping to hear.</td>
+  </tr>
+  <tr>
+    <td>"Where's the Product Hunt link?"</td>
+    <td>Reply with the PH link. Don't put it in the body of the post — keeping it comment-only keeps the post Rule-3-clean.</td>
+  </tr>
+  <tr>
+    <td>Negative comment with no question</td>
+    <td>Upvote it, don't reply. Reddit weights "OP engages with negative feedback gracefully" but the threshold is "reads it", not "argues with it".</td>
+  </tr>
+</table>
+
+<h2 id="crosspost">7 · Cross-post matrix</h2>
+<p>The body in §4 is written for r/buildinpublic. For other subs, swap the title and tweak the first paragraph only. Same body otherwise — Reddit AutoModerator does <em>not</em> flag identical bodies across subs in 2026 as long as titles differ.</p>
+
+<table>
+  <tr><th>Sub</th><th>When</th><th>Title swap</th><th>Notes</th></tr>
+  <tr>
+    <td>r/SideProject</td>
+    <td>May 15 · 15:30 CEST</td>
+    <td>"I just launched a daily game where you guess video games from screenshots — 6 months solo, full stack inside"</td>
+    <td><span class="pill ok">link-friendly</span> Lead with launch. Keep the stack section because it's the differentiator here.</td>
+  </tr>
+  <tr>
+    <td>r/IndieDev</td>
+    <td>May 15 · 19:00 CEST</td>
+    <td>"Devlog: shipped my daily screenshot-guessing game today after 6 months — fuzzy match, scoring curve, what I'd do differently"</td>
+    <td><span class="pill ok">devlog-friendly</span> Trim the §4 "Numbers as of right now" — feels like bragging here.</td>
+  </tr>
+  <tr>
+    <td>r/webdev</td>
+    <td>May 16 · 10:00 CEST</td>
+    <td>"How I shipped a real-time daily game with React 19 + Socket.io + Postgres as a solo dev (6 months, ~€18/mo to run)"</td>
+    <td><span class="pill warn">stack-focused</span> Front-load the stack section. Move the "what almost killed it" lower. Link still last.</td>
+  </tr>
+  <tr>
+    <td>r/reactjs</td>
+    <td>May 16 · 14:00 CEST</td>
+    <td>"6-month React 19 + Vite 7 + Tailwind v4 project shipping today — what I learned about Zustand persist, RTF bundles, and Embla"</td>
+    <td><span class="pill warn">react-focused</span> Drop the backend parts; expand "Month 5: tried to add Three.js" into half the post.</td>
+  </tr>
+  <tr>
+    <td>r/InternetIsBeautiful</td>
+    <td>May 16 · 17:00 CEST (only if r/buildinpublic post is &gt;300 upvotes)</td>
+    <td>"A daily game where you guess the video game from one screenshot. New 10 every day."</td>
+    <td><span class="pill risk">one-shot</span> Drop the dev journal entirely — IIB downvotes anything that reads like making-of. Title + GIF + link. That's it.</td>
+  </tr>
+  <tr>
+    <td>r/tipofmyjoystick</td>
+    <td>Never as a top-level post</td>
+    <td>—</td>
+    <td><span class="pill risk">comment, never link</span> Only engage in the existing "what game is this?" threads with a real answer. Optionally mention The Box in your user flair. See social-media-launch-plan §2.1.</td>
+  </tr>
+</table>
+
+<h2 id="dont">8 · What not to do</h2>
+<ul class="dont">
+  <li><b>Do not</b> include the PH link in the body. It looks like a vote-rally and PH will notice. Reply with the PH link only when someone asks.</li>
+  <li><b>Do not</b> use "Excited to share" / "Thrilled to announce" / any LinkedIn opener. Reddit's instinct is to downvote on sight.</li>
+  <li><b>Do not</b> post on a weekend. r/buildinpublic engagement on Saturday/Sunday is ~40% of weekday peak. Friday morning is the next-best slot if the launch slips.</li>
+  <li><b>Do not</b> edit the title after posting (Reddit won't let you anyway). Edit body sparingly and only with an "EDIT:" label at the top.</li>
+  <li><b>Do not</b> delete and repost if it doesn't gain traction in the first hour. The post-mortem is the post.</li>
+  <li><b>Do not</b> reply to negative comments more than once. One graceful reply, then upvote and move on.</li>
+  <li><b>Do not</b> claim numbers that aren't real. "0 paying users" is the right thing to write at T-0. Pretending otherwise is the fastest way to lose this sub's trust.</li>
+  <li><b>Do not</b> ask people to upvote the PH listing from inside the Reddit post — PH bans for this.</li>
+  <li><b>Do not</b> reuse this exact body on Hacker News. HN voice is different (more terse, less narrative). Draft separately if HN ends up in scope.</li>
+</ul>
+
+<h2 id="checklist">9 · Pre-post checklist (do tonight)</h2>
+<ul class="do">
+  <li>Confirm <code>https://the-box.battistella.ovh</code> serves a clean landing page and the OG preview renders correctly when the URL is pasted into Reddit's composer.</li>
+  <li>Build the launch GIF/MP4 (4s loop, same asset as PH gallery cover). Save under 20MB — Reddit's text-post media limit.</li>
+  <li>Have the alt text ready (see §4 media block).</li>
+  <li>Check r/buildinpublic AutoModerator rules — open the sub in a private window and verify there's no posting-frequency requirement (e.g. "comment karma ≥10 in this sub before posting"). If there is, post a thoughtful comment on another launch today first.</li>
+  <li>Verify your Reddit account has &gt;30 days age + &gt;100 karma. Subs in this category routinely auto-remove sub-100-karma posts.</li>
+  <li>Pre-draft the §6 replies for the 4 most-likely comments (scoring formula, Better Auth, clean architecture, Wordle clone). Pasting from a draft saves 30s per reply, which is the difference between hitting every comment in 15min and not.</li>
+  <li>Set a phone alarm for 09:25 CEST tomorrow. Post at 09:30 sharp.</li>
+  <li>Open the r/buildinpublic post in a second browser tab right after posting. Refresh every 2 minutes for the first hour and reply as comments land.</li>
+</ul>
+
+<hr>
+
+<p class="meta">Strategy spine: <a href="./social-media-launch-plan.html">social-media-launch-plan.html</a> · <a href="./producthunt-launch-plan.html">producthunt-launch-plan.html</a> · <a href="./x-launch-thread.html">x-launch-thread.html</a></p>
+
+</main>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Adds tasks/reddit-launch-post.html: a 6-month build-journal post drafted
for r/buildinpublic (rules 3 and 7 honoured), with three title options, a
comment playbook, and a cross-post matrix for r/SideProject, r/IndieDev,
r/webdev, r/reactjs and r/InternetIsBeautiful. Posting slot is 09:30 CEST
on 2026-05-15 — 30 minutes after the PH go-live so cross-traffic flows
both ways. All game-mechanic claims verified against docs/game-flow.md
and pricing against packages/backend/src/config/billing.ts.