### PR TITLE
Fix fuzzy match for parenthesized alternate game names

### DIFF
--- a/packages/backend/src/domain/services/fuzzy-match.service.test.ts
+++ b/packages/backend/src/domain/services/fuzzy-match.service.test.ts
@@ -162,6 +162,28 @@ describe('fuzzy-match.service', () => {
     })
   })
 
+  describe('parenthesised alternate names (screenshot regression)', () => {
+    // Screenshot: "farenheit" was typed for "Fahrenheit (Indigo Prophecy)"
+    // and rejected because the parenthesised regional name dragged the
+    // full-string JW down from ~0.91 (vs "Fahrenheit") to ~0.77.
+    it('accepts a one-letter typo of the base name', () => {
+      expectMatch('farenheit', 'Fahrenheit (Indigo Prophecy)')
+    })
+
+    it('accepts the exact base name', () => {
+      expectMatch('Fahrenheit', 'Fahrenheit (Indigo Prophecy)')
+    })
+
+    it('accepts the parenthesised alternate name', () => {
+      expectMatch('Indigo Prophecy', 'Fahrenheit (Indigo Prophecy)')
+    })
+
+    it('still rejects unrelated guesses against parenthesised titles', () => {
+      expectNoMatch('max payne', 'Fahrenheit (Indigo Prophecy)')
+      expectNoMatch('max payne 3', 'Fahrenheit (Indigo Prophecy)')
+    })
+  })
+
   describe('expansion-suffix titles (screenshot regression)', () => {
     // Screenshot: the challenge "Warhammer 40,000: Dawn of War - Dark Crusade"
     // rejected both base-game guesses. The expansion suffix and the comma'd

--- a/packages/backend/src/domain/services/fuzzy-match.service.ts
+++ b/packages/backend/src/domain/services/fuzzy-match.service.ts
@@ -162,6 +162,31 @@ function stripExpansionSuffix(name: string): string {
 }
 
 /**
+ * Pull a parenthesised alternate name out of a title, e.g.
+ * "Fahrenheit (Indigo Prophecy)" -> { base: "Fahrenheit", aliases: ["Indigo Prophecy"] }.
+ * Regional re-releases routinely carry the other-market name in parens, and
+ * both forms are valid answers. Without this, the parenthesised tokens get
+ * folded into the normalised target and crush the JW score for short
+ * guesses against the base ("farenheit" vs "fahrenheit indigo prophecy"
+ * drops from 0.91 to 0.77, falling under the full-match threshold).
+ *
+ * Returns the input untouched when no parenthesised chunk is present, and
+ * skips empty-base or empty-alias results so we never recurse on "".
+ */
+function extractParenthesizedAliases(name: string): { base: string; aliases: string[] } {
+  const aliases: string[] = []
+  const re = /\s*\(([^)]+)\)\s*/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(name)) !== null) {
+    const inner = match[1]?.trim()
+    if (inner) aliases.push(inner)
+  }
+  if (aliases.length === 0) return { base: name, aliases: [] }
+  const base = name.replace(re, ' ').replace(/\s+/g, ' ').trim()
+  return { base: base || name, aliases }
+}
+
+/**
  * Parse a game title into structured components
  *
  * Examples:
@@ -754,6 +779,17 @@ export function createFuzzyMatchService(deps: FuzzyMatchServiceDeps): FuzzyMatch
 
     isMatch(input: string, gameName: string, aliases: string[] = []): boolean {
       if (isMatchEnhanced(input, gameName, aliases, log)) {
+        return true
+      }
+      // Parenthesised alternate name (e.g. "Fahrenheit (Indigo Prophecy)"):
+      // retry against the base name with the parenthesised text promoted to
+      // an alias, so "farenheit" can clear the subtitle threshold against
+      // "Fahrenheit" instead of being judged against the full string.
+      const paren = extractParenthesizedAliases(gameName)
+      if (
+        paren.aliases.length > 0 &&
+        isMatchEnhanced(input, paren.base, [...aliases, ...paren.aliases], log)
+      ) {
         return true
       }
       // Retry against the base title with any " - Expansion" suffix removed,


### PR DESCRIPTION
## Summary

Improves fuzzy matching for game titles with parenthesized alternate names (e.g., "Fahrenheit (Indigo Prophecy)"). Previously, the parenthesized regional name would drag down the Jaro-Winkler score for short guesses against the base name, causing valid matches to be rejected.

## Changes

- **Added `extractParenthesizedAliases()` function** – Extracts parenthesized text from game titles and returns both the base name and extracted aliases. Handles multiple parenthesized chunks and safely skips empty results.

- **Enhanced match logic in `createFuzzyMatchService()`** – After the standard match check, now retries against the base name with parenthesized text promoted to aliases. This allows "farenheit" to match "Fahrenheit" (0.91 JW score) instead of being judged against the full string "Fahrenheit Indigo Prophecy" (0.77 JW score, below threshold).

- **Added regression tests** – Four new test cases covering:
  - One-letter typo of base name ("farenheit" → "Fahrenheit (Indigo Prophecy)")
  - Exact base name match
  - Parenthesized alternate name match
  - Rejection of unrelated guesses

## Implementation Details

The `extractParenthesizedAliases()` function uses a global regex to find all parenthesized chunks, trims whitespace, and reconstructs the base name by removing all parenthesized sections. The match retry is only attempted when parenthesized aliases are found, avoiding unnecessary overhead for standard titles.

https://claude.ai/code/session_0172bDUAiE43bdZwSrKd1JMG