### PR TITLE
fix(game): prevent replay scoring and off-by-one early completion in daily game

### DIFF
--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -245,6 +245,7 @@ export interface SessionRepository {
     scoreEarned: number
   }): Promise<void>
   getCorrectAnswersCount(tierSessionId: string): Promise<number>
+  hasCorrectGuessForPosition(tierSessionId: string, position: number): Promise<boolean>
   countGuessesBySession(gameSessionId: string): Promise<number>
   getCorrectPositions(gameSessionId: string): Promise<number[]>
   deleteGameSession(userId: string, challengeId: number): Promise<boolean>

--- a/packages/backend/src/domain/services/game.service.submit-guess.test.ts
+++ b/packages/backend/src/domain/services/game.service.submit-guess.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createGameService, GameError, type GameServiceDeps } from './game.service.js'
+import type { DomainLogger } from '../ports/logger.js'
+
+const silentLogger: DomainLogger = {
+  child: () => silentLogger,
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+}
+
+const TOTAL_SCREENSHOTS = 10
+
+/**
+ * Minimal in-memory test harness for `submitGuess`. The real service talks to
+ * Postgres via injected repository ports; here we model just enough of the
+ * `guesses` / `tier_sessions` tables to exercise the completion-tally and
+ * anti-replay logic, which is where the two bugs found by the persona bug
+ * hunt live:
+ *
+ *  1. Off-by-one completion: `saveGuess` runs BEFORE `getCorrectAnswersCount`,
+ *     so the count already includes the current correct guess; the extra
+ *     `+ (isCorrect ? 1 : 0)` in the service double-counted it and the
+ *     challenge finished after 9 of 10 screenshots.
+ *  2. Replay: nothing stopped a client from re-POSTing a winning answer for a
+ *     position it had already solved (the round-timer guard only checks
+ *     `round_position === position`, which is never cleared after a correct
+ *     guess), re-banking score and inserting another correct row.
+ */
+function buildHarness() {
+  const guesses: Array<{ position: number; isCorrect: boolean }> = []
+  const tierSession = {
+    id: 'tier-1',
+    user_id: 'user-1',
+    game_session_id: 'game-1',
+    daily_challenge_id: 1,
+    is_catch_up: false,
+    round_started_at: new Date(Date.now() - 5000) as Date | null,
+    round_position: 1 as number | null,
+    score: 0,
+    correct_answers: 0,
+    wrong_guesses: 0,
+    game_total_score: 0,
+  }
+
+  const sessionRepository = {
+    withTierSessionLock: async <T>(_id: string, fn: () => Promise<T>) => fn(),
+    findTierSessionWithContext: async () => ({ ...tierSession }),
+    saveGuess: async (data: { position: number; isCorrect: boolean }) => {
+      guesses.push({ position: data.position, isCorrect: data.isCorrect })
+    },
+    // Mirrors the repository: number of DISTINCT positions with a correct
+    // guess. The just-saved guess is already visible here (autocommitted on a
+    // pooled connection before this read), exactly as in production.
+    getCorrectAnswersCount: async () => {
+      const solved = new Set(guesses.filter((g) => g.isCorrect).map((g) => g.position))
+      return solved.size
+    },
+    hasCorrectGuessForPosition: async (_id: string, position: number) =>
+      guesses.some((g) => g.isCorrect && g.position === position),
+    updateTierSession: async (
+      _id: string,
+      data: { score: number; correctAnswers: number; wrongGuesses: number }
+    ) => {
+      tierSession.score = data.score
+      tierSession.correct_answers = data.correctAnswers
+      tierSession.wrong_guesses = data.wrongGuesses
+    },
+    updateGameSession: async (_id: string, data: { totalScore: number }) => {
+      tierSession.game_total_score = data.totalScore
+    },
+    findAchievementGuessData: async () => [],
+  }
+
+  const deps = {
+    logger: silentLogger,
+    fuzzyMatchService: {
+      // The harness submits the literal answer 'right' for a correct guess.
+      isMatch: (guess: string) => guess.trim() === 'right',
+    },
+    achievementService: {
+      checkAchievementsAfterGame: async () => [],
+    },
+    challengeRepository: {},
+    sessionRepository,
+    screenshotRepository: {
+      findWithGame: async () => ({
+        screenshot: { gameId: 99 },
+        gameName: 'Halo',
+        coverImageUrl: null,
+        aliases: [],
+        releaseYear: 2001,
+        metacritic: null,
+      }),
+      getGameByScreenshotId: async () => ({ publisher: 'MS', developer: 'Bungie' }),
+    },
+    userRepository: {
+      findById: async () => ({ currentStreak: 0 }),
+      updateStreak: async () => {},
+      updateScore: async () => {},
+    },
+    inventoryRepository: { useItems: async () => false },
+    gameRepository: { getGenresById: async () => [] },
+    funnelEventRepository: { record: async () => {} },
+    positionSecondChanceRepository: { findPending: async () => null },
+  } as unknown as GameServiceDeps
+
+  const service = createGameService(deps)
+
+  const submit = (position: number, text: string) => {
+    // Simulate the client fetching the screenshot for `position`, which is the
+    // only thing that stamps the round timer server-side.
+    tierSession.round_position = position
+    tierSession.round_started_at = new Date(Date.now() - 5000)
+    return service.submitGuess({
+      tierSessionId: tierSession.id,
+      screenshotId: position,
+      position,
+      gameId: null,
+      guessText: text,
+      roundTimeTakenMs: 5000,
+      userId: 'user-1',
+    })
+  }
+
+  return { submit, guesses, tierSession }
+}
+
+describe('game.service submitGuess — completion tally', () => {
+  let h: ReturnType<typeof buildHarness>
+  beforeEach(() => {
+    h = buildHarness()
+  })
+
+  it('does NOT complete the challenge until all 10 screenshots are solved', async () => {
+    for (let pos = 1; pos <= TOTAL_SCREENSHOTS - 1; pos++) {
+      const res = await h.submit(pos, 'right')
+      assert.equal(res.isCorrect, true)
+      assert.equal(
+        res.isCompleted,
+        false,
+        `challenge must not be complete after solving ${pos}/${TOTAL_SCREENSHOTS}`
+      )
+      assert.equal(res.screenshotsFound, pos, `screenshotsFound should equal solved count (${pos})`)
+    }
+
+    const last = await h.submit(TOTAL_SCREENSHOTS, 'right')
+    assert.equal(last.isCompleted, true, 'challenge must complete on the 10th solved screenshot')
+    assert.equal(last.completionReason, 'all_found')
+    assert.equal(last.screenshotsFound, TOTAL_SCREENSHOTS)
+  })
+
+  it('rejects re-submitting a guess for an already-solved position (anti-replay)', async () => {
+    const first = await h.submit(1, 'right')
+    assert.equal(first.isCorrect, true)
+    assert.equal(first.screenshotsFound, 1)
+
+    await assert.rejects(
+      () => h.submit(1, 'right'),
+      (err: unknown) => err instanceof GameError && err.code === 'POSITION_ALREADY_SOLVED',
+      'a second correct guess on the same position must be rejected'
+    )
+
+    // The replay must not have banked a second correct row or extra score.
+    assert.equal(
+      h.guesses.filter((g) => g.isCorrect && g.position === 1).length,
+      1,
+      'only one correct guess row should exist for position 1'
+    )
+  })
+
+  it('still allows multiple wrong attempts on an unsolved position', async () => {
+    const wrong1 = await h.submit(1, 'nope')
+    assert.equal(wrong1.isCorrect, false)
+    const wrong2 = await h.submit(1, 'still wrong')
+    assert.equal(wrong2.isCorrect, false)
+    // A correct guess after wrong attempts must still be accepted.
+    const correct = await h.submit(1, 'right')
+    assert.equal(correct.isCorrect, true)
+    assert.equal(correct.screenshotsFound, 1)
+  })
+})

