### PR TITLE
feat(notifications): personalized evening nudge with the day's leader

### DIFF
--- a/packages/backend/migrations/20260610_add_evening_nudge_cooldown.ts
+++ b/packages/backend/migrations/20260610_add_evening_nudge_cooldown.ts
@@ -1,0 +1,27 @@
+import type { Knex } from 'knex'
+
+/**
+ * Supports the personalized "beat the leader" evening nudge.
+ *
+ * - `last_evening_nudge_at` mirrors `last_streak_risk_email_at`: the cooldown
+ *   timestamp the recurring evening-nudge worker stamps on enqueue so a BullMQ
+ *   retry (or a second container) can't double-push the same user.
+ * - `feature_in_notifications` is the leader's *featuring* opt-out. It is
+ *   deliberately separate from `email_marketing_consent` (which governs whether
+ *   a user *receives* mail) — this flag governs whether a user's name may be
+ *   *mentioned* in other people's notifications when they top the board. Ships
+ *   defaulted-on; the profile toggle UI is a fast-follow.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.timestamp('last_evening_nudge_at', { useTz: true }).nullable()
+    table.boolean('feature_in_notifications').notNullable().defaultTo(true)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user', (table) => {
+    table.dropColumn('last_evening_nudge_at')
+    table.dropColumn('feature_in_notifications')
+  })
+}

--- a/packages/backend/src/domain/services/display-name-safety.test.ts
+++ b/packages/backend/src/domain/services/display-name-safety.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isDisplayNameSafe } from './display-name-safety.js'
+
+describe('isDisplayNameSafe', () => {
+  it('accepts ordinary display names', () => {
+    for (const name of ['PixelHero', 'Marie-Claire', 'xX_Gamer_Xx', 'José', '日本語']) {
+      assert.equal(isDisplayNameSafe(name), true, `expected safe: ${name}`)
+    }
+  })
+
+  it('rejects empty / whitespace / nullish', () => {
+    assert.equal(isDisplayNameSafe(''), false)
+    assert.equal(isDisplayNameSafe('   '), false)
+    assert.equal(isDisplayNameSafe(null), false)
+    assert.equal(isDisplayNameSafe(undefined), false)
+  })
+
+  it('rejects profanity regardless of case', () => {
+    assert.equal(isDisplayNameSafe('FuCkER'), false)
+    assert.equal(isDisplayNameSafe('grosse merde'), false)
+  })
+
+  it('rejects accented slurs after diacritic stripping', () => {
+    // "enculé" → normalized "encule" hits the blocklist.
+    assert.equal(isDisplayNameSafe('Enculé'), false)
+  })
+
+  it('rejects brand / authority impersonation', () => {
+    assert.equal(isDisplayNameSafe('admin'), false)
+    assert.equal(isDisplayNameSafe('TheBox Official'), false)
+    assert.equal(isDisplayNameSafe('support'), false)
+  })
+
+  it('rejects names containing links', () => {
+    assert.equal(isDisplayNameSafe('visit evil.com'), false)
+    assert.equal(isDisplayNameSafe('http://x'), false)
+  })
+
+  it('rejects absurdly long names', () => {
+    assert.equal(isDisplayNameSafe('a'.repeat(41)), false)
+  })
+})

--- a/packages/backend/src/domain/services/display-name-safety.ts
+++ b/packages/backend/src/domain/services/display-name-safety.ts
@@ -1,0 +1,60 @@
+/**
+ * Display-name safety gate for outbound notifications.
+ *
+ * The "beat the leader" nudge interpolates a *user-chosen* display name into an
+ * email / push sent to many other players. Broadcasting an unmoderated string
+ * under our brand is a trust-and-safety risk (slurs, impersonation), so the
+ * leader's name is only featured when it passes this gate — otherwise the
+ * caller falls back to score-only generic copy.
+ *
+ * Pure and dependency-free so it is trivially unit-testable. The matching is a
+ * deliberately blunt substring check over an accent-stripped, lowercased form:
+ * over-blocking is acceptable here (we just drop to generic copy), whereas a
+ * single slur reaching thousands of inboxes is not.
+ */
+
+// Lowercased, diacritic-stripped substrings that disqualify a name. Kept
+// representative rather than exhaustive — the fallback is safe generic copy,
+// and the list can grow without touching callers.
+const BLOCKED_SUBSTRINGS: readonly string[] = [
+  // English profanity / slurs
+  'fuck', 'shit', 'bitch', 'cunt', 'nigger', 'nigga', 'faggot', 'fag',
+  'rape', 'rapist', 'nazi', 'hitler', 'asshole', 'whore', 'slut', 'pedo',
+  'pedophile', 'retard',
+  // French profanity / slurs (accent-stripped forms)
+  'merde', 'putain', 'salope', 'connard', 'connasse', 'encule', 'enfoire',
+  'pute', 'batard', 'nique', 'pede', 'tapette', 'negre', 'bougnoule',
+  // Brand / authority impersonation
+  'admin', 'administrator', 'moderator', 'modo', 'thebox', 'the box',
+  'official', 'officiel', 'support', 'staff', 'systeme', 'system',
+]
+
+const MAX_REASONABLE_LENGTH = 40
+
+function normalize(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // strip combining diacritics
+    .toLowerCase()
+}
+
+/**
+ * Returns true when `name` is safe to feature verbatim in an outbound
+ * notification. Empty / whitespace-only names, names containing a URL, and
+ * names hitting the blocklist are rejected.
+ */
+export function isDisplayNameSafe(name: string | null | undefined): boolean {
+  if (!name) return false
+  const trimmed = name.trim()
+  if (trimmed.length === 0) return false
+  if (trimmed.length > MAX_REASONABLE_LENGTH) return false
+
+  const normalized = normalize(trimmed)
+
+  // No links — a name like "win at evil.example" must never be broadcast.
+  if (normalized.includes('http') || normalized.includes('www.') || normalized.includes('.com')) {
+    return false
+  }
+
+  return !BLOCKED_SUBSTRINGS.some((bad) => normalized.includes(bad))
+}

