### PR TITLE
fix(game): stack results CTA above secondary actions on completed card

### DIFF
--- a/packages/frontend/src/pages/GamePage.tsx
+++ b/packages/frontend/src/pages/GamePage.tsx
@@ -527,27 +527,29 @@ export default function GamePage() {
                       </span>
                     </div>
 
-                    <div className="flex flex-col sm:flex-row gap-2 sm:gap-3 w-full">
-                      <Button variant="gaming" asChild className="flex-1">
+                    <div className="flex flex-col gap-2 sm:gap-3 w-full">
+                      <Button variant="gaming" asChild className="w-full">
                         <Link to={localizedPath('/results')}>
                           <Trophy className="w-4 h-4 mr-2" />
                           {t('game.completionChoice.seeResults')}
                         </Link>
                       </Button>
-                      <Button variant="outline" asChild className="flex-1">
-                        <Link to={localizedPath('/')}>
-                          <Home className="w-4 h-4 mr-2" />
-                          {t('common.home')}
-                        </Link>
-                      </Button>
-                      {session && session.user && session.user.id && (
+                      <div className="flex flex-col sm:flex-row gap-2 sm:gap-3 w-full">
                         <Button variant="outline" asChild className="flex-1">
-                          <Link to={localizedPath('/history')}>
-                            <History className="w-4 h-4 mr-2" />
-                            {t('common.history')}
+                          <Link to={localizedPath('/')}>
+                            <Home className="w-4 h-4 mr-2" />
+                            {t('common.home')}
                           </Link>
                         </Button>
-                      )}
+                        {session && session.user && session.user.id && (
+                          <Button variant="outline" asChild className="flex-1">
+                            <Link to={localizedPath('/history')}>
+                              <History className="w-4 h-4 mr-2" />
+                              {t('common.history')}
+                            </Link>
+                          </Button>
+                        )}
+                      </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
Three buttons in one row on the daily-challenge already-completed card looked cramped and unbalanced.

## Change
- Promote "Voir les résultats" (primary) to its own full-width row
- Keep "Accueil" and "Historique" side-by-side as outline actions below

## Test plan
- [ ] Visit `/play` after completing today's daily challenge — confirm the completed card shows the results CTA on top, with Home + History stacked below
- [ ] As a guest (no session) — confirm only Home renders on the secondary row
- [ ] Mobile width — confirm secondary row stacks vertically

https://claude.ai/code/session_01K4P2RyrtfG8wDXDG1P4YgQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4P2RyrtfG8wDXDG1P4YgQ)_