--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -552,6 +552,23 @@ export function createGameService(deps: GameServiceDeps): GameService {
       throw new GameError('SESSION_NOT_FOUND', 'Session not found', 404)
     }
 
+    // Anti-replay: a position can only be SOLVED once. The round-timer guard
+    // below only checks `round_position === data.position`, and that field is
+    // never cleared after a correct guess — so without this check a client
+    // could re-POST the same winning answer for an already-solved slot,
+    // re-banking score and inserting a second correct row (which also
+    // inflated the completion tally). Wrong guesses may still repeat; we only
+    // block re-scoring a position that already has a correct guess. Running
+    // inside the tier-session advisory lock makes this check-then-insert
+    // race-safe against two concurrent winning submits.
+    if (await sessionRepository.hasCorrectGuessForPosition(data.tierSessionId, data.position)) {
+      throw new GameError(
+        'POSITION_ALREADY_SOLVED',
+        'This screenshot has already been solved.',
+        409
+      )
+    }
+
     const screenshotData = await screenshotRepository.findWithGame(data.screenshotId)
     if (!screenshotData) {
       throw new GameError('SCREENSHOT_NOT_FOUND', 'Screenshot not found', 404)
@@ -777,9 +794,13 @@ export function createGameService(deps: GameServiceDeps): GameService {
       wrongGuesses: newWrongGuesses,
     })
 
