### PR TITLE
fix(frontend): percentile display inversion and cross-user state leak on signOut

### DIFF
--- a/packages/frontend/src/components/game/PercentileBanner.tsx
+++ b/packages/frontend/src/components/game/PercentileBanner.tsx
@@ -39,8 +39,9 @@ export function PercentileBanner({
     return null
   }
 
-  // Calculate "top X%" - if percentile is 85, user is in top 15%
-  const topPercent = Math.max(1, 100 - percentile)
+  // Backend already returns "top X%" semantics (1 = best player, 100 = worst).
+  // Just clamp to a sensible minimum for display.
+  const topPercent = Math.max(1, percentile)
 
   return (
     <m.div

--- a/packages/frontend/src/hooks/useAuth.ts
+++ b/packages/frontend/src/hooks/useAuth.ts
@@ -2,6 +2,9 @@ import { useCallback } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useSession, signOut as authSignOut } from '@/lib/auth-client'
+import { useGameStore } from '@/stores/gameStore'
+import { useDailyLoginStore } from '@/stores/dailyLoginStore'
+import { useAchievementStore } from '@/stores/achievementStore'
 
 /**
  * Custom hook for authentication logic
@@ -27,11 +30,16 @@ export function useAuth() {
       if (result.error) {
         console.error('Sign out error:', result.error)
       }
-      // Navigate regardless of error to ensure user is redirected
-      navigate(`/${currentLang}`)
     } catch (err) {
       console.error('Sign out failed:', err)
-      // Navigate even on error to ensure user is redirected
+    } finally {
+      // Clear per-user client state so a subsequent login on the same
+      // browser doesn't briefly see the previous user's game session
+      // (persisted in localStorage), inventory, or achievement
+      // notifications.
+      useGameStore.getState().resetGame()
+      useDailyLoginStore.getState().reset()
+      useAchievementStore.getState().reset()
       navigate(`/${currentLang}`)
     }
   }, [navigate, currentLang])


### PR DESCRIPTION
## Summary

Senior-dev bug hunt pass — two real bugs found and fixed.

### 1. `PercentileBanner` double-inverted the percentile

The backend's `leaderboardRepository.getPercentileForScore` returns "top X%" semantics where **1 = best player, 100 = worst** (see comment + math at `packages/backend/src/infrastructure/repositories/leaderboard.repository.ts:99-100`). `ShareCard` and `gameStore.bestPercentile` (`Math.min`) both already treat the value that way.

`PercentileBanner` was the odd one out: it did `Math.max(1, 100 - percentile)`, so the top player (percentile=1) was rendered as **"Top 99%"** — backwards. Using the value directly aligns the banner with the rest of the codebase.

### 2. `signOut` did not reset per-user client state

`useAuth.signOut` called Better Auth's signOut and navigated, but never reset the Zustand stores. That leaked across users on a shared browser:
- `gameStore` is `persist`-backed in localStorage, so user A's mid-flight session would still be there when user B logged in.
- `dailyLoginStore` and `achievementStore` are in-memory but kept user A's inventory and unseen achievement notifications until the next fetch overwrote them.

Now we call `resetGame()` / `reset()` / `reset()` in a `finally` block so they run even if Better Auth's signOut throws.

## Test plan
- [x] `npm run build:types`, `build:backend`, frontend `tsc -b` — all clean
- [x] `npm run lint` — clean
- [x] `npm test` — 204/204 pass
- [ ] Manual: sign in as user A, play a daily challenge to mid-game, sign out, sign in as user B → game store, daily-login inventory and achievement notifications should all be empty for user B
- [ ] Manual: finish a daily challenge as a top-ranked player and verify the percentile banner renders "Top 1%" (or whatever low number) instead of "Top 99%"


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgj5N5N8kwf11er4fWdyco)_