### PR TITLE
fix(i18n): close translation gaps across game and admin workflows

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -48,7 +48,8 @@
       "first": "1st place",
       "second": "2nd place",
       "third": "3rd place"
-    }
+    },
+    "menuDescription": "Site navigation and account links"
   },
   "nav": {
     "primary": "Primary navigation",
@@ -441,7 +442,8 @@
       "totalScore": "Your Total Score",
       "penaltyApplied": "Penalty",
       "finalScore": "Final Score",
-      "points": "points"
+      "points": "points",
+      "error": "Failed to end the game. Please try again."
     },
     "hints": {
       "yearTooltip": "Show release year (-20%)",
@@ -463,7 +465,8 @@
       "developerHint": "Developer",
       "genreHint": "Genre",
       "penalty": "-20%",
-      "penaltyApplied": "Hint penalty: -{{penalty}} points"
+      "penaltyApplied": "Hint penalty: -{{penalty}} points",
+      "percentagePenalty": "20% penalty"
     },
     "secondChance": {
       "title": "Activate a second chance?",
@@ -487,7 +490,11 @@
       "gamesRemaining_other": "{{count}} games left to guess",
       "continuePlaying": "Continue Playing",
       "seeResults": "See Results"
-    }
+    },
+    "submit": "Submit guess",
+    "guessCorrect": "Correct guess!",
+    "guessIncorrect": "Incorrect guess. Try again.",
+    "wrongGuessPenalty": "Wrong guess penalty: -{{penalty}} pts"
   },
   "home": {
     "title": "The Box",
@@ -762,7 +769,18 @@
         "candidateCount_other": "{{count}} candidates",
         "selected": "Selected",
         "choose": "Choose",
-        "refetch": "Refetch"
+        "refetch": "Refetch",
+        "refetchSource": "Re-fetch ({{source}})"
+      },
+      "startConfirm": {
+        "title": "Start the global fetch?",
+        "body": "All curated and resolved games will be queued. The server caps the queue at 1000 games maximum.",
+        "confirm": "Start"
+      },
+      "cancelConfirm": {
+        "title": "Cancel the ongoing ingestion?",
+        "body": "Tasks already running will finish. All pending tasks (maps:*) will be removed from the queue.",
+        "confirm": "Cancel all"
       }
     },
     "emailLog": {
@@ -1447,7 +1465,12 @@
         "streakRiskEmail": "Sends an alert email to players whose daily streak is about to expire, encouraging them to come back and play.",
         "relanceEmail": "Sends a re-engagement email to registered users who haven't played yet, encouraging them to try their first challenge.",
         "inactiveUserReminder": "Sends a win-back email to long-inactive users to invite them back to the platform.",
-        "default": "Automatic system scheduled task."
+        "default": "Automatic system scheduled task.",
+        "createWeeklyTournament": "Creates a new weekly tournament so players can compete on a fresh weekly leaderboard.",
+        "endWeeklyTournament": "Closes the active weekly tournament, finalizes rankings, and awards the winners.",
+        "createMonthlyTournament": "Creates a new monthly tournament so players can compete on a fresh monthly leaderboard.",
+        "endMonthlyTournament": "Closes the active monthly tournament, finalizes rankings, and awards the winners.",
+        "sendTournamentReminders": "Sends reminder emails to participants about ongoing tournaments and approaching deadlines."
       },
       "categories": {
         "Challenge": "Challenge",
@@ -1475,6 +1498,16 @@
         "title": "Sync Job Already Running",
         "description": "A sync-all job is already in progress or paused. Would you like to cancel it and start a new one?",
         "cancelAndRestart": "Cancel & Restart"
+      },
+      "statusLabel": "Status",
+      "expand": "Expand",
+      "minimize": "Minimize",
+      "remove": "Remove",
+      "filter": {
+        "all": "All",
+        "active": "Active",
+        "completed": "Done",
+        "failed": "Failed"
       }
     },
     "fullImport": {
@@ -1637,7 +1670,8 @@
       "recipientEmailPlaceholder": "Enter email address",
       "emailRequired": "Please enter a recipient email address",
       "invalidEmail": "Please enter a valid email address"
-    }
+    },
+    "cancel": "Cancel"
   },
   "pricing": {
     "title": "The Box Premium",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -48,7 +48,8 @@
       "first": "1re place",
       "second": "2e place",
       "third": "3e place"
-    }
+    },
+    "menuDescription": "Navigation du site et liens du compte"
   },
   "nav": {
     "primary": "Navigation principale",
@@ -441,7 +442,8 @@
       "totalScore": "Votre Score Total",
       "penaltyApplied": "Pénalité",
       "finalScore": "Score final",
-      "points": "points"
+      "points": "points",
+      "error": "Échec de la fin de partie. Veuillez réessayer."
     },
     "hints": {
       "yearTooltip": "Afficher l'année de sortie (-20%)",
@@ -463,7 +465,8 @@
       "developerHint": "Développeur",
       "genreHint": "Genre",
       "penalty": "-20%",
-      "penaltyApplied": "Pénalité d'indice : -{{penalty}} points"
+      "penaltyApplied": "Pénalité d'indice : -{{penalty}} points",
+      "percentagePenalty": "pénalité de 20 %"
     },
     "secondChance": {
       "title": "Activer une seconde chance ?",
@@ -487,7 +490,11 @@
       "gamesRemaining_other": "{{count}} jeux restants à deviner",
       "continuePlaying": "Continuer à jouer",
       "seeResults": "Voir les résultats"
-    }
+    },
+    "submit": "Valider la proposition",
+    "guessCorrect": "Bonne réponse !",
+    "guessIncorrect": "Mauvaise réponse. Réessayez.",
+    "wrongGuessPenalty": "Pénalité de mauvaise réponse : -{{penalty}} pts"
   },
   "home": {
     "title": "The Box",
@@ -762,7 +769,18 @@
         "candidateCount_other": "{{count}} candidates",
         "selected": "Sélectionnée",
         "choose": "Choisir",
-        "refetch": "Re-récupérer"
+        "refetch": "Re-récupérer",
+        "refetchSource": "Re-récupérer ({{source}})"
+      },
+      "startConfirm": {
+        "title": "Lancer la récupération globale ?",
+        "body": "Tous les jeux curés et résolus seront mis en file. Le serveur tronque la file à 1000 jeux maximum.",
+        "confirm": "Lancer"
+      },
+      "cancelConfirm": {
+        "title": "Annuler l'ingestion en cours ?",
+        "body": "Les tâches déjà actives terminent leur exécution. Toutes les tâches en attente (maps:*) seront supprimées de la file.",
+        "confirm": "Tout annuler"
       }
     },
     "emailLog": {
@@ -1447,7 +1465,12 @@
         "streakRiskEmail": "Envoie un email d'alerte aux joueurs dont la série quotidienne est sur le point d'expirer afin de les inciter à revenir jouer.",
         "relanceEmail": "Envoie un email de relance aux utilisateurs inscrits qui n'ont pas encore joué pour les encourager à essayer leur premier défi.",
         "inactiveUserReminder": "Envoie un email de réactivation aux utilisateurs inactifs depuis longtemps pour les inviter à revenir sur la plateforme.",
-        "default": "Tâche planifiée automatique du système."
+        "default": "Tâche planifiée automatique du système.",
+        "createWeeklyTournament": "Crée un nouveau tournoi hebdomadaire pour que les joueurs s'affrontent sur un classement hebdomadaire inédit.",
+        "endWeeklyTournament": "Clôture le tournoi hebdomadaire en cours, finalise les classements et récompense les gagnants.",
+        "createMonthlyTournament": "Crée un nouveau tournoi mensuel pour que les joueurs s'affrontent sur un classement mensuel inédit.",
+        "endMonthlyTournament": "Clôture le tournoi mensuel en cours, finalise les classements et récompense les gagnants.",
+        "sendTournamentReminders": "Envoie des e-mails de rappel aux participants concernant les tournois en cours et les échéances à venir."
       },
       "categories": {
         "Challenge": "Défi",
@@ -1475,6 +1498,16 @@
         "title": "Synchronisation déjà en cours",
         "description": "Une tâche de synchronisation est déjà en cours ou en pause. Voulez-vous l'annuler et en démarrer une nouvelle ?",
         "cancelAndRestart": "Annuler et relancer"
+      },
+      "statusLabel": "Statut",
+      "expand": "Agrandir",
+      "minimize": "Réduire",
+      "remove": "Supprimer",
+      "filter": {
+        "all": "Tous",
+        "active": "Actifs",
+        "completed": "Terminés",
+        "failed": "Échoués"
       }
     },
     "games": {
@@ -1637,7 +1670,8 @@
       "recipientEmailPlaceholder": "Entrez l'adresse email",
       "emailRequired": "Veuillez entrer une adresse email destinataire",
       "invalidEmail": "Veuillez entrer une adresse email valide"
-    }
+    },
+    "cancel": "Annuler"
   },
   "pricing": {
     "title": "The Box Premium",

--- a/packages/frontend/src/components/admin/JobRow.tsx
+++ b/packages/frontend/src/components/admin/JobRow.tsx
@@ -365,7 +365,7 @@ export function JobRow({ job, isExpanded, isJobLoading, onToggle, onTrigger }: J
                   <Loader2 className="size-3.5 text-neon-blue shrink-0 animate-spin" />
                   <div className="flex flex-col">
                     <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
-                      {t('admin.jobs.status')}
+                      {t('admin.jobs.statusLabel')}
                     </span>
                     <span className="text-xs font-medium text-neon-blue/80">
                       {t('admin.jobs.running')}


### PR DESCRIPTION
## Summary

A review of the end-to-end user workflow surfaced a cluster of i18n discrepancies where translation keys were referenced in code but absent from both locale files. Because every call relied on an inline `defaultValue` (or no fallback at all), the gaps were invisible at build time but leaked the wrong language — or a raw key — to real users.

Concretely:

- **French players (primary language) saw English** in the game UI: the submit `aria-label`, the correct / incorrect guess screen-reader announcements, the wrong-guess penalty, the hint percentage penalty, and the end-game error toast.
- **English admins saw French**: the geo-fetch start/cancel confirm dialogs and the `Cancel` button fell back to French strings (`Annuler`, `Lancer`, …).
- **Tournament job descriptions rendered raw keys**: `admin.jobs.descriptions.{create,end}{Weekly,Monthly}Tournament` and `sendTournamentReminders` had *no* fallback, so the admin job panel displayed `admin.jobs.descriptions.createWeeklyTournament` verbatim.
- **The active-job Status label was broken**: `t('admin.jobs.status')` resolved to the status *object*, rendering the key instead of a label.

## Changes

- Added the **28 missing keys** to both `en` and `fr` `translation.json`, keeping the files at full key parity (2055 ⇄ 2055):
  - Game UI: `game.submit`, `game.guessCorrect`, `game.guessIncorrect`, `game.wrongGuessPenalty`, `game.hints.percentagePenalty`, `game.endGame.error`, `common.menuDescription`
  - Admin jobs: `statusLabel`, `expand`, `minimize`, `remove`, `filter.{all,active,completed,failed}`, and the five tournament `descriptions.*`
  - Geo-fetch: `startConfirm.{title,body,confirm}`, `cancelConfirm.{title,body,confirm}`, `drawer.refetchSource`, and `admin.cancel`
- Pointed `JobRow.tsx` at the new `admin.jobs.statusLabel` key so the active-job status renders a real label.

## Verification

- `npm run build:frontend` — clean (types rebuilt first)
- `npm run lint` — clean
- `npm test` — 25/25 pass
- Re-ran a key-usage audit: **0** statically-referenced keys remain missing from the locales, and en/fr stay at full parity.

https://claude.ai/code/session_019HqP6dY3exDToDZzwD98aj

---
_Generated by [Claude Code](https://claude.ai/code/session_019HqP6dY3exDToDZzwD98aj)_