### PR TITLE
fix(game): show full screenshot at base scale (object-contain)

### DIFF
--- a/packages/frontend/src/components/ui/game-carousel.tsx
+++ b/packages/frontend/src/components/ui/game-carousel.tsx
@@ -70,8 +70,9 @@ function useImageZoom(resetKey: unknown) {
             if (!el || !natW || !natH) return { x, y }
             const bw = el.clientWidth
             const bh = el.clientHeight
-            // Match the rendered object-fit: cover on all viewports.
-            const fit = Math.max(bw / natW, bh / natH)
+            // Match the rendered object-fit: contain — the whole screenshot
+            // must be visible at base scale so players don't lose pixels.
+            const fit = Math.min(bw / natW, bh / natH)
             const contentW = natW * fit * scale
             const contentH = natH * fit * scale
             const maxX = Math.max(0, (contentW - bw) / 2)
@@ -324,7 +325,7 @@ export function GameCarousel({
                                             alt={image.alt || `Screenshot ${index + 1}`}
                                             draggable={false}
                                             className={cn(
-                                                'w-full h-full object-cover',
+                                                'w-full h-full object-contain',
                                                 'transition-opacity duration-300',
                                                 loadedImages.has(index) ? 'opacity-100' : 'opacity-0',
                                                 imageClassName


### PR DESCRIPTION
## Summary

- The screenshot viewer was using `object-cover` on both desktop and mobile (since #270), which crops parts of every screenshot whose aspect ratio doesn't match the container.
- With `MIN_SCALE = 1` the zoom-out button is disabled at the cover-fit, so the cropped pixels were unrecoverable — the user's two screenshots show the TimeSplitters 2 logo cut off at the top on desktop and the "Back" prompt cut off at the bottom on mobile.
- For a screenshot guessing game, losing pixels is the wrong trade-off. Switched the img to `object-contain` so the entire screenshot is visible at the default zoom, and flipped the pan-clamp fit calculation from `Math.max` (cover) to `Math.min` (contain) so panning math stays accurate when zoomed in.

## Test plan

- [ ] Open a daily challenge on desktop — full screenshot is visible end-to-end, no cropping
- [ ] Open the same challenge on mobile (portrait) — landscape screenshot now letterboxes inside the frame instead of being cropped
- [ ] Zoom in once and pan around — image stays clamped to its visible edges
- [ ] Navigate prev/next screenshots — zoom resets, image fits cleanly

https://claude.ai/code/session_01SGhwepWrpWhBF5HyaT6Nay

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGhwepWrpWhBF5HyaT6Nay)_