### PR TITLE
fix(game): clear positionAttempts on new game, not on metadata fetch

### DIFF
--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -318,11 +318,16 @@ export default function GamePage() {
       setError(null)
 
       // Reset relevant game state to ensure clean slate for new game
-      // This clears any persisted state from previously completed games
+      // This clears any persisted state from previously completed games.
+      // positionAttempts is keyed by position number (1..10) and is the
+      // source of the per-guess `attempts` snapshot in addGuessResult, so
+      // missing it here let yesterday's wrong tries bleed into today's
+      // results page.
       useGameStore.setState({
         totalScore: 0,
         correctAnswers: 0,
         guessResults: [],
+        positionAttempts: {},
         lastResult: null,
         screenshotsFound: 0,
       })

--- a/packages/frontend/src/stores/gameStore.ts
+++ b/packages/frontend/src/stores/gameStore.ts
@@ -187,26 +187,10 @@ export const useGameStore = create<GameState>()(
 
         setSessionId: (id, tierSessionId) => set({ sessionId: id, tierSessionId }),
 
-        // Switching to a different challenge (day rollover, catch-up to
-        // another date) must wipe transient session state. `guessResults`
-        // and `positionAttempts` are persisted to localStorage and are
-        // append-only via addGuessResult/recordAttempt, so without this
-        // reset the Results page would show guesses from previous days.
-        // Personal bests are preserved.
-        setChallengeId: (id, date) => {
-          const { challengeId: currentId, personalBests } = get()
-          if (currentId !== null && currentId !== id) {
-            set({
-              ...initialState,
-              _hasHydrated: true,
-              personalBests,
-              challengeId: id,
-              challengeDate: date,
-            })
-          } else {
-            set({ challengeId: id, challengeDate: date })
-          }
-        },
+        setChallengeId: (id, date) => set({
+          challengeId: id,
+          challengeDate: date
+        }),
 
         setScreenshot: (screenshot, position, total) => set({
           currentScreenshot: screenshot,


### PR DESCRIPTION
## Summary
Follow-up to #256, which introduced a regression: the empty Results page screenshot you saw was caused by my previous `setChallengeId` fix wiping the just-completed challenge's data the moment `/game` fetched the next day's challenge metadata — well before the user clicks "Start Challenge".

## Root cause (corrected)
`handleStartGame` (`GamePage.tsx:319-330`) already had a reset block that cleared `guessResults`, `totalScore`, etc. when starting a new game — but it was **missing `positionAttempts`**. Since `positionAttempts` is keyed by position number (1..10) and gets snapshotted into each `addGuessResult({ ..., attempts })`, yesterday's wrong tries at position 3 bled into today's correct-guess attempts list. That's where the cumulative "14 tentatives" badges came from.

## Changes
- **Revert** the over-aggressive reset I added to `setChallengeId` in #256. `setChallengeId` is back to a plain setter, so `/results` keeps displaying the most recently completed challenge until the next game actually begins.
- **Add** `positionAttempts: {}` to the existing reset block in `handleStartGame`. That block runs only when the user clicks "Start Challenge", which is the correct trigger.

## Test plan
- [x] `npm run build:frontend` — typecheck + bundle clean
- [x] `npm run lint` — no new warnings/errors
- [x] Backend unit tests (201) pass via husky pre-commit
- [ ] Manual: finish a daily challenge → open `/results` (data shows) → open `/game` (data still shows on `/results`) → start a new challenge → finish it → `/results` shows only the new challenge's data with attempts scoped to it
- [ ] Manual: confirm catch-up flow (different `challengeId`) doesn't accumulate attempts across days

https://claude.ai/code/session_01M56j3xY5grPFx6H2Vhonfy

---
_Generated by [Claude Code](https://claude.ai/code/session_01M56j3xY5grPFx6H2Vhonfy)_