### PR TITLE
Backfill is_catch_up flag for sessions affected by timezone bug

### DIFF
--- a/packages/backend/migrations/20260521_backfill_is_catch_up.ts
+++ b/packages/backend/migrations/20260521_backfill_is_catch_up.ts
@@ -1,0 +1,32 @@
+import type { Knex } from 'knex'
+
+// Backfill rows that the timezone bug fixed in #267 left stranded.
+//
+// `startChallenge` was computing `todayStr` from `today.toISOString().split('T')[0]`
+// after applying `today.setHours(0,0,0,0)` (local midnight). In the production
+// container TZ (`Europe/Paris`, UTC+1/+2) local midnight maps to the previous
+// UTC day, so the date-string comparison flagged every fresh daily session
+// as `is_catch_up = true`. The leaderboard query filters those out, which
+// emptied the daily leaderboard for every day the bug was live (the buggy
+// code shipped with the file in commit e86f384 on 2026-05-15 and was fixed
+// in commit 3a891d4 on 2026-05-21 ~07:24 UTC).
+//
+// A row is a false-positive catch-up iff the user started the session on the
+// same UTC day as the challenge's `challenge_date`. Real catch-ups were
+// started on a later UTC day, so they're untouched.
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    UPDATE game_sessions gs
+    SET is_catch_up = false
+    FROM daily_challenges dc
+    WHERE gs.daily_challenge_id = dc.id
+      AND gs.is_catch_up = true
+      AND (gs.started_at AT TIME ZONE 'UTC')::date = dc.challenge_date
+  `)
+}
+
+export async function down(_knex: Knex): Promise<void> {
+  // No-op: we can't reliably reconstruct which rows we flipped without
+  // storing a marker, and re-flagging them to is_catch_up = true would just
+  // restore the original bug. The data fix stands.
+}


### PR DESCRIPTION
## Summary

Adds a database migration to fix false-positive `is_catch_up` flags that were set on daily challenge sessions due to a timezone bug in the `startChallenge` function.

## Background

The `startChallenge` function was computing the date string from `today.toISOString().split('T')[0]` after setting local midnight via `setHours(0,0,0,0)`. In the production container (TZ: `Europe/Paris`, UTC+1/+2), local midnight maps to the previous UTC day, causing every fresh daily session to be incorrectly flagged as `is_catch_up = true`. This emptied the daily leaderboard for every day the bug was live (shipped in commit e86f384 on 2026-05-15, fixed in commit 3a891d4 on 2026-05-21).

## Changes

- **Migration `20260521_backfill_is_catch_up.ts`**: Corrects false-positive catch-up flags by resetting `is_catch_up = false` for sessions where the user started on the same UTC day as the challenge's `challenge_date`. Real catch-ups (started on later UTC days) are left untouched.
- The `down()` migration is a no-op since we cannot reliably reconstruct which rows were flipped without additional markers, and re-flagging them would restore the original bug.

## Implementation Details

- Uses a PostgreSQL `UPDATE...FROM` join to correlate `game_sessions` with `daily_challenges`
- Converts `started_at` to UTC before comparing dates to ensure consistent timezone handling
- Targets only rows currently marked as `is_catch_up = true` to minimize scope

https://claude.ai/code/session_01KU8KPr7PfcMcXDbBXfB1gs