### PR TITLE
Add results button to game completion screen

### DIFF
--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -529,6 +529,12 @@ export default function GamePage() {
 
                     <div className="flex flex-col sm:flex-row gap-2 sm:gap-3 w-full">
                       <Button variant="gaming" asChild className="flex-1">
+                        <Link to={localizedPath('/results')}>
+                          <Trophy className="w-4 h-4 mr-2" />
+                          {t('game.completionChoice.seeResults')}
+                        </Link>
+                      </Button>
+                      <Button variant="outline" asChild className="flex-1">
                         <Link to={localizedPath('/')}>
                           <Home className="w-4 h-4 mr-2" />
                           {t('common.home')}


### PR DESCRIPTION
## Summary
Added a new "See Results" button to the game completion choice screen that navigates to the results page, allowing players to immediately view their game results after completing a challenge.

## Changes
- Added a primary "See Results" button (gaming variant) that links to `/results` with a Trophy icon
- Converted the existing "Home" button to a secondary outline variant
- Both buttons are displayed side-by-side in the completion choice modal

## Implementation Details
- The new button uses the `localizedPath()` helper to support multi-language routing
- Maintains the existing flex layout with responsive gap spacing (gap-2 on mobile, gap-3 on desktop)
- Uses the Trophy icon from Lucide to visually represent the results action
- Button text is localized via the `game.completionChoice.seeResults` translation key

https://claude.ai/code/session_01K4P2RyrtfG8wDXDG1P4YgQ