### PR TITLE
fix(game): stop leaderboard answers dialog overflowing horizontally

### DIFF
--- a/packages/frontend/src/components/game/SessionDetails.tsx
+++ b/packages/frontend/src/components/game/SessionDetails.tsx
@@ -113,7 +113,7 @@ export function SessionDetails({
   )
 
   return (
-    <div className={compact ? 'space-y-3 sm:space-y-4' : 'space-y-4 sm:space-y-6'}>
+    <div className={`min-w-0 ${compact ? 'space-y-3 sm:space-y-4' : 'space-y-4 sm:space-y-6'}`}>
       {/* Score hero */}
       <m.div
         initial={reducedMotion ? false : { opacity: 0, y: 20 }}

--- a/packages/frontend/src/components/game/SessionResultsList.tsx
+++ b/packages/frontend/src/components/game/SessionResultsList.tsx
@@ -29,12 +29,13 @@ export function SessionResultsList({
   columns?: 1 | 2
 }) {
   const { t } = useTranslation()
-  // Multi-column relies on CSS columns; framer's per-item x-transform can
-  // confuse `break-inside-avoid`, so the slide-in is dropped in that mode.
+  // Two-column uses CSS grid with minmax(0,1fr) tracks (Tailwind grid-cols-2)
+  // so each column has a definite width and the row contents can truncate —
+  // CSS multi-column leaves children unconstrained and overflows instead.
   const isGrid = columns === 2
   const animate = !reducedMotion && !isGrid
   return (
-    <ul className={isGrid ? 'list-none gap-4 md:columns-2' : 'space-y-2 sm:space-y-3 list-none'}>
+    <ul className={isGrid ? 'list-none grid grid-cols-1 md:grid-cols-2 gap-2 sm:gap-3' : 'space-y-2 sm:space-y-3 list-none'}>
       {results.map((result, index) => {
         const isUnguessed =
           !result.isCorrect && result.userGuess === null && result.scoreEarned === -50
@@ -49,7 +50,7 @@ export function SessionResultsList({
             initial={animate ? { opacity: 0, x: -20 } : false}
             animate={animate ? { opacity: 1, x: 0 } : undefined}
             transition={animate ? { duration: 0.3, delay: index * 0.05 } : undefined}
-            className={`flex items-start gap-2 sm:gap-3 p-2.5 sm:p-3 rounded-lg ${isGrid ? 'break-inside-avoid mb-4' : ''} ${isUnguessed ? 'bg-destructive/10 border border-destructive/20' : 'bg-secondary/50'
+            className={`flex items-start gap-2 sm:gap-3 p-2.5 sm:p-3 rounded-lg ${isGrid ? 'min-w-0' : ''} ${isUnguessed ? 'bg-destructive/10 border border-destructive/20' : 'bg-secondary/50'
               }`}
           >
             <span className="text-muted-foreground text-sm sm:text-base w-5 sm:w-6 shrink-0 pt-0.5" aria-hidden="true">{result.position}.</span>


### PR DESCRIPTION
## Problem

After widening the leaderboard answers dialog to two columns (#287), a **horizontal scrollbar** appeared and the dialog grew past `max-w-4xl`, with long game titles clipped at the viewport edge.

## Cause

The two-column layout used **CSS multi-column** (`columns-2`). Multi-column gives its children no definite width, so the flex rows computed their min-content from the *full, untruncated* game titles — the list ballooned wider than the dialog and forced overflow (and, via grid `min-width: auto`, pushed the dialog itself wider than its max-width).

## Fix

- Results now use a **CSS grid** (`grid-cols-1 md:grid-cols-2`). Tailwind's `grid-cols-2` resolves to `minmax(0, 1fr)` tracks, giving each column a constrained width so the existing `truncate` on the title actually takes effect.
- Added `min-w-0` to the `SessionDetails` root so it shrinks to the dialog width instead of being held open by its content.

Net: no horizontal scrollbar, dialog stays at `max-w-4xl`, titles truncate cleanly.

## Verification

- `tsc -b` (frontend): clean.
- `npm run lint`: clean.
- `npm test`: 225 + 25 pass.

https://claude.ai/code/session_0196FRQhWgtdhfyk9N6j1fMv

---
_Generated by [Claude Code](https://claude.ai/code/session_0196FRQhWgtdhfyk9N6j1fMv)_