### PR TITLE
feat(game): relocate zoom controls to clear the capture

### DIFF
--- a/packages/frontend/src/components/ui/game-carousel.tsx
+++ b/packages/frontend/src/components/ui/game-carousel.tsx
@@ -244,6 +244,29 @@ export function GameCarousel({
     const zoom = useImageZoom(images[currentIndex]?.url ?? currentIndex)
     const { view } = zoom
 
+    // Zoom controls collapse to a single button so the capture's bottom-left
+    // corner stays mostly clear; they expand on tap and re-collapse when idle.
+    // While the image is zoomed in (scale > 1) we force them open so "reset"
+    // remains one tap away.
+    const [zoomExpanded, setZoomExpanded] = useState(false)
+    const zoomIdleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    const scheduleZoomCollapse = useCallback(() => {
+        if (zoomIdleTimer.current) clearTimeout(zoomIdleTimer.current)
+        zoomIdleTimer.current = setTimeout(() => setZoomExpanded(false), 2500)
+    }, [])
+
+    const openZoomControls = useCallback(() => {
+        setZoomExpanded(true)
+        scheduleZoomCollapse()
+    }, [scheduleZoomCollapse])
+
+    useEffect(() => () => {
+        if (zoomIdleTimer.current) clearTimeout(zoomIdleTimer.current)
+    }, [])
+
+    const showZoomCluster = zoomExpanded || view.scale > 1.01
+
     // Track user interaction to enable haptic feedback
     useEffect(() => {
         const handleInteraction = () => {
@@ -386,46 +409,63 @@ export function GameCarousel({
                 </CarouselContent>
             </Carousel>
 
-            {/* Zoom Controls */}
+            {/* Zoom Controls — anchored to the capture's bottom-left corner so
+                the image's center and the other three corners stay clear.
+                Collapsed to a single button by default; expands on tap and
+                auto-collapses when idle (kept open while zoomed in). */}
             {enableZoom && (
-                <div className="absolute top-1/2 -translate-y-1/2 left-4 z-30 flex flex-col items-center gap-1 bg-black/60 backdrop-blur-sm rounded-lg p-1.5 pointer-events-auto transition-all duration-200">
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-8 text-foreground/80 hover:text-foreground hover:bg-foreground/20"
-                        onClick={zoom.zoomIn}
-                        disabled={view.scale >= MAX_SCALE - 0.01}
-                        title="Zoom in"
-                    >
-                        <ZoomIn className="size-4" />
-                    </Button>
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-8 text-foreground/80 hover:text-foreground hover:bg-foreground/20"
-                        onClick={zoom.zoomOut}
-                        disabled={view.scale <= MIN_SCALE + 0.01}
-                        title="Zoom out"
-                    >
-                        <ZoomOut className="size-4" />
-                    </Button>
-                    <div className={cn(
-                        "flex flex-col items-center gap-1 overflow-hidden transition-all duration-200",
-                        view.scale > 1.01 ? "max-h-20 opacity-100" : "max-h-0 opacity-0"
-                    )}>
+                <div className="absolute bottom-4 left-4 z-30 pointer-events-auto">
+                    {showZoomCluster ? (
+                        <div className="flex flex-col items-center gap-1 bg-black/60 backdrop-blur-sm rounded-lg p-1.5 transition-all duration-200">
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="size-8 text-foreground/80 hover:text-foreground hover:bg-foreground/20"
+                                onClick={() => { zoom.zoomIn(); scheduleZoomCollapse() }}
+                                disabled={view.scale >= MAX_SCALE - 0.01}
+                                title="Zoom in"
+                            >
+                                <ZoomIn className="size-4" />
+                            </Button>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="size-8 text-foreground/80 hover:text-foreground hover:bg-foreground/20"
+                                onClick={() => { zoom.zoomOut(); scheduleZoomCollapse() }}
+                                disabled={view.scale <= MIN_SCALE + 0.01}
+                                title="Zoom out"
+                            >
+                                <ZoomOut className="size-4" />
+                            </Button>
+                            <div className={cn(
+                                "flex flex-col items-center gap-1 overflow-hidden transition-all duration-200",
+                                view.scale > 1.01 ? "max-h-20 opacity-100" : "max-h-0 opacity-0"
+                            )}>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="size-8 text-foreground/80 hover:text-foreground hover:bg-foreground/20"
+                                    onClick={() => { zoom.reset(); scheduleZoomCollapse() }}
+                                    title="Reset zoom"
+                                >
+                                    <RotateCcw className="size-4" />
+                                </Button>
+                                <span className="text-xs text-foreground/60 px-2 tabular-nums">
+                                    {Math.round(view.scale * 100)}%
+                                </span>
+                            </div>
+                        </div>
+                    ) : (
                         <Button
                             variant="ghost"
                             size="icon"
-                            className="size-8 text-foreground/80 hover:text-foreground hover:bg-foreground/20"
-                            onClick={zoom.reset}
-                            title="Reset zoom"
+                            className="size-9 rounded-full bg-black/60 backdrop-blur-sm text-foreground/70 hover:text-foreground hover:bg-black/70 opacity-80 transition-all duration-200"
+                            onClick={openZoomControls}
+                            title="Zoom"
                         >
-                            <RotateCcw className="size-4" />
+                            <ZoomIn className="size-4" />
                         </Button>
-                        <span className="text-xs text-foreground/60 px-2 tabular-nums">
-                            {Math.round(view.scale * 100)}%
-                        </span>
-                    </div>
+                    )}
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Problem

On mobile, four control clusters were overlaid **on top of** the game capture (the screenshot players must identify), obscuring image content needed to guess:

| Control | Old position |
|---------|-------------|
| Timer | top-left corner |
| Score + End Game | top-right corner |
| **Zoom +/-** | **left edge, vertically centered** |
| Report/Flag | bottom-right corner |

The timer, score, and report controls already sit in corners and ride the existing edge gradient. The **zoom cluster was the worst offender** — it floated at the left-center of the image, directly on the rule-of-thirds focal point, covering live content in both reported screenshots.

## Approach

A workflow of two subagents (a mobile-UX design pass studying the real screenshots + a code-constraints mapping pass) converged on the same fix: **evacuate the center**. The cleanest, lowest-risk, highest-impact win is to move zoom into a corner rather than undertake a heavier HUD-bar refactor that would steal vertical height from the already-short mobile capture (and would risk the E2E selectors tied to the `SCORE` text and `role="timer"`).

## Change

`packages/frontend/src/components/ui/game-carousel.tsx`:

- **Relocated** the zoom cluster from `top-1/2 left-4` (left-center) to `bottom-4 left-4` (bottom-left corner).
- **Collapsed** it to a single low-opacity button by default; it expands on tap and **auto-collapses after ~2.5s idle**. While the image is zoomed in (`scale > 1`) the cluster stays open so **reset** remains one tap away.
- Pinch-to-zoom and drag-to-pan are unaffected — the buttons remain a secondary, discoverable affordance.

## Result

Controls now sit cleanly in the four corners (timer TL · score TR · zoom BL · report BR) with the **entire center of the capture unobstructed**, and the bottom-left corner itself is mostly clear thanks to the collapsed button.

## Verification

- `npm run build:types` + `npm run build:frontend` — typecheck/build pass
- `npm run lint` — pass
- Unit tests run green via the husky pre-commit hook

> Note: a manual mobile spot-check of the expand/collapse interaction and the new corner placement is still worth doing before marking ready for review.


---
_Generated by [Claude Code](https://claude.ai/code/session_019DDWF2AiPwGyJggcT3H6Zy)_