### PR TITLE
Handle expansion suffixes and comma-grouped numbers in fuzzy matching

### DIFF
--- a/packages/backend/src/domain/services/fuzzy-match.service.test.ts
+++ b/packages/backend/src/domain/services/fuzzy-match.service.test.ts
@@ -161,4 +161,29 @@ describe('fuzzy-match.service', () => {
       expectMatch('go counter strike', 'Counter-Strike: Global Offensive', ['counter strike go'])
     })
   })
+
+  describe('expansion-suffix titles (screenshot regression)', () => {
+    // Screenshot: the challenge "Warhammer 40,000: Dawn of War - Dark Crusade"
+    // rejected both base-game guesses. The expansion suffix and the comma'd
+    // franchise number must both be optional.
+    it('accepts the base game for an expansion-suffixed title', () => {
+      expectMatch('Warhammer dawn of war', 'Warhammer 40,000: Dawn of War - Dark Crusade')
+      expectMatch('Warhammer 40000 dawn of war', 'Warhammer 40,000: Dawn of War - Dark Crusade')
+    })
+
+    it('accepts the full expansion title', () => {
+      expectMatch(
+        'warhammer 40000 dawn of war dark crusade',
+        'Warhammer 40,000: Dawn of War - Dark Crusade'
+      )
+    })
+
+    it('still rejects an unrelated guess for an expansion-suffixed title', () => {
+      expectNoMatch('sim city 3000', "Command & Conquer: Red Alert 2 - Yuri's Revenge")
+    })
+
+    it('reads a comma-grouped franchise number as flavour, not a sequel number', () => {
+      assert.equal(service.parseGameTitle('Warhammer 40,000').seriesNumber, null)
+    })
+  })
 })

--- a/packages/backend/src/domain/services/fuzzy-match.service.ts
+++ b/packages/backend/src/domain/services/fuzzy-match.service.ts
@@ -96,15 +96,20 @@ function extractSeriesNumber(text: string): { number: number | null; remaining: 
     }
   }
 
-  // Check for Arabic number anywhere with word boundary (e.g., "Witcher 3", "Portal 2", "Fallout 4")
-  const arabicMatch = text.match(/\b(\d+)\b/)
-  if (arabicMatch && arabicMatch[1]) {
-    const num = parseInt(arabicMatch[1], 10)
+  // Check for Arabic number anywhere with word boundary (e.g., "Witcher 3", "Portal 2", "Fallout 4").
+  // Digit groups with thousands separators ("Warhammer 40,000") are read as
+  // one number so they parse identically to the separator-free form — both
+  // land above the sequel-number ceiling and are treated as franchise
+  // flavour, not a series number. Without this, "40,000" yields just "40".
+  const arabicMatch = text.match(/\b\d{1,3}(?:[.,]\d{3})+\b|\b\d+\b/)
+  if (arabicMatch) {
+    const raw = arabicMatch[0]
+    const num = parseInt(raw.replace(/[.,]/g, ''), 10)
     if (num > 0 && num <= 50) {
       // Reasonable game sequel number
       return {
         number: num,
-        remaining: text.replace(arabicMatch[0], ' ').replace(/\s+/g, ' ').trim(),
+        remaining: text.replace(raw, ' ').replace(/\s+/g, ' ').trim(),
       }
     }
   }
@@ -144,6 +149,19 @@ function stripCommonPrefixes(text: string): string {
 }
 
 /**
+ * Drop a trailing expansion / DLC suffix introduced by a spaced dash, e.g.
+ * "Dawn of War - Dark Crusade" -> "Dawn of War" or
+ * "Wild Hunt – Blood and Wine" -> "Wild Hunt". The base game is a fair
+ * guess for an expansion-titled challenge, so the pre-dash core is offered
+ * as an extra match candidate. Hyphens without surrounding spaces
+ * ("Half-Life", "Spider-Man") are part of the name and left untouched.
+ */
+function stripExpansionSuffix(name: string): string {
+  const match = name.match(/^(.+?)\s+[-–—]\s+.+$/)
+  return match?.[1]?.trim() ?? name
+}
+
+/**
  * Parse a game title into structured components
  *
  * Examples:
@@ -165,13 +183,6 @@ function parseGameTitle(title: string): ParsedGameTitle {
   if (colonIndex > 0) {
     seriesPart = strippedEdition.slice(0, colonIndex).trim()
     subtitlePart = strippedEdition.slice(colonIndex + 1).trim()
-
-    // Handle DLC suffix in subtitle (e.g., "Wild Hunt – Blood and Wine")
-    const dlcMatch = subtitlePart.match(/^(.+?)(?:\s*[-–—]\s*.+)$/)
-    if (dlcMatch) {
-      // Keep the full subtitle including DLC for matching
-      // but also store the base subtitle
-    }
   } else {
     seriesPart = strippedEdition
   }
@@ -742,7 +753,18 @@ export function createFuzzyMatchService(deps: FuzzyMatchServiceDeps): FuzzyMatch
     },
 
     isMatch(input: string, gameName: string, aliases: string[] = []): boolean {
-      return isMatchEnhanced(input, gameName, aliases, log)
+      if (isMatchEnhanced(input, gameName, aliases, log)) {
+        return true
+      }
+      // Retry against the base title with any " - Expansion" suffix removed,
+      // so the base game is accepted for an expansion-titled challenge
+      // (e.g. "Warhammer Dawn of War" for
+      // "Warhammer 40,000: Dawn of War - Dark Crusade").
+      const core = stripExpansionSuffix(gameName)
+      if (core !== gameName && isMatchEnhanced(input, core, aliases, log)) {
+        return true
+      }
+      return false
     },
 
     getBestMatchScore(


### PR DESCRIPTION
## Summary

Improves game title matching in the fuzzy-match service to handle two edge cases that were causing valid guesses to be rejected:

1. **Expansion/DLC suffixes** – titles like "Warhammer 40,000: Dawn of War - Dark Crusade" now match against the base game ("Dawn of War") when the expansion suffix is stripped
2. **Comma-grouped franchise numbers** – numbers like "40,000" in "Warhammer 40,000" are now correctly parsed as a single number and treated as franchise flavour rather than a sequel number

## Key Changes

- **Enhanced Arabic number parsing** in `extractSeriesNumber()`:
  - Updated regex to match both comma/period-separated thousands groups (`\d{1,3}(?:[.,]\d{3})+`) and regular digits
  - Strips separators before parsing to ensure "40,000" and "40000" are treated identically
  - Both forms correctly exceed the sequel-number ceiling (50) and are excluded from series matching

- **New `stripExpansionSuffix()` function**:
  - Removes trailing expansion/DLC suffixes introduced by spaced dashes (` - `, ` – `, ` — `)
  - Preserves hyphens without surrounding spaces (e.g., "Half-Life", "Spider-Man")
  - Extracted as a reusable utility for clarity

- **Updated `isMatch()` logic**:
  - First attempts standard matching against the full game name
  - Falls back to matching against the base title (with expansion suffix removed) if the first attempt fails
  - Allows base-game guesses to satisfy expansion-titled challenges

- **Removed dead code** in `parseGameTitle()`:
  - Deleted unused DLC-suffix handling logic that was never applied

## Tests

Added comprehensive test suite covering:
- Base game matching for expansion-suffixed titles
- Full expansion title matching
- Rejection of unrelated guesses
- Correct parsing of comma-grouped franchise numbers as non-sequel values

Fixes screenshot regression where "Warhammer dawn of war" was rejected for "Warhammer 40,000: Dawn of War - Dark Crusade".

https://claude.ai/code/session_01X9dYvcbwwBLY6Cm1w1MAcL