### PR TITLE
fix(game): prevent countdown reset by skipping away and back

### DIFF
--- a/packages/frontend/e2e/countdown.spec.ts
+++ b/packages/frontend/e2e/countdown.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
-import { loginAsUser, waitForGameLoad, startDailyGame } from './helpers/game-helpers'
+import { loginAsUser, waitForGameLoad, startDailyGame, skipScreenshot } from './helpers/game-helpers'
 
 /**
  * E2E for the per-screenshot 45s countdown timer.
@@ -81,5 +81,42 @@ test.describe('Daily Game - Countdown Timer', () => {
     await expect
       .poll(async () => readTimerSeconds(page), { timeout: 10000 })
       .toBeGreaterThan(30)
+  })
+
+  test('navigating away and back does NOT reset the countdown (exploit closed)', async ({ page }) => {
+    await startPlayingWithFrozenClock(page)
+
+    // Spend ~15s on position 1 → ~30s remaining.
+    await page.clock.fastForward(15_000)
+    await page.waitForTimeout(150)
+    const p1Before = await readTimerSeconds(page)
+    expect(p1Before).toBeGreaterThanOrEqual(28)
+    expect(p1Before).toBeLessThanOrEqual(32)
+
+    // Skip to position 2 (banks ~15s into position 1) — fresh ~45s there.
+    await skipScreenshot(page)
+    await expect.poll(async () => readTimerSeconds(page), { timeout: 10000 }).toBeGreaterThan(40)
+
+    // Navigate back to position 1 (skipped → revisitable).
+    await page.getByRole('tab').filter({ hasText: /^1$/ }).first().click()
+    await page.waitForTimeout(300)
+
+    // Exploit check: the timer RESUMES at ~30s, it is NOT reset to 45.
+    const p1After = await readTimerSeconds(page)
+    expect(p1After).toBeGreaterThan(20)
+    expect(p1After).toBeLessThanOrEqual(31)
+
+    // …and it keeps ticking DOWN from the resumed value.
+    await page.clock.fastForward(5_000)
+    await page.waitForTimeout(150)
+    const ticking = await readTimerSeconds(page)
+    expect(ticking).toBeLessThan(p1After)
+
+    // Exhausting the remaining budget still times the position out — the
+    // round-trip didn't buy extra time.
+    await page.clock.fastForward((ticking + 1) * 1000)
+    await expect(
+      page.getByRole('tab').filter({ hasText: /^1$/ }).first()
+    ).toHaveAttribute('aria-label', /timed out/i)
   })
 })

--- a/packages/frontend/src/hooks/useCountdownTimer.ts
+++ b/packages/frontend/src/hooks/useCountdownTimer.ts
@@ -48,6 +48,11 @@ export function useCountdownTimer(): CountdownState {
   const limitSeconds = useGameStore(
     (s) => s.currentScreenshotData?.timeLimitSeconds ?? DEFAULT_TIME_LIMIT_SECONDS
   )
+  // Active time already banked on this position from previous visits — the
+  // countdown resumes from the remaining budget rather than resetting.
+  const timeSpentMs = useGameStore(
+    (s) => s.positionStates[s.currentPosition]?.timeSpentMs ?? 0
+  )
 
   // Active only when the loaded screenshot is the one we're playing. During the
   // brief navigation/fetch gap `screenshotPosition` lags `currentPosition`, so
@@ -73,7 +78,7 @@ export function useCountdownTimer(): CountdownState {
     return () => clearInterval(id)
   }, [roundStartedAt, limitMs, isActive])
 
-  const remainingMs = computeRemainingMs(now, roundStartedAt, limitMs)
+  const remainingMs = computeRemainingMs(now, roundStartedAt, limitMs, timeSpentMs)
   const seconds = toSeconds(remainingMs)
 
   return {
@@ -95,24 +100,25 @@ export function useCountdownTimer(): CountdownState {
 export function useRoundTimer(): CountdownState {
   const state = useCountdownTimer()
   const { t } = useTranslation()
-  const roundStartedAt = useGameStore((s) => s.roundStartedAt)
+  const currentPosition = useGameStore((s) => s.currentPosition)
 
-  // Remember which round we've already timed out, so the expiry effect — which
-  // keeps re-running while `isExpired` stays true during the fetch gap — only
-  // acts once.
-  const firedForRound = useRef<number | null>(null)
+  // Latch per POSITION (not per `roundStartedAt`, which now re-stamps on every
+  // segment): a position times out at most once, and the effect — which keeps
+  // re-running while `isExpired` stays true during the fetch gap — only acts on
+  // the first crossing.
+  const firedForPosition = useRef<number | null>(null)
 
   useEffect(() => {
-    if (!state.isExpired || roundStartedAt == null) return
-    if (firedForRound.current === roundStartedAt) return
+    if (!state.isExpired) return
+    if (firedForPosition.current === currentPosition) return
 
     const store = useGameStore.getState()
-    const { currentPosition, positionStates } = store
+    const { currentPosition: pos, positionStates } = store
     // Only time out a screenshot the player is actively guessing. Guards the
     // race where an in-flight correct guess has already marked it 'correct'.
-    if (positionStates[currentPosition]?.status !== 'in_progress') return
+    if (positionStates[pos]?.status !== 'in_progress') return
 
-    firedForRound.current = roundStartedAt
+    firedForPosition.current = pos
     toast.error(t('game.timeUp'))
 
     const next = store.timeOutCurrentPosition()
@@ -122,7 +128,7 @@ export function useRoundTimer(): CountdownState {
         console.error('Failed to end game after timeout:', err)
       })
     }
-  }, [state.isExpired, roundStartedAt, t])
+  }, [state.isExpired, currentPosition, t])
 
   return state
 }

--- a/packages/frontend/src/hooks/useGameGuess.ts
+++ b/packages/frontend/src/hooks/useGameGuess.ts
@@ -37,10 +37,14 @@ export function useGameGuess(submissionService: GuessSubmissionService) {
         }
       }
 
-      // Calculate round time (from current screenshot start to now)
-      const roundTimeTakenMs = store.roundStartedAt
-        ? Date.now() - store.roundStartedAt
-        : 0
+      // Total active time on this screenshot = time banked on previous visits
+      // plus the current segment. Sending the accumulated value (not just the
+      // current segment) stops the skip-away-and-back trick from also resetting
+      // the speed multiplier — the server takes Math.max(server, client), so
+      // the honest larger time wins with no backend change.
+      const liveSegmentMs = store.roundStartedAt ? Date.now() - store.roundStartedAt : 0
+      const accumulatedMs = store.positionStates[store.currentPosition]?.timeSpentMs ?? 0
+      const roundTimeTakenMs = Math.max(0, accumulatedMs + liveSegmentMs)
 
       // Check if hints were used for current position
       const currentPosState = store.positionStates[store.currentPosition]

--- a/packages/frontend/src/lib/countdown.test.ts
+++ b/packages/frontend/src/lib/countdown.test.ts
@@ -40,6 +40,38 @@ describe('computeRemainingMs', () => {
   })
 })
 
+describe('computeRemainingMs with banked time (resume budget)', () => {
+  it('resumes from the remaining budget, not the full limit', () => {
+    // 30s already spent, a fresh segment just started → 15s left, NOT 45.
+    assert.equal(computeRemainingMs(1000, 1000, LIMIT, 30_000), 15_000)
+  })
+
+  it('subtracts the live segment from the remaining budget', () => {
+    // 30s banked + 5s into the new segment → 10s left.
+    assert.equal(computeRemainingMs(6000, 1000, LIMIT, 30_000), 10_000)
+  })
+
+  it('is 0 when the budget is already exhausted, regardless of a fresh start', () => {
+    assert.equal(computeRemainingMs(1000, 1000, LIMIT, 45_000), 0)
+    assert.equal(computeRemainingMs(1000, 1000, LIMIT, 60_000), 0)
+  })
+
+  it('shows the remaining budget (not the full limit) while paused', () => {
+    assert.equal(computeRemainingMs(5000, null, LIMIT, 30_000), 15_000)
+  })
+
+  it('clamps clock skew to the remaining budget, never the full limit', () => {
+    // now before startedAt would naively give the full limit — must cap at budget.
+    assert.equal(computeRemainingMs(500, 1000, LIMIT, 30_000), 15_000)
+  })
+
+  it('a re-stamp after navigating back can never exceed the remaining budget', () => {
+    // The exploit: returning to a position re-stamps startedAt = now. The
+    // remaining must stay <= budget, never jump back to 45.
+    assert.ok(computeRemainingMs(1000, 1000, LIMIT, 30_000) <= 15_000)
+  })
+})
+
 describe('remainingSeconds', () => {
   it('ceils so a partial second still reads as 1', () => {
     assert.equal(remainingSeconds(400), 1)

--- a/packages/frontend/src/lib/countdown.ts
+++ b/packages/frontend/src/lib/countdown.ts
@@ -17,24 +17,28 @@ export const CRITICAL_THRESHOLD_SECONDS = 5
 export type TimerPhase = 'normal' | 'warning' | 'critical'
 
 /**
- * Milliseconds left on the round, clamped to `[0, limitMs]`.
+ * Milliseconds left on the round, clamped to `[0, budget]` where the budget is
+ * `limitMs - alreadySpentMs` (time spent on previous visits to this position).
  *
  * Recomputed from the wall clock (`now - startedAt`) rather than decrementing a
- * counter, so a throttled/backgrounded tab can never desync — when it resumes
- * it reads the true elapsed. Clamping makes it clock-skew safe: a `now` before
- * `startedAt` yields the full limit (never more), and an overshoot yields 0
- * (never negative).
+ * counter, so a throttled/backgrounded tab can never desync. Clamping makes it
+ * clock-skew safe: a `now` before `startedAt` yields the remaining budget
+ * (never the full limit — this is what stops navigate-away-and-back from
+ * resetting the timer), and an overshoot yields 0 (never negative).
  */
 export function computeRemainingMs(
   now: number,
   startedAt: number | null,
-  limitMs: number
+  limitMs: number,
+  alreadySpentMs = 0
 ): number {
   if (limitMs <= 0) return 0
-  if (startedAt == null) return limitMs
-  const remaining = limitMs - (now - startedAt)
+  const budget = limitMs - Math.max(0, alreadySpentMs)
+  if (budget <= 0) return 0
+  if (startedAt == null) return budget
+  const remaining = budget - (now - startedAt)
   if (remaining <= 0) return 0
-  if (remaining > limitMs) return limitMs
+  if (remaining > budget) return budget
   return remaining
 }
 

