### PR TITLE
Externalize rewards inbox description to i18n

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2022,6 +2022,7 @@
   "rewards": {
     "inboxTitle": "Your rewards",
     "inboxAria": "Open my rewards",
+    "inboxDescription": "Recent reward grants from milestones, payouts, and reactivation campaigns.",
     "loading": "Loading…",
     "empty": "Nothing to claim right now.",
     "claim": "Claim",
@@ -2033,7 +2034,8 @@
       "hint_developer": "Developer hint",
       "hint_genre": "Genre hint",
       "second_chance": "Second chance",
-      "streak_freeze": "Streak freeze"
+      "streak_freeze": "Streak freeze",
+      "ambassador": "Ambassador badge"
     },
     "sources": {
       "reactivation": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2022,6 +2022,7 @@
   "rewards": {
     "inboxTitle": "Tes récompenses",
     "inboxAria": "Ouvrir mes récompenses",
+    "inboxDescription": "Récompenses récentes liées aux paliers, classements et campagnes de retour.",
     "loading": "Chargement…",
     "empty": "Rien à réclamer pour l'instant.",
     "claim": "Réclamer",
@@ -2033,7 +2034,8 @@
       "hint_developer": "Indice Développeur",
       "hint_genre": "Indice Genre",
       "second_chance": "Seconde chance",
-      "streak_freeze": "Protection de série"
+      "streak_freeze": "Protection de série",
+      "ambassador": "Badge Ambassadeur"
     },
     "sources": {
       "reactivation": {

--- a/packages/frontend/src/components/rewards/RewardsInboxBell.tsx
+++ b/packages/frontend/src/components/rewards/RewardsInboxBell.tsx
@@ -95,10 +95,7 @@ export function RewardsInboxBell({ className }: RewardsInboxBellProps) {
                 <SheetHeader>
                     <SheetTitle>{t('rewards.inboxTitle')}</SheetTitle>
                     <SheetDescription className="sr-only">
-                        {t(
-                            'rewards.inboxDescription',
-                            'Recent reward grants from milestones, payouts, and reactivation campaigns.',
-                        )}
+                        {t('rewards.inboxDescription')}
                     </SheetDescription>
                 </SheetHeader>
                 <div className="mt-6 flex flex-col gap-3 overflow-y-auto pb-4">


### PR DESCRIPTION
## Summary
Moved the hardcoded rewards inbox description from the React component to the i18n translation files, enabling proper localization support and following the project's i18n conventions.

## Key Changes
- **Frontend Component**: Removed the default fallback text from `RewardsInboxBell.tsx` and simplified the `t()` call to use only the translation key
- **English Translations**: Added `inboxDescription` key to `en/translation.json` with the description text
- **French Translations**: Added `inboxDescription` key to `fr/translation.json` with the French translation
- **Bonus**: Added missing `ambassador` badge type to both English and French translation files

## Implementation Details
- The description text was previously passed as a fallback parameter to the `t()` function; it's now properly managed through the translation system
- This change ensures the rewards inbox description respects the user's language preference
- The `SheetDescription` component retains its `sr-only` class for accessibility

https://claude.ai/code/session_0141Ct1vuHSHofhz6A1gK74b