### PR TITLE
Fix daily challenge date comparison timezone bug

### DIFF
--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -366,7 +366,15 @@ export function createGameService(deps: GameServiceDeps): GameService {
     const challengeDate = new Date(challenge.challenge_date)
     challengeDate.setHours(0, 0, 0, 0)
 
-    const todayStr = today.toISOString().split('T')[0]
+    // Use UTC for the date-string comparison: the daily-challenge worker
+    // dates challenges via `getTodayDateUTC()`, so `todayStr` has to come
+    // from the same UTC clock. The previous code passed `today` (which
+    // had `setHours(0,0,0,0)` applied — local midnight) through
+    // `toISOString()`, which in any TZ ahead of UTC (e.g. Europe/Paris,
+    // the production container TZ) silently rolled the date back a day
+    // and flagged every fresh daily session as `is_catch_up = true`,
+    // hiding it from the daily leaderboard.
+    const todayStr = new Date().toISOString().split('T')[0]
     const challengeDateStr = typeof challenge.challenge_date === 'string'
       ? challenge.challenge_date
       : challengeDate.toISOString().split('T')[0]


### PR DESCRIPTION
## Summary
Fixed a critical timezone bug in the daily challenge service that caused all fresh daily sessions in UTC+ timezones to be incorrectly flagged as catch-up sessions, hiding them from the daily leaderboard.

## Problem
The previous code used `today.toISOString().split('T')[0]` to generate the date string for comparison, where `today` had `setHours(0,0,0,0)` applied (local midnight). In timezones ahead of UTC (e.g., Europe/Paris, the production container timezone), `toISOString()` silently converted local midnight to UTC, rolling the date back by one day. This caused the date comparison to fail for fresh daily sessions, incorrectly marking them as `is_catch_up = true`.

## Solution
Changed the date string generation to use `new Date().toISOString().split('T')[0]`, which always produces the UTC date. This aligns with how the daily-challenge worker dates challenges via `getTodayDateUTC()`, ensuring both sides of the comparison use the same UTC clock.

## Key Changes
- Replaced `today.toISOString().split('T')[0]` with `new Date().toISOString().split('T')[0]` in `game.service.ts`
- Added detailed comment explaining the timezone issue and the fix

## Impact
- Daily challenge sessions in UTC+ timezones will now correctly appear on the daily leaderboard
- No database changes required; fix is purely in the comparison logic

https://claude.ai/code/session_01Q3WnWo5rJfoeGSygkgtdqE