### PR TITLE
fix(leaderboard): block viewing today's answers before completing the challenge

### DIFF
--- a/packages/backend/src/domain/services/user.service.ts
+++ b/packages/backend/src/domain/services/user.service.ts
@@ -24,7 +24,10 @@ const PREMIUM_CATCH_UP_DAYS = 365
 
 export interface UserService {
   getGameHistory(userId: string, isPremium?: boolean): Promise<GameHistoryResponse>
-  getPublicGameSessionDetails(sessionId: string): Promise<GameSessionDetailsResponse>
+  getPublicGameSessionDetails(
+    sessionId: string,
+    requesterId?: string
+  ): Promise<GameSessionDetailsResponse>
   getGameSessionDetails(
     sessionId: string,
     userId: string
@@ -240,12 +243,29 @@ export function createUserService(deps: UserServiceDeps): UserService {
     },
 
     async getPublicGameSessionDetails(
-      sessionId: string
+      sessionId: string,
+      requesterId?: string
     ): Promise<GameSessionDetailsResponse> {
       const gameSession = await sessionRepository.findCompletedGameSessionById(sessionId)
       if (!gameSession) {
         throw new Error('Session not found or not completed')
       }
+
+      // Anti-cheat: viewing another player's answers reveals the correct
+      // games. For the current daily challenge, only allow it once the
+      // requester has completed that same challenge themselves. Past
+      // challenges stay open (catch-up scores don't count on the leaderboard).
+      const challenge = await challengeRepository.findById(gameSession.daily_challenge_id)
+      const today = new Date().toISOString().split('T')[0]
+      if (challenge && challenge.challenge_date === today) {
+        const requesterSession = requesterId
+          ? await sessionRepository.findGameSession(requesterId, gameSession.daily_challenge_id)
+          : null
+        if (!requesterSession?.is_completed) {
+          throw new Error('TODAY_CHALLENGE_NOT_COMPLETED')
+        }
+      }
+
       return buildSessionDetailsResponse(gameSession)
     },
 

--- a/packages/backend/src/presentation/routes/leaderboard.routes.ts
+++ b/packages/backend/src/presentation/routes/leaderboard.routes.ts
@@ -1,14 +1,15 @@
 import { Router } from 'express'
 import { leaderboardService, userService } from '../../domain/services/index.js'
+import { optionalAuthMiddleware } from '../middleware/auth.middleware.js'
 
 const router = Router()
 
 // Get public session details (for viewing other players' answers)
-router.get('/session/:sessionId', async (req, res, next) => {
+router.get('/session/:sessionId', optionalAuthMiddleware, async (req, res, next) => {
   try {
     const { sessionId } = req.params
 
-    if (!sessionId) {
+    if (!sessionId || typeof sessionId !== 'string') {
       res.status(400).json({
         success: false,
         error: { code: 'INVALID_SESSION_ID', message: 'Session ID is required' },
@@ -16,13 +17,23 @@ router.get('/session/:sessionId', async (req, res, next) => {
       return
     }
 
-    const data = await userService.getPublicGameSessionDetails(sessionId)
+    const data = await userService.getPublicGameSessionDetails(sessionId, req.userId)
 
     res.json({
       success: true,
       data,
     })
   } catch (error) {
+    if (error instanceof Error && error.message === 'TODAY_CHALLENGE_NOT_COMPLETED') {
+      res.status(403).json({
+        success: false,
+        error: {
+          code: 'TODAY_CHALLENGE_NOT_COMPLETED',
+          message: "Complete today's challenge to view other players' answers",
+        },
+      })
+      return
+    }
     if (error instanceof Error && error.message.includes('not found')) {
       res.status(404).json({
         success: false,

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -549,7 +549,8 @@
     "correct": "Correct",
     "skipped": "Skipped",
     "errorLoading": "Failed to load player answers",
-    "clickToView": "Click to view this player's answers"
+    "clickToView": "Click to view this player's answers",
+    "todayLocked": "Complete today's challenge to view other players' answers."
   },
   "history": {
     "title": "Game History",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -549,7 +549,8 @@
     "correct": "Correct",
     "skipped": "Passé",
     "errorLoading": "Impossible de charger les réponses",
-    "clickToView": "Cliquez pour voir les réponses de ce joueur"
+    "clickToView": "Cliquez pour voir les réponses de ce joueur",
+    "todayLocked": "Termine le défi du jour pour voir les réponses des autres joueurs."
   },
   "history": {
     "title": "Historique des Parties",

--- a/packages/frontend/src/pages/LeaderboardPage.tsx
+++ b/packages/frontend/src/pages/LeaderboardPage.tsx
@@ -184,6 +184,8 @@ export default function LeaderboardPage() {
       const data = await res.json()
       if (data.success && data.data) {
         setPlayerSession(data.data)
+      } else if (data.error?.code === 'TODAY_CHALLENGE_NOT_COMPLETED') {
+        setSessionError(t('leaderboard.todayLocked'))
       } else {
         setSessionError(t('leaderboard.errorLoading'))
       }


### PR DESCRIPTION
The public session-details endpoint returned any completed session's full
answers — including the correct game names — with no requester check, so a
player could read today's correct answers from the leaderboard before
playing. Gate the current daily challenge: only reveal another player's
answers once the requester has completed that same challenge. Past
challenges stay open (catch-up scores don't count on the leaderboard).

https://claude.ai/code/session_01RcYpKgsXbBsN7o9s39twKQ