### PR TITLE
Fix theme preview swatches to use fixed hex colors

### DIFF
--- a/packages/frontend/src/components/profile/ThemeSwitcher.tsx
+++ b/packages/frontend/src/components/profile/ThemeSwitcher.tsx
@@ -83,11 +83,10 @@ export function ThemeSwitcher({ selected, isPremium, onChange }: ThemeSwitcherPr
                 )}
               >
                 <div
-                  className={cn(
-                    'h-12 rounded-md mb-2 bg-linear-to-r',
-                    theme.swatch.from,
-                    theme.swatch.to,
-                  )}
+                  className="h-12 rounded-md mb-2"
+                  style={{
+                    backgroundImage: `linear-gradient(to right, ${theme.swatch.from}, ${theme.swatch.to})`,
+                  }}
                 />
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium">

--- a/packages/frontend/src/lib/themes.ts
+++ b/packages/frontend/src/lib/themes.ts
@@ -23,9 +23,10 @@ export interface ThemeMeta {
   // backend re-validates on PUT /api/user/theme so a tampered client
   // can't slip a premium theme through.
   premium: boolean
-  // Tailwind classes for a pair of swatches the selector renders so the
-  // user can preview the palette without applying it. These reference
-  // semantic tokens so the swatches re-skin alongside the theme itself.
+  // Fixed hex colors for the preview swatch. Must NOT reference CSS
+  // variables / Tailwind semantic tokens — those re-skin with the active
+  // `data-theme`, which would make every card look like the currently
+  // selected theme instead of previewing its own palette.
   swatch: { from: string; to: string }
 }
 
@@ -34,31 +35,31 @@ export const THEMES: ReadonlyArray<ThemeMeta> = [
     key: 'default',
     i18nKey: 'default',
     premium: false,
-    swatch: { from: 'from-neon-purple', to: 'to-neon-pink' },
+    swatch: { from: '#a855f7', to: '#f472b6' },
   },
   {
     key: 'neon_pink',
     i18nKey: 'neonPink',
     premium: true,
-    swatch: { from: 'from-neon-pink', to: 'to-primary' },
+    swatch: { from: '#f472b6', to: '#ec4899' },
   },
   {
     key: 'cyber_blue',
     i18nKey: 'cyberBlue',
     premium: true,
-    swatch: { from: 'from-neon-blue', to: 'to-neon-cyan' },
+    swatch: { from: '#3b82f6', to: '#06b6d4' },
   },
   {
     key: 'emerald_matrix',
     i18nKey: 'emeraldMatrix',
     premium: true,
-    swatch: { from: 'from-success', to: 'to-neon-cyan' },
+    swatch: { from: '#22c55e', to: '#06b6d4' },
   },
   {
     key: 'sunset_blaze',
     i18nKey: 'sunsetBlaze',
     premium: true,
-    swatch: { from: 'from-warning', to: 'to-error' },
+    swatch: { from: '#eab308', to: '#ef4444' },
   },
 ]
 


### PR DESCRIPTION
## Summary
Fixed theme preview swatches in the theme selector to use fixed hex color values instead of Tailwind semantic token classes. This prevents preview cards from re-skinning when the active theme changes, ensuring each card accurately displays its own palette.

## Changes
- **Theme metadata** (`packages/frontend/src/lib/themes.ts`):
  - Updated `swatch` field documentation to clarify that hex colors are required (not CSS variables or Tailwind tokens)
  - Converted all theme swatch values from Tailwind class names to fixed hex color pairs:
    - `default`: `#a855f7` → `#f472b6`
    - `neon_pink`: `#f472b6` → `#ec4899`
    - `cyber_blue`: `#3b82f6` → `#06b6d4`
    - `emerald_matrix`: `#22c55e` → `#06b6d4`
    - `sunset_blaze`: `#eab308` → `#ef4444`

- **Theme switcher component** (`packages/frontend/src/components/profile/ThemeSwitcher.tsx`):
  - Replaced Tailwind class-based gradient (`bg-linear-to-r` + `from-*` + `to-*`) with inline `style` prop
  - Applied `linear-gradient(to right, ...)` using the hex color values from theme metadata
  - Removed dependency on `cn()` utility for swatch styling

## Implementation Details
The issue was that Tailwind semantic token classes (e.g., `from-neon-purple`) reference CSS variables that change when the active `data-theme` attribute updates. This caused all preview cards to visually match the currently selected theme instead of showing their own distinct palettes. By using fixed hex colors in inline styles, each preview card now independently displays its intended color scheme regardless of the active theme.

https://claude.ai/code/session_01TD2s76vzz2Zf2YWqxXtcGP