### PR TITLE
feat(leaderboard): show captures found and avg discovery time per player

### DIFF
--- a/packages/backend/src/infrastructure/repositories/leaderboard.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/leaderboard.repository.ts
@@ -9,6 +9,8 @@ interface LeaderboardRow {
   username: string | null
   display_name: string | null
   avatar_url: string | null
+  captures_found: string | null // count comes as string
+  avg_capture_time_ms: string | null // AVG comes as string
 }
 
 interface MonthlyLeaderboardRow {
@@ -18,6 +20,24 @@ interface MonthlyLeaderboardRow {
   username: string | null
   display_name: string | null
   avatar_url: string | null
+  captures_found: string | null
+  avg_capture_time_ms: string | null
+}
+
+// Per-session stats over correct guesses only: how many captures the
+// player found and the time spent on the guesses that found them.
+// Joined into both boards so each row can show discovery count + speed.
+function correctGuessStatsSubquery() {
+  return db('guesses')
+    .join('tier_sessions', 'guesses.tier_session_id', 'tier_sessions.id')
+    .where('guesses.is_correct', true)
+    .groupBy('tier_sessions.game_session_id')
+    .select(
+      'tier_sessions.game_session_id',
+      db.raw('COUNT(*) as captures_found'),
+      db.raw('SUM(guesses.time_taken_ms) as capture_time_ms')
+    )
+    .as('guess_stats')
 }
 
 export const leaderboardRepository = {
@@ -27,6 +47,7 @@ export const leaderboardRepository = {
     // order is stable across refreshes.
     const sessions = await db('game_sessions')
       .join('user', 'game_sessions.user_id', 'user.id')
+      .leftJoin(correctGuessStatsSubquery(), 'guess_stats.game_session_id', 'game_sessions.id')
       .where('game_sessions.daily_challenge_id', challengeId)
       .andWhere('game_sessions.is_completed', true)
       .andWhere('game_sessions.is_catch_up', false) // Exclude catch-up sessions from leaderboard
@@ -45,6 +66,10 @@ export const leaderboardRepository = {
         'user.username',
         'user.display_name',
         'user.avatar_url',
+        db.raw('COALESCE(guess_stats.captures_found, 0) as captures_found'),
+        db.raw(
+          'guess_stats.capture_time_ms / NULLIF(guess_stats.captures_found, 0) as avg_capture_time_ms'
+        ),
         // DENSE_RANK so tied scores share the same rank instead of
         // pushing the rest of the board down a slot.
         db.raw(
@@ -60,6 +85,11 @@ export const leaderboardRepository = {
       displayName: session.display_name ?? session.username ?? 'Anonymous',
       avatarUrl: session.avatar_url ?? undefined,
       totalScore: session.total_score,
+      correctAnswers: Number(session.captures_found ?? 0),
+      avgCaptureTimeMs:
+        session.avg_capture_time_ms != null
+          ? Math.round(Number(session.avg_capture_time_ms))
+          : undefined,
       completedAt: session.completed_at?.toISOString(),
     }))
   },
@@ -121,6 +151,7 @@ export const leaderboardRepository = {
     const rows = await db('game_sessions')
       .join('user', 'game_sessions.user_id', 'user.id')
       .join('daily_challenges', 'game_sessions.daily_challenge_id', 'daily_challenges.id')
+      .leftJoin(correctGuessStatsSubquery(), 'guess_stats.game_session_id', 'game_sessions.id')
       .where('game_sessions.is_completed', true)
       .andWhere('game_sessions.is_catch_up', false) // Exclude catch-up sessions from monthly leaderboard
       .whereRaw('"user"."isAnonymous" = ?', [false])
@@ -135,6 +166,10 @@ export const leaderboardRepository = {
         'game_sessions.user_id',
         db.raw('SUM(game_sessions.total_score) as total_score'),
         db.raw('COUNT(game_sessions.id) as games_played'),
+        db.raw('COALESCE(SUM(guess_stats.captures_found), 0) as captures_found'),
+        db.raw(
+          'SUM(guess_stats.capture_time_ms) / NULLIF(SUM(guess_stats.captures_found), 0) as avg_capture_time_ms'
+        ),
         'user.username',
         'user.display_name',
         'user.avatar_url',
@@ -153,6 +188,11 @@ export const leaderboardRepository = {
       avatarUrl: row.avatar_url ?? undefined,
       totalScore: Number(row.total_score),
       gamesPlayed: Number(row.games_played),
+      correctAnswers: Number(row.captures_found ?? 0),
+      avgCaptureTimeMs:
+        row.avg_capture_time_ms != null
+          ? Math.round(Number(row.avg_capture_time_ms))
+          : undefined,
     }))
   },
 }

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -616,7 +616,9 @@
     "skipped": "Skipped",
     "errorLoading": "Failed to load player answers",
     "clickToView": "Click to view this player's answers",