--- a/packages/backend/src/domain/services/evening-nudge-copy.test.ts
+++ b/packages/backend/src/domain/services/evening-nudge-copy.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildEveningNudge,
+  truncateDisplayName,
+} from './evening-nudge-copy.js'
+
+describe('buildEveningNudge', () => {
+  it('named leader (fr) interpolates name + grouped score and stays gender-neutral', () => {
+    const { title, body } = buildEveningNudge('fr', {
+      leaderName: 'PixelHero',
+      leaderScore: 4820,
+    })
+    assert.match(title, /défi du jour/)
+    assert.ok(body.includes('PixelHero'))
+    // FR groups thousands with a narrow no-break space (U+202F); match any separator.
+    assert.match(body, /4\s820/, `expected grouped score, got: ${body}`)
+    // No gendered past-participle agreement on the player.
+    assert.doesNotMatch(body, /détrôné|battu·e|le coiffer/)
+  })
+
+  it('named leader (en) interpolates name + comma-grouped score', () => {
+    const { body } = buildEveningNudge('en', {
+      leaderName: 'PixelHero',
+      leaderScore: 12345,
+    })
+    assert.ok(body.includes('PixelHero'))
+    assert.ok(body.includes('12,345'))
+    assert.ok(/lead/i.test(body))
+  })
+
+  it('anon leader (name null) uses score-only copy and never an empty name slot', () => {
+    const fr = buildEveningNudge('fr', { leaderName: null, leaderScore: 900 })
+    assert.ok(fr.body.includes('900'))
+    assert.doesNotMatch(fr.body, /null|undefined/)
+    assert.doesNotMatch(fr.body, /\bmène\b/) // not the named-leader phrasing
+
+    const en = buildEveningNudge('en', { leaderName: null, leaderScore: 900 })
+    assert.ok(en.body.includes('900'))
+    assert.ok(/top score/i.test(en.body))
+  })
+
+  it('empty board (score null) tells the recipient to be the first', () => {
+    const fr = buildEveningNudge('fr', { leaderName: null, leaderScore: null })
+    assert.ok(/première personne|premier/i.test(fr.body))
+
+    const en = buildEveningNudge('en', { leaderName: null, leaderScore: null })
+    assert.ok(/be the first/i.test(en.body))
+  })
+
+  it('empty board ignores a stray name when there is no score', () => {
+    const { body } = buildEveningNudge('fr', { leaderName: 'Ghost', leaderScore: null })
+    assert.doesNotMatch(body, /Ghost/)
+  })
+})
+
+describe('truncateDisplayName', () => {
+  it('passes short names through untouched', () => {
+    assert.equal(truncateDisplayName('PixelHero'), 'PixelHero')
+  })
+
+  it('ellipsizes names longer than the cap', () => {
+    const out = truncateDisplayName('A'.repeat(40))
+    assert.ok(out.endsWith('…'))
+    assert.ok(out.length <= 20)
+  })
+
+  it('trims surrounding whitespace', () => {
+    assert.equal(truncateDisplayName('  Neo  '), 'Neo')
+  })
+})

