### PR TITLE
Display discovery time for correct guesses across results pages

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -327,6 +327,8 @@
       "good": "Nice!",
       "label": "Speed"
     },
+    "discoveryTime": "Found in {{time}}",
+    "discoveryTimeShort": "{{time}}",
     "powerUps": {
       "x2Timer": "Double Time",
       "hint": "Hint"

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -327,6 +327,8 @@
       "good": "Bien joué !",
       "label": "Vitesse"
     },
+    "discoveryTime": "Trouvé en {{time}}",
+    "discoveryTimeShort": "{{time}}",
     "powerUps": {
       "x2Timer": "Temps Double",
       "hint": "Indice"

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -6,6 +6,23 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Format a duration in milliseconds for display next to a guess result.
+ * Returns "1.2s" under a minute, "1m23s" beyond.
+ */
+export function formatDiscoveryTime(timeTakenMs: number): string {
+  if (!Number.isFinite(timeTakenMs) || timeTakenMs <= 0) return "0s"
+  const totalSeconds = timeTakenMs / 1000
+  if (totalSeconds < 60) {
+    return totalSeconds < 10
+      ? `${totalSeconds.toFixed(1)}s`
+      : `${Math.round(totalSeconds)}s`
+  }
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = Math.round(totalSeconds - minutes * 60)
+  return seconds === 0 ? `${minutes}m` : `${minutes}m${seconds}s`
+}
+
+/**
  * Calculate speed multiplier based on time taken to find the screenshot
  * Matches the backend logic in game.service.ts
  * @param timeTakenMs Time in milliseconds from screenshot shown to correct guess

--- a/packages/frontend/src/pages/GameHistoryDetailsPage.tsx
+++ b/packages/frontend/src/pages/GameHistoryDetailsPage.tsx
@@ -11,7 +11,7 @@ import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { gameApi } from '@/lib/api/game'
 import { getApiErrorMessage } from '@/lib/api-errors'
 import type { GameSessionDetailsResponse, GuessAttempt } from '@/types'
-import { calculateSpeedMultiplier } from '@/lib/utils'
+import { calculateSpeedMultiplier, formatDiscoveryTime } from '@/lib/utils'
 import { GuessAttemptsList } from '@/components/game/GuessAttemptsList'
 import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe'
 
@@ -291,11 +291,14 @@ export default function GameHistoryDetailsPage() {
                         <GuessAttemptsList attempts={result.attempts} />
                       </>
                     )}
-                    {result.isCorrect && result.scoreEarned > 0 && multiplier > 1.0 && (
+                    {result.isCorrect && result.timeTakenMs > 0 && (
                       <div className="flex items-center gap-1 sm:gap-1.5 text-xs text-muted-foreground mt-1">
                         <Clock className="w-3 h-3 sm:w-3.5 sm:h-3.5 shrink-0" aria-hidden="true" />
                         <span className="whitespace-nowrap">
-                          100 pts × {multiplier.toFixed(1)}x {t('game.speed.label')}
+                          {t('game.discoveryTime', { time: formatDiscoveryTime(result.timeTakenMs) })}
+                          {result.scoreEarned > 0 && multiplier > 1.0 && (
+                            <> · 100 × {multiplier.toFixed(1)}x {t('game.speed.label')}</>
+                          )}
                         </span>
                       </div>
                     )}

--- a/packages/frontend/src/pages/LeaderboardPage.tsx
+++ b/packages/frontend/src/pages/LeaderboardPage.tsx
@@ -7,7 +7,8 @@ import { fr, enUS } from 'date-fns/locale'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
-import { Trophy, Medal, Award, Loader2, Crown, Calendar, CalendarDays, Check, X, Eye, Minus } from 'lucide-react'
+import { Trophy, Medal, Award, Loader2, Crown, Calendar, CalendarDays, Check, X, Eye, Minus, Clock } from 'lucide-react'
+import { formatDiscoveryTime } from '@/lib/utils'
 import { PageHero } from '@/components/layout/PageHero'
 import { DatePicker } from '@/components/ui/date-picker'
 import { MonthPicker } from '@/components/ui/month-picker'
@@ -651,6 +652,12 @@ export default function LeaderboardPage() {
                                 {t('game.yourGuess')}: {item.guess.userGuess}
                               </div>
                             ) : null}
+                            {item.guess.isCorrect && item.guess.timeTakenMs > 0 && (
+                              <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+                                <Clock className="w-3 h-3 shrink-0" aria-hidden="true" />
+                                <span>{t('game.discoveryTime', { time: formatDiscoveryTime(item.guess.timeTakenMs) })}</span>
+                              </div>
+                            )}
                           </div>
                           <div className="flex items-center gap-2 shrink-0">
                             {item.guess.isCorrect ? (

--- a/packages/frontend/src/pages/ResultsPage.tsx
+++ b/packages/frontend/src/pages/ResultsPage.tsx
@@ -15,7 +15,7 @@ import { usePercentileRank } from '@/hooks/usePercentileRank'
 import { PercentileBanner } from '@/components/game/PercentileBanner'
 import { ShareCard } from '@/components/game/ShareCard'
 import { GuessAttemptsList } from '@/components/game/GuessAttemptsList'
-import { calculateSpeedMultiplier } from '@/lib/utils'
+import { calculateSpeedMultiplier, formatDiscoveryTime } from '@/lib/utils'
 import { useEffect } from 'react'
 
 export default function ResultsPage() {
@@ -236,19 +236,19 @@ export default function ResultsPage() {
                               <Badge variant="success" className="text-xs sm:text-sm font-bold">
                                 +{result.scoreEarned}
                               </Badge>
-                              {(() => {
+                              {result.timeTakenMs > 0 && (() => {
                                 const multiplier = calculateSpeedMultiplier(result.timeTakenMs)
-                                if (multiplier > 1.0) {
-                                  return (
-                                    <div className="flex items-center gap-1 sm:gap-1.5 text-xs text-muted-foreground">
-                                      <Clock className="w-3 h-3 sm:w-3.5 sm:h-3.5" />
-                                      <span className="whitespace-nowrap">
-                                        100 pts × {multiplier.toFixed(1)}x {t('game.speed.label')}
-                                      </span>
-                                    </div>
-                                  )
-                                }
-                                return null
+                                return (
+                                  <div className="flex items-center gap-1 sm:gap-1.5 text-xs text-muted-foreground">
+                                    <Clock className="w-3 h-3 sm:w-3.5 sm:h-3.5" />
+                                    <span className="whitespace-nowrap">
+                                      {t('game.discoveryTime', { time: formatDiscoveryTime(result.timeTakenMs) })}
+                                      {multiplier > 1.0 && (
+                                        <> · {multiplier.toFixed(1)}x</>
+                                      )}
+                                    </span>
+                                  </div>
+                                )
                               })()}
                             </div>
                           ) : isUnguessed ? (
@@ -326,19 +326,19 @@ export default function ResultsPage() {
                           <Badge variant="success" className="text-sm font-bold">
                             +{result.scoreEarned}
                           </Badge>
-                          {(() => {
+                          {result.timeTakenMs > 0 && (() => {
                             const multiplier = calculateSpeedMultiplier(result.timeTakenMs)
-                            if (multiplier > 1.0) {
-                              return (
-                                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                                  <Clock className="w-3.5 h-3.5" />
-                                  <span className="whitespace-nowrap">
-                                    100 pts × {multiplier.toFixed(1)}x {t('game.speed.label')}
-                                  </span>
-                                </div>
-                              )
-                            }
-                            return null
+                            return (
+                              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                <Clock className="w-3.5 h-3.5" />
+                                <span className="whitespace-nowrap">
+                                  {t('game.discoveryTime', { time: formatDiscoveryTime(result.timeTakenMs) })}
+                                  {multiplier > 1.0 && (
+                                    <> · {multiplier.toFixed(1)}x</>
+                                  )}
+                                </span>
+                              </div>
+                            )
                           })()}
                         </div>
                       ) : isUnguessed ? (


### PR DESCRIPTION
## Summary
Refactored how discovery time (time taken to find the correct screenshot) is displayed across the application. Instead of only showing a speed multiplier when it exceeds 1.0x, we now always display the formatted discovery time for correct guesses, with the speed multiplier shown conditionally as a secondary indicator.

## Key Changes

- **New utility function** `formatDiscoveryTime()` in `lib/utils.ts` that formats milliseconds into human-readable durations (e.g., "1.2s", "1m23s")
- **ResultsPage.tsx**: Updated both mobile and desktop result displays to show discovery time for all correct guesses with `timeTakenMs > 0`, with speed multiplier displayed only when > 1.0x
- **GameHistoryDetailsPage.tsx**: Updated history detail view to display discovery time and conditionally show speed multiplier bonus
- **LeaderboardPage.tsx**: Added discovery time display to leaderboard guess details for correct guesses
- **Translations**: Added `game.discoveryTime` and `game.discoveryTimeShort` keys to English and French locale files

## Implementation Details

- Discovery time is now always shown when available (timeTakenMs > 0), improving transparency about guess speed
- Speed multiplier is displayed as a secondary indicator (separated by "·") only when multiplier > 1.0x
- Formatting logic handles edge cases: returns "0s" for invalid/non-positive values, uses one decimal place for times under 10 seconds, rounds to nearest second otherwise
- Consistent UI pattern applied across all three pages that display guess results

https://claude.ai/code/session_01YQskzB86FNHACkskNQFW4C