-    "todayLocked": "Complete today's challenge to view other players' answers."
+    "todayLocked": "Complete today's challenge to view other players' answers.",
+    "capturesFound": "Captures found",
+    "avgCaptureTime": "Average time per capture"
   },
   "history": {
     "title": "Game History",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -616,7 +616,9 @@
     "skipped": "Passé",
     "errorLoading": "Impossible de charger les réponses",
     "clickToView": "Cliquez pour voir les réponses de ce joueur",
-    "todayLocked": "Termine le défi du jour pour voir les réponses des autres joueurs."
+    "todayLocked": "Termine le défi du jour pour voir les réponses des autres joueurs.",
+    "capturesFound": "Captures découvertes",
+    "avgCaptureTime": "Temps moyen par capture"
   },
   "history": {
     "title": "Historique des Parties",

--- a/packages/frontend/src/components/leaderboard/LeaderboardPanels.tsx
+++ b/packages/frontend/src/components/leaderboard/LeaderboardPanels.tsx
@@ -3,7 +3,7 @@ import { m } from 'framer-motion'
 import type { Locale } from 'date-fns'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Trophy, Medal, Award, Loader2, Eye } from 'lucide-react'
+import { Trophy, Medal, Award, Loader2, Eye, Images, Timer } from 'lucide-react'
 import { DatePicker } from '@/components/ui/date-picker'
 import { MonthPicker } from '@/components/ui/month-picker'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
@@ -16,6 +16,8 @@ export interface LeaderboardEntry {
   displayName: string
   avatarUrl?: string
   totalScore: number
+  correctAnswers?: number
+  avgCaptureTimeMs?: number
   completedAt?: string
 }
 
@@ -27,6 +29,8 @@ export interface MonthlyLeaderboardEntry {
   avatarUrl?: string
   totalScore: number
   gamesPlayed: number
+  correctAnswers?: number
+  avgCaptureTimeMs?: number
 }
 
 export interface AchievementLeaderboardEntry {
@@ -63,6 +67,45 @@ function LoadingState() {
     <div className="flex justify-center py-12">
       <Loader2 className="size-8 animate-spin text-primary" />
     </div>
+  )
+}
+
+function formatAvgTime(ms: number) {
+  const seconds = ms / 1000
+  return seconds >= 10 ? `${Math.round(seconds)}s` : `${seconds.toFixed(1)}s`
+}
+
+// Captures found + average time to find one. Hidden on mobile — the row
+// variant lives in the @username subtitle line instead.
+function CaptureStats({ entry }: { entry: { correctAnswers?: number; avgCaptureTimeMs?: number } }) {
+  const { t } = useTranslation()
+  if (entry.correctAnswers === undefined) return null
+  return (
+    <div className="hidden sm:flex items-center gap-3 shrink-0 text-xs text-muted-foreground">
+      <span className="flex items-center gap-1" title={t('leaderboard.capturesFound')}>
+        <Images className="size-3.5" />
+        {entry.correctAnswers}
+      </span>
+      {entry.avgCaptureTimeMs !== undefined && (
+        <span className="flex items-center gap-1" title={t('leaderboard.avgCaptureTime')}>
+          <Timer className="size-3.5" />
+          {formatAvgTime(entry.avgCaptureTimeMs)}
+        </span>
+      )}
+    </div>
+  )
+}
+
+// Mobile fallback: same stats appended to the @username line.
+function CaptureStatsInline({ entry }: { entry: { correctAnswers?: number; avgCaptureTimeMs?: number } }) {
+  if (entry.correctAnswers === undefined) return null
+  return (
+    <span className="sm:hidden">
+      {' '}· {entry.correctAnswers} <Images className="inline size-3" aria-hidden />
+      {entry.avgCaptureTimeMs !== undefined && (
+        <> · {formatAvgTime(entry.avgCaptureTimeMs)} <Timer className="inline size-3" aria-hidden /></>
+      )}
+    </span>
   )
 }
 