--- a/packages/backend/src/domain/services/evening-nudge-copy.ts
+++ b/packages/backend/src/domain/services/evening-nudge-copy.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure copy builder for the personalized evening "play today's challenge"
+ * nudge. No infrastructure imports — the worker resolves the leader, applies
+ * the safety / opt-out gate, then asks this module for the strings.
+ *
+ * Three branches, driven entirely by the context shape so each is unit-testable
+ * in isolation:
+ *   - named leader  → `leaderName` + `leaderScore` present  ("beat {name}")
+ *   - anon leader   → `leaderScore` present, `leaderName` null (name unsafe or
+ *                     opted out of featuring → score-only, privacy-safe)
+ *   - empty board   → `leaderScore` null (nobody has played yet → "be first")
+ *
+ * The self-leader case is handled by the caller (it never sends to today's
+ * leader in v1), so it is intentionally absent here.
+ */
+
+export type EveningNudgeLocale = 'fr' | 'en'
+
+export interface EveningNudgeContext {
+  /** Safe, already-truncated leader display name, or null for score-only / empty. */
+  leaderName: string | null
+  /** Today's top score, or null when nobody has played yet. */
+  leaderScore: number | null
+}
+
+export interface EveningNudgeCopy {
+  title: string
+  body: string
+}
+
+const MAX_NAME_LENGTH = 20
+
+/**
+ * Trim and ellipsize a display name so it can't blow past push-title limits
+ * (the OS hard-truncates around ~40 chars and a long name would eat the body).
+ */
+export function truncateDisplayName(name: string, max = MAX_NAME_LENGTH): string {
+  const trimmed = name.trim()
+  if (trimmed.length <= max) return trimmed
+  return `${trimmed.slice(0, max - 1).trimEnd()}…`
+}
+
+/** Group thousands deterministically (no ICU dependency, stable across envs). */
+function formatScore(score: number, locale: EveningNudgeLocale): string {
+  const sep = locale === 'fr' ? ' ' : ',' // narrow no-break space for fr
+  return Math.round(score).toString().replace(/\B(?=(\d{3})+(?!\d))/g, sep)
+}
+
+export function buildEveningNudge(
+  locale: EveningNudgeLocale,
+  ctx: EveningNudgeContext,
+): EveningNudgeCopy {
+  const fr = locale === 'fr'
+  const title = fr ? "Le défi du jour t'attend 🎮" : "Today's challenge is waiting 🎮"
+
+  // Empty board — nobody has set a score yet.
+  if (ctx.leaderScore == null) {
+    return {
+      title,
+      body: fr
+        ? 'Personne n’a encore joué aujourd’hui. Sois la première personne à poser un score !'
+        : 'Nobody has played today yet. Be the first to set a score!',
+    }
+  }
+
+  const score = formatScore(ctx.leaderScore, locale)
+
+  // Named leader — the personalized case the feature was requested for.
+  if (ctx.leaderName) {
+    return {
+      title,
+      body: fr
+        ? `${ctx.leaderName} mène avec ${score} pts. À toi de jouer avant minuit pour reprendre la tête !`
+        : `${ctx.leaderName} leads with ${score} pts. Play before midnight to take the lead!`,
+    }
+  }
+
+  // Anonymous leader — score is public, but the name is unsafe or opted out.
+  return {
+    title,
+    body: fr
+      ? `Le meilleur score du jour est de ${score} pts. À toi de jouer avant minuit pour le battre !`
+      : `Today's top score is ${score} pts. Play before midnight and beat it!`,
+  }
+}

