### PR TITLE
fix(frontend): iPhone compliance — stop iOS focus zoom on form controls

### DIFF
--- a/packages/frontend/e2e/iphone-compliance.spec.ts
+++ b/packages/frontend/e2e/iphone-compliance.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * iPhone compliance suite
+ *
+ * Guards the mobile-Safari pitfalls that don't show up on a desktop browser:
+ *
+ *   1. Zoom-on-focus — iOS Safari zooms the viewport whenever a focused
+ *      <input>/<textarea>/<select> has a computed font-size below 16px. Every
+ *      form control on a public page must therefore render at >= 16px on a
+ *      phone-width viewport.
+ *   2. Horizontal overflow — a single over-wide element makes the whole page
+ *      rubber-band sideways on a phone. The document must not scroll wider
+ *      than the viewport.
+ *   3. Viewport / PWA head — `viewport-fit=cover` (notch handling) plus the
+ *      apple-touch-icon and apple-mobile-web-app meta tags must be present.
+ *   4. Touch targets — the mobile BottomNav entries must clear the 44px
+ *      minimum (WCAG 2.5.5 / Apple HIG).
+ *
+ * The spec emulates an iPhone 13 viewport (390x844, 3x, touch) via
+ * `test.use(devices['iPhone 13'])`. It runs under the configured Chromium
+ * projects so it works in CI without the WebKit binary; the assertions are
+ * engine-independent because they read computed styles and layout box sizes.
+ * For a true Mobile-Safari pass, enable the commented "Mobile Safari" project
+ * in playwright.config.ts and run with WebKit installed.
+ *
+ * Prerequisites: dev servers running (`npm run dev`) + seeded DB
+ * (`npm run e2e:seed`). Only public pages (home, login) are exercised so the
+ * suite stays resilient to auth/seed state.
+ */
+import { test, expect, devices } from '@playwright/test'
+
+// Apply the iPhone 13 emulation (390x844, 3x DPR, touch, mobile UA) but drop
+// `defaultBrowserType` so the spec inherits the running project's engine. That
+// keeps it green under the Chromium projects CI already runs — enable the
+// commented "Mobile Safari" project for a genuine WebKit pass.
+const { defaultBrowserType: _engine, ...iPhone13 } = devices['iPhone 13']
+test.use(iPhone13)
+
+/** iOS Safari only suppresses zoom-on-focus at 16px or larger. */
+const MIN_NO_ZOOM_FONT_PX = 16
+/** WCAG 2.5.5 / Apple HIG minimum interactive target. */
+const MIN_TOUCH_TARGET_PX = 44
+
+test.describe('iPhone compliance', () => {
+  test('login form controls render at >= 16px (no iOS zoom-on-focus)', async ({ page }) => {
+    await page.goto('/en/login')
+    await page.waitForSelector('form')
+
+    const controls = page.locator('form input, form textarea, form select')
+    const count = await controls.count()
+    expect(count, 'login form should expose at least one control').toBeGreaterThan(0)
+
+    for (let i = 0; i < count; i++) {
+      const control = controls.nth(i)
+      if (!(await control.isVisible())) continue
+
+      const fontSizePx = await control.evaluate(
+        (el) => parseFloat(getComputedStyle(el).fontSize),
+      )
+      const descriptor = await control.evaluate((el) => {
+        const type = el.getAttribute('type') ?? el.tagName.toLowerCase()
+        const name = el.getAttribute('name') ?? el.getAttribute('placeholder') ?? ''
+        return `${type}${name ? ` (${name})` : ''}`
+      })
+
+      expect(
+        fontSizePx,
+        `${descriptor} font-size must be >= ${MIN_NO_ZOOM_FONT_PX}px to avoid iOS focus zoom`,
+      ).toBeGreaterThanOrEqual(MIN_NO_ZOOM_FONT_PX)
+    }
+  })
+
+  for (const path of ['/en', '/en/login']) {
+    test(`no horizontal overflow at iPhone width on ${path}`, async ({ page }) => {
+      await page.goto(path)
+      await page.waitForLoadState('load')
+      // Let layout settle (fonts, late-mounting chrome) before measuring.
+      await expect(page.locator('body')).toBeVisible()
+
+      const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }))
+
+      // 1px slack absorbs sub-pixel rounding on the 3x device scale factor.
+      expect(
+        scrollWidth,
+        `${path} scrolls ${scrollWidth - clientWidth}px wider than the viewport`,
+      ).toBeLessThanOrEqual(clientWidth + 1)
+    })
+  }
+
+  test('document head declares notch-safe viewport and Apple PWA tags', async ({ page }) => {
+    await page.goto('/en')
+
+    const viewport = await page.locator('meta[name="viewport"]').getAttribute('content')
+    expect(viewport, 'viewport meta must opt into the safe-area with viewport-fit=cover')
+      .toContain('viewport-fit=cover')
+    expect(viewport).toContain('width=device-width')
+
+    await expect(page.locator('link[rel="apple-touch-icon"]')).toHaveCount(1)
+    await expect(
+      page.locator('meta[name="apple-mobile-web-app-capable"]'),
+    ).toHaveAttribute('content', 'yes')
+  })
+
+  test('mobile bottom-nav targets clear the 44px minimum', async ({ page }) => {
+    await page.goto('/en')
+    await page.waitForLoadState('load')
+
+    const nav = page.getByRole('navigation', { name: /menu|navigation/i }).last()
+    await expect(nav).toBeVisible()
+    const links = nav.getByRole('link')
+    const count = await links.count()
+    expect(count, 'mobile bottom-nav should render its links').toBeGreaterThan(0)
+
+    for (let i = 0; i < count; i++) {
+      const box = await links.nth(i).boundingBox()
+      expect(box, `bottom-nav link ${i} should have a layout box`).not.toBeNull()
+      expect(
+        box!.height,
+        `bottom-nav link ${i} is ${box!.height}px tall (< ${MIN_TOUCH_TARGET_PX}px)`,
+      ).toBeGreaterThanOrEqual(MIN_TOUCH_TARGET_PX)
+    }
+  })
+})

