### PR TITLE
feat(game): widen leaderboard answers dialog + average guess time

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -336,6 +336,7 @@
     "totalScore": "Total Score",
     "correctAnswers": "Correct Answers",
     "accuracy": "Accuracy",
+    "averageTime": "Avg. time",
     "scoreQuality": {
       "label": "Score quality",
       "mastered": "Mastered",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -336,6 +336,7 @@
     "totalScore": "Score Total",
     "correctAnswers": "Bonnes Réponses",
     "accuracy": "Précision",
+    "averageTime": "Temps moyen",
     "scoreQuality": {
       "label": "Qualité du score",
       "mastered": "Maîtrisé",

--- a/packages/frontend/src/components/game/SessionDetails.tsx
+++ b/packages/frontend/src/components/game/SessionDetails.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
-import { Trophy, Target } from 'lucide-react'
+import { Trophy, Target, Clock } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
@@ -9,6 +9,7 @@ import { PercentileBanner } from '@/components/game/PercentileBanner'
 import { ShareCard } from '@/components/game/ShareCard'
 import { SessionResultsList } from '@/components/game/SessionResultsList'
 import { countCorrect, computeAccuracy } from '@/lib/sessionResults'
+import { formatDiscoveryTime } from '@/lib/utils'
 import type { GuessResult } from '@/types'
 
 export interface SessionDetailsProps {
@@ -44,6 +45,11 @@ export interface SessionDetailsProps {
 
   /** Skip the surrounding Card (used inside a dialog that is already a panel). */
   bare?: boolean
+  /**
+   * `compact` shrinks the hero and lays the results out in two columns —
+   * tuned for the leaderboard dialog. Pages use the roomy `comfortable`.
+   */
+  density?: 'comfortable' | 'compact'
   reducedMotion?: boolean
 }
 
@@ -72,6 +78,7 @@ export function SessionDetails({
   shareEnabled = false,
   actions,
   bare = false,
+  density = 'comfortable',
   reducedMotion = false,
 }: SessionDetailsProps) {
   const { t } = useTranslation()
@@ -80,16 +87,33 @@ export function SessionDetails({
   const isZero = totalScore === 0
   const showZeroState = isZero && Boolean(zeroScore)
 
+  // Mean discovery time across the positions the player actually found.
+  const timed = results.filter(r => r.isCorrect && r.timeTakenMs > 0)
+  const averageTimeMs = timed.length
+    ? Math.round(timed.reduce((sum, r) => sum + r.timeTakenMs, 0) / timed.length)
+    : null
+
+  const compact = density === 'compact'
+  const iconWrapSize = compact ? 'size-12 sm:size-14' : 'size-14 sm:size-20'
+  const iconSize = compact ? 'size-6 sm:size-7' : 'size-7 sm:size-10'
+  const titleCls = compact
+    ? 'text-lg sm:text-2xl font-bold mb-1 sm:mb-2'
+    : 'text-xl sm:text-3xl md:text-4xl font-bold mb-1.5 sm:mb-3'
+  const scoreCls = compact
+    ? 'text-3xl sm:text-4xl font-bold mb-1.5 sm:mb-2'
+    : 'text-4xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-2 sm:mb-4'
+
   const list = (
     <SessionResultsList
       results={results}
       totalScreenshots={totalScreenshots}
       reducedMotion={reducedMotion}
+      columns={compact ? 2 : 1}
     />
   )
 
   return (
-    <div className="space-y-4 sm:space-y-6">
+    <div className={compact ? 'space-y-3 sm:space-y-4' : 'space-y-4 sm:space-y-6'}>
       {/* Score hero */}
       <m.div
         initial={reducedMotion ? false : { opacity: 0, y: 20 }}
@@ -99,10 +123,10 @@ export function SessionDetails({
       >
         {showZeroState ? (
           <div
-            className="inline-flex items-center justify-center size-14 sm:size-20 mb-2 sm:mb-4 rounded-full bg-secondary border border-border"
+            className={`inline-flex items-center justify-center ${iconWrapSize} mb-2 sm:mb-4 rounded-full bg-secondary border border-border`}
             aria-hidden="true"
           >
-            <Target className="size-7 sm:size-10 text-muted-foreground" />
+            <Target className={`${iconSize} text-muted-foreground`} />
           </div>
         ) : (
           <>
@@ -111,13 +135,13 @@ export function SessionDetails({
               animate={{ scale: 1 }}
               transition={{ duration: reducedMotion ? 0 : 0.5, delay: reducedMotion ? 0 : 0.2, type: reducedMotion ? 'tween' : 'spring' }}
               style={{ boxShadow: isPersonalBest ? 'var(--glow-lg)' : 'var(--glow-md)' }}
-              className={`inline-flex items-center justify-center size-14 sm:size-20 mb-2 sm:mb-4 rounded-full bg-linear-to-br ${isPersonalBest
+              className={`inline-flex items-center justify-center ${iconWrapSize} mb-2 sm:mb-4 rounded-full bg-linear-to-br ${isPersonalBest
                 ? 'from-medal-gold to-medal-gold/70'
                 : 'from-neon-purple to-neon-pink'
                 }`}
               aria-hidden="true"
             >
-              <Trophy className="size-7 sm:size-10 text-white" />
+              <Trophy className={`${iconSize} text-white`} />
             </m.div>
             {isPersonalBest && (
               <div className="mb-2">
@@ -141,7 +165,7 @@ export function SessionDetails({
             <p className="text-xs sm:text-sm text-muted-foreground mb-2 sm:mb-4">{heroTitle}</p>
           </>
         ) : (
-          <h1 className="text-xl sm:text-3xl md:text-4xl font-bold mb-1.5 sm:mb-3 gradient-gaming bg-clip-text text-transparent">
+          <h1 className={`${titleCls} gradient-gaming bg-clip-text text-transparent`}>
             {heroTitle}
           </h1>
         )}
@@ -150,7 +174,7 @@ export function SessionDetails({
           initial={reducedMotion ? false : { opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: reducedMotion ? 0 : 0.5, delay: reducedMotion ? 0 : 0.4 }}
-          className={`text-4xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-2 sm:mb-4 ${isZero
+          className={`${scoreCls} ${isZero
             ? 'text-muted-foreground'
             : isPersonalBest
               ? 'text-medal-gold'
@@ -161,7 +185,7 @@ export function SessionDetails({
           {totalScore} pts
         </m.div>
 
-        <div className="flex justify-center gap-4 sm:gap-6 md:gap-8 text-muted-foreground">
+        <div className="flex justify-center gap-3 sm:gap-6 md:gap-8 text-muted-foreground">
           <div className="flex flex-col items-center">
             <div className="flex items-baseline gap-1">
               <span className="text-foreground font-bold text-lg sm:text-xl md:text-2xl">{correctAnswers}</span>
@@ -174,6 +198,18 @@ export function SessionDetails({
             <span className="text-foreground font-bold text-lg sm:text-xl md:text-2xl">{accuracy}%</span>
             <p className="text-xs sm:text-sm mt-1">{t('game.accuracy')}</p>
           </div>
+          {averageTimeMs !== null && (
+            <>
+              <Separator orientation="vertical" className="h-8 sm:h-10 md:h-12" />
+              <div className="flex flex-col items-center">
+                <span className="flex items-center gap-1 text-foreground font-bold text-lg sm:text-xl md:text-2xl">
+                  <Clock className="size-4 sm:size-5 text-muted-foreground" aria-hidden="true" />
+                  {formatDiscoveryTime(averageTimeMs)}
+                </span>
+                <p className="text-xs sm:text-sm mt-1">{t('game.averageTime')}</p>
+              </div>
+            </>
+          )}
         </div>
       </m.div>
 

--- a/packages/frontend/src/components/game/SessionResultsList.tsx
+++ b/packages/frontend/src/components/game/SessionResultsList.tsx
@@ -20,14 +20,21 @@ export function SessionResultsList({
   results,
   totalScreenshots,
   reducedMotion = false,
+  columns = 1,
 }: {
   results: GuessResult[]
   totalScreenshots: number
   reducedMotion?: boolean
+  /** Lay the rows out in two balanced columns on wider screens (≥ md). */
+  columns?: 1 | 2
 }) {
   const { t } = useTranslation()
+  // Multi-column relies on CSS columns; framer's per-item x-transform can
+  // confuse `break-inside-avoid`, so the slide-in is dropped in that mode.
+  const isGrid = columns === 2
+  const animate = !reducedMotion && !isGrid
   return (
-    <ul className="space-y-2 sm:space-y-3 list-none">
+    <ul className={isGrid ? 'list-none gap-4 md:columns-2' : 'space-y-2 sm:space-y-3 list-none'}>
       {results.map((result, index) => {
         const isUnguessed =
           !result.isCorrect && result.userGuess === null && result.scoreEarned === -50
@@ -39,10 +46,10 @@ export function SessionResultsList({
         return (
           <m.li
             key={result.position}
-            initial={reducedMotion ? false : { opacity: 0, x: -20 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: reducedMotion ? 0 : 0.3, delay: reducedMotion ? 0 : index * 0.05 }}
-            className={`flex items-start gap-2 sm:gap-3 p-2.5 sm:p-3 rounded-lg ${isUnguessed ? 'bg-destructive/10 border border-destructive/20' : 'bg-secondary/50'
+            initial={animate ? { opacity: 0, x: -20 } : false}
+            animate={animate ? { opacity: 1, x: 0 } : undefined}
+            transition={animate ? { duration: 0.3, delay: index * 0.05 } : undefined}
+            className={`flex items-start gap-2 sm:gap-3 p-2.5 sm:p-3 rounded-lg ${isGrid ? 'break-inside-avoid mb-4' : ''} ${isUnguessed ? 'bg-destructive/10 border border-destructive/20' : 'bg-secondary/50'
               }`}
           >
             <span className="text-muted-foreground text-sm sm:text-base w-5 sm:w-6 shrink-0 pt-0.5" aria-hidden="true">{result.position}.</span>

--- a/packages/frontend/src/components/leaderboard/PlayerAnswersDialog.tsx
+++ b/packages/frontend/src/components/leaderboard/PlayerAnswersDialog.tsx
@@ -66,9 +66,9 @@ export function PlayerAnswersDialog({
 
   return (
     <ResponsiveDialog open={!!selectedPlayer} onOpenChange={(open) => !open && onClose()}>
-      <ResponsiveDialogContent className="sm:max-w-2xl">
+      <ResponsiveDialogContent className="sm:max-w-4xl">
         <ResponsiveDialogHeader>
-          <ResponsiveDialogTitle className="flex items-center gap-3 min-w-0 pr-8">
+          <ResponsiveDialogTitle className="flex items-center gap-3 min-w-0 pr-12">
             {selectedPlayer && (
               <>
                 <Avatar className="size-8 shrink-0">
@@ -108,6 +108,7 @@ export function PlayerAnswersDialog({
             totalPlayers={totalPlayers > 0 ? totalPlayers : null}
             shareEnabled={isOwn}
             reducedMotion={reducedMotion}
+            density="compact"
             bare
           />
         )}


### PR DESCRIPTION
## Why

The leaderboard answers dialog (`Réponses de …`) was capped at `max-w-2xl` and rendered its 10 results as a single tall column, so on a wide screen it was narrow with a long scrollbar. It was also missing average guess time as a stat.

## What changed

- **Wider dialog** — `max-w-4xl` on desktop.
- **Two-column results** — `SessionResultsList` gained a `columns` prop; the dialog flows the 10 rows into two balanced columns (CSS multi-column, ≥ md), roughly halving the height. The per-row slide-in is dropped in column mode so `break-inside-avoid` stays clean.
- **Compact density** — `SessionDetails` gained `density="compact"` (smaller hero, tighter spacing) used by the dialog. The `/results` and `/history` pages keep the roomy `comfortable` layout, untouched.
- **Average guess time** — new stat (mean discovery time over found positions) shown next to *Correct answers* and *Accuracy* on every session view (results, history, dialog). New i18n key `game.averageTime` (fr "Temps moyen" / en "Avg. time").

All layout changes are prop-gated, so the two pages render exactly as before; only the dialog opts into the compact two-column treatment.

## Notes

- Considered a sticky header / two-pane split but dropped them: can't visually verify here, and the width + 2-col + compact changes already make the dialog short enough that it rarely scrolls. Lower-risk wins shipped instead.

## Verification

- `tsc -b` (frontend): clean (only the pre-existing repo-wide `baseUrl` deprecation).
- `npm run lint`: clean.
- `npm test`: 225 + 25 pass.

Manual visual pass on the dialog at desktop and mobile widths recommended before un-drafting.

https://claude.ai/code/session_0196FRQhWgtdhfyk9N6j1fMv

---
_Generated by [Claude Code](https://claude.ai/code/session_0196FRQhWgtdhfyk9N6j1fMv)_