### PR TITLE
feat(webhooks): dispatch rank.changed events

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -398,15 +398,16 @@ it and you must revoke and re-register.
 |-------|---------|-----|--------|
 | `session.started` | ✅ | — | Live |
 | `session.completed` | ✅ | ✅ | Live |
+| `rank.changed` | ✅ | — | Live |
 | `screenshot.scored` | — | ✅ | Live (SSE only) |
-| `rank.changed` | — | — | Reserved |
 
 `session.started` fires once when a streamer begins their daily (not on
 resume); its `data` is `{ sessionId, challengeDate, countsForLeaderboard }`.
 
-The reserved event (`rank.changed`) is present in the type system and accepted
-in webhook `events` arrays, but not yet dispatched. Subscribing to it now is
-safe and forward-compatible.
+`rank.changed` fires alongside `session.completed` for the player who just
+finished a ranked session — a rank-only signal for bots that don't need the
+full result. Its `data` is `{ rank, challengeDate }`. It is not dispatched for
+catch-up sessions (those carry no leaderboard rank).
 
 ## Error codes
 

--- a/packages/backend/src/domain/services/index.ts
+++ b/packages/backend/src/domain/services/index.ts
@@ -252,6 +252,18 @@ async function onAfterSessionCompleted(params: {
     rank,
     countsForLeaderboard: !params.isCatchUp,
   })
+
+  // rank.changed — rank-only companion event, completing-streamer-only.
+  // Skipped for catch-up sessions (no leaderboard rank to report).
+  if (!params.isCatchUp && rank !== null) {
+    await webhookDispatch.rankChanged({
+      userId: params.userId,
+      slug: userRow.public_slug,
+      sessionId: params.sessionId,
+      challengeDate: challenge.challenge_date,
+      rank,
+    })
+  }
 }
 
 /**

--- a/packages/backend/src/domain/services/webhook-dispatch.service.ts
+++ b/packages/backend/src/domain/services/webhook-dispatch.service.ts
@@ -3,6 +3,7 @@ import { webhookRepository, webhookDeliveryRepository } from '../../infrastructu
 import { logger } from '../../infrastructure/logger/logger.js'
 import type {
   PublicEventType,
+  RankChangedEvent,
   SessionCompletedEvent,
   SessionStartedEvent,
   WebhookPayload,
@@ -86,6 +87,26 @@ export const webhookDispatch = {
       countsForLeaderboard: params.countsForLeaderboard,
     }
     await fanOut(params.userId, params.slug, 'session.completed', params.sessionId, data)
+  },
+
+  /**
+   * Fires for the player who just finished a ranked session — a rank-only
+   * companion to session.completed. The event id reuses the session id so a
+   * re-run can't double-deliver. Callers must only invoke this for
+   * non-catch-up sessions with a resolved rank.
+   */
+  async rankChanged(params: {
+    userId: string
+    slug: string
+    sessionId: string
+    challengeDate: string
+    rank: number
+  }): Promise<void> {
+    const data: RankChangedEvent = {
+      rank: params.rank,
+      challengeDate: params.challengeDate,
+    }
+    await fanOut(params.userId, params.slug, 'rank.changed', params.sessionId, data)
   },
 }
 

--- a/packages/frontend/src/components/profile/StreamerWebhooksSection.tsx
+++ b/packages/frontend/src/components/profile/StreamerWebhooksSection.tsx
@@ -21,15 +21,15 @@ import type { PublicEventType, WebhookCreated, WebhookSummary } from '@the-box/t
 // Self-contained: fetches its own data, owns its own dialogs. Rendered by
 // StreamerKitCard only when the public profile is enabled.
 
-// session.started + session.completed are dispatched as webhooks today.
-// screenshot.scored is SSE-only (not delivered as a webhook); rank.changed
-// is typed + accepted but not yet dispatched. Non-live entries get a "soon"
-// badge rather than being hidden, so subscriptions stay forward-compatible.
+// session.started, session.completed and rank.changed are dispatched as
+// webhooks. screenshot.scored is SSE-only (not delivered as a webhook) — it
+// gets a "soon" badge rather than being hidden, so a subscription that
+// includes it stays forward-compatible.
 const EVENT_OPTIONS: { value: PublicEventType; live: boolean }[] = [
   { value: 'session.started', live: true },
   { value: 'session.completed', live: true },
+  { value: 'rank.changed', live: true },
   { value: 'screenshot.scored', live: false },
-  { value: 'rank.changed', live: false },
 ]
 
 interface Props {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1584,6 +1584,15 @@ export interface SessionStartedEvent {
   countsForLeaderboard: boolean
 }
 
+// rank.changed payload — fired alongside session.completed for the player
+// who just finished a ranked (non-catch-up) session. A rank-only signal for
+// bots that don't need the full session result. Not dispatched for catch-up
+// sessions (those carry no leaderboard rank).
+export interface RankChangedEvent {
+  rank: number
+  challengeDate: string
+}
+
 // SSE live-channel event names. The same envelope discipline as webhooks,
 // but `id:` / `event:` / `data:` are emitted directly (not wrapped) so
 // `EventSource.addEventListener('session.completed', …)` works out of the box.


### PR DESCRIPTION
## Summary

- Implements `rank.changed`, the last reserved event of the Streamer Kit public API. Firing rule: **completing-streamer-only** — it fires alongside `session.completed` for the player who just finished a ranked session, as a rank-only signal for bots that don't need the full result.
- New `RankChangedEvent` type (`{ rank, challengeDate }`); `webhookDispatch.rankChanged()` reuses the session id as the event id so retries can't double-deliver.
- Skipped for catch-up sessions (no leaderboard rank to report).
- Docs: `rank.changed` moves Reserved → Live — all four public events are now dispatched. Webhook settings UI drops its "soon" badge.

## Test plan

- [x] `npm test` (backend) — 169 tests pass
- [x] Backend + frontend typecheck clean
- [x] Lint clean (pre-existing HistoryPage warning only)

https://claude.ai/code/session_01UB6HFgkcGL2cAXVW9aMUmE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB6HFgkcGL2cAXVW9aMUmE)_