### PR TITLE
fix(auth): center field icons reliably in login/register forms

### DIFF
--- a/packages/frontend/src/components/ui/password.tsx
+++ b/packages/frontend/src/components/ui/password.tsx
@@ -32,7 +32,7 @@ const Password = ({ className, showToggle = true, ref, ...props }: PasswordProps
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+            className="absolute right-3 inset-y-0 my-auto flex h-fit items-center text-muted-foreground hover:text-foreground transition-colors"
             tabIndex={-1}
           >
             {showPassword ? (

--- a/packages/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/packages/frontend/src/pages/ForgotPasswordPage.tsx
@@ -144,7 +144,7 @@ export default function ForgotPasswordPage() {
                       </FormLabel>
                       <FormControl>
                         <div className="relative group">
-                          <Mail className="absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground group-focus-within:text-neon-pink transition-colors" />
+                          <Mail className="absolute left-4 inset-y-0 my-auto size-4 text-muted-foreground group-focus-within:text-neon-pink transition-colors" />
                           <Input
                             type="email"
                             placeholder="you@example.com"

--- a/packages/frontend/src/pages/LoginPage.tsx
+++ b/packages/frontend/src/pages/LoginPage.tsx
@@ -112,7 +112,7 @@ export default function LoginPage() {
                   {t('auth.emailOrUsername')}
                 </label>
                 <div className="relative group">
-                  <User className="absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground group-focus-within:text-neon-purple transition-colors" />
+                  <User className="absolute left-4 inset-y-0 my-auto size-4 text-muted-foreground group-focus-within:text-neon-purple transition-colors" />
                   <Input
                     type="text"
                     placeholder={t('auth.emailOrUsernamePlaceholder')}
@@ -130,7 +130,7 @@ export default function LoginPage() {
                   {t('auth.password')}
                 </label>
                 <div className="relative group">
-                  <Lock className="absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground group-focus-within:text-neon-purple transition-colors z-10" />
+                  <Lock className="absolute left-4 inset-y-0 my-auto size-4 text-muted-foreground group-focus-within:text-neon-purple transition-colors z-10" />
                   <Password
                     placeholder="••••••••"
                     value={formData.password}

--- a/packages/frontend/src/pages/RegisterPage.tsx
+++ b/packages/frontend/src/pages/RegisterPage.tsx
@@ -176,7 +176,7 @@ export default function RegisterPage() {
                       </FormLabel>
                       <FormControl>
                         <div className="relative group">
-                          <User className="absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground group-focus-within:text-neon-cyan transition-colors" />
+                          <User className="absolute left-4 inset-y-0 my-auto size-4 text-muted-foreground group-focus-within:text-neon-cyan transition-colors" />
                           <Input
                             type="text"
                             placeholder={t('auth.usernamePlaceholder')}
@@ -201,7 +201,7 @@ export default function RegisterPage() {
                       </FormLabel>
                       <FormControl>
                         <div className="relative group">
-                          <Mail className="absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground group-focus-within:text-neon-cyan transition-colors" />
+                          <Mail className="absolute left-4 inset-y-0 my-auto size-4 text-muted-foreground group-focus-within:text-neon-cyan transition-colors" />
                           <Input
                             type="email"
                             placeholder="you@example.com"
@@ -226,7 +226,7 @@ export default function RegisterPage() {
                       </FormLabel>
                       <FormControl>
                         <div className="relative group">
-                          <Lock className="absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground group-focus-within:text-neon-cyan transition-colors" />
+                          <Lock className="absolute left-4 inset-y-0 my-auto size-4 text-muted-foreground group-focus-within:text-neon-cyan transition-colors" />
                           <Input
                             type="password"
                             placeholder="••••••••"
@@ -251,7 +251,7 @@ export default function RegisterPage() {
                       </FormLabel>
                       <FormControl>
                         <div className="relative group">
-                          <Lock className="absolute left-4 top-1/2 -translate-y-1/2 size-4 text-muted-foreground group-focus-within:text-neon-cyan transition-colors" />
+                          <Lock className="absolute left-4 inset-y-0 my-auto size-4 text-muted-foreground group-focus-within:text-neon-cyan transition-colors" />
                           <Input
                             type="password"
                             placeholder="••••••••"


### PR DESCRIPTION
## What

The leading icons inside the auth form fields (user / lock / mail) could
render too high instead of vertically centered — visible on the login form
(see reported screenshot).

## Why

The icons were centered with `top-1/2 -translate-y-1/2`. Under Tailwind v4
this compiles to `top: calc(1/2 * 100%)` plus the `translate` CSS property
(`translate: var(--tw-translate-x) var(--tw-translate-y)`). That pairing is
fragile in stricter/older browser engines: if either the `calc()` `top`
value or the custom-property `translate` fails to resolve, the icon falls
back to the top of the field rather than its center.

## Fix

Switch to auto-margin centering of a fixed-height, absolutely-positioned
element: `inset-y-0 my-auto` (`top:0; bottom:0; margin-block:auto`). This
avoids both the `translate` property and the division-in-`calc()` `top`
value, so the icon centers identically everywhere.

Applied to the icons on **Login**, **Register** and **Forgot Password**
forms, and to the show/hide toggle in the shared `Password` component so
both icons in a password field stay aligned.

## Verification

Rendered the exact field markup with the project's real compiled
Tailwind v4 CSS in headless Chromium and measured icon vs. input vertical
centers:

- before & after: `iconCenterY === inputCenterY` (e.g. `199 === 199`,
  `296 === 296`)

The new technique produces identical centering while removing the
two cross-browser failure points. Changes are className-only (valid
Tailwind utilities), so there is no type/build impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DT3meKgQa6m2xz7T5hdnAc)_