### PR TITLE
feat(profile): raise avatar upload limit from 5MB to 10MB

### DIFF
--- a/packages/backend/src/presentation/middleware/upload.middleware.ts
+++ b/packages/backend/src/presentation/middleware/upload.middleware.ts
@@ -40,12 +40,12 @@ const imageFileFilter = (
   }
 }
 
-// Avatar upload middleware (max 5MB)
+// Avatar upload middleware (max 10MB)
 export const avatarUpload = multer({
   storage: avatarStorage,
   fileFilter: imageFileFilter,
   limits: {
-    fileSize: 5 * 1024 * 1024, // 5MB
+    fileSize: 10 * 1024 * 1024, // 10MB
   },
 })
 

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2121,9 +2121,9 @@
       "selectImage": "Choose an image",
       "upload": "Upload",
       "remove": "Remove",
-      "sizeHint": "JPEG, PNG, GIF or WebP. Max 5MB.",
+      "sizeHint": "JPEG, PNG, GIF or WebP. Max 10MB.",
       "invalidType": "Invalid file type. Only JPEG, PNG, GIF, and WebP images are allowed.",
-      "fileTooLarge": "File is too large. Maximum size is 5MB.",
+      "fileTooLarge": "File is too large. Maximum size is 10MB.",
       "uploadError": "Failed to upload avatar. Please try again.",
       "deleteError": "Failed to remove avatar. Please try again."
     }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2121,9 +2121,9 @@
       "selectImage": "Choisir une image",
       "upload": "Télécharger",
       "remove": "Supprimer",
-      "sizeHint": "JPEG, PNG, GIF ou WebP. Max 5 Mo.",
+      "sizeHint": "JPEG, PNG, GIF ou WebP. Max 10 Mo.",
       "invalidType": "Type de fichier invalide. Seuls les formats JPEG, PNG, GIF et WebP sont autorisés.",
-      "fileTooLarge": "Le fichier est trop volumineux. La taille maximum est de 5 Mo.",
+      "fileTooLarge": "Le fichier est trop volumineux. La taille maximum est de 10 Mo.",
       "uploadError": "Échec du téléchargement de l'avatar. Veuillez réessayer.",
       "deleteError": "Échec de la suppression de l'avatar. Veuillez réessayer."
     }

--- a/packages/frontend/src/components/profile/AvatarUpload.tsx
+++ b/packages/frontend/src/components/profile/AvatarUpload.tsx
@@ -22,7 +22,7 @@ interface AvatarUploadProps {
   onAvatarChange: (newAvatarUrl: string | null) => void
 }
 
-const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
 
 interface AvatarUploadState {


### PR DESCRIPTION
## Contexte

La limite d'upload de 5 Mo pour l'image de profil était trop basse. Elle passe à **10 Mo**.

## Changements

La limite était définie à 4 endroits, tous mis à jour de façon cohérente :

- `packages/backend/src/presentation/middleware/upload.middleware.ts` — limite multer `fileSize` 5 → 10 MB (validation serveur, la source de vérité)
- `packages/frontend/src/components/profile/AvatarUpload.tsx` — constante `MAX_FILE_SIZE` 5 → 10 MB (validation client avant envoi)
- `packages/frontend/public/locales/fr/translation.json` — `sizeHint` et `fileTooLarge` : « Max 10 Mo »
- `packages/frontend/public/locales/en/translation.json` — `sizeHint` et `fileTooLarge` : « Max 10MB »

## Notes

- L'upload d'avatar passe en `multipart/form-data` via multer, donc le `express.json({ limit: '256kb' })` global ne le plafonne pas.
- Les types de fichiers acceptés (JPEG, PNG, GIF, WebP) sont inchangés.

https://claude.ai/code/session_01X8aoZaY69TxQpYJiX7BztP

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8aoZaY69TxQpYJiX7BztP)_