### PR TITLE
fix: deep project review — persist hint usage, UTC streaks, monthly ties, path containment

### DIFF
--- a/packages/backend/migrations/20260611_add_hint_from_inventory_to_guesses.ts
+++ b/packages/backend/migrations/20260611_add_hint_from_inventory_to_guesses.ts
@@ -1,0 +1,23 @@
+import type { Knex } from 'knex'
+
+/**
+ * Records whether the hint attached to a guess was paid for from inventory
+ * (or granted free via premium catch-up) rather than via the 20 % score
+ * penalty. `power_up_used` alone can't distinguish the two cases, and both
+ * the session-details view and the admin score-recalculation worker need to
+ * know which guesses actually carried a penalty.
+ *
+ * Historical rows predate `power_up_used` being persisted at all, so they
+ * stay NULL/false — no backfill is possible.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('guesses', (table) => {
+    table.boolean('hint_from_inventory').notNullable().defaultTo(false)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('guesses', (table) => {
+    table.dropColumn('hint_from_inventory')
+  })
+}

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -188,6 +188,7 @@ export interface GuessWithGameRecord {
   sessionElapsedMs: number
   scoreEarned: number
   powerUpUsed: string | null
+  hintFromInventory: boolean
   correctGameId: number
   correctGameName: string
   correctGameSlug: string
@@ -243,6 +244,8 @@ export interface SessionRepository {
     isCorrect: boolean
     sessionElapsedMs: number
     scoreEarned: number
+    powerUpUsed: string | null
+    hintFromInventory: boolean
   }): Promise<void>
   getCorrectAnswersCount(tierSessionId: string): Promise<number>
   hasCorrectGuessForPosition(tierSessionId: string, position: number): Promise<boolean>

--- a/packages/backend/src/domain/services/game.service.submit-guess.test.ts
+++ b/packages/backend/src/domain/services/game.service.submit-guess.test.ts
@@ -31,8 +31,14 @@ const TOTAL_SCREENSHOTS = 10
  *     `round_position === position`, which is never cleared after a correct
  *     guess), re-banking score and inserting another correct row.
  */
