### PR TITLE
Add attempt-based achievements and wrong guess tracking

### DIFF
--- a/packages/backend/migrations/20260525_attempt_achievements.ts
+++ b/packages/backend/migrations/20260525_attempt_achievements.ts
@@ -1,0 +1,126 @@
+import type { Knex } from 'knex'
+
+// Attempt-based achievements. Now that every guess is persisted per
+// screenshot, we can reward the *journey* of cracking a single capture —
+// both stubborn persistence and first-try precision.
+//
+// Four new criteria types are evaluated per-game from GameCompletionData
+// (attempts_in_game, comeback_in_game, first_try_in_game, flawless_game);
+// total_wrong_guesses is a cumulative all-time aggregate. The matching
+// checker functions live in achievement.service.ts.
+
+export async function up(knex: Knex): Promise<void> {
+  const achievements = [
+    {
+      key: 'acharne',
+      name: 'Acharné',
+      description: 'Tente ta chance plus de 10 fois sur une seule capture',
+      category: 'completion',
+      icon_url: '🔁',
+      points: 20,
+      criteria: { type: 'attempts_in_game', count: 10 },
+      tier: 1,
+      is_hidden: false,
+    },
+    {
+      key: 'tete_de_mule',
+      name: 'Tête de mule',
+      description: 'Tente ta chance 20 fois ou plus sur une seule capture',
+      category: 'completion',
+      icon_url: '🐴',
+      points: 50,
+      criteria: { type: 'attempts_in_game', count: 20 },
+      tier: 2,
+      is_hidden: true,
+    },
+    {
+      key: 'jamais_abandonner',
+      name: 'Jamais abandonner',
+      description: 'Identifie une capture après 8 mauvaises propositions ou plus',
+      category: 'completion',
+      icon_url: '💪',
+      points: 45,
+      criteria: { type: 'comeback_in_game', count: 8 },
+      tier: 2,
+      is_hidden: false,
+    },
+    {
+      key: 'du_premier_coup',
+      name: 'Du premier coup',
+      description: 'Identifie une capture dès la première proposition',
+      category: 'accuracy',
+      icon_url: '🎯',
+      points: 15,
+      criteria: { type: 'first_try_in_game', count: 1 },
+      tier: 1,
+      is_hidden: false,
+    },
+    {
+      key: 'sans_hesitation',
+      name: 'Sans hésitation',
+      description: 'Termine un défi sans une seule mauvaise proposition',
+      category: 'accuracy',
+      icon_url: '✨',
+      points: 100,
+      criteria: { type: 'flawless_game', count: 10 },
+      tier: 3,
+      is_hidden: false,
+    },
+    {
+      key: 'tatonneur',
+      name: 'Tâtonneur',
+      description: 'Accumule 100 mauvaises propositions au total',
+      category: 'completion',
+      icon_url: '🧭',
+      points: 25,
+      criteria: { type: 'total_wrong_guesses', count: 100 },
+      tier: 1,
+      is_hidden: false,
+    },
+    {
+      key: 'increvable',
+      name: 'Increvable',
+      description: 'Accumule 1 000 mauvaises propositions au total',
+      category: 'completion',
+      icon_url: '🛡️',
+      points: 150,
+      criteria: { type: 'total_wrong_guesses', count: 1000 },
+      tier: 3,
+      is_hidden: true,
+    },
+  ]
+
+  // Idempotent: skip keys that already exist so the migration is safe to
+  // re-run in seeded test environments (mirrors 20260512_mastery_milestones).
+  const existing = await knex<{ key: string }>('achievements')
+    .whereIn(
+      'key',
+      achievements.map((a) => a.key)
+    )
+    .select('key')
+  const existingKeys = new Set(existing.map((r) => r.key))
+  const toInsert = achievements.filter((a) => !existingKeys.has(a.key))
+
+  if (toInsert.length === 0) return
+
+  await knex('achievements').insert(
+    toInsert.map((a) => ({
+      ...a,
+      criteria: JSON.stringify(a.criteria),
+    }))
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex('achievements')
+    .whereIn('key', [
+      'acharne',
+      'tete_de_mule',
+      'jamais_abandonner',
+      'du_premier_coup',
+      'sans_hesitation',
+      'tatonneur',
+      'increvable',
+    ])
+    .del()
+}

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -371,6 +371,7 @@ export interface AchievementRepository {
   countStartedGameSessions(userId: string): Promise<number>
   countAllGuesses(userId: string): Promise<number>
   countCorrectGuesses(userId: string): Promise<number>
+  countWrongGuesses(userId: string): Promise<number>
   countSpeedCorrectGuesses(userId: string, maxTimeMs: number): Promise<number>
   countHintFreeCompletedGames(userId: string): Promise<number>
   countGenreCorrectGuesses(userId: string, genre: string): Promise<number>

--- a/packages/backend/src/domain/services/achievement.service.ts
+++ b/packages/backend/src/domain/services/achievement.service.ts
@@ -447,6 +447,158 @@ export function createAchievementService(deps: AchievementServiceDeps): Achievem
     return false
   }
 
+  async function checkAttemptsInGame(
+    achievement: AchievementRow,
+    data: GameCompletionData,
+    criteria: Criteria
+  ): Promise<boolean> {
+    // Most guesses on any single screenshot this game. A "capture" is keyed
+    // by screenshotId so attempts never bleed across tiers.
+    const attemptsByScreenshot = new Map<number, number>()
+    for (const guess of data.guesses) {
+      attemptsByScreenshot.set(
+        guess.screenshotId,
+        (attemptsByScreenshot.get(guess.screenshotId) ?? 0) + 1
+      )
+    }
+    const maxAttempts = Math.max(0, ...attemptsByScreenshot.values())
+
+    if (maxAttempts >= criteria.count) {
+      await achievementRepository.awardAchievement(
+        data.userId,
+        achievement.key,
+        maxAttempts,
+        criteria.count
+      )
+      return true
+    }
+
+    return false
+  }
+
+  async function checkComebackInGame(
+    achievement: AchievementRow,
+    data: GameCompletionData,
+    criteria: Criteria
+  ): Promise<boolean> {
+    // Largest run of wrong guesses on a screenshot the user *still*
+    // identified. A position closes on the correct answer, so every wrong
+    // guess on a solved screenshot necessarily preceded the win.
+    const wrongByScreenshot = new Map<number, number>()
+    const solvedScreenshots = new Set<number>()
+    for (const guess of data.guesses) {
+      if (guess.isCorrect) {
+        solvedScreenshots.add(guess.screenshotId)
+      } else {
+        wrongByScreenshot.set(
+          guess.screenshotId,
+          (wrongByScreenshot.get(guess.screenshotId) ?? 0) + 1
+        )
+      }
+    }
+
+    let maxComeback = 0
+    for (const screenshotId of solvedScreenshots) {
+      maxComeback = Math.max(maxComeback, wrongByScreenshot.get(screenshotId) ?? 0)
+    }
+
+    if (maxComeback >= criteria.count) {
+      await achievementRepository.awardAchievement(
+        data.userId,
+        achievement.key,
+        maxComeback,
+        criteria.count
+      )
+      return true
+    }
+
+    return false
+  }
+
+  async function checkFirstTryInGame(
+    achievement: AchievementRow,
+    data: GameCompletionData,
+    criteria: Criteria
+  ): Promise<boolean> {
+    // A screenshot is "first try" when it has a correct guess and zero
+    // wrong guesses — i.e. the only guess made on it was the right one.
+    const wrongByScreenshot = new Map<number, number>()
+    const solvedScreenshots = new Set<number>()
+    for (const guess of data.guesses) {
+      if (guess.isCorrect) {
+        solvedScreenshots.add(guess.screenshotId)
+      } else {
+        wrongByScreenshot.set(
+          guess.screenshotId,
+          (wrongByScreenshot.get(guess.screenshotId) ?? 0) + 1
+        )
+      }
+    }
+
+    let firstTryCount = 0
+    for (const screenshotId of solvedScreenshots) {
+      if ((wrongByScreenshot.get(screenshotId) ?? 0) === 0) {
+        firstTryCount++
+      }
+    }
+
+    if (firstTryCount >= criteria.count) {
+      await achievementRepository.awardAchievement(
+        data.userId,
+        achievement.key,
+        firstTryCount,
+        criteria.count
+      )
+      return true
+    }
+
+    return false
+  }
+
+  async function checkFlawlessGame(
+    achievement: AchievementRow,
+    data: GameCompletionData,
+    criteria: Criteria
+  ): Promise<boolean> {
+    // Flawless = enough correct guesses to clear the challenge AND not a
+    // single wrong guess. `criteria.count` is the screenshot count so a
+    // game with timed-out (un-guessed) positions cannot qualify.
+    const correctCount = data.guesses.filter(g => g.isCorrect).length
+    const wrongCount = data.guesses.filter(g => !g.isCorrect).length
+
+    if (wrongCount === 0 && correctCount >= criteria.count) {
+      await achievementRepository.awardAchievement(
+        data.userId,
+        achievement.key,
+        correctCount,
+        criteria.count
+      )
+      return true
+    }
+
+    return false
+  }
+
+  async function checkTotalWrongGuesses(
+    achievement: AchievementRow,
+    data: GameCompletionData,
+    criteria: Criteria
+  ): Promise<boolean> {
+    const totalWrong = await achievementRepository.countWrongGuesses(data.userId)
+
+    if (totalWrong >= criteria.count) {
+      await achievementRepository.awardAchievement(
+        data.userId,
+        achievement.key,
+        totalWrong,
+        criteria.count
+      )
+      return true
+    }
+
+    return false
+  }
+
   /**
    * Account-age check. Not part of the post-game evaluator switch — fired
    * separately from the BullMQ `milestone-account-age` worker.
@@ -513,6 +665,16 @@ export function createAchievementService(deps: AchievementServiceDeps): Achievem
           return checkCorrectInGame(achievement, data, criteria)
         case 'perfect_score_count':
           return checkPerfectScoreCount(achievement, data, criteria)
+        case 'attempts_in_game':
+          return checkAttemptsInGame(achievement, data, criteria)
+        case 'comeback_in_game':
+          return checkComebackInGame(achievement, data, criteria)
+        case 'first_try_in_game':
+          return checkFirstTryInGame(achievement, data, criteria)
+        case 'flawless_game':
+          return checkFlawlessGame(achievement, data, criteria)
+        case 'total_wrong_guesses':
+          return checkTotalWrongGuesses(achievement, data, criteria)
         default:
           log.warn({ type: criteria.type }, 'Unknown achievement criteria type')
           return false
@@ -544,6 +706,7 @@ export function createAchievementService(deps: AchievementServiceDeps): Achievem
       challengesStarted,
       totalGuesses,
       totalCorrectGuesses,
+      totalWrongGuesses,
       currentStreak,
       speedGuesses3s,
       speedGuesses5s,
@@ -553,6 +716,7 @@ export function createAchievementService(deps: AchievementServiceDeps): Achievem
       achievementRepository.countStartedGameSessions(userId),
       achievementRepository.countAllGuesses(userId),
       achievementRepository.countCorrectGuesses(userId),
+      achievementRepository.countWrongGuesses(userId),
       userRepository.getCurrentStreak(userId),
       achievementRepository.countSpeedCorrectGuesses(userId, 3000),
       achievementRepository.countSpeedCorrectGuesses(userId, 5000),
@@ -576,6 +740,9 @@ export function createAchievementService(deps: AchievementServiceDeps): Achievem
           break
         case 'total_correct_guesses':
           progress[achievement.key] = totalCorrectGuesses
+          break
+        case 'total_wrong_guesses':
+          progress[achievement.key] = totalWrongGuesses
           break
         case 'streak':
           progress[achievement.key] = currentStreak

--- a/packages/backend/src/infrastructure/repositories/achievement.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/achievement.repository.ts
@@ -322,6 +322,17 @@ export class AchievementRepository {
         return Number(row?.count ?? 0)
     }
 
+    async countWrongGuesses(userId: string): Promise<number> {
+        const row = await db('guesses')
+            .join('tier_sessions', 'guesses.tier_session_id', 'tier_sessions.id')
+            .join('game_sessions', 'tier_sessions.game_session_id', 'game_sessions.id')
+            .where('game_sessions.user_id', userId)
+            .where('guesses.is_correct', false)
+            .count<{ count: string }>({ count: '*' })
+            .first()
+        return Number(row?.count ?? 0)
+    }
+
     async countSpeedCorrectGuesses(userId: string, maxTimeMs: number): Promise<number> {
         const row = await db('guesses')
             .join('tier_sessions', 'guesses.tier_session_id', 'tier_sessions.id')

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -261,6 +261,34 @@
       "guessing_machine": {
         "name": "Guessing Machine",
         "description": "Make 500 guesses in total"
+      },
+      "acharne": {
+        "name": "Relentless",
+        "description": "Make more than 10 attempts on a single screenshot"
+      },
+      "tete_de_mule": {
+        "name": "Stubborn",
+        "description": "Make 20 or more attempts on a single screenshot"
+      },
+      "jamais_abandonner": {
+        "name": "Never Give Up",
+        "description": "Identify a screenshot after 8 or more wrong guesses"
+      },
+      "du_premier_coup": {
+        "name": "Bullseye",
+        "description": "Identify a screenshot on your very first guess"
+      },
+      "sans_hesitation": {
+        "name": "No Hesitation",
+        "description": "Finish a challenge without a single wrong guess"
+      },
+      "tatonneur": {
+        "name": "Trial and Error",
+        "description": "Rack up 100 wrong guesses in total"
+      },
+      "increvable": {
+        "name": "Unstoppable",
+        "description": "Rack up 1,000 wrong guesses in total"
       }
     }
   },

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -261,6 +261,34 @@
       "guessing_machine": {
         "name": "Machine à Deviner",
         "description": "Faites 500 propositions au total"
+      },
+      "acharne": {
+        "name": "Acharné",
+        "description": "Tente ta chance plus de 10 fois sur une seule capture"
+      },
+      "tete_de_mule": {
+        "name": "Tête de mule",
+        "description": "Tente ta chance 20 fois ou plus sur une seule capture"
+      },
+      "jamais_abandonner": {
+        "name": "Jamais abandonner",
+        "description": "Identifie une capture après 8 mauvaises propositions ou plus"
+      },
+      "du_premier_coup": {
+        "name": "Du premier coup",
+        "description": "Identifie une capture dès la première proposition"
+      },
+      "sans_hesitation": {
+        "name": "Sans hésitation",
+        "description": "Termine un défi sans une seule mauvaise proposition"
+      },
+      "tatonneur": {
+        "name": "Tâtonneur",
+        "description": "Accumule 100 mauvaises propositions au total"
+      },
+      "increvable": {
+        "name": "Increvable",
+        "description": "Accumule 1 000 mauvaises propositions au total"
       }
     }
   },


### PR DESCRIPTION
## Summary

Introduces five new achievement criteria types that reward both persistence and precision in gameplay, plus cumulative wrong guess tracking. These achievements evaluate the *journey* of solving screenshots—from stubborn persistence through multiple attempts to flawless first-try accuracy.

## Key Changes

**Backend Service Logic** (`achievement.service.ts`)
- Added `checkAttemptsInGame()` – rewards max attempts on any single screenshot within a game
- Added `checkComebackInGame()` – rewards largest streak of wrong guesses on a screenshot the user still solved
- Added `checkFirstTryInGame()` – counts screenshots solved on first attempt (zero wrong guesses)
- Added `checkFlawlessGame()` – rewards completing a challenge with zero wrong guesses across all screenshots
- Added `checkTotalWrongGuesses()` – cumulative all-time wrong guess counter
- Integrated all five new criteria types into the post-game achievement evaluator switch statement
- Added `totalWrongGuesses` to the progress calculation pipeline

**Repository** (`achievement.repository.ts`)
- Added `countWrongGuesses(userId)` – queries total wrong guesses across all game sessions for a user

**Database Migration** (`20260525_attempt_achievements.ts`)
- Inserted 7 new achievements with idempotent logic (safe for re-runs in seeded environments):
  - `acharne` (Relentless) – 10+ attempts on one screenshot
  - `tete_de_mule` (Stubborn) – 20+ attempts on one screenshot
  - `jamais_abandonner` (Never Give Up) – 8+ wrong guesses before solving
  - `du_premier_coup` (Bullseye) – 1 first-try solve
  - `sans_hesitation` (No Hesitation) – flawless game (0 wrong, all correct)
  - `tatonneur` (Trial and Error) – 100 total wrong guesses
  - `increvable` (Unstoppable) – 1,000 total wrong guesses

**Localization** (`translation.json` – en & fr)
- Added English and French names/descriptions for all 7 new achievements

## Implementation Details

- All per-game criteria (`attempts_in_game`, `comeback_in_game`, `first_try_in_game`, `flawless_game`) operate on `GameCompletionData.guesses`, which is keyed by `screenshotId` to prevent attempt bleeding across tiers
- `total_wrong_guesses` is evaluated separately as a cumulative aggregate, not per-game
- Achievement awarding includes the actual metric value and criteria threshold for progress tracking
- Migration uses idempotent insert pattern (checks existing keys before inserting) to support safe re-runs in test environments

https://claude.ai/code/session_01PSsPgmtuTNyZJQQAx6s2bd