### PR TITLE
Fix podium alignment in leaderboard displays

### DIFF
--- a/packages/frontend/src/pages/LeaderboardPage.tsx
+++ b/packages/frontend/src/pages/LeaderboardPage.tsx
@@ -287,7 +287,7 @@ export default function LeaderboardPage() {
 
             {/* Top 3 Podium */}
             {!loading && leaderboard.length >= 3 && (
-              <div className="flex justify-center gap-2 sm:gap-4 mb-8">
+              <div className="flex items-end justify-center gap-2 sm:gap-4 mb-8">
                 {[leaderboard[1], leaderboard[0], leaderboard[2]].map((entry, displayIndex) => {
                   // Reorder: 2nd, 1st, 3rd for visual podium effect
                   const heights = ['h-24', 'h-32', 'h-20']
@@ -393,7 +393,7 @@ export default function LeaderboardPage() {
 
             {/* Top 3 Podium */}
             {!monthlyLoading && monthlyLeaderboard.length >= 3 && (
-              <div className="flex justify-center gap-2 sm:gap-4 mb-8">
+              <div className="flex items-end justify-center gap-2 sm:gap-4 mb-8">
                 {[monthlyLeaderboard[1], monthlyLeaderboard[0], monthlyLeaderboard[2]].map((entry, displayIndex) => {
                   // Reorder: 2nd, 1st, 3rd for visual podium effect
                   const heights = ['h-24', 'h-32', 'h-20']
@@ -493,7 +493,7 @@ export default function LeaderboardPage() {
 
             {/* Top 3 Podium */}
             {!achievementLoading && achievementLeaderboard.length >= 3 && (
-              <div className="flex justify-center gap-2 sm:gap-4 mb-8">
+              <div className="flex items-end justify-center gap-2 sm:gap-4 mb-8">
                 {[achievementLeaderboard[1], achievementLeaderboard[0], achievementLeaderboard[2]].map((entry, displayIndex) => {
                   // Reorder: 2nd, 1st, 3rd for visual podium effect
                   const heights = ['h-24', 'h-32', 'h-20']


### PR DESCRIPTION
## Summary
Adds vertical alignment to the top 3 podium containers across all three leaderboard sections (all-time, monthly, and achievements) to ensure the podium bars align at the bottom regardless of content height variations.

## Changes
- Added `items-end` Tailwind class to the podium flex container in the all-time leaderboard section
- Added `items-end` Tailwind class to the podium flex container in the monthly leaderboard section
- Added `items-end` Tailwind class to the podium flex container in the achievements leaderboard section

## Implementation Details
The podium displays use variable heights (`h-24`, `h-32`, `h-20`) to create a visual ranking effect. Without `items-end`, the flex items align at the top by default, causing misalignment. Adding `items-end` ensures all three podium bars align at their bottom edges, creating a proper podium appearance where the tallest bar (1st place) and shorter bars (2nd and 3rd) sit on the same baseline.

https://claude.ai/code/session_01BFoAZ4AdJC7648txh5p3Ej