### PR TITLE
feat: act on viral-product review — lifetime tier, social proof, value hero, screenshot OG

### DIFF
--- a/docs/billing-stripe.md
+++ b/docs/billing-stripe.md
@@ -25,7 +25,7 @@ Le frontend appelle l'API pour démarrer un Checkout ou ouvrir le portail client
 |------|--------------|---------------|---------|
 | `premium_monthly` | `the_box_premium_monthly` | 3,99 € | Mensuel |
 | `premium_annual` | `the_box_premium_annual` | 29,99 € | Annuel |
-| `supporter_lifetime` | (paiement unique) | À configurer | Lifetime |
+| `supporter_lifetime` | `the_box_supporter_lifetime` | 79,99 € | Paiement unique |
 
 Le script `npm run stripe:check` (depuis `packages/backend`) vérifie en CI que chaque entrée du catalogue correspond bien au prix Stripe (montant, devise, intervalle).
 

--- a/packages/backend/src/config/billing.test.ts
+++ b/packages/backend/src/config/billing.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { BILLING_CATALOG, getCatalogEntry } from './billing.js'
+
+describe('BILLING_CATALOG', () => {
+  it('exposes every tier with a unique lookup_key', () => {
+    const lookupKeys = BILLING_CATALOG.map((e) => e.lookupKey)
+    assert.equal(new Set(lookupKeys).size, lookupKeys.length, 'lookup_keys must be unique')
+    const tiers = BILLING_CATALOG.map((e) => e.tier)
+    assert.equal(new Set(tiers).size, tiers.length, 'tiers must be unique')
+  })
+
+  it('charges a positive EUR amount for every entry', () => {
+    for (const entry of BILLING_CATALOG) {
+      assert.equal(entry.currency, 'eur', `${entry.tier} must be priced in EUR`)
+      assert.ok(entry.unitAmount > 0, `${entry.tier} must have a positive amount`)
+    }
+  })
+
+  it('offers a one-time supporter_lifetime tier (interval=null → checkout mode "payment")', () => {
+    const supporter = getCatalogEntry('supporter_lifetime')
+    assert.ok(supporter, 'supporter_lifetime must be in the catalog')
+    assert.equal(supporter.interval, null, 'supporter_lifetime must be one-time')
+    assert.equal(supporter.lookupKey, 'the_box_supporter_lifetime')
+  })
+
+  it('keeps the recurring tiers recurring', () => {
+    assert.equal(getCatalogEntry('premium_monthly')?.interval, 'month')
+    assert.equal(getCatalogEntry('premium_annual')?.interval, 'year')
+  })
+})

--- a/packages/backend/src/config/billing.ts
+++ b/packages/backend/src/config/billing.ts
@@ -36,6 +36,17 @@ export const BILLING_CATALOG: readonly BillingCatalogEntry[] = [
     currency: 'eur',
     interval: 'year',
   },
