### PR TITLE
fix(frontend): fix mobile notification overlaps on iOS/Android

### DIFF
--- a/packages/frontend/e2e/mobile-notification-ux.spec.ts
+++ b/packages/frontend/e2e/mobile-notification-ux.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Mobile notification & dialog UX
+ *
+ * Exercises the app's transient surfaces at phone viewports (iOS + Android),
+ * where several notifications can be on screen at once and the fixed app chrome
+ * (sticky Header at the top, BottomNav at the bottom, iOS notch) competes for
+ * the same edges:
+ *
+ *   1. Toasts (sonner) must clear the sticky Header — a top-anchored toast that
+ *      lands on the header covers its controls.
+ *   2. The offline banner is pinned above everything at top-0, so it must pad
+ *      for the iOS safe-area itself or its text hides under the notch.
+ *   3. The iOS "add to home screen" hint is bottom-anchored and must sit above
+ *      the fixed BottomNav, not on top of it.
+ *
+ * Devices are emulated with `defaultBrowserType` stripped so the suite runs
+ * under the Chromium projects CI uses (assertions read layout boxes / computed
+ * styles, which are engine-independent). The iOS install hint only renders for
+ * a Safari iOS user-agent, which the iPhone emulation provides.
+ *
+ * Prerequisites: dev servers (`npm run dev`) + seeded DB (`npm run e2e:seed`).
+ * Only public pages (home, pricing) are used so the suite stays resilient.
+ */
+import { test, expect, devices, type Page } from '@playwright/test'
+
+// Emulate a device but drop `defaultBrowserType` so the spec inherits the
+// running project's engine (keeps it green under the Chromium projects CI runs
+// without a WebKit binary).
+function emulate(device: (typeof devices)[string]) {
+  const copy = { ...device }
+  delete (copy as Record<string, unknown>).defaultBrowserType
+  return copy
+}
+
+const iPhone13 = emulate(devices['iPhone 13'])
+const pixel5 = emulate(devices['Pixel 5'])
+
+/** The mobile toast stack must be offset clear of the sticky header. */
+async function expectToastClearsHeader(page: Page) {
+  // PricingPage fires `toast.success` synchronously from the ?checkout= param,
+  // so a toast (and therefore the sonner container) appears without a backend.
+  // `commit` lets us start polling before the toast auto-dismisses.
+  await page.goto('/en/premium?checkout=success', { waitUntil: 'commit' })
+
+  // The container holds the whole stack; its resolved `top` is the offset every
+  // toast inherits, and it's stable even as individual toasts come and go.
+  const toaster = page.locator('[data-sonner-toaster]')
+  await expect(toaster).toBeAttached({ timeout: 10_000 })
+
+  const header = page.getByRole('banner').first()
+  await expect(header).toBeVisible()
+  const headerBox = await header.boundingBox()
+  expect(headerBox, 'header should have a layout box').not.toBeNull()
+
+  const { topPx, offsetVar } = await toaster.evaluate((el) => ({
+    topPx: parseFloat(getComputedStyle(el).top),
+    // Inline var keeps env() unresolved; confirms the safe-area is wired in for
+    // notched devices where the inset is non-zero.
+    offsetVar: (el as HTMLElement).style.getPropertyValue('--mobile-offset-top'),
+  }))
+
+  expect(
+    topPx,
+    `toast stack top (${topPx}px) overlaps the sticky header (${headerBox!.height}px)`,
+  ).toBeGreaterThanOrEqual(headerBox!.height - 1)
+  expect(offsetVar, 'mobile toast offset should reserve the safe-area inset').toContain(
+    'safe-area-inset-top',
+  )
+}
+
+/** The offline banner pins to the top and pads for the safe-area / notch. */
+async function expectOfflineBannerSafe(page: Page) {
+  await page.goto('/en')
+  await page.waitForLoadState('load')
+
+  await page.context().setOffline(true)
+  try {
+    // The OfflineIndicator renders as the page's <output> live region.
+    const banner = page.locator('output').filter({ hasText: /hors ligne|offline/i }).first()
+    await expect(banner).toBeVisible({ timeout: 5_000 })
+
+    const box = await banner.boundingBox()
+    expect(box, 'offline banner should have a layout box').not.toBeNull()
+    // Pinned to the very top of the viewport.
+    expect(box!.y, `offline banner should pin to the top (y=${box!.y})`).toBeLessThanOrEqual(2)
+
+    // Regression guard for the safe-area padding. The banner sits above the
+    // Header at top-0, so it pads its own top with max(env(safe-area-inset-top),
+    // 0.5rem). Emulated Chromium reports a zero inset, so this floors at 8px
+    // here; on a notched device in standalone PWA mode the inset lifts the text
+    // clear of the status bar / notch.
+    const paddingTop = await banner.evaluate(
+      (el) => parseFloat(getComputedStyle(el).paddingTop),
+    )
+    expect(
+      paddingTop,
+      `offline banner should keep top padding (got ${paddingTop}px)`,
+    ).toBeGreaterThanOrEqual(8)
+  } finally {
+    await page.context().setOffline(false)
+  }
+}
+
+test.describe('Mobile notification UX — iOS', () => {
+  test.use(iPhone13)
+
+  test('toast clears the sticky header', async ({ page }) => {
+    await expectToastClearsHeader(page)
+  })
+
+  test('offline banner respects the notch safe-area', async ({ page }) => {
+    await expectOfflineBannerSafe(page)
+  })
+
+  test('iOS install hint sits above the bottom nav', async ({ page }) => {
+    await page.goto('/en')
+
+    // The hint mounts after a short delay; only on a Safari iOS UA.
+    const hint = page.locator('dialog:has(#ios-install-title)').first()
+    await expect(hint).toBeVisible({ timeout: 10_000 })
+
+    const nav = page.getByRole('navigation', { name: /menu|navigation/i }).last()
+    await expect(nav).toBeVisible()
+
+    const hintBox = await hint.boundingBox()
+    const navBox = await nav.boundingBox()
+    expect(hintBox, 'install hint should have a layout box').not.toBeNull()
+    expect(navBox, 'bottom nav should have a layout box').not.toBeNull()
+
+    expect(
+      hintBox!.y + hintBox!.height,
+      `install hint bottom (${hintBox!.y + hintBox!.height}) overlaps the bottom nav (top ${navBox!.y})`,
+    ).toBeLessThanOrEqual(navBox!.y + 1)
+  })
+})
+
+test.describe('Mobile notification UX — Android', () => {
+  test.use(pixel5)
+
+  test('toast clears the sticky header', async ({ page }) => {
+    await expectToastClearsHeader(page)
+  })
+
+  test('offline banner respects the safe-area', async ({ page }) => {
+    await expectOfflineBannerSafe(page)
+  })
+})