--- a/packages/backend/src/domain/services/leaderboard.service.test.ts
+++ b/packages/backend/src/domain/services/leaderboard.service.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createLeaderboardService } from './leaderboard.service.js'
+import type { DomainLogger } from '../ports/logger.js'
+import type { ChallengeRepository, LeaderboardRepository } from '../ports/index.js'
+import type { LeaderboardEntry } from '@the-box/types'
+
+const silentLogger: DomainLogger = {
+  child: () => silentLogger,
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+}
+
+function makeService(opts: {
+  challengeForDate?: { id: number } | null
+  entries?: LeaderboardEntry[]
+}) {
+  const challengeRepository = {
+    findByDate: async () => opts.challengeForDate ?? null,
+  } as unknown as ChallengeRepository
+
+  let lastLimit: number | undefined
+  const leaderboardRepository = {
+    findByChallenge: async (_id: number, limit?: number) => {
+      lastLimit = limit
+      return opts.entries ?? []
+    },
+  } as unknown as LeaderboardRepository
+
+  const service = createLeaderboardService({
+    logger: silentLogger,
+    challengeRepository,
+    leaderboardRepository,
+  })
+  return { service, getLastLimit: () => lastLimit }
+}
+
+const leaderEntry: LeaderboardEntry = {
+  rank: 1,
+  userId: 'user-1',
+  username: 'pixel',
+  displayName: 'PixelHero',
+  totalScore: 4820,
+}
+
+describe('leaderboardService.getTodayLeader', () => {
+  it('returns null when there is no challenge today', async () => {
+    const { service } = makeService({ challengeForDate: null })
+    assert.equal(await service.getTodayLeader(), null)
+  })
+
+  it('returns null when nobody has completed a ranked session', async () => {
+    const { service } = makeService({ challengeForDate: { id: 7 }, entries: [] })
+    assert.equal(await service.getTodayLeader(), null)
+  })
+
+  it('projects the rank-1 entry and fetches only one row', async () => {
+    const { service, getLastLimit } = makeService({
+      challengeForDate: { id: 7 },
+      entries: [leaderEntry],
+    })
+    const leader = await service.getTodayLeader()
+    assert.deepEqual(leader, {
+      userId: 'user-1',
+      displayName: 'PixelHero',
+      totalScore: 4820,
+    })
+    assert.equal(getLastLimit(), 1, 'should ask the repository for a single row')
+  })
+})

--- a/packages/backend/src/domain/services/leaderboard.service.ts
+++ b/packages/backend/src/domain/services/leaderboard.service.ts
@@ -5,11 +5,23 @@ import type {
   LeaderboardRepository,
 } from '../ports/index.js'
 