-    // Get count of screenshots found (correct answers)
-    const screenshotsFound = await sessionRepository.getCorrectAnswersCount(data.tierSessionId)
-    const totalScreenshotsFound = screenshotsFound + (isCorrect ? 1 : 0)
+    // Count of screenshots found (distinct solved positions). This runs AFTER
+    // `saveGuess` above has already persisted the current guess (the insert
+    // autocommits on its pooled connection before this read), so the current
+    // correct guess is already included — we must NOT add it again. The old
+    // `+ (isCorrect ? 1 : 0)` double-counted it and ended the challenge after
+    // 9 of 10 screenshots.
+    const totalScreenshotsFound = await sessionRepository.getCorrectAnswersCount(data.tierSessionId)
 
     // Advance to next position only on correct guess
     const shouldAdvance = isCorrect

--- a/packages/backend/src/infrastructure/repositories/session.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/session.repository.ts
@@ -272,16 +272,36 @@ export const sessionRepository = {
     })
   },
 
+  // Number of screenshots solved = number of DISTINCT positions with a
+  // correct guess. Counting rows (not distinct positions) let a duplicate
+  // correct row for the same position inflate the completion tally, which
+  // combined with the replay vector below could end a challenge before all
+  // ten screenshots were actually solved.
   async getCorrectAnswersCount(tierSessionId: string): Promise<number> {
     log.debug({ tierSessionId }, 'getCorrectAnswersCount')
     const result = await db('guesses')
       .where('tier_session_id', tierSessionId)
       .andWhere('is_correct', true)
-      .count('id as count')
+      .countDistinct('position as count')
       .first<{ count: string }>()
     const count = parseInt(result?.count ?? '0', 10)
     log.debug({ tierSessionId, correctCount: count }, 'getCorrectAnswersCount result')
     return count
+  },
+
+  // Has this (tier_session, position) already been solved? Used by
+  // submitGuess to reject a replayed winning answer. The round-timer guard
+  // alone is insufficient: `round_position` is never cleared after a correct
+  // guess, so a client that simply re-POSTs the same answer for an
+  // already-solved slot would otherwise re-bank score and insert another
+  // correct row.
+  async hasCorrectGuessForPosition(tierSessionId: string, position: number): Promise<boolean> {
+    const row = await db('guesses')
+      .where('tier_session_id', tierSessionId)
+      .andWhere('position', position)
+      .andWhere('is_correct', true)
+      .first<{ id: number }>('id')
+    return !!row
   },
 
   async countGuessesBySession(gameSessionId: string): Promise<number> {

--- a/tasks/daily-game-persona-bug-hunt.html
+++ b/tasks/daily-game-persona-bug-hunt.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- SUMMARY:
+  Multi-persona adversarial bug hunt on the daily game. Four personas (Speedrunner,
+  Timezone Traveler, Score Cheater, Reconnector) probed submitGuess. Found two coupled
+  defects in the completion tally: (1) anyone could replay a winning answer on an
+  already-solved position to re-bank score, and (2) an off-by-one ended the challenge
+  after 9 of 10 screenshots. Both root-caused to saveGuess running before the tally.
+  Fixed: anti-replay guard + distinct-position count, dropped the double-count. Proven
+  by a new node:test unit test (3 cases red→green); full suite 204/204.
+-->
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Daily Game — Persona Bug Hunt</title>
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --panel: #14141c;
+    --border: #262633;
+    --text: #e6e6ef;
+    --muted: #9a9ab0;
+    --purple: #a855f7;
+    --green: #34d399;
+    --red: #f87171;
+    --amber: #fbbf24;
+  }
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: Inter, system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 2.5rem 1.25rem 4rem;
+  }
+  main { max-width: 72ch; margin: 0 auto; }
+  h1, h2, h3 { line-height: 1.25; font-weight: 650; }
+  h1 {
+    font-size: 1.9rem;
+    margin: 0 0 .25rem;
+    text-shadow: 0 0 24px rgba(168, 85, 247, .45);
+  }
+  h2 {
+    font-size: 1.25rem;
+    margin: 2.5rem 0 .75rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: .4rem;
+  }
+  h3 { font-size: 1rem; margin: 1.5rem 0 .4rem; color: var(--purple); }
+  .lede { color: var(--muted); margin: 0 0 1.5rem; }
+  code, .mono { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .88em; }
+  code { background: #1c1c28; padding: .1rem .35rem; border-radius: 4px; color: #d6bcff; }
+  a { color: var(--purple); }
+  a:focus-visible { outline: 2px solid var(--purple); outline-offset: 3px; }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem 1.2rem;
+    margin: 1rem 0;
+  }
+  .tag {
+    display: inline-block;
+    font-family: "JetBrains Mono", monospace;
+    font-size: .72rem;
+    padding: .12rem .5rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    color: var(--muted);
+    margin-right: .35rem;
+  }
+  .tag.crit { color: var(--red); border-color: #5b2330; }
+  .tag.confirmed { color: var(--green); border-color: #1f4d3d; }
+  .tag.fixed { color: var(--green); border-color: #1f4d3d; }
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: .92rem; }
+  th, td { text-align: left; padding: .5rem .6rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; }
+  pre {
+    background: #0f0f17;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: .9rem 1rem;
+    overflow-x: auto;
+    font-family: "JetBrains Mono", monospace;
+    font-size: .82rem;
+  }
+  .del { color: var(--red); }
+  .add { color: var(--green); }
+  ol li, ul li { margin: .3rem 0; }
+  footer { color: var(--muted); font-size: .82rem; margin-top: 3rem; border-top: 1px solid var(--border); padding-top: 1rem; }
+  @media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }
+</style>
+</head>
+<body>
+<main>
+  <h1>Daily Game — Persona Bug Hunt</h1>
+  <p class="lede">An adversarial workflow ran four player personas against the daily-game
+  guess-submission path. It surfaced two coupled defects in the completion tally, both
+  now fixed and covered by a regression test.</p>
+
+  <h2>The workflow</h2>
+  <p>Four personas investigated the same code from different angles, each reporting
+  evidence-backed candidates rather than guesses. Findings were then verified against
+  source before any change.</p>
+  <table>
+    <tr><th>Persona</th><th>Obsession</th><th>Verdict</th></tr>
+    <tr><td>Speedrunner</td><td>Double-submit, replay a completed challenge, race the server</td><td>Pointed at the replay vector ✅</td></tr>
+    <tr><td>Timezone Traveler</td><td>Date boundaries, catch-up window, countdown</td><td>One latent off-by-365/366 in premium window; countdown clean</td></tr>
+    <tr><td>Score Cheater</td><td>Client-trusted scores, hint penalties, timer spoof</td><td>Scoring is server-authoritative — hardened, no exploit</td></tr>
+    <tr><td>Reconnector</td><td>Reload mid-game, stale persisted state, expiry</td><td>Confirmed no absolute session expiry (separate follow-up)</td></tr>
+  </table>
+  <p>The Score Cheater's read (server-authoritative timer via <code>Math.max(server,
+  client)</code>, inventory-atomic hints, leaderboard reads persisted scores) checked out
+  and ruled out the obvious cheats — which sharpened focus on the tally logic the
+  Speedrunner flagged.</p>
+
+  <h2>The bug <span class="tag confirmed">CONFIRMED</span> <span class="tag fixed">FIXED</span></h2>
+  <p>Two defects, one root cause. In <code>submitGuess</code>, <code>saveGuess()</code>
+  persists the current guess <em>before</em> the completion tally is read. Because writes
+  go through the global pool (the advisory lock's transaction is only used to serialise),
+  the freshly-inserted row is already visible to the next read.</p>
+
+  <h3>Defect 1 — Replay an already-solved position <span class="tag crit">scoring integrity</span></h3>
+  <p>The only gate on a guess is the round-timer guard
+  <code>round_position === data.position</code> — and <code>round_position</code> is never
+  cleared after a correct guess. Nothing checked whether the position was already solved,
+  so a client could re-POST the same winning answer for the same slot repeatedly, each
+  replay re-banking score and inserting another <code>is_correct</code> row.</p>
+
+  <h3>Defect 2 — Off-by-one early completion</h3>
+  <p><code>getCorrectAnswersCount()</code> counted <em>all</em> correct rows and the service
+  then added <code>+ (isCorrect ? 1 : 0)</code> on top. Since the current guess was already
+  saved and counted, the current correct guess was counted twice — so the challenge ended
+  after <strong>9 of 10</strong> screenshots, and a single correct guess reported
+  <code>screenshotsFound: 2</code>.</p>
+
+  <div class="panel mono">
+    Exploit sketch: solve position 1, then replay the same answer for position 1 nine
+    more times. Each replay banks ~100–200 points and (via the row-count tally) advances
+    completion — finishing a "perfect" run having ever solved a single screenshot.
+  </div>
+
+  <h2>The fix</h2>
+  <ol>
+    <li><strong>Anti-replay guard</strong> in <code>submitGuess</code>: reject with
+      <code>POSITION_ALREADY_SOLVED</code> (409) when a correct guess already exists for
+      <code>(tier_session, position)</code>. Runs inside the tier-session advisory lock, so
+      it is race-safe against two concurrent winning submits. Wrong guesses may still
+      repeat.</li>
+    <li><strong>Distinct-position count</strong>: <code>getCorrectAnswersCount</code> now
+      uses <code>countDistinct('position')</code> — screenshots-found is distinct solved
+      positions, not raw rows.</li>
+    <li><strong>Drop the double-count</strong>: the tally is the count itself; the stale
+      <code>+1</code> is removed.</li>
+  </ol>
+  <pre><span class="del">- const screenshotsFound = await ...getCorrectAnswersCount(...)</span>
+<span class="del">- const totalScreenshotsFound = screenshotsFound + (isCorrect ? 1 : 0)</span>
+<span class="add">+ const totalScreenshotsFound = await ...getCorrectAnswersCount(...) // distinct, already includes current</span></pre>
+
+  <h2>Verification</h2>
+  <ul>
+    <li>New <code>node:test</code> spec
+      (<span class="mono">game.service.submit-guess.test.ts</span>) — 3 cases: completes
+      only at 10/10, rejects replay of a solved position, still allows multiple wrong
+      attempts. <span class="add">Red against the old code, green after the fix.</span></li>
+    <li>Backend typecheck clean; full suite <strong>204/204</strong>.</li>
+  </ul>
+
+  <footer>
+    Generated for the daily-game bug-hunt workflow. Internal engineering note —
+    senior developers only.
+  </footer>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Persona-driven bug hunt → two coupled daily-game bugs

Ran an adversarial workflow of four player personas against the daily-game guess path (Speedrunner, Timezone Traveler, Score Cheater, Reconnector). The Score Cheater confirmed scoring is already server-authoritative (timer via `Math.max(server, client)`, atomic hint inventory, leaderboard reads persisted scores), which sharpened focus on the **completion tally** in `submitGuess`, where the Speedrunner pointed at a replay vector. Verifying against source turned up **two coupled defects**, both rooted in `saveGuess()` running *before* the tally is read.

### Defect 1 — Replay an already-solved position (scoring integrity)
The only gate on a guess is the round-timer guard `round_position === data.position`, and `round_position` is **never cleared** after a correct guess. Nothing checked whether the position was already solved, so a client could re-POST the same winning answer for the same slot repeatedly — each replay re-banking score and inserting another `is_correct` row.

### Defect 2 — Off-by-one early completion
`getCorrectAnswersCount()` counted **all** correct rows, and the service then added `+ (isCorrect ? 1 : 0)` on top. Because `saveGuess` already persisted (and the count includes) the current guess, it was double-counted — the challenge completed after **9 of 10** screenshots, and a single correct guess reported `screenshotsFound: 2`.

> Combined exploit: solve position 1, then replay the same answer 9 more times → a "perfect" run completed having ever solved one screenshot.

## Fix
1. **Anti-replay guard** in `submitGuess`: reject `POSITION_ALREADY_SOLVED` (409) when a correct guess already exists for `(tier_session, position)`. Inside the tier-session advisory lock → race-safe against concurrent winning submits. Wrong guesses may still repeat.
2. **Distinct-position count**: `getCorrectAnswersCount` now uses `countDistinct('position')`.
3. **Drop the stale `+1`**: the tally is the count itself.

## Verification
- New `node:test` spec `game.service.submit-guess.test.ts` (3 cases: completes only at 10/10, rejects replay, still allows multiple wrong attempts) — **red against old code, green after the fix**.
- Backend typecheck clean; full suite **204/204**.

Report: `tasks/daily-game-persona-bug-hunt.html`.

### Out of scope (noted by personas, not addressed here)
- No absolute session expiry — a daily started near midnight can be submitted >24h later (Reconnector).
- Premium catch-up window is 366 calendar days vs the 365 the constant implies (Timezone Traveler).

https://claude.ai/code/session_01P9NjNVpBrXtB4UCM3JpfFH

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9NjNVpBrXtB4UCM3JpfFH)_