--- a/packages/frontend/src/components/ReportCaptureDialog.tsx
+++ b/packages/frontend/src/components/ReportCaptureDialog.tsx
@@ -224,7 +224,7 @@ export function ReportCaptureDialog({
                             maxLength={500}
                             rows={3}
                             placeholder={t('report.detailsPlaceholder')}
-                            className="flex w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 resize-none"
+                            className="flex w-full rounded-md border border-border bg-card px-3 py-2 text-base md:text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 resize-none"
                         />
                     </div>
                 </div>

--- a/packages/frontend/src/components/geo/GeoPlaySlots.tsx
+++ b/packages/frontend/src/components/geo/GeoPlaySlots.tsx
@@ -659,7 +659,7 @@ function CoordinateInput({
                         onChange={(e) => setX(e.target.value)}
                         disabled={disabled}
                         required
-                        className="w-20 rounded border border-white/20 bg-black/40 p-2 text-center text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                        className="w-20 rounded border border-white/20 bg-black/40 p-2 text-center text-base md:text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
                     />
                 </label>
                 <label className="flex flex-col items-start gap-1 text-white/80">
@@ -674,7 +674,7 @@ function CoordinateInput({
                         onChange={(e) => setY(e.target.value)}
                         disabled={disabled}
                         required
-                        className="w-20 rounded border border-white/20 bg-black/40 p-2 text-center text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                        className="w-20 rounded border border-white/20 bg-black/40 p-2 text-center text-base md:text-sm text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
                     />
                 </label>
                 <Button

--- a/packages/frontend/src/components/ui/input.tsx
+++ b/packages/frontend/src/components/ui/input.tsx
@@ -7,7 +7,10 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "flex h-10 w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground",
+        // `text-base` (16px) on mobile keeps iOS Safari from auto-zooming the
+        // viewport when the field gains focus; `md:text-sm` restores the
+        // tighter desktop scale where zoom-on-focus doesn't apply.
+        "flex h-10 w-full rounded-md border border-border bg-card px-3 py-2 text-base md:text-sm text-foreground",
         "placeholder:text-muted-foreground",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         "disabled:cursor-not-allowed disabled:opacity-50",

--- a/packages/frontend/src/components/ui/password.tsx
+++ b/packages/frontend/src/components/ui/password.tsx
@@ -19,7 +19,9 @@ const Password = ({ className, showToggle = true, ref, ...props }: PasswordProps
           type={showPassword ? "text" : "password"}
           data-slot="password"
           className={cn(
-            "flex h-10 w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground",
+            // 16px on mobile avoids iOS Safari's focus zoom; `md:text-sm`
+            // keeps the desktop scale. Mirrors the base Input component.
+            "flex h-10 w-full rounded-md border border-border bg-card px-3 py-2 text-base md:text-sm text-foreground",
             "placeholder:text-muted-foreground",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
             "disabled:cursor-not-allowed disabled:opacity-50",

--- a/packages/frontend/src/components/ui/select.tsx
+++ b/packages/frontend/src/components/ui/select.tsx
@@ -24,7 +24,10 @@ function SelectTrigger({
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       className={cn(
-        "flex h-9 w-full items-center justify-between rounded-md border border-input bg-card px-3 py-2 text-sm shadow-xs transition-colors",
+        // `h-10` gives a 40px trigger (matches Input, closer to the 44px touch
+        // target) and `text-base md:text-sm` stops iOS Safari zooming when the
+        // native picker opens.
+        "flex h-10 w-full items-center justify-between rounded-md border border-input bg-card px-3 py-2 text-base md:text-sm shadow-xs transition-colors",
         "placeholder:text-muted-foreground",
         "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
         "disabled:cursor-not-allowed disabled:opacity-50",

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -175,6 +175,17 @@ body {
   /* dvh tracks the *current* viewport, so the shell doesn't overflow by the
      mobile browser toolbar height the way 100vh does. */
   min-height: 100dvh;
+  /* iOS Safari inflates font sizes when a phone rotates to landscape; pin the
+     adjustment to 100% so text stays at its intended scale. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+/* Suppress the grey flash iOS Safari paints over tapped links/buttons — the
+   app already has its own active/focus styling, so the default highlight just
+   looks broken on the dark gaming theme. */
+html {
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* Keep focused / anchored elements clear of the sticky header (top) and the


### PR DESCRIPTION
## What

Ran an iPhone (Mobile Safari) compliance pass over the app and fixed the issues it surfaced, then added an automated suite to keep them fixed.

### The main issue: iOS zoom-on-focus
iOS Safari zooms the viewport whenever a focused `input`/`textarea`/`select` renders below **16px**. Several core controls used `text-sm` (14px), so tapping a field on iPhone triggered an unwanted, jarring zoom:

| Control | Before | After |
|---|---|---|
| `ui/input.tsx` (auth, profile, admin) | `text-sm` | `text-base md:text-sm` |
| `ui/password.tsx` (login/register) | `text-sm` | `text-base md:text-sm` |
| `ui/select.tsx` trigger | `text-sm`, `h-9` | `text-base md:text-sm`, `h-10` |
| `ReportCaptureDialog` textarea | `text-sm` | `text-base md:text-sm` |
| `GeoPlaySlots` coord inputs | (default) | `text-base md:text-sm` |

`md:text-sm` keeps the tighter desktop scale where zoom-on-focus doesn't apply. The in-game `GuessInput` was already `text-base md:text-lg` and unaffected.

### Global iOS niceties (`index.css`)
- `-webkit-text-size-adjust: 100%` — no font inflation when an iPhone rotates to landscape.
- `-webkit-tap-highlight-color: transparent` — no grey tap flash over the dark gaming theme.
- Select trigger bumped to `h-10` (40px), closer to the 44px touch-target guideline.

## Test
New `e2e/iphone-compliance.spec.ts` emulates an **iPhone 13** (390×844, 3× DPR, touch) and asserts:
1. Every login form control renders ≥ 16px (no focus zoom).
2. No horizontal overflow at iPhone width on `/en` and `/en/login`.
3. Head declares `viewport-fit=cover` + the Apple PWA / touch-icon tags.
4. Bottom-nav targets clear 44px.

The spec drops the device's `defaultBrowserType` so it runs under the Chromium projects CI already uses (no WebKit binary required); enable the commented `Mobile Safari` project in `playwright.config.ts` for a true WebKit pass.

## Verification
- `npm run build:frontend` — ✅ typechecks + bundles
- `npm run lint` — ✅
- `npm test` (frontend unit) — ✅ 25 passed
- `npx playwright test iphone-compliance --project=chromium` — ✅ 5 passed (confirmed the font-size test fails on the pre-fix 14px controls)

> Note: full backend build and the rest of the e2e suite need Postgres/Redis, which aren't available in this environment. A pre-existing, unrelated `baseUrl` TypeScript deprecation affects the backend build under TS 6.x and is out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWvgH9JBS8HHHroVxV9pSq)_