--- a/packages/frontend/src/components/pwa/IOSInstallHint.tsx
+++ b/packages/frontend/src/components/pwa/IOSInstallHint.tsx
@@ -56,8 +56,11 @@ export function IOSInstallHint() {
       open
       aria-labelledby="ios-install-title"
       className={cn(
-        'fixed inset-x-3 bottom-3 top-auto z-50 m-0 w-auto max-h-none max-w-none rounded-xl border bg-card/95 shadow-lg backdrop-blur',
-        'border-border p-4 flex gap-3 items-start',
+        // Sit just above the mobile BottomNav (matching the other PWA banners);
+        // drop to the corner at md where the BottomNav is hidden. A bare
+        // bottom-3 anchored the hint on top of the fixed bottom nav.
+        'fixed inset-x-3 top-auto bottom-[var(--bottom-nav-space)] z-50 m-0 w-auto max-h-none max-w-none rounded-xl border bg-card/95 shadow-lg backdrop-blur md:bottom-3',
+        'border-border p-4 flex gap-3 items-start sm:max-w-md sm:left-auto sm:right-3',
       )}
     >
       <div className="flex-1 min-w-0">

--- a/packages/frontend/src/components/pwa/OfflineIndicator.tsx
+++ b/packages/frontend/src/components/pwa/OfflineIndicator.tsx
@@ -13,7 +13,10 @@ export function OfflineIndicator() {
     <output
       aria-live="polite"
       className={cn(
-        'fixed inset-x-0 top-0 z-[60] flex items-center justify-center gap-2 px-4 py-2 text-xs sm:text-sm font-medium',
+        // This banner sits above the Header (z-60) pinned to top-0, so it has
+        // to pad for the iOS notch itself — otherwise the text renders under
+        // the status bar / notch on a notched iPhone.
+        'fixed inset-x-0 top-0 z-[60] flex items-center justify-center gap-2 px-4 py-2 pt-[max(env(safe-area-inset-top),0.5rem)] text-xs sm:text-sm font-medium',
         'bg-warning/15 text-warning border-b border-warning/40 backdrop-blur-md',
       )}
     >

--- a/packages/frontend/src/components/ui/sonner.tsx
+++ b/packages/frontend/src/components/ui/sonner.tsx
@@ -12,6 +12,11 @@ export function Toaster(props: ToasterProps) {
       position="top-right"
       richColors
       closeButton
+      // On phones sonner renders edge-to-edge from the top; without an offset
+      // the stack lands on top of the sticky Header (h-14 + the iOS notch) and
+      // covers its controls. Push it below the header and clear of the
+      // safe-area so multiple stacked toasts stay tappable and readable.
+      mobileOffset={{ top: 'calc(env(safe-area-inset-top) + 4rem)', left: '0.75rem', right: '0.75rem' }}
       toastOptions={{
         classNames: {
           toast:


### PR DESCRIPTION
## What

Tested the app's transient surfaces (toasts + the four PWA banners) at iPhone and Pixel viewports, where several notifications can be on screen at once and the fixed chrome (sticky `Header`, fixed `BottomNav`, iOS notch) competes for the same edges. Found and fixed three overlaps.

### Issues found & fixed

| # | Surface | Problem | Fix |
|---|---|---|---|
| 1 | **Toasts** (`sonner`) | Anchored `top-right` with no mobile offset → the stack lands on the sticky `Header` (h-14 + notch) and covers its controls. | Added `mobileOffset` = `calc(env(safe-area-inset-top) + 4rem)` so toasts clear the header and the notch. |
| 2 | **IOSInstallHint** | Anchored at `bottom-3`, sitting directly on top of the fixed mobile `BottomNav`. | Moved above the nav via `var(--bottom-nav-space)` with an `md:bottom-3` corner fallback — matching the other PWA banners. |
| 3 | **OfflineIndicator** | Pinned above the `Header` at `top-0` but with no safe-area padding → text hides under the notch/status bar in standalone PWA mode. | Padded its top with `max(env(safe-area-inset-top), 0.5rem)`. |

### Checked, no change needed
`Dialog` / `ResponsiveDialog` (mobile bottom-sheet + safe-area + `100dvh` scroll) and `Sheet` are already mobile-safe. `InstallPromptBanner` and `PWAUpdatePrompt` already anchor above the bottom nav correctly. The remaining theoretical overlap — `PWAUpdatePrompt` (z-55) on top of `InstallPromptBanner` (z-50) when both are visible at once — is platform/timing-gated and rare (one stays behind the other, neither is lost), so it's left as-is.

## Test
New `e2e/mobile-notification-ux.spec.ts` runs under **iPhone 13** and **Pixel 5** emulation (engine-agnostic, runs on the Chromium projects CI uses) and asserts:
1. The sonner toast container's resolved `top` clears the header height, and its offset var reserves `safe-area-inset-top`.
2. The offline banner pins to `top-0` and keeps its top padding.
3. (iOS) The install hint's bottom edge stays above the `BottomNav`.

## Verification
- `npm run build` — ✅ all packages typecheck
- `npm run lint` — ✅ 0 errors
- `npm test` — ✅ 25 passed
- `npx playwright test mobile-notification-ux` — ✅ 5 passed (against a mock-API dev server; confirmed the toast-offset assertions fail without the fix)

> The toast test polls from `commit` because the no-backend mock env auto-dismisses toasts early; with a real backend (the intended e2e setup) the toast is stable. CI's `ci.yml` runs lint/build/test only, not e2e.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWvgH9JBS8HHHroVxV9pSq)_