+/** Minimal projection of today's rank-1 player for outbound nudges. */
+export interface TodayLeader {
+  userId: string
+  displayName: string
+  totalScore: number
+}
+
 export interface LeaderboardService {
   getTodayLeaderboard(): Promise<LeaderboardResponse>
   getLeaderboardByDate(date: string): Promise<LeaderboardResponse>
   getTodayPercentile(score: number): Promise<PercentileResponse>
   getMonthlyLeaderboard(year: number, month: number): Promise<MonthlyLeaderboardResponse>
+  /**
+   * Today's title holder (rank 1), or null when there is no challenge or
+   * nobody has completed a ranked session yet. Cheap — fetches a single row.
+   */
+  getTodayLeader(): Promise<TodayLeader | null>
 }
 
 export interface LeaderboardServiceDeps {
@@ -70,6 +82,25 @@ export function createLeaderboardService(deps: LeaderboardServiceDeps): Leaderbo
         date,
         challengeId: challenge.id,
         entries,
+      }
+    },
+
+    async getTodayLeader(): Promise<TodayLeader | null> {
+      const today = new Date().toISOString().split('T')[0]!
+
+      const challenge = await challengeRepository.findByDate(today)
+      if (!challenge) return null
+
+      // findByChallenge is already deterministically tie-broken (score desc →
+      // fastest finish → user id) and excludes anonymous + catch-up sessions,
+      // so the first row is unambiguously today's leader. Fetch just one.
+      const [leader] = await leaderboardRepository.findByChallenge(challenge.id, 1)
+      if (!leader) return null
+
+      return {
+        userId: leader.userId,
+        displayName: leader.displayName,
+        totalScore: leader.totalScore,
       }
     },
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -369,6 +369,7 @@ async function start(): Promise<void> {
       'cleanup-anonymous-users',
       'recalculate-scores',
       'streak-risk-email',
+      'evening-nudge',
       'relance-email',
       'inactive-user-reminder',
       'streak-freeze-grant',
@@ -490,6 +491,26 @@ async function start(): Promise<void> {
       logger.info('scheduled recurring streak-risk-email job (daily at 19:00 UTC)')
     } catch (error) {
       logger.warn({ error: String(error) }, 'failed to schedule recurring streak-risk-email job')
+    }
+
+    // Schedule recurring evening-nudge push (daily at 18:00 UTC ~ evening
+    // Europe). Personalizes the "play today's challenge" reminder with the
+    // current title holder. Runs an hour before the streak-risk email; its
+    // candidate query excludes users who will get that email, so no user is
+    // double-nudged. A later slot means the leader/score is more "real" while
+    // still leaving a comfortable window before the midnight UTC reset.
+    try {
+      await importQueue.add(
+        'evening-nudge',
+        {},
+        {
+          repeat: { pattern: '0 18 * * *', tz: 'UTC' },
+          jobId: 'evening-nudge-recurring',
+        }
+      )
+      logger.info('scheduled recurring evening-nudge job (daily at 18:00 UTC)')
+    } catch (error) {
+      logger.warn({ error: String(error) }, 'failed to schedule recurring evening-nudge job')
     }
 
     // Schedule recurring relance (re-engagement) email for users with an

--- a/packages/backend/src/infrastructure/queue/workers/evening-nudge-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/evening-nudge-logic.ts
@@ -1,0 +1,133 @@
+import { db } from '../../database/connection.js'
+import { queueLogger } from '../../logger/logger.js'
+import { pushService } from '../../../domain/services/push.service.js'
+import { buildEveningNudge } from '../../../domain/services/evening-nudge-copy.js'
+import { loadFeaturedLeader } from './featured-leader.js'
+
+const log = queueLogger.child({ worker: 'evening-nudge' })
+
+// Don't re-push the same user within this window even if the job runs twice
+// (retry, or a second container). Mirrors the streak-risk cooldown.
+const MIN_HOURS_BETWEEN_NUDGES = 20
+
+// Don't greet brand-new accounts with a stranger's name on day one.
+const MIN_ACCOUNT_AGE_DAYS = 2
+
+export interface EveningNudgeResult {
+  candidates: number
+  enqueued: number
+  failed: number
+  leaderFeatured: boolean
+  message: string
+}
+
+interface NudgeCandidate {
+  id: string
+  locale: string | null
+}
+
+/**
+ * Users who should get tonight's "beat the leader" push:
+ *   - have at least one active push subscription,
+ *   - are a real (non-anonymous) account older than {@link MIN_ACCOUNT_AGE_DAYS},
+ *   - have NOT played today's challenge,
+ *   - are outside the per-user cooldown,
+ *   - are not today's leader (also implied by "not played today"),
+ *   - are NOT going to receive tonight's streak-risk email — mutual exclusion
+ *     so a single user never gets both evening nudges. The streak-risk worker
+ *     targets `current_streak >= 1 AND email_marketing_consent AND not played
+ *     today`; those users get the (leader-enhanced) email instead.
+ */
+async function findCandidates(leaderUserId: string | null): Promise<NudgeCandidate[]> {
+  let query = db('user')
+    .join('push_subscriptions', 'push_subscriptions.user_id', 'user.id')
+    .where('push_subscriptions.is_active', true)
+    .whereRaw('"user"."isAnonymous" = ?', [false])
+    .whereRaw('(last_played_at IS NULL OR last_played_at < CURRENT_DATE)')
+    .whereRaw(
+      `(last_evening_nudge_at IS NULL OR last_evening_nudge_at < NOW() - INTERVAL '${MIN_HOURS_BETWEEN_NUDGES} hours')`
+    )
+    .whereRaw(`"user"."createdAt" < NOW() - INTERVAL '${MIN_ACCOUNT_AGE_DAYS} days'`)
+    .whereRaw('NOT (current_streak >= 1 AND COALESCE(email_marketing_consent, false) = true)')
+
+  if (leaderUserId) {
+    query = query.whereNot('user.id', leaderUserId)
+  }
+
+  const rows = await query.distinct<NudgeCandidate[]>('user.id as id', 'user.locale as locale')
+  return rows
+}
+
+async function sendOne(
+  candidate: NudgeCandidate,
+  leaderName: string | null,
+  leaderScore: number | null
+): Promise<'enqueued' | 'failed'> {
+  const locale = candidate.locale === 'en' ? 'en' : 'fr'
+  const { title, body } = buildEveningNudge(locale, { leaderName, leaderScore })
+
+  try {
+    await pushService.sendToUser(candidate.id, {
+      type: 'evening_nudge',
+      title,
+      body,
+      url: `/${locale}/play`,
+    })
+    // Stamp on enqueue (push is fire-and-forget via the fan-out worker); the
+    // cooldown makes a re-run a no-op for already-stamped users.
+    await db('user').where('id', candidate.id).update({ last_evening_nudge_at: new Date() })
+    return 'enqueued'
+  } catch (err) {
+    log.warn({ userId: candidate.id, err: String(err) }, 'evening-nudge enqueue failed')
+    return 'failed'
+  }
+}
+
+/**
+ * Recurring evening push that pulls players back to today's daily challenge,
+ * personalized with the current title holder. Fetches the leader ONCE, then
+ * fans out to candidates. Empty board → privacy-safe "be the first" copy;
+ * unsafe / opted-out leader name → score-only copy.
+ */
+export async function sendEveningNudges(
+  onProgress?: (current: number, total: number) => void
+): Promise<EveningNudgeResult> {
+  if (!pushService.isConfigured()) {
+    return {
+      candidates: 0,
+      enqueued: 0,
+      failed: 0,
+      leaderFeatured: false,
+      message: 'push not configured; skipping evening-nudge run',
+    }
+  }
+
+  const leader = await loadFeaturedLeader()
+  const candidates = await findCandidates(leader.userId)
+
+  log.info(
+    { count: candidates.length, leaderFeatured: leader.safeName !== null, hasScore: leader.score !== null },
+    'evening-nudge candidates identified'
+  )
+
+  let enqueued = 0
+  let failed = 0
+
+  for (let i = 0; i < candidates.length; i++) {
+    const outcome = await sendOne(candidates[i]!, leader.safeName, leader.score)
+    if (outcome === 'enqueued') enqueued++
+    else failed++
+    onProgress?.(i + 1, candidates.length)
+  }
+
+  const message = `evening-nudge: ${enqueued} enqueued, ${failed} failed (of ${candidates.length} candidates)`
+  log.info({ candidates: candidates.length, enqueued, failed }, message)
+
+  return {
+    candidates: candidates.length,
+    enqueued,
+    failed,
+    leaderFeatured: leader.safeName !== null,
+    message,
+  }
+}

--- a/packages/backend/src/infrastructure/queue/workers/featured-leader.ts
+++ b/packages/backend/src/infrastructure/queue/workers/featured-leader.ts
@@ -1,0 +1,48 @@
+import { db } from '../../database/connection.js'
+import { leaderboardService } from '../../../domain/services/index.js'
+import { isDisplayNameSafe } from '../../../domain/services/display-name-safety.js'
+import { truncateDisplayName } from '../../../domain/services/evening-nudge-copy.js'
+
+/**
+ * Resolves today's title holder into the shape outbound nudges actually need,
+ * applying the two privacy gates the meeting made launch blockers:
+ *   1. the leader's display name must pass {@link isDisplayNameSafe};
+ *   2. the leader must not have opted out via `feature_in_notifications`.
+ *
+ * When either gate fails we still surface the (public) score so callers can
+ * fall back to score-only copy — only the *name* is withheld.
+ *
+ * Shared by the evening-nudge push worker and the streak-risk email worker so
+ * the gate is applied identically in both places.
+ */
+export interface FeaturedLeader {
+  /** Rank-1 user id, or null when nobody has played today. */
+  userId: string | null
+  /** Today's top score, or null when nobody has played today. */
+  score: number | null
+  /** Safe, truncated name to feature, or null (unsafe / opted out / empty). */
+  safeName: string | null
+}
+
+const EMPTY: FeaturedLeader = { userId: null, score: null, safeName: null }
+
+export async function loadFeaturedLeader(): Promise<FeaturedLeader> {
+  const leader = await leaderboardService.getTodayLeader()
+  if (!leader) return EMPTY
+
+  if (!isDisplayNameSafe(leader.displayName)) {
+    return { userId: leader.userId, score: leader.totalScore, safeName: null }
+  }
+
+  const row = await db('user')
+    .where('id', leader.userId)
+    .select<{ feature_in_notifications: boolean }>('feature_in_notifications')
+    .first()
+  const optedOut = row?.feature_in_notifications === false
+
+  return {
+    userId: leader.userId,
+    score: leader.totalScore,
+    safeName: optedOut ? null : truncateDisplayName(leader.displayName),
+  }
+}

--- a/packages/backend/src/infrastructure/queue/workers/import.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/import.worker.ts
@@ -10,6 +10,7 @@ import { cleanupAnonymousUsers } from './cleanup-anonymous-logic.js'
 import { processRecalculateScoresJob } from './recalculate-scores-logic.js'
 import { clearDailyData } from './clear-daily-data-logic.js'
 import { sendStreakRiskEmails } from './streak-risk-email-logic.js'
+import { sendEveningNudges } from './evening-nudge-logic.js'
 import { sendRelanceEmails } from './relance-email-logic.js'
 import { sendInactiveUserReminderEmails } from './inactive-user-reminder-logic.js'
 import { sendReferralAnnouncementEmails } from './referral-announcement-email-logic.js'
@@ -318,6 +319,20 @@ export const importWorker = new Worker<JobData, JobResult>(
         }
 
         log.info({ jobId: id, result }, 'streak-risk-email job completed')
+        return jobResult
+      }
+
+      if (name === 'evening-nudge') {
+        const result = await sendEveningNudges((current, total) => {
+          const progress = total > 0 ? Math.round((current / total) * 100) : 0
+          job.updateProgress(progress)
+        })
+
+        const jobResult: JobResult = {
+          message: result.message,
+        }
+
+        log.info({ jobId: id, result }, 'evening-nudge job completed')
         return jobResult
       }
 