+  {
+    // One-time "supporter à vie" purchase. interval=null routes the
+    // Checkout Session to mode:'payment' (see billing.routes.ts), and the
+    // checkout.session.completed webhook grants users.supporter_lifetime_at
+    // directly since no Stripe Subscription is ever created.
+    tier: 'supporter_lifetime',
+    lookupKey: 'the_box_supporter_lifetime',
+    unitAmount: 7999,
+    currency: 'eur',
+    interval: null,
+  },
 ] as const
 
 export function getCatalogEntry(tier: BillingTier): BillingCatalogEntry | undefined {

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -487,6 +487,8 @@ export interface DailyLoginRepository {
 export interface LeaderboardRepository {
   findByChallenge(challengeId: number, limit?: number): Promise<LeaderboardEntry[]>
   getPercentileForScore(challengeId: number, score: number): Promise<PercentileResponse>
+  /** Total ranked players (completed, non-catch-up, non-anonymous) for a challenge. */
+  countPlayersByChallenge(challengeId: number): Promise<number>
   findByMonth(year: number, month: number, limit?: number): Promise<MonthlyLeaderboardEntry[]>
 }
 

--- a/packages/backend/src/domain/services/leaderboard.service.test.ts
+++ b/packages/backend/src/domain/services/leaderboard.service.test.ts
@@ -18,6 +18,7 @@ const silentLogger: DomainLogger = {
 function makeService(opts: {
   challengeForDate?: { id: number } | null
   entries?: LeaderboardEntry[]
+  playerCount?: number
 }) {
   const challengeRepository = {
     findByDate: async () => opts.challengeForDate ?? null,
@@ -29,6 +30,7 @@ function makeService(opts: {
       lastLimit = limit
       return opts.entries ?? []
     },
+    countPlayersByChallenge: async () => opts.playerCount ?? 0,
   } as unknown as LeaderboardRepository
 
   const service = createLeaderboardService({
@@ -70,5 +72,20 @@ describe('leaderboardService.getTodayLeader', () => {
       totalScore: 4820,
     })
     assert.equal(getLastLimit(), 1, 'should ask the repository for a single row')
+  })
+})
+
+describe('leaderboardService.getTodayPlayerCount', () => {
+  it('returns count 0 when there is no challenge today', async () => {
+    const { service } = makeService({ challengeForDate: null, playerCount: 42 })
+    const result = await service.getTodayPlayerCount()
+    assert.equal(result.count, 0, 'no challenge means no ranked players')
+    assert.match(result.date, /^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('returns the ranked player count for today\'s challenge', async () => {
+    const { service } = makeService({ challengeForDate: { id: 7 }, playerCount: 128 })
+    const result = await service.getTodayPlayerCount()
+    assert.equal(result.count, 128)
   })
 })

--- a/packages/backend/src/domain/services/leaderboard.service.ts
+++ b/packages/backend/src/domain/services/leaderboard.service.ts
@@ -22,6 +22,12 @@ export interface LeaderboardService {
    * nobody has completed a ranked session yet. Cheap — fetches a single row.
    */
   getTodayLeader(): Promise<TodayLeader | null>
+  /**
+   * How many ranked players have finished today's challenge. Powers the
+   * public "joined by N players today" social-proof badge. Returns count 0
+   * when there is no challenge yet.
+   */
+  getTodayPlayerCount(): Promise<{ date: string; count: number }>
 }
 
 export interface LeaderboardServiceDeps {
@@ -102,6 +108,14 @@ export function createLeaderboardService(deps: LeaderboardServiceDeps): Leaderbo
         displayName: leader.displayName,
         totalScore: leader.totalScore,
       }
+    },
+
+    async getTodayPlayerCount(): Promise<{ date: string; count: number }> {
+      const today = new Date().toISOString().split('T')[0]!
+      const challenge = await challengeRepository.findByDate(today)
+      if (!challenge) return { date: today, count: 0 }
+      const count = await leaderboardRepository.countPlayersByChallenge(challenge.id)
+      return { date: today, count }
     },
 
     async getTodayPercentile(score: number): Promise<PercentileResponse> {

--- a/packages/backend/src/infrastructure/repositories/leaderboard.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/leaderboard.repository.ts
@@ -64,6 +64,21 @@ export const leaderboardRepository = {
     }))
   },
 
+  async countPlayersByChallenge(challengeId: number): Promise<number> {
+    // Mirrors the totalPlayers query in getPercentileForScore: ranked
+    // sessions only (completed, not catch-up, not anonymous). Used by the
+    // public "players today" social-proof badge on the home page.
+    const result = await db('game_sessions')
+      .join('user', 'game_sessions.user_id', 'user.id')
+      .where('game_sessions.daily_challenge_id', challengeId)
+      .andWhere('game_sessions.is_completed', true)
+      .andWhere('game_sessions.is_catch_up', false)
+      .whereRaw('"user"."isAnonymous" = ?', [false])
+      .count('game_sessions.id as count')
+      .first()
+    return Number(result?.count ?? 0)
+  },
+
   async getPercentileForScore(challengeId: number, score: number): Promise<PercentileResponse> {
     // Count total completed sessions for this challenge (excluding anonymous users and catch-up sessions)
     const totalResult = await db('game_sessions')

--- a/packages/backend/src/presentation/routes/billing.routes.ts
+++ b/packages/backend/src/presentation/routes/billing.routes.ts
@@ -14,11 +14,10 @@ const log = logger.child({ route: 'billing' })
 
 const router = Router()
 
-// Only the active subset of BillingTier is accepted by /checkout. The
-// shared union still lists supporter_lifetime so webhook reverse lookups
-// can recognise legacy subscriptions, but the route refuses new checkouts
-// for tiers that aren't in BILLING_CATALOG.
-const TIERS = ['premium_monthly', 'premium_annual'] as const satisfies readonly BillingTier[]
+// Tiers accepted by /checkout — must each have a BILLING_CATALOG entry.
+// supporter_lifetime resolves to a one-time (interval=null) price, which
+// the session below turns into mode:'payment'; the other two are recurring.
+const TIERS = ['premium_monthly', 'premium_annual', 'supporter_lifetime'] as const satisfies readonly BillingTier[]
 
 // Public catalog. Used by the marketing page so the displayed amount is
 // always the same string the rest of the system asserts against. Cached

--- a/packages/backend/src/presentation/routes/leaderboard.routes.ts
+++ b/packages/backend/src/presentation/routes/leaderboard.routes.ts
@@ -62,6 +62,20 @@ router.get('/today', async (_req, res, next) => {
   }
 })
 
+// Public lightweight player count for today's challenge — powers the home
+// page "joined by N players today" social-proof badge. No auth: it's an
+// aggregate with no per-user data. Short cache so the number feels live
+// without hammering the DB on every homepage view.
+router.get('/today/count', async (_req, res, next) => {
+  try {
+    const data = await leaderboardService.getTodayPlayerCount()
+    res.set('Cache-Control', 'public, max-age=60')
+    res.json({ success: true, data })
+  } catch (error) {
+    next(error)
+  }
+})
+
 // Get percentile ranking for a score on today's challenge
 router.get('/today/percentile', async (req, res, next) => {
   try {

--- a/packages/backend/src/presentation/routes/og.routes.ts
+++ b/packages/backend/src/presentation/routes/og.routes.ts
@@ -1,12 +1,38 @@
 import { Router } from 'express'
 import type { Request, Response } from 'express'
+import path from 'path'
+import { readFile } from 'fs/promises'
+import { fileURLToPath } from 'url'
 import { Resvg } from '@resvg/resvg-js'
+import { challengeRepository } from '../../infrastructure/repositories/index.js'
 import { logger } from '../../infrastructure/logger/logger.js'
 
 const router = Router()
 
 const WIDTH = 1200
 const HEIGHT = 630
+
+// Mirror of game.routes' uploads resolver: map a stored `/uploads/...` URL
+// to an absolute path and refuse anything that escapes the uploads dir.
+// Duplicated (not imported) to keep this security check local and explicit.
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const uploadsPath = path.resolve(__dirname, '..', '..', '..', '..', '..', 'uploads')
+
+function resolveUploadFilePath(imageUrl: string): string | null {
+  const relativePath = imageUrl.replace('/uploads/', '')
+  const filePath = path.resolve(uploadsPath, relativePath)
+  if (filePath !== uploadsPath && !filePath.startsWith(uploadsPath + path.sep)) {
+    return null
+  }
+  return filePath
+}
+
+const EXT_MIME: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+}
 
 function escapeXml(unsafe: string): string {
   return unsafe
@@ -17,10 +43,14 @@ function escapeXml(unsafe: string): string {
     .replace(/'/g, '&apos;')
 }
 
+function todayIso(): string {
+  return new Date().toISOString().split('T')[0]!
+}
+
 function sanitizeDate(input: unknown): string {
-  if (typeof input !== 'string') return new Date().toISOString().split('T')[0]!
+  if (typeof input !== 'string') return todayIso()
   const match = /^\d{4}-\d{2}-\d{2}$/.exec(input)
-  if (!match) return new Date().toISOString().split('T')[0]!
+  if (!match) return todayIso()
   return input
 }
 
@@ -39,19 +69,95 @@ function formatDate(iso: string, locale: string): string {
   }
 }
 
-function buildDailySvg(date: string, lang: 'fr' | 'en'): string {
+/**
+ * Load the challenge's first screenshot as a base64 data URI so it can be
+ * embedded directly in the OG SVG (resvg has no network access).
+ *
+ * Guarded to dates <= today: the preview endpoint is deliberately today-only
+ * to avoid leaking *future* challenge screenshots, so we apply the same rule
+ * here — a crafted `?date=<future>` falls back to the plain gradient card.
+ * Fail-soft: any miss returns null and the caller renders the text card.
+ */
+async function loadDailyScreenshotDataUri(date: string): Promise<string | null> {
+  try {
+    if (date > todayIso()) return null
+    const challenge = await challengeRepository.findByDate(date)
+    if (!challenge) return null
+    const tier = await challengeRepository.findTierByNumber(challenge.id, 1)
+    if (!tier) return null
+    const entry = await challengeRepository.findScreenshotAtPosition(tier.id, 1)
+    if (!entry) return null
+
+    const ext = path.extname(entry.image_url).toLowerCase()
+    const mime = EXT_MIME[ext]
+    if (!mime) return null
+
+    const filePath = resolveUploadFilePath(entry.image_url)
+    if (!filePath) return null
+
+    const buffer = await readFile(filePath)
+    return `data:${mime};base64,${buffer.toString('base64')}`
+  } catch (error) {
+    logger.warn({ error: String(error), date }, 'og screenshot embed failed, using text card')
+    return null
+  }
+}
+
+function buildDailySvg(date: string, lang: 'fr' | 'en', imageDataUri: string | null): string {
   const locale = lang === 'en' ? 'en-US' : 'fr-FR'
   const readable = escapeXml(formatDate(date, locale))
+  const brand = escapeXml('THE BOX')
+  const cta = escapeXml(lang === 'fr' ? 'Joue le défi du jour' : 'Play today’s challenge')
+
+  // With a screenshot: a YouTube-thumbnail-style card — the actual (blurred)
+  // game still under a dark scrim, with a "Can you name it?" hook. The blur
+  // keeps it intriguing rather than a spoiler. Without one: the original
+  // gradient text card.
+  if (imageDataUri) {
+    const hook = escapeXml(lang === 'fr' ? 'Tu reconnais ce jeu ?' : 'Can you name this game?')
+    const tagline = escapeXml(
+      lang === 'fr' ? 'Une capture. Un jeu à deviner.' : 'One screenshot. One guess.'
+    )
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
+  <defs>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#a855f7" />
+      <stop offset="50%" stop-color="#ec4899" />
+      <stop offset="100%" stop-color="#06b6d4" />
+    </linearGradient>
+    <linearGradient id="scrim" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a0a0f" stop-opacity="0.55" />
+      <stop offset="55%" stop-color="#0a0a0f" stop-opacity="0.65" />
+      <stop offset="100%" stop-color="#0a0a0f" stop-opacity="0.92" />
+    </linearGradient>
+    <filter id="blur" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="14" />
+    </filter>
+  </defs>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="#0a0a0f"/>
+  <image href="${imageDataUri}" x="0" y="0" width="${WIDTH}" height="${HEIGHT}"
+         preserveAspectRatio="xMidYMid slice" filter="url(#blur)"/>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#scrim)"/>
+  <text x="80" y="120" font-family="sans-serif"
+        font-size="40" font-weight="700" fill="url(#accent)" letter-spacing="4">${brand}</text>
+  <text x="80" y="330" font-family="sans-serif"
+        font-size="84" font-weight="800" fill="#ffffff">${hook}</text>
+  <text x="80" y="400" font-family="sans-serif"
+        font-size="32" font-weight="400" fill="#cbd5e1">${tagline}</text>
+  <rect x="80" y="470" width="400" height="72" rx="36" fill="url(#accent)"/>
+  <text x="280" y="517" font-family="sans-serif"
+        font-size="28" font-weight="700" fill="#0a0a0f" text-anchor="middle">${cta}</text>
+  <text x="1120" y="560" font-family="sans-serif"
+        font-size="24" font-weight="400" fill="#94a3b8" text-anchor="end">${readable}</text>
+</svg>`
+  }
+
   const tagline = escapeXml(
     lang === 'fr'
       ? "Devinez le jeu à partir d'une capture d'écran."
       : 'Guess the game from a screenshot.'
   )
-  const brand = escapeXml('THE BOX')
-  const cta = escapeXml(
-    lang === 'fr' ? 'Joue le défi du jour' : 'Play today’s challenge'
-  )
-
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
   <defs>
@@ -89,10 +195,11 @@ function parseLang(input: unknown): 'fr' | 'en' {
  * Twitter, WhatsApp, iMessage and LinkedIn reject SVG og:images, so the
  * canonical preview URL is the PNG below.
  */
-router.get('/daily.svg', (req: Request, res: Response) => {
+router.get('/daily.svg', async (req: Request, res: Response) => {
   const date = sanitizeDate(req.query.date)
   const lang = parseLang(req.query.lang)
-  const svg = buildDailySvg(date, lang)
+  const image = await loadDailyScreenshotDataUri(date)
+  const svg = buildDailySvg(date, lang, image)
 
   res.setHeader('Content-Type', 'image/svg+xml; charset=utf-8')
   res.setHeader('Cache-Control', 'public, max-age=3600')
@@ -105,10 +212,11 @@ router.get('/daily.svg', (req: Request, res: Response) => {
  * the same SVG template via resvg-js. The challenge for a given UTC date
  * is immutable, so a one-day cache is safe.
  */
-router.get('/daily.png', (req: Request, res: Response) => {
+router.get('/daily.png', async (req: Request, res: Response) => {
   const date = sanitizeDate(req.query.date)
   const lang = parseLang(req.query.lang)
-  const svg = buildDailySvg(date, lang)
+  const image = await loadDailyScreenshotDataUri(date)
+  const svg = buildDailySvg(date, lang, image)
 
   try {
     const png = new Resvg(svg, {

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -498,7 +498,10 @@
   },
   "home": {
     "title": "The Box",
-    "subtitle": "Daily video game challenges with screenshot guessing, speed-based scoring, 21 achievements to unlock, live leaderboards, and win streaks. Play instantly as a guest or create an account.",
+    "headline": "Name the game from one screenshot.",
+    "subtitle": "A fresh video-game challenge every day. Play instantly — no account needed.",
+    "playersToday_one": "{{formatted}} player has taken on today's challenge",
+    "playersToday_other": "{{formatted}} players have taken on today's challenge",
     "playToday": "Play Today's Challenge",
     "dailyGuess": "Daily Guess",
     "geoCta": "Geo Mode",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1678,8 +1678,11 @@
     "subtitle": "Support the game, unlock the full archive, and customize your profile.",
     "billingMonthly": "/month",
     "billingAnnual": "/year",
+    "billingLifetime": "one-time",
     "savingsAnnual": "~37% savings vs monthly",
+    "supporterNote": "Pay once. Premium forever.",
     "ctaSubscribe": "Subscribe",
+    "ctaSupporter": "Become a supporter",
     "ctaManage": "Manage subscription",
     "ctaLogin": "Sign in to subscribe",
     "ctaCurrent": "Current plan",
@@ -1708,6 +1711,10 @@
         "name": "Premium Annual",
         "description": "Best value per month",
         "highlight": "Most popular"
+      },
+      "supporter_lifetime": {
+        "name": "Lifetime Supporter",
+        "description": "Back the game once, keep Premium for good"
       }
     },
     "features": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1678,8 +1678,11 @@
     "subtitle": "Soutenez le jeu, débloquez l'archive complète et personnalisez votre profil.",
     "billingMonthly": "/mois",
     "billingAnnual": "/an",
+    "billingLifetime": "paiement unique",
     "savingsAnnual": "Soit ~37 % d'économies",
+    "supporterNote": "Payez une fois. Premium pour toujours.",
     "ctaSubscribe": "S'abonner",
+    "ctaSupporter": "Devenir supporter",
     "ctaManage": "Gérer mon abonnement",
     "ctaLogin": "Se connecter pour s'abonner",
     "ctaCurrent": "Plan actuel",
@@ -1708,6 +1711,10 @@
         "name": "Premium Annuel",
         "description": "Le meilleur rapport qualité-prix",
         "highlight": "Le plus populaire"
+      },
+      "supporter_lifetime": {
+        "name": "Supporter à vie",
+        "description": "Soutenez le jeu une fois, gardez Premium à vie"
       }
     },
     "features": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -498,7 +498,10 @@
   },
   "home": {
     "title": "The Box",
+    "headline": "Devine le jeu à partir d'une seule capture.",
     "subtitle": "Une capture, un jeu à reconnaître. Voyons si ta culture gaming tient encore debout.",
+    "playersToday_one": "{{formatted}} joueur a relevé le défi du jour",
+    "playersToday_other": "{{formatted}} joueurs ont relevé le défi du jour",
     "playToday": "Jouer au Défi du Jour",
     "dailyGuess": "Défi Quotidien",
     "geoCta": "Mode Géo",

--- a/packages/frontend/src/components/home/HomeDailyCta.tsx
+++ b/packages/frontend/src/components/home/HomeDailyCta.tsx
@@ -109,10 +109,13 @@ export function HomeDailyCta({
         </div>
       )}
 
-      {/* Show appropriate button based on completion status */}
+      {/* Show appropriate button based on completion status.
+          One loud primary action (play / history) so visitors have a single
+          obvious next step; Geo mode is demoted to a quiet secondary link
+          below rather than competing as an equal-weight button. */}
       {!isLoading && (
         <div className="flex flex-col items-center gap-3 sm:gap-4 w-full sm:w-auto">
-          <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-3 sm:gap-4 w-full sm:w-auto">
+          <div className="flex justify-center w-full sm:w-auto">
             {isTodayCompleted ? (
               <Button
                 variant="outline"
@@ -136,23 +139,23 @@ export function HomeDailyCta({
                 {t('home.dailyGuess')}
               </Button>
             )}
-            <Button
-              variant="outline"
-              size="xl"
-              onClick={() => navigate(localizedPath('/geo'))}
-              data-tour="geo-cta"
-              className="gap-2 sm:gap-3 text-sm sm:text-base md:text-lg px-6 sm:px-8 md:px-10 lg:px-12 w-full sm:w-auto border-neon-pink/40 text-neon-pink hover:border-neon-pink hover:text-neon-pink"
-            >
-              <MapPin className="size-4 sm:size-5 md:size-6" />
-              {t('home.geoCta')}
-              <Badge
-                variant="outline"
-                className="ml-1 h-5 px-1.5 text-[10px] font-semibold uppercase tracking-wide border-neon-pink/50 text-neon-pink"
-              >
-                {t('common.alpha')}
-              </Badge>
-            </Button>
           </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate(localizedPath('/geo'))}
+            data-tour="geo-cta"
+            className="gap-1.5 text-xs sm:text-sm text-muted-foreground hover:text-neon-pink"
+          >
+            <MapPin className="size-4" />
+            {t('home.geoCta')}
+            <Badge
+              variant="outline"
+              className="ml-1 h-4 px-1 text-[9px] font-semibold uppercase tracking-wide border-neon-pink/40 text-neon-pink"
+            >
+              {t('common.alpha')}
+            </Badge>
+          </Button>
           {!isTodayCompleted && !hasSession && (
             <p className="text-xs sm:text-sm text-muted-foreground">
               {t('home.guestHint')}

--- a/packages/frontend/src/components/home/HomeSocialProof.tsx
+++ b/packages/frontend/src/components/home/HomeSocialProof.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { m } from 'framer-motion'
+import { Users } from 'lucide-react'
+
+/**
+ * Live social-proof badge: "N players have taken on today's challenge".
+ * Backed by real data from GET /api/leaderboard/today/count — never a
+ * fabricated number. Renders nothing until a positive count arrives, so we
+ * never show a deflating "0 players" on a fresh challenge or while loading.
+ */
+export function HomeSocialProof() {
+  const { t, i18n } = useTranslation()
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/leaderboard/today/count')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (!cancelled && json?.success) setCount(Number(json.data?.count ?? 0))
+      })
+      .catch(() => {
+        /* fail-soft: no badge if the count can't be fetched */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (count <= 0) return null
+
+  const formatted = new Intl.NumberFormat(i18n.language).format(count)
+
+  return (
+    <m.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: 0.3 }}
+      className="mt-4 flex justify-center"
+    >
+      <span className="inline-flex items-center gap-2 rounded-full border border-neon-purple/30 bg-card/60 backdrop-blur-sm px-3 py-1.5 text-xs sm:text-sm text-muted-foreground">
+        <Users className="size-4 text-neon-cyan" aria-hidden="true" />
+        {t('home.playersToday', { count, formatted })}
+      </span>
+    </m.div>
+  )
+}

--- a/packages/frontend/src/components/pricing/PricingCard.tsx
+++ b/packages/frontend/src/components/pricing/PricingCard.tsx
@@ -44,13 +44,22 @@ export function PricingCard({
     [i18n.language],
   )
   const tierKey = `pricing.tiers.${price.tier}`
+  // One-time tiers (interval === null, e.g. supporter_lifetime) aren't a
+  // "subscription" — use patronage wording and a one-time price label.
+  const isOneTime = price.interval === null
   const ctaKey = isCurrentPlan
     ? 'pricing.ctaCurrent'
     : !isLoggedIn
       ? 'pricing.ctaLogin'
-      : 'pricing.ctaSubscribe'
+      : isOneTime
+        ? 'pricing.ctaSupporter'
+        : 'pricing.ctaSubscribe'
 
-  const intervalKey = price.interval === 'month' ? 'pricing.billingMonthly' : 'pricing.billingAnnual'
+  const intervalKey = isOneTime
+    ? 'pricing.billingLifetime'
+    : price.interval === 'month'
+      ? 'pricing.billingMonthly'
+      : 'pricing.billingAnnual'
 
   return (
     <m.div
@@ -86,6 +95,9 @@ export function PricingCard({
           </div>
           {price.tier === 'premium_annual' && (
             <p className="text-xs text-neon-pink/80 font-medium">{t('pricing.savingsAnnual')}</p>
+          )}
+          {isOneTime && (
+            <p className="text-xs text-neon-pink/80 font-medium">{t('pricing.supporterNote')}</p>
           )}
         </CardContent>
 

--- a/packages/frontend/src/components/pricing/PricingTable.tsx
+++ b/packages/frontend/src/components/pricing/PricingTable.tsx
@@ -84,13 +84,14 @@ export function PricingTable() {
 
   const onFreePlan = isAuthenticated && !entitlement?.isPremium
 
-  // Three-card grid: Free (anchor) → Monthly → Annual (highlighted). On
-  // mobile each card stacks; the cap at lg:max-w-5xl keeps cards from
-  // stretching too wide on big screens.
+  // Card grid: Free (anchor) → Monthly → Annual (highlighted) → Lifetime.
+  // Two columns on tablet, four on desktop; on mobile each card stacks.
+  // The max-w cap keeps cards from stretching too wide on big screens.
   return (
-    <div className="grid gap-6 md:grid-cols-3 max-w-5xl mx-auto">
+    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 max-w-6xl mx-auto">
       {!pricesLoaded ? (
         <>
+          <PricingCardSkeleton />
           <PricingCardSkeleton />
           <PricingCardSkeleton />
           <PricingCardSkeleton />

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -13,6 +13,7 @@ import { StreakRiskBanner } from '@/components/daily-login/StreakRiskBanner'
 import { HomeAchievementTeaser } from '@/components/home/HomeAchievementTeaser'
 import { HomeDailyCta } from '@/components/home/HomeDailyCta'
 import { HomePremiumTeaser } from '@/components/home/HomePremiumTeaser'
+import { HomeSocialProof } from '@/components/home/HomeSocialProof'
 import { useBillingStore } from '@/stores/billingStore'
 import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe'
 
@@ -251,13 +252,22 @@ export default function HomePage() {
             className="size-16 sm:size-20 md:size-24 mb-4 sm:mb-5 md:mb-6 mx-auto"
           />
 
-          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-3 sm:mb-4 gradient-gaming-title">
+          {/* Brand wordmark stays small — the logo already carries it — so
+              the value headline is the loudest thing in the hero (principle:
+              sell from the hero, lead with value not the brand name). */}
+          <p className="text-xs sm:text-sm font-semibold uppercase tracking-[0.2em] text-neon-purple/80 mb-2">
             {t('home.title')}
+          </p>
+
+          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-3 sm:mb-4 gradient-gaming-title">
+            {t('home.headline')}
           </h1>
 
           <p className="text-sm sm:text-base md:text-lg lg:text-xl text-muted-foreground max-w-2xl mx-auto px-2 sm:px-4">
             {t('home.subtitle')}
           </p>
+
+          <HomeSocialProof />
         </m.div>
 
         {/* CTA Button */}

--- a/tasks/viral-product-principles-review.html
+++ b/tasks/viral-product-principles-review.html
@@ -1,0 +1,457 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>The Box — 31 Viral-Product Principles Review</title>
+<!-- SUMMARY:
+Scores The Box's landing/pricing/marketing surfaces against Marc Lou's "31 Principles of a Viral Product".
+Verdict: 6 PASS, 14 PARTIAL, 11 FAIL. Biggest gaps: no testimonials/social proof, no founder presence,
+no problem/empathy framing, hero leads with brand name not value, multiple competing CTAs, "does one thing" violated.
+Notable code finding: supporter_lifetime tier exists in types + docs but is NOT in BILLING_CATALOG (no purchasable one-time option).
+Caveat: principles target paid SaaS landing pages; The Box is a freemium daily game, so "no free plan / hard paywall / no subscription" are intentionally off-strategy, not bugs.
+-->
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --panel: #14141c;
+    --panel-2: #1a1a24;
+    --border: #2a2a38;
+    --text: #e7e7ef;
+    --muted: #a0a0b2;
+    --primary: #a855f7;
+    --pass: #4ade80;
+    --partial: #fbbf24;
+    --fail: #f87171;
+    --na: #6b7280;
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } * { transition: none !important; } }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: Inter, system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.6;
+    font-size: 16px;
+  }
+  .wrap { max-width: 78ch; margin: 0 auto; padding: 3rem 1.5rem 6rem; }
+  h1 { font-size: 2rem; line-height: 1.2; margin: 0 0 .5rem; }
+  h1 .glow { color: var(--primary); text-shadow: 0 0 24px rgba(168,85,247,.45); }
+  h2 { font-size: 1.35rem; margin: 3rem 0 1rem; border-bottom: 1px solid var(--border); padding-bottom: .4rem; }
+  h3 { font-size: 1.05rem; margin: 1.5rem 0 .4rem; }
+  p, li { color: var(--text); }
+  .lead { color: var(--muted); font-size: 1.05rem; }
+  code, .mono { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .86em; }
+  code { background: var(--panel-2); padding: .1em .4em; border-radius: 4px; color: #d6bcfa; }
+  a { color: var(--primary); }
+  a:focus-visible, summary:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+
+  .meta { color: var(--muted); font-size: .9rem; margin-top: .25rem; }
+
+  /* scoreboard */
+  .board { display: flex; flex-wrap: wrap; gap: .75rem; margin: 1.5rem 0; }
+  .stat { flex: 1 1 120px; background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: .9rem 1rem; }
+  .stat .n { font-size: 1.8rem; font-weight: 700; font-family: "JetBrains Mono", monospace; }
+  .stat .l { font-size: .8rem; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; }
+  .n.pass { color: var(--pass); } .n.partial { color: var(--partial); }
+  .n.fail { color: var(--fail); } .n.na { color: var(--na); }
+
+  .badge { display: inline-block; font-family: "JetBrains Mono", monospace; font-size: .72rem; font-weight: 700;
+           padding: .15em .55em; border-radius: 5px; letter-spacing: .04em; vertical-align: middle; }
+  .badge.pass { background: rgba(74,222,128,.14); color: var(--pass); border: 1px solid rgba(74,222,128,.35); }
+  .badge.partial { background: rgba(251,191,36,.13); color: var(--partial); border: 1px solid rgba(251,191,36,.35); }
+  .badge.fail { background: rgba(248,113,113,.13); color: var(--fail); border: 1px solid rgba(248,113,113,.35); }
+  .badge.na { background: rgba(107,114,128,.15); color: #9aa0ad; border: 1px solid rgba(107,114,128,.4); }
+
+  .principle { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; margin: .75rem 0; overflow: hidden; }
+  .principle > summary { list-style: none; cursor: pointer; padding: .85rem 1.1rem; display: flex; align-items: baseline; gap: .6rem; }
+  .principle > summary::-webkit-details-marker { display: none; }
+  .principle > summary:hover { background: var(--panel-2); }
+  .principle .num { font-family: "JetBrains Mono", monospace; color: var(--muted); font-size: .8rem; min-width: 1.6rem; }
+  .principle .ptitle { font-weight: 600; flex: 1; }
+  .principle .body { padding: 0 1.1rem 1.1rem 1.1rem; border-top: 1px solid var(--border); }
+  .principle .body p { margin: .7rem 0; }
+  .principle .body .lbl { color: var(--muted); font-size: .78rem; text-transform: uppercase; letter-spacing: .05em; margin-bottom: .1rem; }
+
+  blockquote { margin: .5rem 0; padding: .4rem .9rem; border-left: 3px solid var(--primary); background: var(--panel-2); color: var(--muted); border-radius: 0 6px 6px 0; }
+
+  .callout { border: 1px solid var(--border); border-left: 3px solid var(--partial); background: var(--panel); border-radius: 0 8px 8px 0; padding: .9rem 1.1rem; margin: 1.25rem 0; }
+  .callout.danger { border-left-color: var(--fail); }
+  .callout h3 { margin-top: 0; }
+
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: .92rem; }
+  th, td { text-align: left; padding: .5rem .6rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; }
+
+  ol.recs { padding-left: 1.2rem; }
+  ol.recs li { margin: .5rem 0; }
+  .tag { font-size: .72rem; font-family: "JetBrains Mono", monospace; color: var(--primary); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>The Box vs. the <span class="glow">31 Principles of a Viral Product</span></h1>
+  <p class="meta">Review packet · 2026-06-09 · audience: engineering · source: Marc Lou, "31 Principles of a Viral Product" (Just Ship It, 2026-06-09)</p>
+
+  <p class="lead">A pass over The Box's landing, pricing, OG, and copy surfaces against Lou's 31 patterns. These are a compass, not a checklist &mdash; and several principles are written for paid-SaaS landing pages, while The Box is a <strong>freemium daily game</strong>. Where a "failure" is actually a deliberate, defensible strategy difference, it's flagged as such rather than treated as a defect.</p>
+
+  <div class="board">
+    <div class="stat"><div class="n pass">6</div><div class="l">Pass</div></div>
+    <div class="stat"><div class="n partial">14</div><div class="l">Partial</div></div>
+    <div class="stat"><div class="n fail">11</div><div class="l">Fail</div></div>
+  </div>
+
+  <div class="callout danger">
+    <h3>⚠ Code finding worth a ticket (independent of the principles)</h3>
+    <p>The <code>supporter_lifetime</code> tier is a first-class <code>BillingTier</code> in <code>packages/types/src/index.ts:1331</code> and is fully documented in <code>docs/billing-stripe.md</code> (one-time "supporter à vie" payment, dedicated webhook branch, <code>users.supporter_lifetime_at</code> column). But it is <strong>not present in <code>BILLING_CATALOG</code></strong> (<code>packages/backend/src/config/billing.ts</code>) &mdash; only <code>premium_monthly</code> and <code>premium_annual</code> are. So there is no resolvable price / purchasable path for the lifetime option today. This is exactly the one-time-payment lever principle&nbsp;#27 argues for, sitting half-wired in the codebase. Either finish wiring it or prune the dead tier from types/docs.</p>
+  </div>
+
+  <h2>Per-principle scorecard</h2>
+  <p class="meta">Click any row to expand evidence + recommendation.</p>
+
+  <!-- 1 -->
+  <details class="principle">
+    <summary><span class="num">01</span><span class="ptitle">No free plan</span><span class="badge fail">FAIL*</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>There is an explicit <code>Free</code> tier (€0) on <code>PricingPage.tsx</code> + <code>FreePricingCard.tsx</code>, plus anonymous guest play of the daily challenge.</p>
+      <p class="lbl">Verdict</p>
+      <p><strong>Deliberate, not a defect.</strong> A daily-puzzle game lives and dies on top-of-funnel reach; the free daily challenge <em>is</em> the viral loop. Lou's "no free plan" is a B2B-SaaS rule that doesn't map. Keep the free tier; just make the premium upgrade trigger sharper (see #25, #8).</p>
+    </div>
+  </details>
+
+  <!-- 2 -->
+  <details class="principle">
+    <summary><span class="num">02</span><span class="ptitle">Three colors</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Design system is a dark gaming theme with purple/pink <em>gradients</em> plus cyan accents (OG image uses purple→pink→cyan), neon glows, glassmorphism on the premium teaser.</p>
+      <p class="lbl">Verdict</p>
+      <p>The intent ("one color for the action") is mostly there &mdash; primary actions use the gaming gradient. But multiple competing accents + glassmorphism dilute focus. Note the repo's own HTML-doc rule already bans glassmorphism and caps "one neon glow per page" &mdash; the product UI is held to a looser bar than the docs. Tighten toward: dark bg, one accent for the play CTA.</p>
+    </div>
+  </details>
+
+  <!-- 3 -->
+  <details class="principle">
+    <summary><span class="num">03</span><span class="ptitle">Numbers instead of adjectives</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence — EN subtitle (<code>home.subtitle</code>)</p>
+      <blockquote>"Daily video game challenges with screenshot guessing, speed-based scoring, <strong>21 achievements</strong> to unlock, live leaderboards, and win streaks…"</blockquote>
+      <p class="lbl">Evidence — FR subtitle</p>
+      <blockquote>"Une capture, un jeu à reconnaître. Voyons si ta culture gaming tient encore debout."</blockquote>
+      <p class="lbl">Verdict</p>
+      <p>EN does the numbers thing ("21 achievements", "7 days"). FR has zero numbers (it's pure attitude). The two locales aren't pursuing the same strategy &mdash; the FR is more memorable (#18) but less concrete. Add a number to FR; add the "45s per screenshot" hook to both (it's the most concrete, distinctive mechanic and isn't surfaced in marketing at all).</p>
+    </div>
+  </details>
+
+  <!-- 4 -->
+  <details class="principle">
+    <summary><span class="num">04</span><span class="ptitle">A footer people want to share</span><span class="badge fail">FAIL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p><code>Footer.tsx</code> is legal/utility links only: Terms, Privacy, Cookies, FAQ, Game Rules, Contact, copyright + build version.</p>
+      <p class="lbl">Verdict</p>
+      <p>No shareable closing moment. The natural "finish strong" asset already exists elsewhere — the daily completion messages and the OG share card. Surface a "share your result" / streak flex in the footer or post-game screen instead of ending on legalese.</p>
+    </div>
+  </details>
+
+  <!-- 5 -->
+  <details class="principle">
+    <summary><span class="num">05</span><span class="ptitle">OG image = YouTube thumbnail</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p><code>og.routes.ts</code> renders a 1200×630 SVG/PNG: "THE BOX" wordmark, the formatted date, tagline ("Guess the game from a screenshot."), and a CTA pill ("Play today's challenge"). Good caching, PNG fallback for Twitter/iMessage.</p>
+      <p class="lbl">Verdict</p>
+      <p>Technically solid, visually generic. It's a text card, not a thumbnail with intrigue. It shows <em>no screenshot</em> &mdash; the entire hook of the game is "can you name THIS?" Put a (blurred/cropped) piece of today's actual screenshot on the card with a "Can you name it?" overlay. That's a thumbnail people click.</p>
+    </div>
+  </details>
+
+  <!-- 6 -->
+  <details class="principle">
+    <summary><span class="num">06</span><span class="ptitle">One idea per screen</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Home stacks: hero, daily CTA, premium teaser, achievement teaser. The EN subtitle alone lists 6 features in one sentence.</p>
+      <p class="lbl">Verdict</p>
+      <p>Section-level structure is reasonably one-idea-per-block, but the hero sub-headline tries to say everything. Cut it to one idea: the challenge. Let the lower sections carry achievements/premium.</p>
+    </div>
+  </details>
+
+  <!-- 7 -->
+  <details class="principle">
+    <summary><span class="num">07</span><span class="ptitle">Headline a fifth grader understands</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>The h1 is literally just the brand: "The Box". Meaning is carried entirely by the subtitle.</p>
+      <p class="lbl">Verdict</p>
+      <p>"The Box" is simple words but conveys nothing about the product on its own (also see #20). The OG tagline "Guess the game from a screenshot" is the real fifth-grade headline — promote it into the hero h1 (or as an h2 directly under the wordmark).</p>
+    </div>
+  </details>
+
+  <!-- 8 -->
+  <details class="principle">
+    <summary><span class="num">08</span><span class="ptitle">Hard paywall</span><span class="badge fail">FAIL*</span></summary>
+    <div class="body">
+      <p class="lbl">Verdict</p>
+      <p><strong>Intentional.</strong> Same reasoning as #1 — a hard paywall would kill the daily-habit funnel. Validation here comes from retention/streaks, not credit-card-before-data. Not applicable as written.</p>
+    </div>
+  </details>
+
+  <!-- 9 -->
+  <details class="principle">
+    <summary><span class="num">09</span><span class="ptitle">Copy only you could write</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>FR copy is distinctive and voicey ("Voyons si ta culture gaming tient encore debout"; achievement teaser "Trois trophées que tu n'as pas encore. Encore."). EN copy is a generic feature list a competitor could paste.</p>
+      <p class="lbl">Verdict</p>
+      <p>The French has a personality the English lacks. Port the FR voice into EN rather than translating the feature list. The completion messages (e.g. "did you recognize at least one game?") are the strongest, most ownable copy in the app — mine that tone for the landing page.</p>
+    </div>
+  </details>
+
+  <!-- 10 -->
+  <details class="principle">
+    <summary><span class="num">10</span><span class="ptitle">Show the product before explaining it</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Hero shows a logo + text, then a CTA. No screenshot/demo above the fold. Mitigant: guest play means the real product is one click away.</p>
+      <p class="lbl">Verdict</p>
+      <p>"Show, don't tell" is half-met via instant guest play, but the landing itself tells before it shows. Drop a real (blurred) screenshot + answer field directly in the hero so the game <em>is</em> the hero. This also fixes #20 and #25 at once.</p>
+    </div>
+  </details>
+
+  <!-- 11 -->
+  <details class="principle">
+    <summary><span class="num">11</span><span class="ptitle">Does one thing</span><span class="badge fail">FAIL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Classic mode + Geo mode + tournaments + referrals + premium + web push + public API/streamer kit + 2FA/passkeys. A genuine Swiss Army knife.</p>
+      <p class="lbl">Verdict</p>
+      <p>This is the sharpest tension between the product and the principles. For <em>marketing</em>, pick one thing — "the daily game-screenshot challenge" — and let everything else be discovered after the hook lands. The breadth is fine as product depth; it's a liability only when it's the first thing a new visitor sees. Geo mode being marketed on the home nav (with an "Alpha" badge) dilutes the core pitch.</p>
+    </div>
+  </details>
+
+  <!-- 12 -->
+  <details class="principle">
+    <summary><span class="num">12</span><span class="ptitle">Popcorn pricing (Good / Better / Best)</span><span class="badge pass">PASS</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Exactly three cards: Free (€0) / Premium Monthly (€3.99) / Premium Annual (€29.99, "Most popular" badge, "~37% savings"). Annual is the anchored middle-of-attention.</p>
+      <p class="lbl">Verdict</p>
+      <p>Clean three-choice layout with a highlighted recommended tier. Caveat: it's the same product at two cadences, not true Good/Better/Best feature ladders — but for a single-product game that's the right call.</p>
+    </div>
+  </details>
+
+  <!-- 13 -->
+  <details class="principle">
+    <summary><span class="num">13</span><span class="ptitle">Rides a wave</span><span class="badge pass">PASS</span></summary>
+    <div class="body">
+      <p class="lbl">Verdict</p>
+      <p>Daily one-shot challenge with shareable results is squarely in the Wordle/GeoGuessr wave — a format people already understand and share. The mechanic does half the marketing. Lean harder into the "daily, everyone gets the same one" framing (it's underused in the copy).</p>
+    </div>
+  </details>
+
+  <!-- 14 -->
+  <details class="principle">
+    <summary><span class="num">14</span><span class="ptitle">Steal your best copy from customers</span><span class="badge fail">FAIL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>No testimonials, no captured user quotes, no review surface feeding copy. (Koe feedback widget exists but isn't mined for landing copy.)</p>
+      <p class="lbl">Verdict</p>
+      <p>Can't write like customers talk if you're not capturing how they talk. The Koe widget is a ready-made source — pull the best lines into the landing page.</p>
+    </div>
+  </details>
+
+  <!-- 15 -->
+  <details class="principle">
+    <summary><span class="num">15</span><span class="ptitle">A founder people can see and hear</span><span class="badge fail">FAIL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>No founder face, voice, screen-recording, or personal note anywhere on the marketing surfaces. There <em>is</em> a Remotion marketing-video package — but it's a product promo, not a founder.</p>
+      <p class="lbl">Verdict</p>
+      <p>Easy, high-leverage gap. A 30-second founder screen-recording playing today's challenge would outperform the current text hero. The Remotion pipeline is already in place to produce/host it.</p>
+    </div>
+  </details>
+
+  <!-- 16 -->
+  <details class="principle">
+    <summary><span class="num">16</span><span class="ptitle">Pricing impossible to miss</span><span class="badge pass">PASS</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>"Premium" lives in the header nav with an accent-pink treatment; a premium teaser card sits mid-home. Pricing is at <code>/premium</code>.</p>
+      <p class="lbl">Verdict</p>
+      <p>Pricing is reachable in one click from anywhere and visually distinguished. Met.</p>
+    </div>
+  </details>
+
+  <!-- 17 -->
+  <details class="principle">
+    <summary><span class="num">17</span><span class="ptitle">Headline people remember next day</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Verdict</p>
+      <p>"The Box" the <em>name</em> is sticky; the <em>value</em> headline isn't (it's a feature list). The thing people would actually remember is the dare in the FR copy. Run Lou's test — write 5 headlines around "name the game in 45 seconds", pick the one friends recall a day later.</p>
+    </div>
+  </details>
+
+  <!-- 18 -->
+  <details class="principle">
+    <summary><span class="num">18</span><span class="ptitle">An emotional headline</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Verdict</p>
+      <p>FR nails it ("let's see if your gaming cred still holds up" — provokes ego/challenge). EN is flat and informational. Bring the emotional dare into EN; that's the "wow/wtf/laugh" Lou wants.</p>
+    </div>
+  </details>
+
+  <!-- 19 -->
+  <details class="principle">
+    <summary><span class="num">19</span><span class="ptitle">Something people have never seen</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Verdict</p>
+      <p>Screenshot-guessing is a known genre (clones exist). The novel angle is <strong>Geo mode for game maps</strong> (pinpoint where a screenshot was taken) — genuinely fresh — but it's buried behind an "Alpha" badge and gated to premium. The differentiator isn't the headline. If novelty is the goal, Geo is the surprise to lead with; if focus (#11) is the goal, keep it secondary. Pick one.</p>
+    </div>
+  </details>
+
+  <!-- 20 -->
+  <details class="principle">
+    <summary><span class="num">20</span><span class="ptitle">Sellable from the hero alone</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Hero = wordmark + subtitle + play button. A motivated visitor gets it; a cold visitor sees a brand name and a paragraph.</p>
+      <p class="lbl">Verdict</p>
+      <p>80% won't scroll. The hero needs (1) a value headline not a brand name, and (2) the product shown (a screenshot) not described. Currently it's carried by the subtitle doing too much work. This is the highest-ROI fix.</p>
+    </div>
+  </details>
+
+  <!-- 21 -->
+  <details class="principle">
+    <summary><span class="num">21</span><span class="ptitle">Empathy before selling</span><span class="badge fail">FAIL</span></summary>
+    <div class="body">
+      <p class="lbl">Verdict</p>
+      <p>No problem framing anywhere — the copy jumps straight to features. For a game the "problem" is emotional (boredom, wanting to prove gaming knowledge, daily ritual). The FR dare gestures at it; nothing develops it. Lighter weight than for SaaS, but a one-line "you think you know games?" beat would help.</p>
+    </div>
+  </details>
+
+  <!-- 22 -->
+  <details class="principle">
+    <summary><span class="num">22</span><span class="ptitle">One call to action</span><span class="badge fail">FAIL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Home presents many competing actions: "Play Today's Challenge", "Geo Mode" (Alpha), "History", "Play Yesterday", plus "See plans" in the premium teaser.</p>
+      <p class="lbl">Verdict</p>
+      <p>Multiple paths → decision paralysis. There should be exactly one primary action above the fold: <strong>play today</strong>. Demote Geo/History/Yesterday/plans to secondary/contextual placement.</p>
+    </div>
+  </details>
+
+  <!-- 23 -->
+  <details class="principle">
+    <summary><span class="num">23</span><span class="ptitle">A name people remember</span><span class="badge pass">PASS</span></summary>
+    <div class="body">
+      <p class="lbl">Verdict</p>
+      <p>"The Box" — real words, no wordplay, easy to say/spell. Trade-off: it's generic and SEO-hostile (un-searchable, no category signal). Memorable: yes. Discoverable: no. Met on the letter of the principle.</p>
+    </div>
+  </details>
+
+  <!-- 24 -->
+  <details class="principle">
+    <summary><span class="num">24</span><span class="ptitle">Sell a human desire, not a feature</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Verdict</p>
+      <p>EN copy sells features ("21 achievements, leaderboards, win streaks"). The underlying desire is <em>status</em> ("prove you're a real gamer") — present implicitly in FR, never named in EN. Sell the bragging rights / leaderboard glory; the achievements are just the vehicle.</p>
+    </div>
+  </details>
+
+  <!-- 25 -->
+  <details class="principle">
+    <summary><span class="num">25</span><span class="ptitle">Let people try before buying</span><span class="badge pass">PASS</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Guest play + free daily challenge with full core loop (10 screenshots, scoring, leaderboard) before any signup or payment.</p>
+      <p class="lbl">Verdict</p>
+      <p>Strongest principle alignment in the whole app. "Play before you pay" is the default. Keep it — and make sure the upgrade prompt fires at the moment of desire (e.g. when a free user hits the 7-day archive wall).</p>
+    </div>
+  </details>
+
+  <!-- 26 -->
+  <details class="principle">
+    <summary><span class="num">26</span><span class="ptitle">No weak words</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Mostly concrete. Minor hedging: "~37% savings", "From {{price}} / month", "Best value per month". No egregious "most/many/rarely".</p>
+      <p class="lbl">Verdict</p>
+      <p>Largely clean. The "~" and "From" soften otherwise strong claims — fine for pricing accuracy, but the value copy could make harder statements ("the same challenge for everyone, every day").</p>
+    </div>
+  </details>
+
+  <!-- 27 -->
+  <details class="principle">
+    <summary><span class="num">27</span><span class="ptitle">No subscription</span><span class="badge fail">FAIL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Both paid tiers are recurring (<code>interval: 'month' | 'year'</code> in <code>BILLING_CATALOG</code>). The one-time <code>supporter_lifetime</code> tier is defined in types + docs but <strong>has no catalog entry / purchasable price</strong> (see top callout).</p>
+      <p class="lbl">Verdict</p>
+      <p>Lou: "one-time payments are 10× easier to sell." The lifetime/supporter one-time option is literally half-built. Finishing it would both satisfy this principle and give the "support the game" framing (already used in the pricing subtitle) a concrete product. Recommend wiring <code>supporter_lifetime</code> into the catalog + pricing UI, or removing the dead tier.</p>
+    </div>
+  </details>
+
+  <!-- 28 -->
+  <details class="principle">
+    <summary><span class="num">28</span><span class="ptitle">CTA says what happens next</span><span class="badge pass">PASS</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>Primary CTA is "Play Today's Challenge" / "Défi Quotidien" — specific, action-naming. No generic "Get Started". OG CTA: "Play today's challenge".</p>
+      <p class="lbl">Verdict</p>
+      <p>Met. Minor: "See plans" / "Voir les offres" is weaker than the play CTA — could be "Unlock the full archive" to name the outcome.</p>
+    </div>
+  </details>
+
+  <!-- 29 -->
+  <details class="principle">
+    <summary><span class="num">29</span><span class="ptitle">Don't launch without testimonials</span><span class="badge fail">FAIL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>No testimonials, ratings, user counts, or any third-party proof on the landing page. The achievement teaser shows aspirational locked trophies — not social proof.</p>
+      <p class="lbl">Verdict</p>
+      <p>Highest-impact, lowest-effort gap alongside #15. Even "X players solved today's challenge" (a number you already have) is real-time social proof. Add player counts / streak stats / a few quotes before driving traffic.</p>
+    </div>
+  </details>
+
+  <!-- 30 -->
+  <details class="principle">
+    <summary><span class="num">30</span><span class="ptitle">Describable in under 10 words</span><span class="badge pass">PASS</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>The OG tagline does it in six: "Guess the game from a screenshot." (FR: "Devinez le jeu à partir d'une capture d'écran.")</p>
+      <p class="lbl">Verdict</p>
+      <p>Met — but the one-liner lives in the OG image, not the hero h1. Promote it (ties back to #7, #20).</p>
+    </div>
+  </details>
+
+  <!-- 31 -->
+  <details class="principle">
+    <summary><span class="num">31</span><span class="ptitle">More expensive than competitors</span><span class="badge partial">PARTIAL</span></summary>
+    <div class="body">
+      <p class="lbl">Evidence</p>
+      <p>€3.99/mo, €29.99/yr. For a casual daily game this is mid-to-low, not premium-priced.</p>
+      <p class="lbl">Verdict</p>
+      <p>"Nobody talks about the second cheapest option." Pricing power for a game is real but bounded — most direct competitors (Wordle-likes) are free/ad-supported, so "charge more than competitors" is awkward here. The lifetime/supporter tier (#27) is the better lever: a higher one-time "supporter" price reframes payment as patronage rather than a cheap subscription.</p>
+    </div>
+  </details>
+
+  <h2>Top 5 recommendations (ranked by ROI)</h2>
+  <ol class="recs">
+    <li><span class="tag">#20 #7 #10 #30</span> <strong>Rebuild the hero around the product, not the brand.</strong> Lead with a value headline ("Name the game from one screenshot"), show a real (blurred) screenshot + answer box, single primary CTA. Fixes 4 principles in one change.</li>
+    <li><span class="tag">#29 #14</span> <strong>Add social proof.</strong> "N players solved today" (data you already have) + a handful of Koe-sourced quotes. Cheap, high-trust.</li>
+    <li><span class="tag">#15</span> <strong>Founder screen-recording in the hero.</strong> The Remotion pipeline already exists; a 30s founder clip beats the text block.</li>
+    <li><span class="tag">#27 #31</span> <strong>Finish or kill <code>supporter_lifetime</code>.</strong> Wire it into <code>BILLING_CATALOG</code> + pricing UI as a one-time "supporter" purchase (and consider pricing it boldly), or remove the dead tier from types/docs.</li>
+    <li><span class="tag">#22 #11 #9 #18</span> <strong>Focus the home page.</strong> One primary CTA (play today); demote Geo/History/Yesterday. Port the punchy FR voice into EN so the copy is ownable and emotional.</li>
+  </ol>
+
+  <h2>Scope &amp; caveats</h2>
+  <p class="meta">This review covers marketing/landing/pricing/OG surfaces and copy only — not gameplay, infra, or correctness. Quoted copy is from <code>public/locales/{en,fr}/translation.json</code> and may drift. Six "FAIL/FAIL*" verdicts (#1, #8, partially #27, #31) reflect deliberate freemium-game strategy that diverges from Lou's paid-SaaS framing; they're listed for completeness, not as defects. The principles are a compass, not a spec.</p>
+
+</div>
+</body>
+</html>

--- a/tasks/viral-product-principles-review.html
+++ b/tasks/viral-product-principles-review.html
@@ -441,13 +441,15 @@ Caveat: principles target paid SaaS landing pages; The Box is a freemium daily g
   </details>
 
   <h2>Top 5 recommendations (ranked by ROI)</h2>
+  <p class="meta">Status tags below: <span class="badge pass">DONE</span> shipped in this branch · <span class="badge partial">PARTIAL</span> partly addressed · <span class="badge fail">OPEN</span> not started.</p>
   <ol class="recs">
-    <li><span class="tag">#20 #7 #10 #30</span> <strong>Rebuild the hero around the product, not the brand.</strong> Lead with a value headline ("Name the game from one screenshot"), show a real (blurred) screenshot + answer box, single primary CTA. Fixes 4 principles in one change.</li>
-    <li><span class="tag">#29 #14</span> <strong>Add social proof.</strong> "N players solved today" (data you already have) + a handful of Koe-sourced quotes. Cheap, high-trust.</li>
-    <li><span class="tag">#15</span> <strong>Founder screen-recording in the hero.</strong> The Remotion pipeline already exists; a 30s founder clip beats the text block.</li>
-    <li><span class="tag">#27 #31</span> <strong>Finish or kill <code>supporter_lifetime</code>.</strong> Wire it into <code>BILLING_CATALOG</code> + pricing UI as a one-time "supporter" purchase (and consider pricing it boldly), or remove the dead tier from types/docs.</li>
-    <li><span class="tag">#22 #11 #9 #18</span> <strong>Focus the home page.</strong> One primary CTA (play today); demote Geo/History/Yesterday. Port the punchy FR voice into EN so the copy is ownable and emotional.</li>
+    <li><span class="badge partial">PARTIAL</span> <span class="tag">#20 #7 #10 #30</span> <strong>Rebuild the hero around the product, not the brand.</strong> <em>Done:</em> value headline ("Name the game from one screenshot") promoted to the h1, brand demoted to a small wordmark, single primary CTA (Geo demoted to a quiet link). <em>Still open:</em> the screenshot preview only shows for anonymous, not-completed visitors — consider surfacing it more universally.</li>
+    <li><span class="badge partial">PARTIAL</span> <span class="tag">#29 #14</span> <strong>Add social proof.</strong> <em>Done:</em> a live "N players have taken on today's challenge" badge backed by real data (<code>GET /api/leaderboard/today/count</code>), shown only when the count is positive. <em>Still open:</em> Koe-sourced testimonial quotes (needs real user input — not fabricated).</li>
+    <li><span class="badge fail">OPEN</span> <span class="tag">#15</span> <strong>Founder screen-recording in the hero.</strong> The Remotion pipeline already exists; a 30s founder clip beats the text block. Needs a real recorded asset.</li>
+    <li><span class="badge pass">DONE</span> <span class="tag">#27 #31</span> <strong>Finish <code>supporter_lifetime</code>.</strong> Wired into <code>BILLING_CATALOG</code> + checkout + pricing UI as a one-time €79.99 "supporter" purchase. Remaining: create the matching Stripe price so the card renders active in prod.</li>
+    <li><span class="badge partial">PARTIAL</span> <span class="tag">#22 #11 #9 #18</span> <strong>Focus the home page.</strong> <em>Done:</em> one loud primary CTA (play today); Geo demoted to a quiet secondary link. FR headline/subtitle keep the punchy voice; EN headline tightened. <em>Still open:</em> History/Yesterday prompts still appear contextually.</li>
   </ol>
+  <p class="meta"><strong>Also shipped:</strong> the OG share card now embeds today's actual (blurred) screenshot under a scrim with a "Can you name this game?" hook (principle #5), instead of the text-only date card.</p>
 
   <h2>Scope &amp; caveats</h2>
   <p class="meta">This review covers marketing/landing/pricing/OG surfaces and copy only — not gameplay, infra, or correctness. Quoted copy is from <code>public/locales/{en,fr}/translation.json</code> and may drift. Several "FAIL*" verdicts (#1, #8, #31, and the subscription-default in #27) reflect deliberate freemium-game strategy that diverges from Lou's paid-SaaS framing; they're listed for completeness, not as defects. The principles are a compass, not a spec.</p>

--- a/tasks/viral-product-principles-review.html
+++ b/tasks/viral-product-principles-review.html
@@ -7,9 +7,9 @@
 <title>The Box — 31 Viral-Product Principles Review</title>
 <!-- SUMMARY:
 Scores The Box's landing/pricing/marketing surfaces against Marc Lou's "31 Principles of a Viral Product".
-Verdict: 6 PASS, 14 PARTIAL, 11 FAIL. Biggest gaps: no testimonials/social proof, no founder presence,
+Verdict: 6 PASS, 15 PARTIAL, 10 FAIL (after wiring the lifetime tier in this branch). Biggest gaps: no testimonials/social proof, no founder presence,
 no problem/empathy framing, hero leads with brand name not value, multiple competing CTAs, "does one thing" violated.
-Notable code finding: supporter_lifetime tier exists in types + docs but is NOT in BILLING_CATALOG (no purchasable one-time option).
+Code finding (now fixed in this branch): supporter_lifetime was wired in types/docs/webhook/DB but missing from BILLING_CATALOG + checkout — now added as a one-time tier with a pricing card.
 Caveat: principles target paid SaaS landing pages; The Box is a freemium daily game, so "no free plan / hard paywall / no subscription" are intentionally off-strategy, not bugs.
 -->
 <style>
@@ -101,13 +101,13 @@ Caveat: principles target paid SaaS landing pages; The Box is a freemium daily g
 
   <div class="board">
     <div class="stat"><div class="n pass">6</div><div class="l">Pass</div></div>
-    <div class="stat"><div class="n partial">14</div><div class="l">Partial</div></div>
-    <div class="stat"><div class="n fail">11</div><div class="l">Fail</div></div>
+    <div class="stat"><div class="n partial">15</div><div class="l">Partial</div></div>
+    <div class="stat"><div class="n fail">10</div><div class="l">Fail</div></div>
   </div>
 
-  <div class="callout danger">
-    <h3>⚠ Code finding worth a ticket (independent of the principles)</h3>
-    <p>The <code>supporter_lifetime</code> tier is a first-class <code>BillingTier</code> in <code>packages/types/src/index.ts:1331</code> and is fully documented in <code>docs/billing-stripe.md</code> (one-time "supporter à vie" payment, dedicated webhook branch, <code>users.supporter_lifetime_at</code> column). But it is <strong>not present in <code>BILLING_CATALOG</code></strong> (<code>packages/backend/src/config/billing.ts</code>) &mdash; only <code>premium_monthly</code> and <code>premium_annual</code> are. So there is no resolvable price / purchasable path for the lifetime option today. This is exactly the one-time-payment lever principle&nbsp;#27 argues for, sitting half-wired in the codebase. Either finish wiring it or prune the dead tier from types/docs.</p>
+  <div class="callout">
+    <h3>✓ Code finding — now resolved in this branch</h3>
+    <p>The <code>supporter_lifetime</code> tier was a first-class <code>BillingTier</code> (<code>packages/types/src/index.ts:1331</code>), fully documented in <code>docs/billing-stripe.md</code>, with a webhook branch, a <code>users.supporter_lifetime_at</code> column, and entitlement/grant/revoke logic already in place &mdash; but it was <strong>missing from <code>BILLING_CATALOG</code></strong> and from the <code>/checkout</code> allowlist, so there was no purchasable path. This branch finishes the wiring: a one-time catalog entry (<code>the_box_supporter_lifetime</code>, &euro;79.99, <code>interval: null</code> &rarr; Stripe <code>mode: 'payment'</code>), the tier added to the checkout allowlist, a "Lifetime Supporter / Supporter à vie" pricing card with one-time copy in EN&nbsp;+&nbsp;FR, and a catalog regression test. The one-time-payment lever principle&nbsp;#27 argues for is now live. <em>Remaining ops step: create the matching Stripe price with lookup_key <code>the_box_supporter_lifetime</code> so <code>npm run stripe:check</code> passes and the card renders active in prod.</em></p>
   </div>
 
   <h2>Per-principle scorecard</h2>
@@ -387,12 +387,12 @@ Caveat: principles target paid SaaS landing pages; The Box is a freemium daily g
 
   <!-- 27 -->
   <details class="principle">
-    <summary><span class="num">27</span><span class="ptitle">No subscription</span><span class="badge fail">FAIL</span></summary>
+    <summary><span class="num">27</span><span class="ptitle">No subscription</span><span class="badge partial">PARTIAL ↑</span></summary>
     <div class="body">
       <p class="lbl">Evidence</p>
-      <p>Both paid tiers are recurring (<code>interval: 'month' | 'year'</code> in <code>BILLING_CATALOG</code>). The one-time <code>supporter_lifetime</code> tier is defined in types + docs but <strong>has no catalog entry / purchasable price</strong> (see top callout).</p>
+      <p>Originally both paid tiers were recurring and the one-time <code>supporter_lifetime</code> tier had no catalog entry. <strong>This branch adds the one-time tier</strong> (€79.99, <code>interval: null</code>) to <code>BILLING_CATALOG</code>, the checkout allowlist, and the pricing UI — so the app now offers a one-time option alongside the subscriptions.</p>
       <p class="lbl">Verdict</p>
-      <p>Lou: "one-time payments are 10× easier to sell." The lifetime/supporter one-time option is literally half-built. Finishing it would both satisfy this principle and give the "support the game" framing (already used in the pricing subtitle) a concrete product. Recommend wiring <code>supporter_lifetime</code> into the catalog + pricing UI, or removing the dead tier.</p>
+      <p>Lou: "one-time payments are 10× easier to sell." Moved from FAIL → PARTIAL: the one-time "support the game" product now exists (the framing was already in the pricing subtitle). Subscriptions remain the default path, which is reasonable for a recurring-content game. Remaining: create the Stripe price so the card renders active in prod, and consider whether to promote the lifetime tier harder per principle #31.</p>
     </div>
   </details>
 
@@ -450,7 +450,7 @@ Caveat: principles target paid SaaS landing pages; The Box is a freemium daily g
   </ol>
 
   <h2>Scope &amp; caveats</h2>
-  <p class="meta">This review covers marketing/landing/pricing/OG surfaces and copy only — not gameplay, infra, or correctness. Quoted copy is from <code>public/locales/{en,fr}/translation.json</code> and may drift. Six "FAIL/FAIL*" verdicts (#1, #8, partially #27, #31) reflect deliberate freemium-game strategy that diverges from Lou's paid-SaaS framing; they're listed for completeness, not as defects. The principles are a compass, not a spec.</p>
+  <p class="meta">This review covers marketing/landing/pricing/OG surfaces and copy only — not gameplay, infra, or correctness. Quoted copy is from <code>public/locales/{en,fr}/translation.json</code> and may drift. Several "FAIL*" verdicts (#1, #8, #31, and the subscription-default in #27) reflect deliberate freemium-game strategy that diverges from Lou's paid-SaaS framing; they're listed for completeness, not as defects. The principles are a compass, not a spec.</p>
 
 </div>
 </body>


### PR DESCRIPTION
## What

Reviews The Box against Marc Lou's *"31 Principles of a Viral Product"*, then implements the highest-ROI gaps the review found.

**Review artifact:** `tasks/viral-product-principles-review.html` (self-contained HTML, per the repo's HTML-first convention). Verdict: **6 PASS · 15 PARTIAL · 10 FAIL**, with several "fails" flagged as deliberate freemium-game strategy rather than defects.

## Implemented (4 of the top recommendations)

### 1. One-time `supporter_lifetime` tier (principle #27 / #31) — DONE
Was a first-class `BillingTier` with webhook branch, DB column, and entitlement/grant/revoke logic all in place, but **missing from `BILLING_CATALOG` + the `/checkout` allowlist** → no purchasable path.
- `config/billing.ts` — catalog entry: `the_box_supporter_lifetime`, €79.99, `interval: null` (→ Stripe `mode: 'payment'`, already handled).
- `billing.routes.ts` — added to the `/checkout` `TIERS` allowlist.
- `PricingCard.tsx` — one-time tiers get a "one-time" label + "Become a supporter" CTA + "Pay once. Premium forever." note.
- `PricingTable.tsx` — 4-card responsive grid (Free / Monthly / Annual / Lifetime).
- Locales (en + fr) + `billing.test.ts` regression test + `docs/billing-stripe.md` update.

### 2. Live social-proof badge (principle #29) — real data, never fabricated
- Backend: `GET /api/leaderboard/today/count` → `countPlayersByChallenge` (ranked, non-catch-up, non-anonymous), via the port + repo + service, with a unit test.
- Frontend: `HomeSocialProof` shows "N players have taken on today's challenge" — **only when the count is positive** (no deflating "0 players"). Pluralised + locale-formatted (en/fr).

### 3. Value-led hero + single CTA (principles #20 / #7 / #10 / #22)
- `HomePage` hero now leads with a value headline (`home.headline`, "Name the game from one screenshot") as the h1; the brand "The Box" is demoted to a small wordmark.
- `HomeDailyCta` — one loud primary action (play / history); Geo mode demoted from an equal-weight button to a quiet secondary link.
- EN subtitle tightened; FR keeps its punchy dare.

### 4. Screenshot OG card (principle #5)
- `og.routes.ts` now embeds today's actual screenshot (blurred, base64) under a dark scrim with a "Can you name this game?" hook + CTA, instead of the text-only date card.
- Guarded to dates ≤ today (won't leak future challenges, mirroring the preview endpoint's rule); fail-soft back to the gradient card. Verified resvg renders the embed + Gaussian blur. Preview shared in chat.

## Not done (need assets / real input)
- **Founder video (#15):** needs a real recorded clip (Remotion pipeline exists).
- **Testimonials (#14):** won't fabricate quotes — needs real user input (Koe widget is the source).

## Verification
- `npm run build` ✓ (types + backend + frontend)
- `npm test` ✓ (frontend 25, backend 234 incl. new catalog + leaderboard tests)
- `npm run lint` ✓

## Remaining ops step (not code)
Create the Stripe price with lookup_key `the_box_supporter_lifetime` (€79.99, one-time) so `npm run stripe:check` passes and the lifetime card renders **active** in prod.

https://claude.ai/code/session_01U1YTDQCBqFxAu6C76qsFmW