@@ -160,8 +203,12 @@ export function DailyLeaderboardPanel({
                   </Avatar>
                   <div className="flex-1 min-w-0">
                     <div className="font-semibold truncate">{entry.displayName}</div>
-                    <div className="text-xs text-muted-foreground truncate">@{entry.username}</div>
+                    <div className="text-xs text-muted-foreground truncate">
+                      <span>@{entry.username}</span>
+                      <CaptureStatsInline entry={entry} />
+                    </div>
                   </div>
+                  <CaptureStats entry={entry} />
                   <div className="text-right flex items-center gap-2 shrink-0">
                     <div className="font-bold text-primary">{entry.totalScore}</div>
                     {entry.sessionId && <Eye className="size-4 text-muted-foreground" />}
@@ -267,8 +314,10 @@ export function MonthlyLeaderboardPanel({
                     <div className="text-xs text-muted-foreground truncate">
                       <span>@{entry.username}</span>
                       <span className="sm:hidden"> · {entry.gamesPlayed} {t('leaderboard.gamesPlayed')}</span>
+                      <CaptureStatsInline entry={entry} />
                     </div>
                   </div>
+                  <CaptureStats entry={entry} />
                   <div className="text-right shrink-0">
                     <div className="font-bold text-primary">{entry.totalScore}</div>
                   </div>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -178,6 +178,8 @@ export interface LeaderboardEntry {
   totalScore: number
   correctAnswers?: number
   totalTimeMs?: number
+  /** Average time to find a capture (correct guesses only), in ms */
+  avgCaptureTimeMs?: number
   completedAt?: string
   sessionId?: string
 }
@@ -538,6 +540,9 @@ export interface MonthlyLeaderboardEntry {
   avatarUrl?: string
   totalScore: number
   gamesPlayed: number
+  correctAnswers?: number
+  /** Average time to find a capture (correct guesses only), in ms */
+  avgCaptureTimeMs?: number
 }
 
 export interface MonthlyLeaderboardResponse {


### PR DESCRIPTION
## Summary

Each row on the daily and monthly leaderboards now shows two new per-player stats:

- **Captures found** — number of screenshots the player guessed correctly for the period
- **Average discovery time** — average `time_taken_ms` over the correct guesses only

## Changes

- **`@the-box/types`**: populate the existing `LeaderboardEntry.correctAnswers` field and add `avgCaptureTimeMs` to both `LeaderboardEntry` and `MonthlyLeaderboardEntry` (optional, so existing consumers are unaffected).
- **Backend** (`leaderboard.repository.ts`): a shared per-session aggregate subquery (`guesses` → `tier_sessions`, `is_correct = true`) is left-joined into both `findByChallenge` and `findByMonth`. The daily board reads the per-session count/average directly; the monthly board sums counts and total time per user, then divides (`SUM(time) / NULLIF(SUM(count), 0)`), so the monthly average is correctly weighted across sessions. Rows with zero discoveries get `correctAnswers: 0` and no average.
- **Frontend** (`LeaderboardPanels.tsx`): each daily/monthly list row shows the two stats with `Images`/`Timer` icons (badged section on ≥sm screens, appended to the `@username` subtitle line on mobile, matching the existing `gamesPlayed` pattern). Tooltips use new i18n keys.
- **i18n**: added `leaderboard.capturesFound` / `leaderboard.avgCaptureTime` in `fr` and `en`.

## Verification

- `npm run build` — all packages typecheck/build
- `npm run lint` — clean
- `npm test` — 258 backend + 25 frontend unit tests pass
- Generated SQL for both queries compiled with Knex and reviewed (valid PostgreSQL; subquery join doesn't disturb DENSE_RANK, ordering, or the catch-up/anonymous filters)

https://claude.ai/code/session_01G6QtSuohpeJNzBrjfYgy3q

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6QtSuohpeJNzBrjfYgy3q)_