--- a/packages/backend/src/infrastructure/queue/workers/streak-risk-email-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/streak-risk-email-logic.ts
@@ -3,6 +3,7 @@ import { env } from '../../../config/env.js'
 import { queueLogger } from '../../logger/logger.js'
 import { sendEmail } from '../../email/email-sender.js'
 import { renderEmailHtml, renderEmailText } from '../../email/template.js'
+import { loadFeaturedLeader } from './featured-leader.js'
 
 const log = queueLogger.child({ worker: 'streak-risk-email' })
 
@@ -58,31 +59,47 @@ function plural(n: number): string {
   return n > 1 ? 's' : ''
 }
 
-function buildHtml(displayName: string, streak: number, playUrl: string, unsubscribeUrl: string): string {
+function buildHtml(
+  displayName: string,
+  streak: number,
+  playUrl: string,
+  unsubscribeUrl: string,
+  leaderLine: string | null
+): string {
+  const paragraphs = [
+    `Tu n'as pas encore joué au défi d'aujourd'hui. Sans action avant minuit, ta série de <strong style="color:#f0abfc;">${streak} jour${plural(streak)}</strong> repartira à zéro.`,
+  ]
+  if (leaderLine) paragraphs.push(leaderLine)
   return renderEmailHtml({
     heading: `Ta série de ${streak} jour${plural(streak)} est en danger, ${displayName} !`,
-    paragraphs: [
-      `Tu n'as pas encore joué au défi d'aujourd'hui. Sans action avant minuit, ta série de <strong style="color:#f0abfc;">${streak} jour${plural(streak)}</strong> repartira à zéro.`,
-    ],
+    paragraphs,
     cta: { label: 'Jouer le défi du jour', url: playUrl },
     tip: 'Astuce : invite un ami avec ton lien de parrainage et gagnez tous les deux des indices bonus.',
     footerHtml: `Tu reçois cet e-mail car tu as accepté les notifications marketing. <a href="${unsubscribeUrl}" style="color:#a78bfa;">Se désabonner</a>.`,
   })
 }
 
-function buildText(displayName: string, streak: number, playUrl: string, unsubscribeUrl: string): string {
+function buildText(
+  displayName: string,
+  streak: number,
+  playUrl: string,
+  unsubscribeUrl: string,
+  leaderLine: string | null
+): string {
+  const paragraphs = [
+    `Tu n'as pas encore joué au défi d'aujourd'hui. Sans action avant minuit, ta série de ${streak} jour${plural(streak)} repartira à zéro.`,
+  ]
+  if (leaderLine) paragraphs.push(leaderLine)
   return renderEmailText({
     heading: `Ta série de ${streak} jour${plural(streak)} est en danger, ${displayName} !`,
-    paragraphs: [
-      `Tu n'as pas encore joué au défi d'aujourd'hui. Sans action avant minuit, ta série de ${streak} jour${plural(streak)} repartira à zéro.`,
-    ],
+    paragraphs,
     cta: { label: 'Jouer le défi du jour', url: playUrl },
     tip: 'Astuce : invite un ami avec ton lien de parrainage et gagnez tous les deux des indices bonus.',
     footerLines: [`Se désabonner : ${unsubscribeUrl}`],
   })
 }
 
-async function sendOne(user: StreakCandidate): Promise<'sent' | 'skipped' | 'failed'> {
+async function sendOne(user: StreakCandidate, leaderLine: string | null): Promise<'sent' | 'skipped' | 'failed'> {
   const displayName = user.display_name ?? user.name
   const playUrl = `${env.FRONTEND_URL}/fr/play`
   const unsubscribeUrl = `${env.FRONTEND_URL}/fr/profile`
@@ -92,8 +109,8 @@ async function sendOne(user: StreakCandidate): Promise<'sent' | 'skipped' | 'fai
     userId: user.id,
     to: user.email,
     subject: `Ta série de ${user.current_streak} jour${plural(user.current_streak)} est en danger`,
-    html: buildHtml(displayName, user.current_streak, playUrl, unsubscribeUrl),
-    text: buildText(displayName, user.current_streak, playUrl, unsubscribeUrl),
+    html: buildHtml(displayName, user.current_streak, playUrl, unsubscribeUrl, leaderLine),
+    text: buildText(displayName, user.current_streak, playUrl, unsubscribeUrl, leaderLine),
   })
 
   if (result.status === 'sent') {
@@ -108,12 +125,19 @@ export async function sendStreakRiskEmails(
   const candidates = await findCandidates()
   log.info({ count: candidates.length }, 'streak-risk candidates identified')
 
+  // Personalize with today's title holder when one can safely be featured.
+  // Streak-risk recipients haven't played today, so they are never the leader.
+  const leader = await loadFeaturedLeader()
+  const leaderLine = leader.safeName
+    ? `Et pour te motiver : ${leader.safeName} est en tête du classement du jour avec ${leader.score} pts. Reprends ta place avant minuit !`
+    : null
+
   let sent = 0
   let skipped = 0
   let failed = 0
 
   for (let i = 0; i < candidates.length; i++) {
-    const outcome = await sendOne(candidates[i]!)
+    const outcome = await sendOne(candidates[i]!, leaderLine)
     if (outcome === 'sent') sent++
     else if (outcome === 'skipped') skipped++
     else failed++


### PR DESCRIPTION
## What

Implements the **personalized evening play-reminder** designed in the subagent meeting ([`tasks/evening-nudge-leader-subagents-meeting.html`](https://github.com/Wifsimster/the-box/blob/main/tasks/evening-nudge-leader-subagents-meeting.html), merged in #282). The evening nudge now names today's title holder:

> *« Venez battre {name} qui mène avec {score} pts — à toi de jouer avant minuit pour reprendre la tête ! »*

Follows the meeting's decisions: **both channels**, **one leader lookup per run**, **privacy gates as launch blockers**, and **mutual exclusion** so no one is double-nudged.

## Changes

| Area | File | Notes |
|---|---|---|
| **DB** | `migrations/20260610_add_evening_nudge_cooldown.ts` | `last_evening_nudge_at` (20 h cooldown) + `feature_in_notifications` (leader featuring opt-out, default on) |
| **Domain** | `leaderboard.service.ts` | `getTodayLeader()` → rank-1 player in a single row, reusing the deterministic, anon/catch-up-excluding `findByChallenge` |
| **Domain** | `evening-nudge-copy.ts` | Pure fr/en copy builder: named-leader / score-only / empty-board branches, deterministic thousands grouping, name truncation |
| **Domain** | `display-name-safety.ts` | Profanity/blocklist + impersonation + link gate for the featured name |
| **Infra** | `featured-leader.ts` | Resolves the leader through both privacy gates (safe name **and** not opted out); shared by push + email |
| **Worker** | `evening-nudge-logic.ts` | Recurring push fan-out; candidate query excludes played-today, cooldown, <2-day accounts, and users who'll get the streak-risk email |
| **Wiring** | `index.ts`, `import.worker.ts` | New `evening-nudge` cron at **18:00 UTC** (1 h before the email) + dispatch |
| **Email** | `streak-risk-email-logic.ts` | Injects the leader line when one can be safely featured |

## How the decisions map to code

- **Channel = both**: new push job (primary) + leader line in the 19:00 streak-risk email.
- **Mutual exclusion**: push candidate query drops `current_streak >= 1 AND email_marketing_consent` users — they get the (enhanced) email instead.
- **Edge cases**: empty board → "be the first" copy; recipient is leader → excluded by the not-played-today filter (+ explicit `whereNot`); ties → already deterministic; unsafe/opted-out name → score-only copy.
- 🔒 **Privacy launch blockers**: leader name is featured **only if** it passes `isDisplayNameSafe()` **and** `feature_in_notifications` isn't false; otherwise score-only. Column ships day one. **Profile toggle UI is the documented fast-follow.**

## Tests / checks

- ✅ `npm run build` (all packages typecheck)
- ✅ `npm test` — **225 backend tests pass**, including **18 new** (`evening-nudge-copy`, `display-name-safety`, `leaderboard.service.getTodayLeader`)
- ✅ `npm run lint`

## Notes / follow-ups

- Profile toggle UI for `feature_in_notifications` (column is in place).
- Defend-title push to the current leader (copy drafted in the meeting record).

https://claude.ai/code/session_01M51ur3JsdHMayv5s1Ty77y

---
_Generated by [Claude Code](https://claude.ai/code/session_01M51ur3JsdHMayv5s1Ty77y)_