### PR TITLE
Refactor mobile navigation: add persistent bottom bar, deduplicate Header

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -50,6 +50,18 @@
       "third": "3rd place"
     }
   },
+  "nav": {
+    "primary": "Primary navigation",
+    "footer": "Footer navigation",
+    "mobile": "Main navigation",
+    "skipToContent": "Skip to main content",
+    "tabs": {
+      "home": "Home",
+      "play": "Play",
+      "leaderboard": "Ranking",
+      "profile": "Profile"
+    }
+  },
   "achievements": {
     "filters": {
       "all": "All",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -50,6 +50,18 @@
       "third": "3e place"
     }
   },
+  "nav": {
+    "primary": "Navigation principale",
+    "footer": "Navigation du pied de page",
+    "mobile": "Navigation principale",
+    "skipToContent": "Aller au contenu principal",
+    "tabs": {
+      "home": "Accueil",
+      "play": "Jouer",
+      "leaderboard": "Classement",
+      "profile": "Profil"
+    }
+  },
   "achievements": {
     "filters": {
       "all": "Tous",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -3,7 +3,9 @@ import { Suspense, lazy, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
+import { BottomNav } from '@/components/layout/BottomNav'
 import { Toaster } from '@/components/ui/sonner'
+import { cn } from '@/lib/utils'
 import { ErrorBoundary, LazyComponentErrorBoundary } from '@/components/ErrorBoundary'
 import { RouteSeo } from '@/components/RouteSeo'
 import {
@@ -67,7 +69,7 @@ function LanguageRedirect() {
 
 function LanguageLayout() {
   const { lang } = useParams<{ lang: string }>()
-  const { i18n } = useTranslation()
+  const { t, i18n } = useTranslation()
   const location = useLocation()
   const { data: session } = useSession()
   const { fetchStatus, reset } = useDailyLoginStore()
@@ -118,16 +120,34 @@ function LanguageLayout() {
   }
 
   // Geo play takes the full viewport (no header, no footer). The daily-game
-  // page keeps the global Header so the hamburger / sidebar stays reachable,
-  // but hides the footer to preserve an immersive in-game feel.
+  // page keeps the global Header so the hamburger stays reachable, but hides
+  // the footer to preserve an immersive in-game feel.
   const isFullscreen = /\/geo\/?$/.test(location.pathname)
-  const hideFooter = isFullscreen || location.pathname.endsWith('/play')
+  const isInGame = location.pathname.endsWith('/play')
+  const hideFooter = isFullscreen || isInGame
+  // The BottomNav is mobile chrome — drop it on the fullscreen Geo route and
+  // the in-game /play route, where it would collide with the keyboard-aware
+  // guess input.
+  const hideBottomNav = isFullscreen || isInGame
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div
+      className={cn(
+        'flex min-h-dvh flex-col bg-background',
+        // Reserve space so page content and the footer clear the fixed
+        // BottomNav. border-box keeps this padding inside min-h-dvh.
+        !hideBottomNav && 'pb-[var(--bottom-nav-space)] md:pb-0',
+      )}
+    >
       <RouteSeo />
+      <a
+        href="#main-content"
+        className="sr-only rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-lg focus:not-sr-only focus:fixed focus:left-4 focus:top-[calc(1rem_+_env(safe-area-inset-top))] focus:z-[100]"
+      >
+        {t('nav.skipToContent')}
+      </a>
       {!isFullscreen && <Header />}
-      <main className="flex-1">
+      <main id="main-content" tabIndex={-1} className="flex-1 outline-none">
         <LazyComponentErrorBoundary>
           <Suspense fallback={<LoadingSpinner />}>
             <Outlet />
@@ -135,6 +155,7 @@ function LanguageLayout() {
         </LazyComponentErrorBoundary>
       </main>
       {!hideFooter && <Footer />}
+      {!hideBottomNav && <BottomNav />}
 
       {/* Daily Login Reward Modal */}
       <DailyRewardModal />

--- a/packages/frontend/src/components/layout/BottomNav.tsx
+++ b/packages/frontend/src/components/layout/BottomNav.tsx
@@ -1,0 +1,78 @@
+import { NavLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { BOTTOM_NAV } from '@/components/layout/nav-items'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'
+import { cn } from '@/lib/utils'
+
+/**
+ * Persistent bottom navigation bar for mobile viewports.
+ *
+ * Hidden at the `md` breakpoint and up (the desktop Header carries primary
+ * navigation) through a pure CSS `md:hidden` gate, and unmounted while the
+ * virtual keyboard is open so it never floats on top of a keyboard on form
+ * pages such as /login or /contact.
+ *
+ * `LanguageLayout` mounts this and gates it off the fullscreen Geo and in-game
+ * `/play` routes. The bar reserves `env(safe-area-inset-bottom)` so its tap
+ * targets clear the iOS home indicator / Android gesture bar.
+ */
+export function BottomNav() {
+  const { t } = useTranslation()
+  const { localizedPath } = useLocalizedPath()
+  const { isKeyboardOpen } = useKeyboardHeight()
+
+  if (isKeyboardOpen) return null
+
+  return (
+    <nav
+      aria-label={t('nav.mobile')}
+      className={cn(
+        'fixed inset-x-0 bottom-0 z-40 md:hidden',
+        'border-t border-border/60 bg-background/95 backdrop-blur-md',
+        'supports-[backdrop-filter]:bg-background/80',
+        'pb-[env(safe-area-inset-bottom)]',
+      )}
+    >
+      <ul className="mx-auto flex h-[var(--bottom-nav-h)] max-w-md items-stretch">
+        {BOTTOM_NAV.map((item) => {
+          const Icon = item.icon
+          return (
+            <li key={item.key} className="flex-1">
+              <NavLink
+                to={localizedPath(item.path)}
+                end={item.end}
+                className={({ isActive }) =>
+                  cn(
+                    'relative flex h-full flex-col items-center justify-center gap-1 px-1',
+                    'text-[11px] font-medium transition-colors',
+                    'outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+                    isActive
+                      ? 'text-primary'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )
+                }
+              >
+                {({ isActive }) => (
+                  <>
+                    {/* Non-text active indicator — a primary-coloured top bar,
+                        readable independently of the icon/label colour. */}
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        'absolute inset-x-4 top-0 h-0.5 rounded-full bg-primary transition-opacity',
+                        isActive ? 'opacity-100' : 'opacity-0',
+                      )}
+                    />
+                    <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+                    <span className="leading-none">{t(item.labelKey)}</span>
+                  </>
+                )}
+              </NavLink>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/packages/frontend/src/components/layout/Footer.tsx
+++ b/packages/frontend/src/components/layout/Footer.tsx
@@ -19,7 +19,10 @@ export function Footer() {
 
   return (
     <footer className="py-4 text-center relative z-10">
-      <nav className="flex items-center justify-center gap-6 text-sm flex-wrap">
+      <nav
+        aria-label={t('nav.footer')}
+        className="flex items-center justify-center gap-6 text-sm flex-wrap"
+      >
         <Link
           to={localizedPath('/terms')}
           className="text-muted-foreground hover:text-neon-purple transition-colors"

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, NavLink, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import type { LucideIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -18,7 +19,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Trophy, Home, LogOut, Settings, History, Menu, User, ChevronDown, MapPin, Sparkles, Play, LifeBuoy, Compass } from 'lucide-react'
+import { Menu, User, ChevronDown, History, LogOut, Settings, Sparkles, LifeBuoy, Compass } from 'lucide-react'
+import { PRIMARY_NAV, type NavLinkItem } from '@/components/layout/nav-items'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
 import { DailyRewardBadge } from '@/components/daily-login'
@@ -30,73 +32,77 @@ import { InstallPromptButton } from '@/components/pwa'
 import { requestTourReplay } from '@/components/onboarding/tour-storage'
 import { cn } from '@/lib/utils'
 
-interface NavigationLinksProps {
-  isMobile?: boolean
-  t: (key: string) => string
-  localizedPath: (path: string) => string
-  onMobileClick?: () => void
-  showPremiumUpsell: boolean
+// The premium link is an upsell rendered conditionally, so it lives outside the
+// shared PRIMARY_NAV array. It still routes through NavItemLink so it picks up
+// active-route styling and `aria-current` on /premium.
+const PREMIUM_NAV_ITEM: NavLinkItem = {
+  key: 'premium',
+  labelKey: 'common.premium',
+  icon: Sparkles,
+  path: '/premium',
 }
 
-function NavigationLinks({ isMobile = false, t, localizedPath, onMobileClick, showPremiumUpsell }: NavigationLinksProps) {
-  const mobileClasses = isMobile ? "w-full justify-start" : ""
-  const iconClass = isMobile ? "mr-2" : "mr-1"
-  const handleClick = isMobile ? onMobileClick : undefined
+/**
+ * A single primary-navigation destination, rendered as a react-router NavLink
+ * so the active route gets `aria-current="page"` automatically. Two layouts:
+ * `desktop` (inline, top bar) and `drawer` (full-width, mobile menu).
+ */
+function NavItemLink({
+  item,
+  variant,
+  accent = false,
+  onNavigate,
+}: {
+  item: NavLinkItem
+  variant: 'desktop' | 'drawer'
+  /** Premium tint — neon-pink idle colour for the upsell link. */
+  accent?: boolean
+  onNavigate?: () => void
+}) {
+  const { t } = useTranslation()
+  const { localizedPath } = useLocalizedPath()
+  const Icon = item.icon
 
   return (
-    <>
-      <Button variant="ghost" size="sm" asChild className={mobileClasses}>
-        <Link to={localizedPath('/')} onClick={handleClick}>
-          <Home className={`w-4 h-4 ${iconClass}`} />
-          {t('common.home')}
-        </Link>
-      </Button>
-
-      <Button variant="ghost" size="sm" asChild className={mobileClasses}>
-        <Link to={localizedPath('/play')} onClick={handleClick}>
-          <Play className={`w-4 h-4 ${iconClass}`} />
-          {t('common.dailyGuess')}
-        </Link>
-      </Button>
-
-      <Button variant="ghost" size="sm" asChild className={mobileClasses}>
-        <Link
-          to={localizedPath('/leaderboard')}
-          onClick={handleClick}
-          data-tour="leaderboard-link"
+    <NavLink
+      to={localizedPath(item.path)}
+      end={item.end}
+      onClick={onNavigate}
+      data-tour={item.dataTour}
+      className={({ isActive }) =>
+        cn(
+          'inline-flex h-11 items-center gap-2 rounded-md px-3 text-sm transition-colors',
+          'outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          variant === 'drawer' && 'w-full justify-start',
+          isActive
+            ? 'font-semibold text-primary'
+            : accent
+              ? 'font-medium text-neon-pink hover:bg-muted hover:text-neon-pink/80'
+              : 'font-medium text-foreground/80 hover:bg-muted hover:text-foreground',
+          // Non-text active indicators: an inset underline on desktop, a tinted
+          // surface in the drawer — both readable without relying on colour.
+          variant === 'desktop' && isActive && 'shadow-[inset_0_-2px_0_0_var(--color-primary)]',
+          variant === 'drawer' && isActive && 'bg-primary/10',
+        )
+      }
+    >
+      <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>{t(item.labelKey)}</span>
+      {item.badgeKey && (
+        <Badge
+          variant="outline"
+          className="ml-1 h-4 px-1 text-[10px] font-semibold uppercase tracking-wide border-neon-pink/50 text-neon-pink"
         >
-          <Trophy className={`w-4 h-4 ${iconClass}`} />
-          {t('common.leaderboard')}
-        </Link>
-      </Button>
-
-      <Button variant="ghost" size="sm" asChild className={mobileClasses}>
-        <Link to={localizedPath('/geo')} onClick={handleClick}>
-          <MapPin className={`w-4 h-4 ${iconClass}`} />
-          {t('common.geo')}
-          <Badge variant="outline" className="ml-2 h-4 px-1 text-[10px] font-semibold uppercase tracking-wide border-neon-pink/50 text-neon-pink">
-            {t('common.alpha')}
-          </Badge>
-        </Link>
-      </Button>
-
-      {/* Premium upsell — hidden once the user already has it, so the header stops
-          nagging paying users. The link itself stays available via /premium. */}
-      {showPremiumUpsell && (
-        <Button variant="ghost" size="sm" asChild className={cn(mobileClasses, 'text-neon-pink hover:text-neon-pink/80')}>
-          <Link to={localizedPath('/premium')} onClick={handleClick}>
-            <Sparkles className={`w-4 h-4 ${iconClass}`} />
-            {t('common.premium')}
-          </Link>
-        </Button>
+          {t(item.badgeKey)}
+        </Badge>
       )}
-    </>
+    </NavLink>
   )
 }
 
 // Koe widget owns its own launcher and panel state internally — there is no
 // imperative open API. Clicking the floating launcher button toggles the
-// panel, so we reuse that same DOM seam to open it from the user menu.
+// panel, so we reuse that same DOM seam to open it from the account menu.
 const isKoeConfigured = Boolean(
   import.meta.env.VITE_KOE_PROJECT_KEY && import.meta.env.VITE_KOE_API_URL,
 )
@@ -108,13 +114,134 @@ function openKoeSupport() {
   launcher?.click()
 }
 
+type AccountEntry =
+  | { type: 'link'; key: string; icon: LucideIcon; label: string; to: string; iconClassName?: string }
+  | { type: 'action'; key: string; icon: LucideIcon; label: string; onSelect: () => void }
+  | { type: 'separator'; key: string }
+
+/**
+ * The signed-in account menu. The set of entries is declared once here and
+ * rendered for both the mobile drawer (`Button` rows) and the desktop dropdown
+ * (`DropdownMenuItem` rows), so the two never drift apart.
+ */
+function AccountMenu({
+  variant,
+  isAdmin,
+  isPremium,
+  onNavigate,
+  onReplayTour,
+  onSignOut,
+}: {
+  variant: 'drawer' | 'dropdown'
+  isAdmin: boolean
+  isPremium: boolean
+  /** Drawer only — closes the Sheet after a selection. */
+  onNavigate?: () => void
+  onReplayTour: () => void
+  onSignOut: () => void
+}) {
+  const { t } = useTranslation()
+  const { localizedPath } = useLocalizedPath()
+
+  const entries: AccountEntry[] = [
+    { type: 'link', key: 'profile', icon: User, label: t('common.profile'), to: localizedPath('/profile') },
+    { type: 'link', key: 'history', icon: History, label: t('common.history'), to: localizedPath('/history') },
+    {
+      type: 'link',
+      key: 'premium',
+      icon: Sparkles,
+      iconClassName: 'text-neon-pink',
+      label: isPremium ? t('common.manageSubscription') : t('common.subscribeToPremium'),
+      to: localizedPath('/premium'),
+    },
+    ...(isKoeConfigured
+      ? [{ type: 'action', key: 'support', icon: LifeBuoy, label: t('common.support'), onSelect: openKoeSupport } as AccountEntry]
+      : []),
+    ...(isAdmin
+      ? [{ type: 'link', key: 'admin', icon: Settings, label: t('common.admin'), to: localizedPath('/admin') } as AccountEntry]
+      : []),
+    { type: 'separator', key: 'sep' },
+    { type: 'action', key: 'tour', icon: Compass, label: t('tour.replayCta'), onSelect: onReplayTour },
+    { type: 'action', key: 'logout', icon: LogOut, label: t('common.logout'), onSelect: onSignOut },
+  ]
+
+  if (variant === 'drawer') {
+    return (
+      <div className="flex flex-col gap-1">
+        {entries.map((entry) => {
+          if (entry.type === 'separator') {
+            return <div key={entry.key} className="my-1 border-t border-border" />
+          }
+          const Icon = entry.icon
+          if (entry.type === 'link') {
+            return (
+              <Button key={entry.key} variant="ghost" asChild className="h-11 w-full justify-start gap-2 px-3">
+                <Link to={entry.to} onClick={onNavigate}>
+                  <Icon className={cn('h-4 w-4 shrink-0', entry.iconClassName)} aria-hidden="true" />
+                  {entry.label}
+                </Link>
+              </Button>
+            )
+          }
+          return (
+            <Button
+              key={entry.key}
+              variant="ghost"
+              className="h-11 w-full justify-start gap-2 px-3"
+              onClick={() => {
+                onNavigate?.()
+                entry.onSelect()
+              }}
+            >
+              <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+              {entry.label}
+            </Button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {entries.map((entry) => {
+        if (entry.type === 'separator') {
+          return <DropdownMenuSeparator key={entry.key} />
+        }
+        const Icon = entry.icon
+        if (entry.type === 'link') {
+          return (
+            <DropdownMenuItem key={entry.key} asChild>
+              <Link to={entry.to} className="flex cursor-pointer items-center gap-2">
+                <Icon className={cn('h-4 w-4', entry.iconClassName)} aria-hidden="true" />
+                {entry.label}
+              </Link>
+            </DropdownMenuItem>
+          )
+        }
+        return (
+          <DropdownMenuItem
+            key={entry.key}
+            onClick={entry.onSelect}
+            className="flex cursor-pointer items-center gap-2"
+          >
+            <Icon className="h-4 w-4" aria-hidden="true" />
+            {entry.label}
+          </DropdownMenuItem>
+        )
+      })}
+    </>
+  )
+}
+
 /**
  * Header component
  *
- * Refactored to use custom useAuth hook following SOLID principles
- * - Authentication logic extracted to useAuth hook
- * - Component focuses only on UI rendering
- * - Mobile responsive with hamburger menu
+ * Sticky app header. On mobile it carries a hamburger that opens the full
+ * navigation drawer plus the daily-reward widgets; on desktop it shows the
+ * primary nav inline alongside the account dropdown. Primary navigation is
+ * driven by the shared `PRIMARY_NAV` config so the drawer, the desktop bar and
+ * the mobile BottomNav stay in sync.
  */
 export function Header() {
   const { t } = useTranslation()
@@ -132,7 +259,8 @@ export function Header() {
   const closeRewardModal = useDailyLoginStore((state) => state.closeModal)
   const billingEntitlement = useBillingStore((state) => state.entitlement)
   const fetchBillingEntitlement = useBillingStore((state) => state.fetchEntitlement)
-  const showPremiumUpsell = !billingEntitlement?.isPremium
+  const isPremium = Boolean(billingEntitlement?.isPremium)
+  const showPremiumUpsell = !isPremium
 
   // Hydrate billing entitlement once we know who the user is. Anonymous
   // visitors get a 401 → store falls back to FREE_ENTITLEMENT silently.
@@ -157,169 +285,120 @@ export function Header() {
     return () => window.removeEventListener('scroll', handleScroll)
   }, [])
 
-  // Show login/register buttons if there's no session
-  // Also check if session is valid (has user data)
-  // This handles cases where the session endpoint returns invalid data
+  // Show login/register buttons if there's no session. Also check the session
+  // is valid (has user data) — the session endpoint can return invalid data.
   const hasValidSession = session && session.user && session.user.id
   const showAuthButtons = !hasValidSession
+  const isAdmin = session?.user?.role === 'admin'
+  const displayName = session?.user?.name || session?.user?.email?.split('@')[0]
+  const isSignedIn = Boolean(hasValidSession) && !isPending
 
   return (
     <header
       className={cn(
         'sticky top-0 z-50 w-full border-b backdrop-blur-md supports-[backdrop-filter]:backdrop-blur-md transition-colors duration-200',
+        // Pad the status bar so content clears the iOS notch when the app runs
+        // as an installed PWA (apple-mobile-web-app-status-bar-style is
+        // black-translucent). Resolves to 0 in a normal browser tab.
+        'pt-[env(safe-area-inset-top)]',
         isScrolled
           ? 'border-border/40 bg-background/80 supports-[backdrop-filter]:bg-background/70 shadow-md shadow-black/20'
           : 'border-border/20 bg-transparent',
       )}
     >
       <div className="container mx-auto flex h-14 sm:h-16 items-center justify-between px-4">
-        {/* Mobile Menu Button - shown on mobile, hidden on md and up */}
+        {/* Mobile menu trigger — shown below md */}
         <div className="flex md:hidden">
           <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="sm" aria-label={t('common.toggleMenu')}>
-                <Menu className="h-5 w-5" />
+              <Button variant="ghost" size="icon" className="size-11" aria-label={t('common.toggleMenu')}>
+                <Menu className="h-5 w-5" aria-hidden="true" />
                 <span className="sr-only">{t('common.toggleMenu')}</span>
               </Button>
             </SheetTrigger>
-            <SheetContent side="left" className="w-[280px] sm:w-[320px]">
+            <SheetContent side="left" className="w-[300px] overflow-y-auto sm:w-[340px]">
               <SheetHeader>
                 <SheetTitle className="text-left">{t('common.menu')}</SheetTitle>
                 <SheetDescription className="sr-only">
                   {t('common.menuDescription', 'Site navigation and account links')}
                 </SheetDescription>
               </SheetHeader>
-              <div className="flex flex-col gap-2 mt-6">
-                <NavigationLinks isMobile={true} t={t} localizedPath={localizedPath} onMobileClick={() => setMobileMenuOpen(false)} showPremiumUpsell={showPremiumUpsell} />
 
+              <nav aria-label={t('nav.mobile')} className="mt-6 flex flex-col gap-1">
+                {PRIMARY_NAV.map((item) => (
+                  <NavItemLink
+                    key={item.key}
+                    item={item}
+                    variant="drawer"
+                    onNavigate={() => setMobileMenuOpen(false)}
+                  />
+                ))}
+                {showPremiumUpsell && (
+                  <NavItemLink
+                    item={PREMIUM_NAV_ITEM}
+                    variant="drawer"
+                    accent
+                    onNavigate={() => setMobileMenuOpen(false)}
+                  />
+                )}
+              </nav>
+
+              <div className="mt-4">
                 <InstallPromptButton variant="mobile" onInstalled={() => setMobileMenuOpen(false)} />
+              </div>
 
-                {/* Mobile Auth Section */}
-                <div className="border-t border-border pt-4 mt-4">
-                  {showAuthButtons ? (
-                    <>
-                      <Button variant="ghost" size="sm" asChild className="w-full justify-start">
-                        <Link to={localizedPath('/login')} onClick={() => setMobileMenuOpen(false)}>
-                          {t('common.login')}
-                        </Link>
-                      </Button>
-                      <Button variant="gaming" size="sm" asChild className="w-full mt-2">
-                        <Link to={localizedPath('/register')} onClick={() => setMobileMenuOpen(false)}>
-                          {t('common.register')}
-                        </Link>
-                      </Button>
-                    </>
-                  ) : (
-                    hasValidSession && !isPending && (
-                      <div className="flex flex-col gap-3">
-                        <div className="flex items-center justify-between">
-                          {session?.user?.role === 'admin' ? (
-                            <Badge variant="admin">
-                              {session.user?.name || session.user?.email?.split('@')[0]}
-                            </Badge>
-                          ) : (
-                            <span className="text-sm text-muted-foreground">
-                              {session.user?.name || session.user?.email?.split('@')[0]}
-                            </span>
-                          )}
-                          {/* Daily Reward Badge for mobile */}
-                          <div className="flex items-center gap-1">
-                            <RewardsInboxBell />
-                            <DailyRewardBadge onClick={() => setMobileMenuOpen(false)} />
-                          </div>
-                        </div>
-                        <Button variant="ghost" size="sm" asChild className="w-full justify-start">
-                          <Link to={localizedPath('/profile')} onClick={() => setMobileMenuOpen(false)}>
-                            <User className="w-4 h-4 mr-2" />
-                            {t('common.profile')}
-                          </Link>
-                        </Button>
-                        <Button variant="ghost" size="sm" asChild className="w-full justify-start">
-                          <Link to={localizedPath('/history')} onClick={() => setMobileMenuOpen(false)}>
-                            <History className="w-4 h-4 mr-2" />
-                            {t('common.history')}
-                          </Link>
-                        </Button>
-                        <Button variant="ghost" size="sm" asChild className="w-full justify-start">
-                          <Link to={localizedPath('/premium')} onClick={() => setMobileMenuOpen(false)}>
-                            <Sparkles className="w-4 h-4 mr-2 text-neon-pink" />
-                            {billingEntitlement?.isPremium ? t('common.manageSubscription') : t('common.subscribeToPremium')}
-                          </Link>
-                        </Button>
-                        {isKoeConfigured && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => {
-                              setMobileMenuOpen(false)
-                              openKoeSupport()
-                            }}
-                            className="w-full justify-start"
-                          >
-                            <LifeBuoy className="w-4 h-4 mr-2" />
-                            {t('common.support')}
-                          </Button>
-                        )}
-                        {session?.user?.role === 'admin' && (
-                          <Button variant="ghost" size="sm" asChild className="w-full justify-start">
-                            <Link to={localizedPath('/admin')} onClick={() => setMobileMenuOpen(false)}>
-                              <Settings className="w-4 h-4 mr-2" />
-                              {t('common.admin')}
-                            </Link>
-                          </Button>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => {
-                            setMobileMenuOpen(false)
-                            handleReplayTour()
-                          }}
-                          className="w-full justify-start"
-                        >
-                          <Compass className="w-4 h-4 mr-2" />
-                          {t('tour.replayCta')}
-                        </Button>
-                        <Button variant="ghost" size="sm" onClick={() => {
-                          signOut()
-                          setMobileMenuOpen(false)
-                        }} className="w-full justify-start">
-                          <LogOut className="w-4 h-4 mr-2" />
-                          {t('common.logout')}
-                        </Button>
-                      </div>
-                    )
-                  )}
-                </div>
+              <div className="mt-4 border-t border-border pt-4">
+                {showAuthButtons ? (
+                  <div className="flex flex-col gap-2">
+                    <Button variant="ghost" asChild className="h-11 w-full justify-start px-3">
+                      <Link to={localizedPath('/login')} onClick={() => setMobileMenuOpen(false)}>
+                        {t('common.login')}
+                      </Link>
+                    </Button>
+                    <Button variant="gaming" asChild className="h-11 w-full">
+                      <Link to={localizedPath('/register')} onClick={() => setMobileMenuOpen(false)}>
+                        {t('common.register')}
+                      </Link>
+                    </Button>
+                  </div>
+                ) : (
+                  isSignedIn && (
+                    <AccountMenu
+                      variant="drawer"
+                      isAdmin={isAdmin}
+                      isPremium={isPremium}
+                      onNavigate={() => setMobileMenuOpen(false)}
+                      onReplayTour={handleReplayTour}
+                      onSignOut={signOut}
+                    />
+                  )
+                )}
               </div>
             </SheetContent>
           </Sheet>
         </div>
 
-        {/* Mobile Username Display - shown on mobile, hidden on md and up */}
-        <div className="flex md:hidden items-center">
-          {hasValidSession && !isPending && session.user?.name !== 'Anonymous' && (
-            <Link to={localizedPath('/profile')} className="flex items-center hover:opacity-80 transition-opacity">
-              {session?.user?.role === 'admin' ? (
-                <Badge variant="admin" className="text-xs cursor-pointer">
-                  {session.user?.name || session.user?.email?.split('@')[0]}
-                </Badge>
-              ) : (
-                <span className="text-xs sm:text-sm font-semibold text-foreground truncate max-w-37.5 sm:max-w-50 underline decoration-2 decoration-primary underline-offset-4">
-                  {session.user?.name || session.user?.email?.split('@')[0]}
-                </span>
-              )}
-            </Link>
+        {/* Desktop primary navigation — shown at md and up */}
+        <nav aria-label={t('nav.primary')} className="hidden items-center gap-1 md:flex lg:gap-2">
+          {PRIMARY_NAV.map((item) => (
+            <NavItemLink key={item.key} item={item} variant="desktop" />
+          ))}
+          {showPremiumUpsell && <NavItemLink item={PREMIUM_NAV_ITEM} variant="desktop" accent />}
+        </nav>
+
+        {/* Mobile reward widgets — surfaced in the header (not buried in the
+            drawer) so the daily-streak loop is glanceable on first paint */}
+        <div className="flex items-center gap-1 md:hidden">
+          {isSignedIn && (
+            <>
+              <RewardsInboxBell />
+              <DailyRewardBadge />
+            </>
           )}
         </div>
 
-        {/* Desktop Navigation - hidden on mobile, shown on md and up */}
-        <nav className="hidden md:flex items-center gap-1 lg:gap-2">
-          <NavigationLinks isMobile={false} t={t} localizedPath={localizedPath} showPremiumUpsell={showPremiumUpsell} />
-        </nav>
-
-        {/* Auth Buttons - Desktop - hidden on mobile, shown on md and up */}
-        <div className="hidden md:flex items-center gap-2 lg:gap-3">
+        {/* Desktop account zone — shown at md and up */}
+        <div className="hidden items-center gap-2 md:flex lg:gap-3">
           <InstallPromptButton variant="desktop" />
           {showAuthButtons && (
             <>
@@ -327,88 +406,45 @@ export function Header() {
                 <Link to={localizedPath('/login')}>{t('common.login')}</Link>
               </Button>
               <Button variant="gaming" size="sm" asChild>
-                <Link to={localizedPath('/register')}>
-                  {t('common.register')}
-                </Link>
+                <Link to={localizedPath('/register')}>{t('common.register')}</Link>
               </Button>
             </>
           )}
-          {hasValidSession && !isPending && (
+          {isSignedIn && (
             <>
-              {/* Async Rewards Inbox */}
               <RewardsInboxBell />
-              {/* Daily Login Reward Badge */}
               <span data-tour="daily-reward-badge" className="inline-flex">
                 <DailyRewardBadge />
               </span>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  data-tour="profile-menu"
-                  className="flex items-center gap-2 hover:bg-primary/10 transition-all border-0"
-                >
-                  <User className="w-4 h-4 text-white" />
-                  {session?.user?.role === 'admin' ? (
-                    <Badge variant="admin" className="cursor-pointer text-xs">
-                      {session.user?.name || session.user?.email?.split('@')[0]}
-                    </Badge>
-                  ) : (
-                    <span className="text-sm font-bold text-white">
-                      {session.user?.name || session.user?.email?.split('@')[0]}
-                    </span>
-                  )}
-                  <ChevronDown className="w-4 h-4 text-white" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuItem asChild>
-                  <Link to={localizedPath('/profile')} className="flex items-center gap-2 cursor-pointer">
-                    <User className="w-4 h-4" />
-                    {t('common.profile')}
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link to={localizedPath('/history')} className="flex items-center gap-2 cursor-pointer">
-                    <History className="w-4 h-4" />
-                    {t('common.history')}
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link to={localizedPath('/premium')} className="flex items-center gap-2 cursor-pointer">
-                    <Sparkles className="w-4 h-4 text-neon-pink" />
-                    {billingEntitlement?.isPremium ? t('common.manageSubscription') : t('common.subscribeToPremium')}
-                  </Link>
-                </DropdownMenuItem>
-                {isKoeConfigured && (
-                  <DropdownMenuItem
-                    onClick={openKoeSupport}
-                    className="flex items-center gap-2 cursor-pointer"
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    data-tour="profile-menu"
+                    className="flex items-center gap-2 border-0 hover:bg-primary/10"
                   >
-                    <LifeBuoy className="w-4 h-4" />
-                    {t('common.support')}
-                  </DropdownMenuItem>
-                )}
-                {session?.user?.role === 'admin' && (
-                  <DropdownMenuItem asChild>
-                    <Link to={localizedPath('/admin')} className="flex items-center gap-2 cursor-pointer">
-                      <Settings className="w-4 h-4" />
-                      {t('common.admin')}
-                    </Link>
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleReplayTour} className="flex items-center gap-2 cursor-pointer">
-                  <Compass className="w-4 h-4" />
-                  {t('tour.replayCta')}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={signOut} className="cursor-pointer">
-                  <LogOut className="w-4 h-4" />
-                  {t('common.logout')}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                    <User className="h-4 w-4" aria-hidden="true" />
+                    {isAdmin ? (
+                      <Badge variant="admin" className="cursor-pointer text-xs">
+                        {displayName}
+                      </Badge>
+                    ) : (
+                      <span className="text-sm font-bold">{displayName}</span>
+                    )}
+                    <ChevronDown className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <AccountMenu
+                    variant="dropdown"
+                    isAdmin={isAdmin}
+                    isPremium={isPremium}
+                    onReplayTour={handleReplayTour}
+                    onSignOut={signOut}
+                  />
+                </DropdownMenuContent>
+              </DropdownMenu>
             </>
           )}
         </div>

--- a/packages/frontend/src/components/layout/nav-items.ts
+++ b/packages/frontend/src/components/layout/nav-items.ts
@@ -1,0 +1,66 @@
+import type { LucideIcon } from 'lucide-react'
+import { Home, Play, Trophy, MapPin, User } from 'lucide-react'
+
+/**
+ * A destination link in the app's navigation. `path` is unlocalized — callers
+ * wrap it with `useLocalizedPath()` before passing it to a router link.
+ */
+export interface NavLinkItem {
+  /** Stable identifier, also used as a React key and `data-tour` suffix. */
+  key: string
+  /** i18n key for the visible label. */
+  labelKey: string
+  icon: LucideIcon
+  /** Unlocalized route, e.g. `/play`. */
+  path: string
+  /**
+   * Exact-match the route. Used for Home (`/`) so its NavLink isn't marked
+   * active on every nested route.
+   */
+  end?: boolean
+  /** Optional small badge shown after the label (e.g. the Geo "alpha" tag). */
+  badgeKey?: string
+  /** Optional `data-tour` anchor id for the onboarding tour. */
+  dataTour?: string
+}
+
+/**
+ * Primary site sections — rendered in the desktop top bar and the mobile
+ * navigation drawer. Premium is intentionally excluded: it is an upsell that
+ * disappears for paying users, so the Header renders it conditionally.
+ */
+export const PRIMARY_NAV: NavLinkItem[] = [
+  { key: 'home', labelKey: 'common.home', icon: Home, path: '/', end: true },
+  { key: 'play', labelKey: 'common.dailyGuess', icon: Play, path: '/play' },
+  {
+    key: 'leaderboard',
+    labelKey: 'common.leaderboard',
+    icon: Trophy,
+    path: '/leaderboard',
+    dataTour: 'leaderboard-link',
+  },
+  {
+    key: 'geo',
+    labelKey: 'common.geo',
+    icon: MapPin,
+    path: '/geo',
+    badgeKey: 'common.alpha',
+  },
+]
+
+/**
+ * Thumb-reachable destinations for the mobile bottom navigation bar. Kept to
+ * four items so each tap target stays generous on small phones. Labels use the
+ * shorter `nav.tabs.*` strings rather than the full `common.*` titles.
+ */
+export const BOTTOM_NAV: NavLinkItem[] = [
+  { key: 'home', labelKey: 'nav.tabs.home', icon: Home, path: '/', end: true },
+  { key: 'play', labelKey: 'nav.tabs.play', icon: Play, path: '/play' },
+  {
+    key: 'leaderboard',
+    labelKey: 'nav.tabs.leaderboard',
+    icon: Trophy,
+    path: '/leaderboard',
+  },
+  { key: 'profile', labelKey: 'nav.tabs.profile', icon: User, path: '/profile' },
+]

--- a/packages/frontend/src/components/pwa/InstallPromptBanner.tsx
+++ b/packages/frontend/src/components/pwa/InstallPromptBanner.tsx
@@ -93,7 +93,9 @@ export function InstallPromptBanner() {
       aria-labelledby="pwa-install-banner-title"
       aria-describedby="pwa-install-banner-desc"
       className={cn(
-        'fixed inset-x-3 bottom-3 z-50 rounded-xl border bg-card/95 shadow-lg backdrop-blur',
+        // Sit just above the mobile BottomNav; drop to the corner at md where
+        // the BottomNav is hidden.
+        'fixed inset-x-3 bottom-[var(--bottom-nav-space)] z-50 rounded-xl border bg-card/95 shadow-lg backdrop-blur md:bottom-3',
         'border-border p-4 flex gap-3 items-start sm:max-w-md sm:left-auto sm:right-3',
       )}
     >

--- a/packages/frontend/src/components/pwa/PWAUpdatePrompt.tsx
+++ b/packages/frontend/src/components/pwa/PWAUpdatePrompt.tsx
@@ -67,7 +67,9 @@ export function PWAUpdatePrompt() {
       aria-describedby="pwa-update-panel-desc"
       aria-live="polite"
       className={cn(
-        'fixed inset-x-3 bottom-3 z-[55] rounded-xl border bg-card/95 shadow-lg backdrop-blur',
+        // Sit just above the mobile BottomNav; drop to the corner at md where
+        // the BottomNav is hidden.
+        'fixed inset-x-3 bottom-[var(--bottom-nav-space)] z-[55] rounded-xl border bg-card/95 shadow-lg backdrop-blur md:bottom-3',
         'border-primary/30 p-4 flex gap-3 items-start sm:max-w-md sm:left-auto sm:right-3',
       )}
     >

--- a/packages/frontend/src/components/ui/sheet.tsx
+++ b/packages/frontend/src/components/ui/sheet.tsx
@@ -36,9 +36,9 @@ const sheetVariants = cva(
         top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
           "inset-x-0 bottom-0 border-t pb-[max(env(safe-area-inset-bottom),1.5rem)] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r pt-[max(env(safe-area-inset-top),1.5rem)] pb-[max(env(safe-area-inset-bottom),1.5rem)] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4 border-l pt-[max(env(safe-area-inset-top),1.5rem)] pb-[max(env(safe-area-inset-bottom),1.5rem)] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -5,6 +5,12 @@
 :root {
   color-scheme: dark;
   --radius: 0.625rem;
+  /* Mobile BottomNav sizing. `--bottom-nav-h` is the bar itself; the layout
+     content padding and the PWA banners reserve `--bottom-nav-space` (bar +
+     iOS home-indicator inset) so nothing renders under the fixed bar. Kept as
+     a single source of truth so the bar and the reserved space can't drift. */
+  --bottom-nav-h: 4rem;
+  --bottom-nav-space: calc(4rem + env(safe-area-inset-bottom));
   /* Dark violet theme (default since dark-only) */
   --background: oklch(0.129 0.042 283.713);
   --foreground: oklch(0.984 0.003 247.858);
@@ -149,7 +155,17 @@ body {
   color: var(--color-foreground);
   font-family: var(--font-sans);
   margin: 0;
-  min-height: 100vh;
+  /* dvh tracks the *current* viewport, so the shell doesn't overflow by the
+     mobile browser toolbar height the way 100vh does. */
+  min-height: 100dvh;
+}
+
+/* Keep focused / anchored elements clear of the sticky header (top) and the
+   mobile BottomNav (bottom) when the browser scrolls them into view —
+   WCAG 2.2 SC 2.4.11 Focus Not Obscured. */
+html {
+  scroll-padding-top: 5rem;
+  scroll-padding-bottom: calc(var(--bottom-nav-h) + 1rem);
 }
 
 /* Default keyboard focus ring. Components that need a custom ring can

--- a/tasks/mobile-layout-navigation-meeting.html
+++ b/tasks/mobile-layout-navigation-meeting.html
@@ -1,0 +1,367 @@
+<!doctype html>
+<!-- SUMMARY:
+Personas meeting on app layout + navigation, mobile-first. Four personas (UX,
+mobile QA, frontend eng, a11y) converged: the hamburger-only mobile nav is wrong
+for a daily-engagement game. Decision — add a persistent 4-tab bottom navigation
+bar (Home/Play/Leaderboard/Profile), refactor the 419-line Header onto a shared
+typed nav config, and fix the P0/P1 accessibility + safe-area gaps. Shipped on
+branch claude/mobile-layout-improvements-2XZOp.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="robots" content="noindex">
+<title>Mobile Layout &amp; Navigation — Personas Meeting</title>
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --bg-elev: #14141c;
+    --fg: #e8e8f0;
+    --muted: #9a9ab0;
+    --border: #2a2a38;
+    --primary: #a855f7;
+    --danger: #f87171;
+    --warn: #fbbf24;
+    --ok: #34d399;
+    --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    --sans: Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { background: var(--bg); color: var(--fg); }
+  body {
+    font-family: var(--sans);
+    line-height: 1.55;
+    margin: 0;
+    padding: 2.5rem 1.25rem 4rem;
+    font-size: 15px;
+  }
+  main { max-width: 72ch; margin: 0 auto; }
+  h1, h2, h3 { font-weight: 600; line-height: 1.2; }
+  h1 { font-size: 1.75rem; margin: 0 0 0.5rem; letter-spacing: -0.01em; }
+  h2 {
+    font-size: 1.15rem; margin: 2.25rem 0 0.75rem;
+    padding-bottom: 0.4rem; border-bottom: 1px solid var(--border);
+  }
+  h3 { font-size: 0.95rem; margin: 1.25rem 0 0.4rem; color: var(--fg); }
+  p, ul, ol { margin: 0.55rem 0; }
+  ul, ol { padding-left: 1.3rem; }
+  li { margin: 0.2rem 0; }
+  code, kbd {
+    font-family: var(--mono); font-size: 0.85em;
+    background: var(--bg-elev); border: 1px solid var(--border);
+    border-radius: 4px; padding: 0.05em 0.35em;
+  }
+  pre {
+    font-family: var(--mono); font-size: 0.82rem; line-height: 1.5;
+    background: var(--bg-elev); border: 1px solid var(--border);
+    border-radius: 8px; padding: 0.85rem 1rem; overflow-x: auto;
+    margin: 0.6rem 0;
+  }
+  pre code { background: none; border: none; padding: 0; }
+  a { color: var(--primary); }
+  a:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+
+  .meta {
+    color: var(--muted); font-size: 0.85rem;
+    margin: 0 0 1.5rem; font-family: var(--mono);
+  }
+  .glow { color: var(--primary); text-shadow: 0 0 12px rgba(168, 85, 247, 0.45); }
+  .badge {
+    display: inline-block; padding: 0.1rem 0.5rem;
+    border-radius: 999px; font-size: 0.7rem; font-family: var(--mono);
+    text-transform: uppercase; letter-spacing: 0.04em; vertical-align: middle;
+    margin-left: 0.4rem;
+  }
+  .badge.internal { background: rgba(168, 85, 247, 0.15); color: var(--primary); border: 1px solid rgba(168, 85, 247, 0.35); }
+  .badge.ok       { background: rgba(52, 211, 153, 0.12);  color: var(--ok);     border: 1px solid rgba(52, 211, 153, 0.35); }
+  .badge.warn     { background: rgba(251, 191, 36, 0.12);  color: var(--warn);   border: 1px solid rgba(251, 191, 36, 0.35); }
+  .badge.danger   { background: rgba(248, 113, 113, 0.12); color: var(--danger); border: 1px solid rgba(248, 113, 113, 0.35); }
+
+  .persona {
+    border: 1px solid var(--border); border-radius: 10px;
+    padding: 1rem 1.1rem; margin: 0.75rem 0; background: var(--bg-elev);
+  }
+  .persona header {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 0.5rem; margin-bottom: 0.35rem;
+  }
+  .persona h3 { margin: 0; }
+  .persona .role { color: var(--muted); font-size: 0.78rem; font-family: var(--mono); }
+
+  table { width: 100%; border-collapse: collapse; font-size: 0.88rem; margin: 0.6rem 0; }
+  th, td { text-align: left; padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 500; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; }
+  td code { word-break: break-word; }
+
+  .decision { border-left: 3px solid var(--primary); padding: 0.4rem 0.9rem; margin: 0.4rem 0; background: rgba(168, 85, 247, 0.06); border-radius: 0 6px 6px 0; }
+  .decision strong { color: var(--primary); }
+
+  .pri { font-family: var(--mono); font-size: 0.7rem; font-weight: 600; padding: 0.02em 0.3em; border-radius: 3px; }
+  .pri.p0 { background: rgba(248, 113, 113, 0.15); color: var(--danger); }
+  .pri.p1 { background: rgba(251, 191, 36, 0.15);  color: var(--warn); }
+  .pri.p2 { background: rgba(154, 154, 176, 0.15); color: var(--muted); }
+
+  figure { margin: 1rem 0; }
+  figure svg { width: 100%; height: auto; display: block; border: 1px solid var(--border); border-radius: 10px; background: var(--bg-elev); }
+  figcaption { color: var(--muted); font-size: 0.8rem; margin-top: 0.4rem; text-align: center; }
+
+  hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { transition: none !important; animation: none !important; }
+  }
+</style>
+</head>
+<body>
+<main>
+
+<h1>Mobile Layout &amp; Navigation — Personas Meeting <span class="badge internal">Internal</span></h1>
+<p class="meta">
+  branch: <code>claude/mobile-layout-improvements-2XZOp</code> ·
+  date: 2026-05-17 ·
+  audience: engineering
+</p>
+
+<p>
+  Four personas were spawned in parallel to review &ldquo;The Box&rdquo;&rsquo;s
+  application layout and navigation, with a brief to improve the mobile-first
+  experience. Each had a narrow lens — UX/product, real-device QA, frontend
+  implementation, and WCAG 2.2 accessibility — and reported back with
+  prioritised, file-level findings. This note captures the synthesis, the
+  agreed decisions, and what shipped.
+</p>
+
+<h2>Verdict</h2>
+<div class="decision">
+  <strong>Adopt a persistent mobile bottom navigation bar.</strong> All four
+  personas converged independently: a hamburger drawer is the wrong
+  <em>primary</em> navigation for a daily-engagement game. It buries every
+  destination behind a three-tap interaction in the hardest-to-reach corner of
+  the screen, exposes no information architecture, and offers no
+  &ldquo;you are here&rdquo; signal. The drawer is kept as a complete
+  overflow/account menu; the bottom bar becomes the one-tap primary nav.
+</div>
+
+<h2>Starting point</h2>
+<p>
+  No sidebar exists. Mobile navigation is a single left-edge hamburger
+  <code>Sheet</code> drawer; desktop is a top horizontal nav plus a user
+  dropdown. The <code>Header.tsx</code> file is 419 lines and duplicates the
+  navigation and account sections between the two layouts. Nav items render as
+  <code>Button size="sm"</code> (32&nbsp;px tall). There is no active-route
+  indication, no skip link, and no <code>env(safe-area-inset-*)</code> handling
+  on the header or the drawer.
+</p>
+
+<figure>
+  <svg viewBox="0 0 720 300" role="img"
+       aria-label="Before and after: a phone with hamburger-only navigation versus a phone with a hamburger plus a four-tab bottom navigation bar.">
+    <!-- BEFORE -->
+    <text x="150" y="28" fill="#9a9ab0" font-family="JetBrains Mono, monospace" font-size="12" text-anchor="middle">BEFORE</text>
+    <rect x="60" y="40" width="180" height="240" rx="18" fill="#14141c" stroke="#2a2a38"/>
+    <!-- header -->
+    <rect x="60" y="40" width="180" height="34" rx="18" fill="#0a0a0f"/>
+    <rect x="60" y="56" width="180" height="18" fill="#0a0a0f"/>
+    <line x1="60" y1="74" x2="240" y2="74" stroke="#2a2a38"/>
+    <rect x="74" y="51" width="16" height="12" rx="2" fill="#9a9ab0"/>
+    <!-- content -->
+    <rect x="84" y="100" width="132" height="14" rx="4" fill="#2a2a38"/>
+    <rect x="84" y="124" width="132" height="42" rx="8" fill="#3a2a4a"/>
+    <rect x="84" y="178" width="132" height="10" rx="3" fill="#1f1f2b"/>
+    <rect x="84" y="194" width="100" height="10" rx="3" fill="#1f1f2b"/>
+    <text x="150" y="262" fill="#f87171" font-family="JetBrains Mono, monospace" font-size="9" text-anchor="middle">nav = 3 taps, top-left only</text>
+
+    <!-- AFTER -->
+    <text x="570" y="28" fill="#a855f7" font-family="JetBrains Mono, monospace" font-size="12" text-anchor="middle" style="text-shadow:0 0 12px rgba(168,85,247,.45)">AFTER</text>
+    <rect x="480" y="40" width="180" height="240" rx="18" fill="#14141c" stroke="#2a2a38"/>
+    <!-- header -->
+    <rect x="480" y="40" width="180" height="34" rx="18" fill="#0a0a0f"/>
+    <rect x="480" y="56" width="180" height="18" fill="#0a0a0f"/>
+    <line x1="480" y1="74" x2="660" y2="74" stroke="#2a2a38"/>
+    <rect x="494" y="51" width="16" height="12" rx="2" fill="#9a9ab0"/>
+    <circle cx="624" cy="57" r="6" fill="#3a2a4a"/>
+    <circle cx="642" cy="57" r="6" fill="#3a2a4a"/>
+    <!-- content -->
+    <rect x="504" y="100" width="132" height="14" rx="4" fill="#2a2a38"/>
+    <rect x="504" y="124" width="132" height="42" rx="8" fill="#3a2a4a"/>
+    <rect x="504" y="178" width="132" height="10" rx="3" fill="#1f1f2b"/>
+    <rect x="504" y="194" width="100" height="10" rx="3" fill="#1f1f2b"/>
+    <!-- bottom nav -->
+    <line x1="480" y1="238" x2="660" y2="238" stroke="#2a2a38"/>
+    <rect x="498" y="238" width="36" height="3" rx="1.5" fill="#a855f7"/>
+    <g fill="#a855f7"><rect x="510" y="248" width="12" height="12" rx="2"/></g>
+    <g fill="#9a9ab0">
+      <rect x="554" y="248" width="12" height="12" rx="2"/>
+      <rect x="598" y="248" width="12" height="12" rx="2"/>
+      <rect x="642" y="248" width="12" height="12" rx="2"/>
+    </g>
+    <g fill="#9a9ab0" font-family="JetBrains Mono, monospace" font-size="7" text-anchor="middle">
+      <text x="516" y="272" fill="#a855f7">Home</text>
+      <text x="560" y="272">Play</text>
+      <text x="604" y="272">Rank</text>
+      <text x="648" y="272">Prof</text>
+    </g>
+  </svg>
+  <figcaption>Mobile navigation model — before (hamburger only) vs. after (hamburger overflow + persistent bottom bar with active-state indicator).</figcaption>
+</figure>
+
+<h2>Personas &amp; Findings</h2>
+
+<div class="persona">
+  <header>
+    <h3>UX / Product Designer <span class="badge danger">Re-architect</span></h3>
+    <span class="role">mobile-first · daily-habit loop</span>
+  </header>
+  <p>
+    A hamburger fits content-heavy sites with deep, infrequent navigation —
+    &ldquo;The Box&rdquo; is the opposite: a small destination set, visited
+    daily, on phones. The drawer adds friction exactly where an engagement app
+    must remove it, and opens from the top-left, the worst one-handed reach.
+  </p>
+  <ul>
+    <li><span class="pri p0">P0</span> Persistent bottom bar — <strong>Home · Play · Leaderboard · Profile</strong> — with a visible active indicator and ≥48&nbsp;px targets; hidden on <code>/play</code> and <code>/geo</code>.</li>
+    <li><span class="pri p1">P1</span> Surface the daily-reward badge in the header — it was buried inside the drawer, invisible on first paint, undermining the streak loop.</li>
+    <li><span class="pri p2">P2</span> Decide Geo&rsquo;s status; bump remaining 32&nbsp;px controls to 44&nbsp;px.</li>
+  </ul>
+</div>
+
+<div class="persona">
+  <header>
+    <h3>Mobile QA / Real-Device <span class="badge warn">Safe-area risks</span></h3>
+    <span class="role">notch · keyboard · dvh · PWA standalone</span>
+  </header>
+  <p>
+    A fixed bottom bar collides with the iOS home indicator and Android gesture
+    bar unless it reserves <code>env(safe-area-inset-bottom)</code>. The sticky
+    header has no <code>safe-area-inset-top</code>, so in installed-PWA mode
+    (<code>black-translucent</code> status bar) it renders behind the notch.
+    The left <code>Sheet</code> ignores safe areas entirely.
+  </p>
+  <ul>
+    <li><span class="pri p0">P0</span> Header <code>padding-top</code> = inset-top; bottom bar = inset-bottom; <code>Sheet</code> left/right insets; bottom bar must hide while the virtual keyboard is open on form pages.</li>
+    <li><span class="pri p1">P1</span> Shell heights <code>100vh</code> → <code>100dvh</code>; reserve content/footer space so nothing scrolls under the fixed bar.</li>
+    <li><span class="pri p2">P2</span> Enable a Mobile WebKit Playwright project — iOS is where these bugs live.</li>
+  </ul>
+</div>
+
+<div class="persona">
+  <header>
+    <h3>Frontend Engineer <span class="badge ok">Build plan</span></h3>
+    <span class="role">React 19 · Tailwind v4 · shadcn/ui</span>
+  </header>
+  <p>
+    Hand-roll a small <code>BottomNav</code> on <code>NavLink</code> — do
+    <em>not</em> abuse Radix <code>Tabs</code> (its panels/roving-tabindex fight
+    react-router) and do <em>not</em> install the shadcn <code>sidebar</code>
+    block (heavy, solves a problem a 5-link top bar doesn&rsquo;t have). The
+    419-line Header duplicates its nav and account lists; extract one typed
+    config consumed by all three surfaces.
+  </p>
+  <ul>
+    <li><span class="pri p0">P0</span> Shared <code>nav-items.ts</code> config; Header refactor; <code>NavLink</code> for active state (Home needs <code>end</code> against the localized prefix).</li>
+    <li><span class="pri p1">P1</span> <code>BottomNav</code> component mounted in <code>LanguageLayout</code>; z-index re-stack so PWA banners float above the bar.</li>
+    <li><span class="pri p2">P2</span> A <code>--bottom-nav-h</code> token so the bar height and reserved padding can&rsquo;t drift.</li>
+  </ul>
+</div>
+
+<div class="persona">
+  <header>
+    <h3>Accessibility (WCAG 2.2 AA) <span class="badge danger">3 AA gaps</span></h3>
+    <span class="role">landmarks · targets · focus</span>
+  </header>
+  <p>
+    Three concrete AA gaps, none needing architectural change: no skip link
+    (<code>SC 2.4.1</code>), 32&nbsp;px nav targets with sub-24&nbsp;px spacing
+    (<code>SC 2.5.8</code>), and no active-route signalling at all — no
+    <code>aria-current</code> (<code>SC 4.1.2 / 2.4.8</code>).
+  </p>
+  <ul>
+    <li><span class="pri p0">P0</span> Skip link to <code>&lt;main&gt;</code>; ≥44&nbsp;px targets; <code>aria-current="page"</code> + a non-colour active indicator (<code>SC 1.4.1 / 1.4.11</code>).</li>
+    <li><span class="pri p1">P1</span> Distinct <code>aria-label</code> on each <code>&lt;nav&gt;</code> landmark; drawer becomes a real <code>&lt;nav&gt;</code>; <code>scroll-padding</code> for Focus-Not-Obscured (<code>SC 2.4.11</code>).</li>
+    <li><span class="pri p2">P2</span> <code>aria-hidden</code> on decorative icons.</li>
+  </ul>
+</div>
+
+<h2>Decisions</h2>
+<div class="decision">
+  <strong>Scope — full consensus set.</strong> Bottom nav + Header dedup
+  refactor + all P0/P1 accessibility and safe-area fixes. <em>(Confirmed with
+  the requester.)</em>
+</div>
+<div class="decision">
+  <strong>Bottom-bar destinations — Home · Play · Leaderboard · Profile.</strong>
+  Four items for generous thumb spacing. Geo (alpha) stays reachable from the
+  Home page and the drawer rather than taking a top-level tab.
+  <em>(Confirmed with the requester.)</em>
+</div>
+
+<h2>What shipped</h2>
+<table>
+  <thead><tr><th>File</th><th>Change</th><th>Source</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>layout/nav-items.ts</code> <em>(new)</em></td>
+      <td>Typed <code>PRIMARY_NAV</code> + <code>BOTTOM_NAV</code> config — single source of truth for every nav surface.</td>
+      <td>Frontend</td>
+    </tr>
+    <tr>
+      <td><code>layout/BottomNav.tsx</code> <em>(new)</em></td>
+      <td>Mobile bottom bar: 4 <code>NavLink</code> tabs, <code>md:hidden</code>, <code>aria-current</code>, non-colour active indicator, <code>safe-area-inset-bottom</code>, unmounts while the keyboard is open.</td>
+      <td>UX, Frontend, A11y, QA</td>
+    </tr>
+    <tr>
+      <td><code>layout/Header.tsx</code></td>
+      <td>Consumes the shared config; <code>NavLink</code> active states + <code>aria-current</code>; one <code>AccountMenu</code> renderer for drawer &amp; dropdown so the nav and account lists are declared once, not duplicated per layout; <code>safe-area-inset-top</code>; 44&nbsp;px targets; reward widgets surfaced into the header; labelled <code>&lt;nav&gt;</code> landmarks.</td>
+      <td>All four</td>
+    </tr>
+    <tr>
+      <td><code>App.tsx</code></td>
+      <td>Skip link; <code>&lt;main id="main-content"&gt;</code> landmark; mounts <code>BottomNav</code> (gated off <code>/play</code> &amp; <code>/geo</code>); content padding reserves the bar; <code>min-h-dvh</code>.</td>
+      <td>A11y, Frontend, QA</td>
+    </tr>
+    <tr>
+      <td><code>layout/Footer.tsx</code></td>
+      <td><code>aria-label</code> on the footer <code>&lt;nav&gt;</code> landmark.</td>
+      <td>A11y</td>
+    </tr>
+    <tr>
+      <td><code>ui/sheet.tsx</code></td>
+      <td>Left/right drawer variants reserve top &amp; bottom safe-area insets.</td>
+      <td>QA</td>
+    </tr>
+    <tr>
+      <td><code>index.css</code></td>
+      <td><code>--bottom-nav-h</code> / <code>--bottom-nav-space</code> tokens; <code>scroll-padding</code> (SC 2.4.11); <code>100dvh</code> shell.</td>
+      <td>Frontend, A11y, QA</td>
+    </tr>
+    <tr>
+      <td><code>pwa/InstallPromptBanner.tsx</code>, <code>pwa/PWAUpdatePrompt.tsx</code></td>
+      <td>Float above the bottom bar on mobile; corner-anchored at <code>md</code>.</td>
+      <td>Frontend</td>
+    </tr>
+    <tr>
+      <td><code>locales/{en,fr}/translation.json</code></td>
+      <td><code>nav.*</code> keys — landmark labels, skip-link text, bottom-tab labels.</td>
+      <td>A11y</td>
+    </tr>
+  </tbody>
+</table>
+<p>
+  <code>npm run build</code>, <code>npm run lint</code> (0 errors) and
+  <code>npm test</code> (169 pass) are green. The bottom bar, active states,
+  drawer, and the <code>/play</code> &amp; <code>/geo</code> gating were
+  verified visually in a headless browser at a 390&nbsp;px viewport.
+</p>
+
+<h2>Out of scope — follow-ups</h2>
+<ul>
+  <li><strong>Geo escape affordance.</strong> The fullscreen <code>/geo</code> route has no visible exit control (UX flagged P0). It is a route-specific concern, separate from this layout/nav pass — track separately.</li>
+  <li><strong>Mobile E2E.</strong> Enable a Mobile WebKit Playwright project and add specs for bottom-nav navigation, safe-area insets, and the keyboard-open state.</li>
+  <li><strong>PageHero reduced motion.</strong> Its Framer Motion entrance animations are JS-driven and not covered by the global CSS <code>prefers-reduced-motion</code> rule (a11y P2).</li>
+  <li><strong>Landscape.</strong> Consider auto-hiding the bottom bar in landscape phone orientation, where header + bar eat ~30% of the viewport (QA consideration).</li>
+</ul>
+
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Implements a persistent mobile bottom navigation bar (Home · Play · Leaderboard · Profile) and refactors the 419-line Header component to eliminate duplication. Extracts navigation configuration into a shared typed config (`nav-items.ts`) consumed by the desktop header, mobile drawer, and new bottom nav. Addresses P0/P1 accessibility gaps (skip link, 44px targets, `aria-current`) and safe-area insets for notch/gesture-bar clearance.

## Key Changes

**Navigation Architecture**
- New `nav-items.ts` exports `PRIMARY_NAV` (desktop/drawer) and `BOTTOM_NAV` (mobile bar) as typed `NavLinkItem[]` configs
- Eliminates hand-rolled nav duplication between mobile and desktop layouts
- Shared config ensures the three surfaces (desktop bar, mobile drawer, bottom bar) never drift

**Header Refactor**
- Extracts `NavItemLink` component to render a single nav destination as a `NavLink` with active-state styling and `aria-current="page"`
- Extracts `AccountMenu` component to render account/profile/logout entries for both drawer and dropdown variants
- Reduces Header from 419 lines to ~350 lines; removes conditional rendering duplication
- Imports only the icons actually used; removes unused `Trophy`, `Home`, `Play`, `MapPin` from the header's direct imports

**New BottomNav Component**
- Persistent fixed bar at mobile viewports (`md:hidden`), hidden on desktop
- Reserves `env(safe-area-inset-bottom)` for iOS home indicator / Android gesture bar
- Unmounts when virtual keyboard is open (via `useKeyboardHeight` hook) so it never floats over form inputs
- Non-text active indicator (top bar) readable without relying on colour alone (WCAG 1.4.1/1.4.11)
- Mounted in `LanguageLayout`; hidden on fullscreen routes (`/play`, `/geo`)

**Accessibility & Safe Areas**
- Header now reserves `pt-[env(safe-area-inset-top)]` so sticky header clears iOS notch in PWA standalone mode
- All nav items use `aria-hidden="true"` on decorative icons
- `NavLink` components automatically emit `aria-current="page"` on active routes
- Added `aria-label` to all `<nav>` landmarks (`nav.primary`, `nav.mobile`, `nav.footer`)
- Distinct button sizes: 44px (11 × 4 rem) for all interactive targets

**Styling & Layout**
- New CSS variables in `index.css`: `--bottom-nav-h` (4rem) and `--bottom-nav-space` (bar + inset) so reserved padding and bar height stay in sync
- Updated `Sheet` component to reserve safe-area insets on all sides
- PWA banners (`InstallPromptBanner`, `PWAUpdatePrompt`) z-index adjusted to float above the bottom bar (z-40)
- Footer gains `aria-label="nav.footer"` for landmark clarity

**i18n**
- New `nav.*` translation keys: `primary`, `footer`, `mobile`, `skipToContent`, and `nav.tabs.*` (shorter labels for bottom bar)
- Translations added for English and French

**App Layout**
- `LanguageLayout` now mounts `BottomNav` and gates it off fullscreen routes
- Content padding reserved via `--bottom-nav-space` so nothing scrolls under the fixed bar
- Keyboard height detection prevents the bar from floating over form inputs

## Implementation Notes

- `NavItemLink` uses `NavLink` (not `Link`) so active routes get `aria-current="page"` automatically; Home uses `end={true}` to avoid false positives on nested routes
- Premium upsell link lives outside `PRIMARY_NAV` and renders conditionally in Header/drawer; still uses `NavItemLink` for consistent active styling
- Account menu entries are declared once in `AccountMenu` and rendered for both drawer (full-width buttons) and dropdown (menu items) so the two never drift
- `useKeyboardHeight` hook detects virtual keyboard to hide the bottom bar on form pages

https://claude.ai/code/session_01B4k9vQgowe2xBZzmAjFbW5