### PR TITLE
Reset transient game state when switching challenges

### DIFF
--- a/packages/frontend/src/stores/gameStore.ts
+++ b/packages/frontend/src/stores/gameStore.ts
@@ -187,10 +187,26 @@ export const useGameStore = create<GameState>()(
 
         setSessionId: (id, tierSessionId) => set({ sessionId: id, tierSessionId }),
 
-        setChallengeId: (id, date) => set({
-          challengeId: id,
-          challengeDate: date
-        }),
+        // Switching to a different challenge (day rollover, catch-up to
+        // another date) must wipe transient session state. `guessResults`
+        // and `positionAttempts` are persisted to localStorage and are
+        // append-only via addGuessResult/recordAttempt, so without this
+        // reset the Results page would show guesses from previous days.
+        // Personal bests are preserved.
+        setChallengeId: (id, date) => {
+          const { challengeId: currentId, personalBests } = get()
+          if (currentId !== null && currentId !== id) {
+            set({
+              ...initialState,
+              _hasHydrated: true,
+              personalBests,
+              challengeId: id,
+              challengeDate: date,
+            })
+          } else {
+            set({ challengeId: id, challengeDate: date })
+          }
+        },
 
         setScreenshot: (screenshot, position, total) => set({
           currentScreenshot: screenshot,


### PR DESCRIPTION
## Summary
Modified `setChallengeId` in the game store to properly reset transient session state when switching to a different challenge. This prevents stale guess results and position attempts from previous days from appearing on the Results page during day rollovers or catch-up mode.

## Key Changes
- **State reset logic**: When `setChallengeId` is called with a different challenge ID than the current one, the store now resets to `initialState` while preserving:
  - `_hasHydrated` flag (to maintain hydration status)
  - `personalBests` (user's historical best scores should persist across days)
  - The new `challengeId` and `challengeDate`
- **Append-only data handling**: `guessResults` and `positionAttempts` are persisted to localStorage and built up via `addGuessResult`/`recordAttempt`. Without this reset, these would accumulate across challenge switches and display incorrect historical data on the Results page.
- **Backward compatibility**: If switching to the same challenge ID (e.g., page refresh), only the challenge metadata is updated without a full state reset.

## Implementation Details
- Uses the Zustand `get()` function to access current state within the action
- Conditional logic checks if `currentId !== null && currentId !== id` to determine if a full reset is needed
- Preserves the spread of `initialState` to ensure all transient fields are cleared while maintaining the exceptions listed above

https://claude.ai/code/session_01M56j3xY5grPFx6H2Vhonfy