--- a/packages/frontend/src/stores/gameStore.ts
+++ b/packages/frontend/src/stores/gameStore.ts
@@ -205,10 +205,36 @@ export const useGameStore = create<GameState>()(
           totalScreenshots: total,
         }),
 
-        setScreenshotData: (data) => set({
-          currentScreenshotData: data,
-          currentPosition: data.position,
-          roundStartedAt: Date.now(),
+        setScreenshotData: (data) => set((state) => {
+          const now = Date.now()
+          const prevPos = state.currentScreenshotData?.position
+          let positionStates = state.positionStates
+
+          // Flush the segment we're leaving into the outgoing position's
+          // accumulator so the countdown RESUMES (never resets) when the player
+          // comes back. Only for a real segment on a DIFFERENT position — a
+          // same-position re-fetch must not double-count, and the timer simply
+          // continues from the live `roundStartedAt` re-stamp.
+          if (prevPos != null && prevPos !== data.position && state.roundStartedAt != null) {
+            const segment = Math.max(0, now - state.roundStartedAt)
+            const prevState = positionStates[prevPos]
+            if (prevState) {
+              positionStates = {
+                ...positionStates,
+                [prevPos]: {
+                  ...prevState,
+                  timeSpentMs: (prevState.timeSpentMs ?? 0) + segment,
+                },
+              }
+            }
+          }
+
+          return {
+            currentScreenshotData: data,
+            currentPosition: data.position,
+            roundStartedAt: now,
+            positionStates,
+          }
         }),
 
         setScreenshotsFound: (count) => set({ screenshotsFound: count }),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -290,6 +290,14 @@ export interface PositionState {
    * and the disabled state of the inventory item.
    */
   secondChanceActivated?: boolean
+  /**
+   * Total active (on-screen) milliseconds already spent guessing this
+   * position, excluding the segment currently in progress. Lets the countdown
+   * timer RESUME from the remaining budget when the player navigates back to a
+   * skipped position instead of resetting to the full limit. Persisted with
+   * `positionStates`, so a refresh can't reset it either.
+   */
+  timeSpentMs?: number
 }
 
 // ============================================

--- a/tasks/round-countdown-timer.html
+++ b/tasks/round-countdown-timer.html
@@ -5,6 +5,8 @@
   status, non-revisitable, revealed as unfound at end). Client-only (no server enforcement v1).
   timeLimitSeconds plumbed through ScreenshotResponse (default 45). Tested via page.clock e2e +
   pure-helper unit tests. Outcome of the UX/architect/QA sub-agent design meeting.
+  v2: per-position active-time budget (timeSpentMs) so navigating away and back RESUMES the
+  countdown instead of resetting it — closes the skip-and-return exploit (incl. the speed multiplier).
 -->
 <html lang="en">
 <head>
@@ -128,8 +130,8 @@ information. <code>role="timer"</code> + a localized <code>aria-label</code>; ro
     <p class="muted">A single latched effect (keyed on <code>roundStartedAt</code>, gated to <code>status === 'in_progress'</code>) calls <code>timeOutCurrentPosition()</code>: marks <span class="tag">timed_out</span>, advances to the next playable position, or ends the game if none remain.</p>
   </div>
   <div class="card">
-    <h3>Wall-clock honesty</h3>
-    <p class="muted">No pause on <code>document.hidden</code> (matches the server's own elapsed measure, no cheat vector). Recompute-from-clock means a throttled background tab can't desync — it shows expired on return.</p>
+    <h3>Resume budget (anti-reset)</h3>
+    <p class="muted">Each position carries a persisted <code>timeSpentMs</code> accumulator. <code>setScreenshotData</code> flushes the segment you're leaving into the outgoing position, so navigating away and back <strong>resumes</strong> the remaining budget instead of resetting to 45s. No <code>document.hidden</code> pause within a segment (matches the server's elapsed measure). The timeout latch keys on <code>currentPosition</code>, and <code>useGameGuess</code> sends the accumulated time so the server's <code>Math.max</code> also neutralises the speed-multiplier reset.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## The exploit

The 45s countdown could be **reset to full by skipping to another screenshot and navigating back**. Every `getScreenshot` re-stamped `roundStartedAt` (client, `setScreenshotData`) and `round_started_at` (server, `markRoundStarted`), so revisiting a position handed the player a fresh 45s — effectively unlimited time, **and** a reset of the speed multiplier (the server's `Math.max(server, client)` saw two freshly-reset clocks).

Found via a sub-agent audit (skip→previous, progress-dot navigation, and refresh were all reset vectors).

## The fix — per-position active-time budget

Each `PositionState` now carries a persisted `timeSpentMs`. When the player leaves a screenshot, `setScreenshotData` **flushes the elapsed segment into the outgoing position's accumulator**, so the countdown **resumes from the remaining budget** on return instead of resetting. Total stays 45s of *actual time on that screenshot* — the legitimate skip-and-return mechanic is preserved (strategy A from the design meeting; the alternative "wall-clock from first view" was rejected as hostile to the existing "review skipped" feature and the terminal `timed_out` semantics).

| File | Change |
|---|---|
| `types` | `PositionState.timeSpentMs?` (rides along in the already-persisted `positionStates`) |
| `lib/countdown.ts` | `computeRemainingMs(now, startedAt, limitMs, alreadySpentMs=0)` clamps to the **remaining budget**, never the full limit |
| `stores/gameStore.ts` | `setScreenshotData` flushes the leaving segment into the previous position (guarded `prevPos !== data.position` so a same-position re-fetch can't double-count) |
| `hooks/useCountdownTimer.ts` | subtract banked time; **re-key the timeout latch to `currentPosition`** (since `roundStartedAt` now re-stamps per segment) |
| `hooks/useGameGuess.ts` | send `accumulated + liveSegment` as `roundTimeTakenMs` → the server's existing `Math.max` neutralises the speed-multiplier reset, **no backend change** |

`roundStartedAt` stays **not persisted** by design (a refresh can't keep ticking while away); the persisted `timeSpentMs` is what survives a refresh, so refresh can't reset the budget either.

## Testing

- ✅ `npm run build` (types + backend + frontend), `npm run lint`
- ✅ `npm test` — backend 207, frontend 25 (6 new banked-time `computeRemainingMs` cases)
- ✍️ `e2e/countdown.spec.ts`: new `page.clock` test — spend ~15s on position 1, skip to 2 (fresh ~45s), navigate back, assert the timer **resumes at ~30s (not 45)** and still times the position out when the budget is spent. **Not run in this container** (no Docker/Postgres/PW browsers); run with `docker compose -f compose.local.yml up -d` + `npm run e2e:seed` + `npm run test:e2e`.

## Scope / follow-up

Client-only (consistent with v1). A determined attacker can still edit `localStorage`; the tamper-proof version (server-side per-position accumulator + stop re-stamping `round_started_at` on revisit) is a flagged follow-up requiring a schema migration.

Builds on the merged #277. PRD updated: `tasks/round-countdown-timer.html`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDkKLoAu2vhHfE2DbjqeyW)_