### PR TITLE
Add "Mastery" column label to i18n translations

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -76,7 +76,8 @@
       "completion": "Completion",
       "genre": "Genre",
       "score": "Score",
-      "streak": "Streak"
+      "streak": "Streak",
+      "mastery": "Mastery"
     },
     "difficulty": {
       "easy": "Easy",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -76,7 +76,8 @@
       "completion": "Complétion",
       "genre": "Genre",
       "score": "Score",
-      "streak": "Série"
+      "streak": "Série",
+      "mastery": "Maîtrise"
     },
     "difficulty": {
       "easy": "Facile",


### PR DESCRIPTION
## Summary
Add the "Mastery" column label to both English and French translation files to support a new mastery metric in the game statistics display.

## Changes
- **English** (`en/translation.json`): Added `"mastery": "Mastery"` to the `columns` section
- **French** (`fr/translation.json`): Added `"mastery": "Maîtrise"` to the `columns` section

These translations enable the frontend to display a mastery column in user statistics and leaderboard views with proper i18n support for both supported languages.

https://claude.ai/code/session_01DsU74XQas8aHUn9pHgGFoR