### PR TITLE
feat(achievements): notify unlocks over the /notifications socket

### DIFF
--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -5,6 +5,7 @@ import type {
   GuessResponse,
   EndGameResponse,
   Game,
+  NewlyEarnedAchievement,
   Screenshot,
 } from '@the-box/types'
 import type { DomainLogger } from '../ports/logger.js'
@@ -1020,6 +1021,7 @@ export function createGameService(deps: GameServiceDeps): GameService {
     })
 
     // Check achievements after game completion (forfeit)
+    let newlyEarnedAchievements: NewlyEarnedAchievement[] = []
     try {
       const user = await userRepository.findById(userId)
 
@@ -1035,7 +1037,7 @@ export function createGameService(deps: GameServiceDeps): GameService {
         allGuesses.map(g => g.screenshotId)
       )
 
-      await achievementService.checkAchievementsAfterGame({
+      newlyEarnedAchievements = await achievementService.checkAchievementsAfterGame({
         userId,
         sessionId: sessionId,
         challengeId: session.daily_challenge_id,
@@ -1097,6 +1099,8 @@ export function createGameService(deps: GameServiceDeps): GameService {
       isCompleted: true,
       completionReason: 'forfeit',
       unfoundGames,
+      newlyEarnedAchievements:
+        newlyEarnedAchievements.length > 0 ? newlyEarnedAchievements : undefined,
     }
   },
   }

--- a/packages/backend/src/infrastructure/queue/workers/milestone-account-age-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/milestone-account-age-logic.ts
@@ -1,6 +1,7 @@
 import { db } from '../../database/connection.js'
 import { queueLogger } from '../../logger/logger.js'
 import { achievementService } from '../../../domain/services/index.js'
+import { emitAchievementUnlocked } from '../../socket/socket.js'
 
 const log = queueLogger.child({ worker: 'milestone-account-age' })
 
@@ -83,6 +84,9 @@ export async function evaluateAccountAgeMilestones(
             if (earned.length > 0) {
                 usersWithUnlocks++
                 totalUnlocks += earned.length
+                // This sweep is the only unlock path for account-age
+                // milestones — without this push the user is never told.
+                emitAchievementUnlocked(user.id, earned)
             }
         } catch (error) {
             failures++

--- a/packages/backend/src/infrastructure/socket/socket.ts
+++ b/packages/backend/src/infrastructure/socket/socket.ts
@@ -6,8 +6,10 @@ import { logger } from '../logger/logger.js'
 import { auth } from '../auth/auth.js'
 import { importQueueEvents } from '../queue/queues.js'
 import type {
+    AchievementUnlockedEvent,
     GeoRewardedEvent,
     GeoTierUpEvent,
+    NewlyEarnedAchievement,
     RewardGrantedEvent,
     UserPremiumGrantedEvent,
 } from '@the-box/types'
@@ -358,6 +360,29 @@ export function emitRewardGranted(userId: string, event: RewardGrantedEvent): vo
     const ns = userNotificationsNamespace()
     if (!ns) return
     ns.to(`user:${userId}`).emit('reward:granted', event)
+}
+
+/**
+ * Emit an achievement-unlock to the user-notifications namespace. Called
+ * from every unlock path — game completion + forfeit (`game.routes`) and
+ * the account-age milestone worker — AFTER the `user_achievements` rows are
+ * persisted, so the user sees a celebratory toast on whatever page they are
+ * on. Best-effort: a missed emit (offline client) is reconciled when the
+ * achievements page next loads, so this emit is not authoritative.
+ */
+export function emitAchievementUnlocked(
+    userId: string,
+    achievements: NewlyEarnedAchievement[]
+): void {
+    if (achievements.length === 0) return
+    const ns = userNotificationsNamespace()
+    if (!ns) return
+    const event: AchievementUnlockedEvent = {
+        userId,
+        achievements,
+        unlockedAt: new Date().toISOString(),
+    }
+    ns.to(`user:${userId}`).emit('achievement:unlocked', event)
 }
 
 // ---------- Geo-fetch pipeline (admin-only) ----------

--- a/packages/backend/src/presentation/routes/game.routes.ts
+++ b/packages/backend/src/presentation/routes/game.routes.ts
@@ -6,6 +6,7 @@ import { billingService } from '../../domain/services/billing.service.js'
 import { challengeRepository, gameRepository, screenshotRepository } from '../../infrastructure/repositories/index.js'
 import { authMiddleware, optionalAuthMiddleware } from '../middleware/auth.middleware.js'
 import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
+import { emitAchievementUnlocked } from '../../infrastructure/socket/socket.js'
 
 // Public preview is cheap to compute but the image endpoint streams
 // raw files — tighter cap for the image route, more forgiving for the
@@ -291,6 +292,12 @@ router.post('/guess', authMiddleware, async (req, res, next) => {
       isPremium,
     })
 
+    // Push the unlock to the user's /notifications socket so the toast
+    // lands immediately, even before the results page mounts.
+    if (data.newlyEarnedAchievements?.length) {
+      emitAchievementUnlocked(req.userId!, data.newlyEarnedAchievements)
+    }
+
     res.json({
       success: true,
       data,
@@ -373,6 +380,12 @@ router.post('/end', authMiddleware, async (req, res, next) => {
     }
 
     const data = await gameService.endGame(sessionId, req.userId!)
+
+    // Forfeit can still cross achievement thresholds; the EndGame response
+    // body doesn't drive a toast, so the socket push is the only cue here.
+    if (data.newlyEarnedAchievements?.length) {
+      emitAchievementUnlocked(req.userId!, data.newlyEarnedAchievements)
+    }
 
     res.json({
       success: true,

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/pwa'
 import { DailyRewardModal } from '@/components/daily-login'
 import { useDailyLoginStore } from '@/stores/dailyLoginStore'
+import { useAchievementStore } from '@/stores/achievementStore'
 import { useSession } from '@/lib/auth-client'
 import { useReferralCapture } from '@/hooks/useReferralCapture'
 import { useGoatCounterPageviews } from '@/lib/analytics'
@@ -98,7 +99,8 @@ function LanguageLayout() {
   }, [session?.user?.id, session?.user?.role, fetchStatus, reset])
 
   // Subscribe the authenticated user to the `/notifications` socket so account
-  // events (Premium grants, future alerts) reach them on any page.
+  // events (Premium grants, achievement unlocks, future alerts) reach them on
+  // any page.
   useEffect(() => {
     const userId = session?.user?.id
     if (!userId) {
@@ -106,6 +108,19 @@ function LanguageLayout() {
       return
     }
     connectNotificationsSocket(userId)
+  }, [session?.user?.id])
+
+  // The /notifications socket toasts achievement unlocks itself; this also
+  // refreshes the cached achievements grid so it reflects a socket-delivered
+  // unlock (e.g. a background account-age milestone) without a reload.
+  useEffect(() => {
+    if (!session?.user?.id) return
+    const onAchievementUnlocked = (): void => {
+      void useAchievementStore.getState().fetchUserAchievements()
+    }
+    window.addEventListener('achievement:unlocked', onAchievementUnlocked)
+    return () =>
+      window.removeEventListener('achievement:unlocked', onAchievementUnlocked)
   }, [session?.user?.id])
 
   // Apply the user's chosen UI theme on every session change. Free users

--- a/packages/frontend/src/lib/achievementToasts.ts
+++ b/packages/frontend/src/lib/achievementToasts.ts
@@ -1,0 +1,31 @@
+import type { NewlyEarnedAchievement } from '@the-box/types'
+import { showAchievementToast } from '@/components/achievement'
+import { playAchievementSound } from '@/lib/audio'
+
+// Achievement keys already surfaced as a toast in this browser session. An
+// achievement can only be unlocked once per user, so a process-wide guard
+// is safe — and it stops the real-time `/notifications` socket push and the
+// results-page render from both toasting the same unlock.
+const toastedKeys = new Set<string>()
+
+/**
+ * Surface the achievement-unlock toast for any achievements not already
+ * shown this session. Plays the celebratory sound once when at least one
+ * fresh toast is shown; multiple achievements stagger by 300ms.
+ *
+ * Safe to call from anywhere — the socket handler and the results page both
+ * route through here, so a unlock delivered by both collapses to one toast.
+ */
+export function notifyAchievementsUnlocked(
+    achievements: NewlyEarnedAchievement[]
+): void {
+    const fresh = achievements.filter((a) => !toastedKeys.has(a.key))
+    if (fresh.length === 0) return
+
+    void playAchievementSound()
+
+    fresh.forEach((achievement, index) => {
+        toastedKeys.add(achievement.key)
+        setTimeout(() => showAchievementToast(achievement), index * 300)
+    })
+}

--- a/packages/frontend/src/lib/notifications-socket.ts
+++ b/packages/frontend/src/lib/notifications-socket.ts
@@ -1,7 +1,12 @@
 import { io, Socket } from 'socket.io-client'
-import type { RewardGrantedEvent, UserPremiumGrantedEvent } from '@the-box/types'
+import type {
+    AchievementUnlockedEvent,
+    RewardGrantedEvent,
+    UserPremiumGrantedEvent,
+} from '@the-box/types'
 import { toast as sonner } from 'sonner'
 import i18n from '@/lib/i18n'
+import { notifyAchievementsUnlocked } from '@/lib/achievementToasts'
 
 const SOCKET_URL = import.meta.env.VITE_API_URL || undefined
 
@@ -69,6 +74,19 @@ export function connectNotificationsSocket(userId: string | null | undefined): v
             if (typeof window !== 'undefined') {
                 window.dispatchEvent(
                     new CustomEvent('reward:granted', { detail: e })
+                )
+            }
+        })
+        // Achievement unlocks (game completion, forfeit, account-age
+        // milestones) — surface a celebratory toast the moment the unlock
+        // lands, on any page. notifyAchievementsUnlocked de-duplicates so a
+        // game unlock also rendered by the results page only toasts once.
+        // The window event lets the achievement store refresh its grid.
+        s.on('achievement:unlocked', (e: AchievementUnlockedEvent) => {
+            notifyAchievementsUnlocked(e.achievements)
+            if (typeof window !== 'undefined') {
+                window.dispatchEvent(
+                    new CustomEvent('achievement:unlocked', { detail: e })
                 )
             }
         })

--- a/packages/frontend/src/pages/ResultsPage.tsx
+++ b/packages/frontend/src/pages/ResultsPage.tsx
@@ -8,7 +8,7 @@ import { Separator } from '@/components/ui/separator'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useGameStore } from '@/stores/gameStore'
 import { useAchievementStore } from '@/stores/achievementStore'
-import { showAchievementToast } from '@/components/achievement'
+import { notifyAchievementsUnlocked } from '@/lib/achievementToasts'
 import { Trophy, Home, CheckCircle, XCircle, Award, Clock } from 'lucide-react'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { usePercentileRank } from '@/hooks/usePercentileRank'
@@ -16,8 +16,7 @@ import { PercentileBanner } from '@/components/game/PercentileBanner'
 import { ShareCard } from '@/components/game/ShareCard'
 import { GuessAttemptsList } from '@/components/game/GuessAttemptsList'
 import { calculateSpeedMultiplier } from '@/lib/utils'
-import { useEffect, useRef } from 'react'
-import { playAchievementSound } from '@/lib/audio'
+import { useEffect } from 'react'
 
 export default function ResultsPage() {
   const { t } = useTranslation()
@@ -39,28 +38,14 @@ export default function ResultsPage() {
 
   const unseenNotifications = notifications.filter(n => !n.seen)
 
-  // Track if we've already shown toasts for these achievements
-  const shownToastsRef = useRef<Set<string>>(new Set())
-
-  // Show rich achievement toasts and play sound for newly unlocked achievements
+  // Surface achievement toasts. The /notifications socket usually shows
+  // these the instant the unlock lands; notifyAchievementsUnlocked
+  // de-duplicates by key, so this render is a fallback for a missed socket
+  // push rather than a second toast.
   useEffect(() => {
-    const newAchievements = unseenNotifications.filter(
-      n => !shownToastsRef.current.has(n.achievement.key)
-    )
-
-    if (newAchievements.length > 0) {
-      playAchievementSound()
-
-      newAchievements.forEach((notification, index) => {
-        // Stagger the toasts slightly for multiple achievements
-        setTimeout(() => {
-          showAchievementToast(notification.achievement)
-          markNotificationAsSeen(notification.achievement.key)
-        }, index * 300)
-
-        shownToastsRef.current.add(notification.achievement.key)
-      })
-    }
+    if (unseenNotifications.length === 0) return
+    notifyAchievementsUnlocked(unseenNotifications.map(n => n.achievement))
+    unseenNotifications.forEach(n => markNotificationAsSeen(n.achievement.key))
   }, [unseenNotifications, markNotificationAsSeen])
 
   // Calculate correct answers from guess results (more reliable than store)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -426,6 +426,7 @@ export interface EndGameResponse {
     game: Game
     screenshot: Screenshot
   }>
+  newlyEarnedAchievements?: NewlyEarnedAchievement[]
 }
 
 // Search API
@@ -1270,6 +1271,19 @@ export interface UserPremiumGrantedEvent {
   userId: string
   tier: 'supporter_lifetime'
   grantedAt: string
+}
+
+// Realtime payload for the `/notifications` namespace, fired the moment a
+// user unlocks one or more achievements — game completion, forfeit, or a
+// background account-age milestone sweep. The frontend surfaces each as a
+// celebratory toast so the unlock is seen immediately, on any page. The
+// `user_achievements` rows are already persisted, so a missed emit (offline
+// client) is reconciled when the achievements page next loads — this emit
+// is best-effort, not authoritative.
+export interface AchievementUnlockedEvent {
+  userId: string
+  achievements: NewlyEarnedAchievement[]
+  unlockedAt: string
 }
 
 // Capture eligibility reporting. A user can flag a screenshot they believe


### PR DESCRIPTION
Achievement unlocks were only surfaced as a toast on the results page,
so forfeit-path and background account-age milestone unlocks were never
shown to the player. Emit each unlock on the per-user /notifications
socket so a celebratory toast lands immediately on any page; the
results-page render now de-duplicates by key as a fallback for a missed
socket push.

https://claude.ai/code/session_011zxK8KSgeERNScMDbcpK4Z