### PR TITLE
feat(themes): add Matrix green and Sunset blaze premium themes

### DIFF
--- a/packages/backend/src/config/themes.ts
+++ b/packages/backend/src/config/themes.ts
@@ -10,7 +10,12 @@
 
 export const DEFAULT_THEME_KEY = 'default' as const
 
-export const PREMIUM_THEME_KEYS = ['neon_pink', 'cyber_blue'] as const
+export const PREMIUM_THEME_KEYS = [
+  'neon_pink',
+  'cyber_blue',
+  'emerald_matrix',
+  'sunset_blaze',
+] as const
 
 export type PremiumThemeKey = (typeof PREMIUM_THEME_KEYS)[number]
 

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2452,7 +2452,9 @@
     "options": {
       "default": "Violet (default)",
       "neonPink": "Neon pink",
-      "cyberBlue": "Cyber blue"
+      "cyberBlue": "Cyber blue",
+      "emeraldMatrix": "Matrix green",
+      "sunsetBlaze": "Sunset blaze"
     }
   },
   "premiumGate": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2452,7 +2452,9 @@
     "options": {
       "default": "Violet (par défaut)",
       "neonPink": "Rose néon",
-      "cyberBlue": "Bleu cyber"
+      "cyberBlue": "Bleu cyber",
+      "emeraldMatrix": "Vert matrix",
+      "sunsetBlaze": "Coucher embrasé"
     }
   },
   "premiumGate": {

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -362,6 +362,22 @@ html {
   --border-interactive: oklch(0.74 0.18 230 / 0.55);
 }
 
+[data-theme="emerald_matrix"] {
+  --primary: oklch(0.74 0.18 150);
+  --ring: oklch(0.78 0.2 150);
+  --neon-purple: #34d399;
+  --neon-pink: #10b981;
+  --border-interactive: oklch(0.74 0.18 150 / 0.55);
+}
+
+[data-theme="sunset_blaze"] {
+  --primary: oklch(0.74 0.18 40);
+  --ring: oklch(0.78 0.2 40);
+  --neon-purple: #fb923c;
+  --neon-pink: #ef4444;
+  --border-interactive: oklch(0.74 0.18 40 / 0.55);
+}
+
 /* =====================================================================
    Premium cosmetics (entitlement-derived, not stored in inventory)
    ---------------------------------------------------------------------

--- a/packages/frontend/src/lib/themes.ts
+++ b/packages/frontend/src/lib/themes.ts
@@ -6,7 +6,12 @@
 //   2. Add a matching `[data-theme="<key>"]` block in `src/index.css`
 //      that overrides the variables you want re-skinned.
 
-export type ThemeKey = 'default' | 'neon_pink' | 'cyber_blue'
+export type ThemeKey =
+  | 'default'
+  | 'neon_pink'
+  | 'cyber_blue'
+  | 'emerald_matrix'
+  | 'sunset_blaze'
 
 export interface ThemeMeta {
   key: ThemeKey
@@ -42,6 +47,18 @@ export const THEMES: ReadonlyArray<ThemeMeta> = [
     i18nKey: 'cyberBlue',
     premium: true,
     swatch: { from: 'from-neon-blue', to: 'to-neon-cyan' },
+  },
+  {
+    key: 'emerald_matrix',
+    i18nKey: 'emeraldMatrix',
+    premium: true,
+    swatch: { from: 'from-success', to: 'to-neon-cyan' },
+  },
+  {
+    key: 'sunset_blaze',
+    i18nKey: 'sunsetBlaze',
+    premium: true,
+    swatch: { from: 'from-warning', to: 'to-error' },
   },
 ]
 


### PR DESCRIPTION
Extends the premium theme catalog with two new options:
- emerald_matrix (Vert matrix / Matrix green): green palette
- sunset_blaze (Coucher embrasé / Sunset blaze): orange-red palette

Updates the frontend catalog, backend validation keyset, CSS variable
overrides, and FR/EN translations.