### PR TITLE
Fix daily login streak reset on servers east of UTC

### DIFF
--- a/packages/backend/src/domain/services/daily-login.service.test.ts
+++ b/packages/backend/src/domain/services/daily-login.service.test.ts
@@ -312,3 +312,72 @@ describe('dailyLoginService.getStatus — streak freeze auto-consume', () => {
         assert.equal(invState.useItemsCalls.length, 0)
     })
 })
+
+describe('dailyLoginService.getStatus — last_login_date as a Date object', () => {
+    // The `pg` driver parses DATE columns into JS Date objects built at
+    // LOCAL midnight. These tests pin the process TZ east of UTC so the
+    // regression (reading the date back in UTC, shifting it a day, and
+    // resetting the streak) is caught regardless of where tests run.
+
+    it('continues the streak when the driver returns yesterday as a local-midnight Date', async () => {
+        const originalTz = process.env.TZ
+        process.env.TZ = 'Asia/Tokyo'
+        try {
+            const [y, m, d] = dateOffset(1).split('-').map(Number)
+            const yesterdayAsLocalDate = new Date(y!, m! - 1, d!)
+
+            const { repo: invRepo } = makeFakeInventory(0)
+            const { repo: dailyRepo, state: dailyState } = makeFakeDailyLogin({
+                current_login_streak: 3,
+                longest_login_streak: 3,
+                last_login_date: yesterdayAsLocalDate as unknown as string,
+                current_day_in_cycle: 3,
+            }, invRepo)
+
+            const service = createDailyLoginService({
+                logger: silentLogger,
+                dailyLoginRepository: dailyRepo,
+                inventoryRepository: invRepo,
+            })
+
+            const status = await service.getStatus('user-1')
+
+            assert.equal(status.currentStreak, 4, 'streak should advance, not reset')
+            assert.equal(status.currentDayInCycle, 4)
+            assert.equal(dailyState.updates.length, 1, 'streak row should be persisted once')
+            assert.equal(dailyState.updates[0]?.lastLoginDate, todayUTC())
+        } finally {
+            process.env.TZ = originalTz
+        }
+    })
+
+    it('treats a same-day re-call as no new login when today is a local-midnight Date', async () => {
+        const originalTz = process.env.TZ
+        process.env.TZ = 'Asia/Tokyo'
+        try {
+            const [y, m, d] = todayUTC().split('-').map(Number)
+            const todayAsLocalDate = new Date(y!, m! - 1, d!)
+
+            const { repo: invRepo } = makeFakeInventory(0)
+            const { repo: dailyRepo, state: dailyState } = makeFakeDailyLogin({
+                current_login_streak: 3,
+                longest_login_streak: 3,
+                last_login_date: todayAsLocalDate as unknown as string,
+                current_day_in_cycle: 3,
+            }, invRepo)
+
+            const service = createDailyLoginService({
+                logger: silentLogger,
+                dailyLoginRepository: dailyRepo,
+                inventoryRepository: invRepo,
+            })
+
+            const status = await service.getStatus('user-1')
+
+            assert.equal(status.currentStreak, 3, 'streak should be unchanged')
+            assert.equal(dailyState.updates.length, 0, 'no streak write on same-day re-call')
+        } finally {
+            process.env.TZ = originalTz
+        }
+    })
+})

--- a/packages/backend/src/domain/services/daily-login.service.ts
+++ b/packages/backend/src/domain/services/daily-login.service.ts
@@ -92,13 +92,25 @@ function calculateStreak(
 }
 
 /**
- * Normalize date from database. PostgreSQL returns Date objects for DATE
- * columns; render them in UTC so they line up with `getToday()` above.
+ * Normalize `last_login_date` from the database to a YYYY-MM-DD string.
+ *
+ * The `pg` driver parses DATE columns into JS `Date` objects built at
+ * LOCAL midnight (`new Date(year, month, day)`) — a calendar date with no
+ * meaningful time-of-day or zone. Rendering such a Date with
+ * `toISOString()` reinterprets that local-midnight instant in UTC, which
+ * rolls the calendar date back a day on any server east of UTC (e.g.
+ * Europe/Paris): yesterday then looks like two days ago and the login
+ * streak resets every single day. Read the date back with the LOCAL
+ * getters, mirroring how `pg` built the object, so the stored calendar
+ * date survives intact regardless of the process timezone.
  */
 function normalizeDate(date: string | Date | null): string | null {
   if (!date) return null
   if (date instanceof Date) {
-    return date.toISOString().slice(0, 10)
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
   }
   return date
 }
@@ -161,22 +173,11 @@ export function createDailyLoginService(deps: DailyLoginServiceDeps): DailyLogin
       // Get or create streak record
       const streakRecord = await dailyLoginRepository.getOrCreateUserStreak(userId)
 
-      // Normalize date from database (PostgreSQL returns Date object)
-      const rawLastLoginDate = streakRecord.last_login_date
-      const lastLoginDate = normalizeDate(rawLastLoginDate as string | Date | null)
-      const today = getToday()
-
-      log.info(
-        {
-          userId,
-          rawLastLoginDate,
-          rawType: typeof rawLastLoginDate,
-          normalizedLastLoginDate: lastLoginDate,
-          today,
-          isEqual: lastLoginDate === today,
-        },
-        'getStatus date comparison debug'
+      // Normalize date from database (PostgreSQL returns a Date object)
+      const lastLoginDate = normalizeDate(
+        streakRecord.last_login_date as string | Date | null
       )
+      const today = getToday()
 
       // Calculate new streak values
       let { newStreak, newLongestStreak, newDayInCycle, isNewLogin } = calculateStreak(


### PR DESCRIPTION
## Summary

Fixes a critical bug in the daily login streak logic where the streak would reset every day on servers running in timezones east of UTC (e.g., Asia/Tokyo, Europe/Paris). The issue was caused by incorrect date normalization when the PostgreSQL `pg` driver returns DATE columns as local-midnight `Date` objects.

## Root Cause

The `pg` driver parses PostgreSQL DATE columns into JavaScript `Date` objects constructed at local midnight (`new Date(year, month, day)`). The previous implementation called `toISOString()` on these objects, which reinterprets the local-midnight instant in UTC. On servers east of UTC, this shifts the calendar date back by one day, causing the streak logic to think yesterday's login was two days ago and incorrectly reset the streak.

## Key Changes

- **`normalizeDate()` function**: Changed from using `toISOString().slice(0, 10)` to reading the date back using local getters (`getFullYear()`, `getMonth()`, `getDate()`). This preserves the calendar date as stored by `pg`, regardless of process timezone.
- **Removed debug logging**: Cleaned up temporary `log.info()` call that was used for debugging the date comparison.
- **Added comprehensive test coverage**: Two new test cases that pin the process timezone to Asia/Tokyo to catch this regression:
  - Verifies streak continues when `last_login_date` is yesterday as a local-midnight Date
  - Verifies same-day re-calls don't trigger a new login when today is a local-midnight Date

## Implementation Details

The fix mirrors how the `pg` driver constructs the Date object in the first place—by using local date component getters instead of UTC-based serialization. This ensures the stored calendar date survives intact regardless of the server's timezone offset.

https://claude.ai/code/session_014BbLsp6z6G19bgpyeH5Qcw