-function buildHarness() {
-  const guesses: Array<{ position: number; isCorrect: boolean }> = []
+function buildHarness(opts: { hintInInventory?: boolean } = {}) {
+  const guesses: Array<{
+    position: number
+    isCorrect: boolean
+    powerUpUsed: string | null
+    hintFromInventory: boolean
+    scoreEarned: number
+  }> = []
   const tierSession = {
     id: 'tier-1',
     user_id: 'user-1',
@@ -50,8 +56,20 @@ function buildHarness() {
   const sessionRepository = {
     withTierSessionLock: async <T>(_id: string, fn: () => Promise<T>) => fn(),
     findTierSessionWithContext: async () => ({ ...tierSession }),
-    saveGuess: async (data: { position: number; isCorrect: boolean }) => {
-      guesses.push({ position: data.position, isCorrect: data.isCorrect })
+    saveGuess: async (data: {
+      position: number
+      isCorrect: boolean
+      powerUpUsed: string | null
+      hintFromInventory: boolean
+      scoreEarned: number
+    }) => {
+      guesses.push({
+        position: data.position,
+        isCorrect: data.isCorrect,
+        powerUpUsed: data.powerUpUsed,
+        hintFromInventory: data.hintFromInventory,
+        scoreEarned: data.scoreEarned,
+      })
     },
     // Mirrors the repository: number of DISTINCT positions with a correct
     // guess. The just-saved guess is already visible here (autocommitted on a
@@ -103,7 +121,7 @@ function buildHarness() {
       updateStreak: async () => {},
       updateScore: async () => {},
     },
-    inventoryRepository: { useItems: async () => false },
+    inventoryRepository: { useItems: async () => !!opts.hintInInventory },
     gameRepository: { getGenresById: async () => [] },
     funnelEventRepository: { record: async () => {} },
     positionSecondChanceRepository: { findPending: async () => null },
@@ -111,7 +129,11 @@ function buildHarness() {
 
   const service = createGameService(deps)
 
-  const submit = (position: number, text: string) => {
+  const submit = (
+    position: number,
+    text: string,
+    powerUpUsed?: 'hint_year' | 'hint_publisher' | 'hint_developer' | 'hint_genre'
+  ) => {
     // Simulate the client fetching the screenshot for `position`, which is the
     // only thing that stamps the round timer server-side.
     tierSession.round_position = position
@@ -124,6 +146,7 @@ function buildHarness() {
       guessText: text,
       roundTimeTakenMs: 5000,
       userId: 'user-1',
+      powerUpUsed,
     })
   }
 
@@ -182,5 +205,39 @@ describe('game.service submitGuess — completion tally', () => {
     const correct = await h.submit(1, 'right')
     assert.equal(correct.isCorrect, true)
     assert.equal(correct.screenshotsFound, 1)
+  })
+})
+
+describe('game.service submitGuess — hint persistence', () => {
+  it('persists powerUpUsed and the penalty path when the hint is not in inventory', async () => {
+    const h = buildHarness({ hintInInventory: false })
+    const res = await h.submit(1, 'right', 'hint_genre')
+    assert.equal(res.isCorrect, true)
+
+    const saved = h.guesses[0]!
+    assert.equal(saved.powerUpUsed, 'hint_genre', 'hint type must be persisted on the guess row')
+    assert.equal(saved.hintFromInventory, false)
+    // 5s round → 1.5x multiplier → 150 points, minus the 20% hint penalty (30).
+    assert.equal(saved.scoreEarned, 120, 'score must carry the 20% hint penalty')
+    assert.equal(res.hintPenalty, 30)
+  })
+
+  it('persists hintFromInventory=true and skips the penalty when the hint is in inventory', async () => {
+    const h = buildHarness({ hintInInventory: true })
+    const res = await h.submit(1, 'right', 'hint_year')
+    assert.equal(res.isCorrect, true)
+
+    const saved = h.guesses[0]!
+    assert.equal(saved.powerUpUsed, 'hint_year')
+    assert.equal(saved.hintFromInventory, true, 'inventory-paid hint must be flagged')
+    assert.equal(saved.scoreEarned, 150, 'inventory hint must not cost score')
+    assert.equal(res.hintFromInventory, true)
+  })
+
+  it('persists powerUpUsed=null for a plain guess', async () => {
+    const h = buildHarness()
+    await h.submit(1, 'right')
+    assert.equal(h.guesses[0]!.powerUpUsed, null)
+    assert.equal(h.guesses[0]!.hintFromInventory, false)
   })
 })

--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -207,8 +207,13 @@ export function createGameService(deps: GameServiceDeps): GameService {
     userId: string,
     user: { currentStreak: number; longestStreak?: number; lastPlayedAt?: string } | null
   ): Promise<{ currentStreak: number; longestStreak: number }> {
+    // Day boundaries are UTC: challenges are dated by the daily-challenge
+    // worker's getTodayDateUTC() and daily-login streaks compare UTC date
+    // strings. Local midnight (the old behaviour) drifted a day in any TZ
+    // ahead of UTC (e.g. Europe/Paris, the production container TZ), so a
+    // player finishing every UTC day could see daysDiff 0 or 2 instead of 1.
     const today = new Date()
-    today.setHours(0, 0, 0, 0)
+    today.setUTCHours(0, 0, 0, 0)
 
     let currentStreak = user?.currentStreak || 0
     let longestStreak = user?.longestStreak || 0
@@ -220,7 +225,7 @@ export function createGameService(deps: GameServiceDeps): GameService {
       log.info({ userId, currentStreak, longestStreak }, 'First game - streak started')
     } else {
       const lastPlayed = new Date(lastPlayedAtStr)
-      lastPlayed.setHours(0, 0, 0, 0)
+      lastPlayed.setUTCHours(0, 0, 0, 0)
 
       const daysDiff = Math.floor((today.getTime() - lastPlayed.getTime()) / (1000 * 60 * 60 * 24))
 

--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -754,6 +754,8 @@ export function createGameService(deps: GameServiceDeps): GameService {
       // actually drove the score, not the client's self-report.
       sessionElapsedMs: effectiveTimeTakenMs,
       scoreEarned,
+      powerUpUsed: data.powerUpUsed ?? null,
+      hintFromInventory,
     })
 
     if (pendingSecondChanceActivationId !== null) {

--- a/packages/backend/src/domain/services/user.service.ts
+++ b/packages/backend/src/domain/services/user.service.ts
@@ -94,11 +94,16 @@ export function createUserService(deps: UserServiceDeps): UserService {
         }))
 
         if (correctGuess) {
-          // Calculate hint penalty (20% of score if hint was used)
+          // Calculate hint penalty (20% of score if hint was used). All four
+          // hint types carry the penalty, but only when the hint was NOT paid
+          // from inventory (inventory/premium hints are free).
           let hintPenalty: number | undefined
           if (
-            correctGuess.powerUpUsed === 'hint_year' ||
-            correctGuess.powerUpUsed === 'hint_publisher'
+            !correctGuess.hintFromInventory &&
+            (correctGuess.powerUpUsed === 'hint_year' ||
+              correctGuess.powerUpUsed === 'hint_publisher' ||
+              correctGuess.powerUpUsed === 'hint_developer' ||
+              correctGuess.powerUpUsed === 'hint_genre')
           ) {
             // The score_earned already has hint penalty deducted, so we need to calculate original
             // Original score = scoreEarned / 0.8, hint penalty = original * 0.2

--- a/packages/backend/src/infrastructure/queue/workers/recalculate-scores-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/recalculate-scores-logic.ts
@@ -97,7 +97,8 @@ function calculateSpeedMultiplier(timeTakenMs: number): number {
 function calculateGuessScore(
     isCorrect: boolean,
     timeTakenMs: number,
-    powerUpUsed: string | null
+    powerUpUsed: string | null,
+    hintFromInventory: boolean
 ): number {
     if (!isCorrect) {
         return 0
@@ -108,8 +109,15 @@ function calculateGuessScore(
     // Cap max score per screenshot at 200 points
     scoreEarned = Math.min(scoreEarned, 200)
 
-    // Calculate hint penalty as 20% of earned score (after speed multiplier)
-    if (powerUpUsed === 'hint_year' || powerUpUsed === 'hint_publisher') {
+    // Calculate hint penalty as 20% of earned score (after speed multiplier).
+    // All four hint types carry the penalty in game.service.ts; hints paid
+    // from inventory (or free premium catch-up hints) carry none.
+    const isHint =
+        powerUpUsed === 'hint_year' ||
+        powerUpUsed === 'hint_publisher' ||
+        powerUpUsed === 'hint_developer' ||
+        powerUpUsed === 'hint_genre'
+    if (isHint && !hintFromInventory) {
         const hintPenalty = Math.round(scoreEarned * HINT_PENALTY_MULTIPLIER)
         scoreEarned -= hintPenalty
     }
@@ -146,6 +154,7 @@ async function recalculateSessionScore(
             'guesses.is_correct',
             'guesses.time_taken_ms',
             'guesses.power_up_used',
+            'guesses.hint_from_inventory',
             'guesses.score_earned as old_guess_score'
         )
         .orderBy('guesses.created_at', 'asc')
@@ -159,7 +168,8 @@ async function recalculateSessionScore(
         const guessScore = calculateGuessScore(
             guess.is_correct,
             guess.time_taken_ms || 0,
-            guess.power_up_used
+            guess.power_up_used,
+            !!guess.hint_from_inventory
         )
         newScore += guessScore
 

--- a/packages/backend/src/infrastructure/repositories/leaderboard.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/leaderboard.repository.ts
@@ -116,17 +116,22 @@ export const leaderboardRepository = {
       // refreshes don't shuffle rows.
       .orderByRaw('SUM(game_sessions.total_score) DESC, game_sessions.user_id ASC')
       .limit(limit)
-      .select<MonthlyLeaderboardRow[]>(
+      .select<(MonthlyLeaderboardRow & { dense_rank: string })[]>(
         'game_sessions.user_id',
         db.raw('SUM(game_sessions.total_score) as total_score'),
         db.raw('COUNT(game_sessions.id) as games_played'),
         'user.username',
         'user.display_name',
-        'user.avatar_url'
+        'user.avatar_url',
+        // DENSE_RANK so tied monthly totals share the same rank, matching
+        // the daily board instead of splitting ties by user id.
+        db.raw(
+          'DENSE_RANK() OVER (ORDER BY SUM(game_sessions.total_score) DESC) as dense_rank'
+        )
       )
 
-    return rows.map((row, index) => ({
-      rank: index + 1,
+    return rows.map((row) => ({
+      rank: Number(row.dense_rank),
       userId: row.user_id,
       username: row.username ?? 'Anonymous',
       displayName: row.display_name ?? row.username ?? 'Anonymous',

--- a/packages/backend/src/infrastructure/repositories/session.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/session.repository.ts
@@ -248,6 +248,8 @@ export const sessionRepository = {
     isCorrect: boolean
     sessionElapsedMs: number
     scoreEarned: number
+    powerUpUsed: string | null
+    hintFromInventory: boolean
   }): Promise<void> {
     log.info(
       {
@@ -269,6 +271,8 @@ export const sessionRepository = {
       time_taken_ms: data.sessionElapsedMs,
       session_elapsed_ms: data.sessionElapsedMs,
       score_earned: data.scoreEarned,
+      power_up_used: data.powerUpUsed,
+      hint_from_inventory: data.hintFromInventory,
     })
   },
 
@@ -420,6 +424,7 @@ export const sessionRepository = {
     sessionElapsedMs: number
     scoreEarned: number
     powerUpUsed: string | null
+    hintFromInventory: boolean
     correctGameId: number
     correctGameName: string
     correctGameSlug: string
@@ -451,6 +456,7 @@ export const sessionRepository = {
           session_elapsed_ms: number
           score_earned: number
           power_up_used: string | null
+          hint_from_inventory: boolean
           correct_game_id: number
           correct_game_name: string
           correct_game_slug: string
@@ -473,6 +479,7 @@ export const sessionRepository = {
         'guesses.session_elapsed_ms',
         'guesses.score_earned',
         'guesses.power_up_used',
+        'guesses.hint_from_inventory',
         'correct_game.id as correct_game_id',
         'correct_game.name as correct_game_name',
         'correct_game.slug as correct_game_slug',
@@ -505,6 +512,7 @@ export const sessionRepository = {
         sessionElapsedMs: row.session_elapsed_ms,
         scoreEarned: row.score_earned,
         powerUpUsed: row.power_up_used,
+        hintFromInventory: row.hint_from_inventory,
         correctGameId: row.correct_game_id,
         correctGameName: row.correct_game_name,
         correctGameSlug: row.correct_game_slug,

--- a/packages/backend/src/presentation/routes/game.routes.ts
+++ b/packages/backend/src/presentation/routes/game.routes.ts
@@ -20,6 +20,19 @@ const router = Router()
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const uploadsPath = path.resolve(__dirname, '..', '..', '..', '..', '..', 'uploads')
 
+// Map a stored `/uploads/...` URL to an absolute file path, refusing any
+// value whose resolved path escapes the uploads directory. imageUrl comes
+// from the DB (admin-managed), but a crafted `/uploads/../...` value must
+// not turn either image route into an arbitrary-file read.
+function resolveUploadFilePath(imageUrl: string): string | null {
+  const relativePath = imageUrl.replace('/uploads/', '')
+  const filePath = path.resolve(uploadsPath, relativePath)
+  if (filePath !== uploadsPath && !filePath.startsWith(uploadsPath + path.sep)) {
+    return null
+  }
+  return filePath
+}
+
 // Resolve today's first easy-tier screenshot. Shared by the public
 // preview endpoints so anonymous visitors can glimpse the challenge
 // before signing up without gaining access to the rest of the set.
@@ -84,8 +97,14 @@ router.get('/preview/image', previewImageLimiter, async (_req, res, next) => {
       return
     }
 
-    const relativePath = preview.imageUrl.replace('/uploads/', '')
-    const filePath = path.join(uploadsPath, relativePath)
+    const filePath = resolveUploadFilePath(preview.imageUrl)
+    if (!filePath) {
+      res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Screenshot not found' },
+      })
+      return
+    }
 
     res.sendFile(
       filePath,
@@ -169,8 +188,14 @@ router.get('/image/:screenshotId', authMiddleware, async (req, res, next) => {
     }
 
     // Convert /uploads/screenshots/... to absolute file path
-    const relativePath = screenshot.imageUrl.replace('/uploads/', '')
-    const filePath = path.join(uploadsPath, relativePath)
+    const filePath = resolveUploadFilePath(screenshot.imageUrl)
+    if (!filePath) {
+      res.status(404).json({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Screenshot not found' },
+      })
+      return
+    }
 
     res.sendFile(filePath, {
       maxAge: '1d',


### PR DESCRIPTION
## Summary

Deep bug-hunting review of the whole project (backend domain/infra/routes + frontend stores/services/hooks). Four verified bugs fixed; several reported suspects were checked and confirmed false alarms (see below).

### 1. `guesses.power_up_used` was never written (highest impact)
The column exists and is **read** by four features, but the only insert path (`saveGuess`) never persisted it, so every row was `NULL`:
- "no hints used" achievements were granted to players who used hints
- the profile hint-usage matrix always showed zeros
- session details never displayed the hint penalty
- the admin **score-recalculation worker silently stripped hint penalties** from every recalculated score

Fix: persist `power_up_used` plus a new `hint_from_inventory` flag (migration `20260611_add_hint_from_inventory_to_guesses.ts`) so penalty-paid and inventory/premium-paid hints are distinguishable. Session details now show the penalty for all four hint types (developer/genre were missed) and only when a penalty actually applied; the recalculation worker now matches live scoring (all four hint types, no penalty for inventory hints). Historical rows can't be backfilled — they stay `NULL`/false, which preserves today's behavior for old data.

### 2. Play streak used local midnight, challenges use UTC
`calculateAndUpdateStreak` floored dates at **local** midnight while daily challenges are dated UTC (a prior fix in `getTodayChallenge` documents the same TZ drift in the Europe/Paris production container). A player finishing every UTC day could get a local-day diff of 0 (streak not extended) or 2 (grace wrongly consumed). Now uses UTC midnights, consistent with `daily-login.service`.

### 3. Monthly leaderboard split ties by user id
Daily board ranks with `DENSE_RANK()` so equal scores share a rank; monthly board used the array index. Two players tied on monthly total got ranks 1 and 2. Monthly now uses the same window function.

### 4. Image routes vulnerable to path traversal via stored `imageUrl`
Both `/api/game/preview/image` and `/api/game/image/:id` joined the DB-stored URL onto the uploads root with a bare string replace; a crafted `/uploads/../...` value would serve arbitrary files. Resolved paths are now verified to stay inside the uploads directory (defense in depth — `imageUrl` is admin-managed).

## Findings investigated and rejected (false alarms)
- `setUTCHours(24,0,0,0)` in `useNextDailyCountdown` — valid next-UTC-midnight idiom
- frontend `gameStore` personal-best streak — self-consistently UTC
- `useEffectEvent` from `react` — exists in React 19.2 (project uses 19.2.3)
- percentile formula `rank/total*100` — correct for "top X%" semantics
- inventory decrement race — single atomic `UPDATE ... WHERE quantity >= n`

## Testing
- `npm run build` — all packages typecheck
- `npm test` — 253 tests pass (3 new regression tests covering hint persistence: penalty path, inventory path, plain guess)
- `npm run lint` — clean
- Migration is a single add-column with default; not run against live Postgres here (no Docker in this environment), but exercised by typecheck

https://claude.ai/code/session_01QBLg8ZFn3FPd9iYCT7Vghv

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBLg8ZFn3FPd9iYCT7Vghv)_