### PR TITLE
feat(pwa): localized "What's New" changelog dialog

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2727,6 +2727,36 @@
       "dismiss": "Dismiss"
     }
   },
+  "changelog": {
+    "title": "What's new",
+    "versionLine": "Version {{version}} · {{date}}",
+    "openTitle": "See what's new in this version",
+    "gotIt": "Got it",
+    "empty": "This release ships under-the-hood improvements and fixes.",
+    "sections": {
+      "features": "New features",
+      "improvements": "Improvements",
+      "fixes": "Fixes"
+    },
+    "releases": {
+      "2.127.0": {
+        "summary": "We rebuilt how hints work and polished the app on mobile.",
+        "features": [
+          "Hints are now fused directly into the guess field, with letters of the answer revealed one at a time.",
+          "The masked-title skeleton stays hidden until the first letter is revealed, so nothing spoils the round early."
+        ],
+        "improvements": [
+          "Form controls now meet iPhone sizing rules, so tapping a field no longer zooms the page.",
+          "Notification banners no longer overlap on iOS and Android."
+        ],
+        "fixes": [
+          "Unknown referral codes now return a clear \"not found\" instead of a generic error.",
+          "Request validation is fully compatible with Express 5.",
+          "Several accessibility labels were corrected across tabs, progress bars and the countdown clock."
+        ]
+      }
+    }
+  },
   "seo": {
     "home": {
       "title": "The Box — Daily Video Game Guessing Challenge",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2727,6 +2727,36 @@
       "dismiss": "Fermer"
     }
   },
+  "changelog": {
+    "title": "Nouveautés",
+    "versionLine": "Version {{version}} · {{date}}",
+    "openTitle": "Voir les nouveautés de cette version",
+    "gotIt": "J'ai compris",
+    "empty": "Cette version apporte des améliorations et corrections internes.",
+    "sections": {
+      "features": "Nouveautés",
+      "improvements": "Améliorations",
+      "fixes": "Corrections"
+    },
+    "releases": {
+      "2.127.0": {
+        "summary": "Nous avons repensé le fonctionnement des indices et peaufiné l'app sur mobile.",
+        "features": [
+          "Les indices sont désormais intégrés directement dans le champ de réponse, avec les lettres de la solution révélées une à une.",
+          "Le squelette du titre masqué reste caché jusqu'à la première lettre révélée, pour ne rien dévoiler trop tôt."
+        ],
+        "improvements": [
+          "Les champs de formulaire respectent les règles de taille iPhone : toucher un champ ne zoome plus la page.",
+          "Les bannières de notification ne se chevauchent plus sur iOS et Android."
+        ],
+        "fixes": [
+          "Un code de parrainage inconnu renvoie désormais un message « introuvable » clair au lieu d'une erreur générique.",
+          "La validation des requêtes est entièrement compatible avec Express 5.",
+          "Plusieurs libellés d'accessibilité ont été corrigés sur les onglets, les barres de progression et le chronomètre."
+        ]
+      }
+    }
+  },
   "seo": {
     "home": {
       "title": "The Box — Le défi quotidien de jeux vidéo",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { ErrorBoundary, LazyComponentErrorBoundary } from '@/components/ErrorBou
 import { RouteSeo } from '@/components/RouteSeo'
 import {
   PWAUpdatePrompt,
+  ChangelogDialog,
   OfflineIndicator,
   IOSInstallHint,
   InstallPromptBanner,
@@ -243,6 +244,7 @@ function App() {
       {/* PWA: offline banner + service-worker update toast + install prompts */}
       <OfflineIndicator />
       <PWAUpdatePrompt />
+      <ChangelogDialog />
       <InstallPromptBanner />
       <IOSInstallHint />
       </LazyMotion>

--- a/packages/frontend/src/components/layout/Footer.tsx
+++ b/packages/frontend/src/components/layout/Footer.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { useOpenChangelog } from '@/components/pwa'
 import { format } from 'date-fns'
 
 // Get build-time constants (injected by Vite at build time)
@@ -10,6 +11,7 @@ const buildTime = typeof __BUILD_TIME__ !== 'undefined' ? __BUILD_TIME__ : null
 export function Footer() {
   const { t } = useTranslation()
   const { localizedPath } = useLocalizedPath()
+  const openChangelog = useOpenChangelog()
   const currentYear = new Date().getFullYear()
 
   // Format build time for display
@@ -64,7 +66,15 @@ export function Footer() {
         &copy; {currentYear} The Box. {t('footer.allRightsReserved')}
         {appVersion !== 'dev' && (
           <>
-            {' • '}v{appVersion}
+            {' • '}
+            <button
+              type="button"
+              onClick={openChangelog}
+              className="underline-offset-2 hover:text-neon-purple hover:underline transition-colors"
+              title={t('changelog.openTitle')}
+            >
+              v{appVersion}
+            </button>
             {formattedBuildTime && ` • ${formattedBuildTime}`}
           </>
         )}

--- a/packages/frontend/src/components/pwa/ChangelogDialog.tsx
+++ b/packages/frontend/src/components/pwa/ChangelogDialog.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useMemo, type ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Sparkles, Wrench, Zap } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { useChangelogStore } from '@/stores/changelogStore'
+import {
+  CHANGELOG_SECTIONS,
+  compareVersions,
+  getLatestRelease,
+  type ChangelogSection,
+} from '@/data/changelog'
+
+/** Build-time version of the running bundle (see vite.config.ts). */
+const APP_VERSION =
+  typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'
+
+/** Localized i18n shape for a single release block. */
+interface ReleaseContent {
+  summary?: string
+  features?: string[]
+  improvements?: string[]
+  fixes?: string[]
+}
+
+const SECTION_ICONS: Record<
+  ChangelogSection,
+  typeof Sparkles
+> = {
+  features: Sparkles,
+  improvements: Zap,
+  fixes: Wrench,
+}
+
+const SECTION_ACCENT: Record<ChangelogSection, string> = {
+  features: 'text-primary',
+  improvements: 'text-neon-pink',
+  fixes: 'text-muted-foreground',
+}
+
+/**
+ * "What's New" dialog. Surfaces the newest release's notes once after the app
+ * updates to that version, and on demand when opened from the footer version
+ * chip. All copy is localized; the bullet content comes from the active i18n
+ * bundle keyed by version, so it follows the player's language.
+ */
+export function ChangelogDialog(): ReactElement | null {
+  const { t, i18n } = useTranslation()
+  const open = useChangelogStore((s) => s.open)
+  const lastSeenVersion = useChangelogStore((s) => s.lastSeenVersion)
+  const openChangelog = useChangelogStore((s) => s.openChangelog)
+  const markSeen = useChangelogStore((s) => s.markSeen)
+
+  const release = getLatestRelease()
+
+  // Auto-open the changelog the first time a player runs a freshly-shipped
+  // version. Brand-new visitors (no recorded version) are marked seen silently
+  // so they aren't greeted by release notes for a build they never "upgraded"
+  // from. Runs once on mount.
+  useEffect(() => {
+    if (!release) return
+    if (APP_VERSION === 'dev') return
+    // Only announce notes for the build that's actually running.
+    if (APP_VERSION !== release.version) return
+    if (lastSeenVersion === APP_VERSION) return
+
+    if (lastSeenVersion === null) {
+      markSeen(APP_VERSION)
+      return
+    }
+
+    if (compareVersions(APP_VERSION, lastSeenVersion) > 0) {
+      openChangelog()
+    } else {
+      markSeen(APP_VERSION)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Pull the localized block for this release out of the active i18n bundle.
+  const content = useMemo<ReleaseContent | null>(() => {
+    if (!release) return null
+    const releases = t('changelog.releases', { returnObjects: true }) as
+      | Record<string, ReleaseContent>
+      | string
+    if (!releases || typeof releases !== 'object') return null
+    return releases[release.version] ?? null
+    // i18n.language is a dependency so the block re-resolves on language switch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [release, t, i18n.language])
+
+  if (!release) return null
+
+  const handleClose = (next: boolean): void => {
+    if (!next) markSeen(APP_VERSION === 'dev' ? release.version : APP_VERSION)
+  }
+
+  const formattedDate = (() => {
+    const parsed = new Date(release.date)
+    if (Number.isNaN(parsed.getTime())) return release.date
+    return parsed.toLocaleDateString(i18n.language, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  })()
+
+  const sections = CHANGELOG_SECTIONS.map((key) => ({
+    key,
+    items: content?.[key] ?? [],
+  })).filter((section) => section.items.length > 0)
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <span
+              className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary"
+              aria-hidden="true"
+            >
+              <Sparkles className="size-4" />
+            </span>
+            <div className="flex flex-col text-left">
+              <DialogTitle>{t('changelog.title')}</DialogTitle>
+              <span className="text-xs text-muted-foreground">
+                {t('changelog.versionLine', {
+                  version: release.version,
+                  date: formattedDate,
+                })}
+              </span>
+            </div>
+          </div>
+          {content?.summary && (
+            <DialogDescription className="pt-1">
+              {content.summary}
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        {sections.length > 0 ? (
+          <div className="flex flex-col gap-4">
+            {sections.map(({ key, items }) => {
+              const Icon = SECTION_ICONS[key]
+              return (
+                <section key={key} className="flex flex-col gap-1.5">
+                  <h3 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+                    <Icon
+                      className={cn('size-4', SECTION_ACCENT[key])}
+                      aria-hidden="true"
+                    />
+                    {t(`changelog.sections.${key}`)}
+                  </h3>
+                  <ul className="flex flex-col gap-1 pl-1.5">
+                    {items.map((item, index) => (
+                      <li
+                        key={index}
+                        className="flex gap-2 text-sm text-muted-foreground"
+                      >
+                        <span
+                          className={cn(
+                            'mt-1.5 size-1.5 shrink-0 rounded-full bg-current',
+                            SECTION_ACCENT[key],
+                          )}
+                          aria-hidden="true"
+                        />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )
+            })}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {t('changelog.empty')}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button onClick={() => handleClose(false)}>
+            {t('changelog.gotIt')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default ChangelogDialog

--- a/packages/frontend/src/components/pwa/index.ts
+++ b/packages/frontend/src/components/pwa/index.ts
@@ -1,4 +1,6 @@
 export { PWAUpdatePrompt } from './PWAUpdatePrompt'
+export { ChangelogDialog } from './ChangelogDialog'
+export { useOpenChangelog } from '@/stores/changelogStore'
 export { OfflineIndicator } from './OfflineIndicator'
 export { InstallPromptButton } from './InstallPromptButton'
 export { InstallPromptBanner } from './InstallPromptBanner'

--- a/packages/frontend/src/data/changelog.ts
+++ b/packages/frontend/src/data/changelog.ts
@@ -1,0 +1,74 @@
+/**
+ * Changelog registry — drives the "What's New" dialog (`ChangelogDialog`).
+ *
+ * This is the single source of truth for *which* releases get surfaced to
+ * players and *when* they shipped. The human-readable, translatable bullet
+ * points live in the i18n bundles under `changelog.releases.<version>` (one
+ * block per locale in `public/locales/<lng>/translation.json`), so the dialog
+ * renders in the player's language. Keep this list ordered newest-first and
+ * add an entry only for releases worth announcing in-app.
+ *
+ * The running app's version comes from the build-time `__APP_VERSION__`
+ * constant (see `vite.config.ts`). The dialog shows a release's notes once,
+ * the first time a player runs that version.
+ */
+
+export type ChangelogSection = 'features' | 'improvements' | 'fixes'
+
+/** Order in which sections render inside the dialog. */
+export const CHANGELOG_SECTIONS: ChangelogSection[] = [
+  'features',
+  'improvements',
+  'fixes',
+]
+
+export interface ChangelogRelease {
+  /** Semver string, must match a `changelog.releases.<version>` i18n key. */
+  version: string
+  /** ISO date (YYYY-MM-DD) the release shipped — shown next to the version. */
+  date: string
+}
+
+/**
+ * Releases surfaced in-app, newest first. The first entry is treated as the
+ * "current" notes shown after an update and when a player opens the changelog
+ * manually from the footer.
+ */
+export const CHANGELOG: ChangelogRelease[] = [
+  { version: '2.127.0', date: '2026-06-13' },
+]
+
+/** The newest announced release, or `null` when the list is empty. */
+export function getLatestRelease(): ChangelogRelease | null {
+  return CHANGELOG[0] ?? null
+}
+
+/** Look up a release entry by its version string. */
+export function getReleaseByVersion(
+  version: string,
+): ChangelogRelease | undefined {
+  return CHANGELOG.find((release) => release.version === version)
+}
+
+/**
+ * Compare two semver strings (numeric `major.minor.patch`, ignoring any
+ * pre-release suffix). Returns a positive number when `a > b`, negative when
+ * `a < b`, and `0` when equal. Non-numeric / `dev` inputs sort lowest.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string): number[] =>
+    v
+      .split('-')[0]
+      .split('.')
+      .map((part) => Number.parseInt(part, 10) || 0)
+
+  const pa = parse(a)
+  const pb = parse(b)
+  const length = Math.max(pa.length, pb.length)
+
+  for (let i = 0; i < length; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}

--- a/packages/frontend/src/stores/changelogStore.ts
+++ b/packages/frontend/src/stores/changelogStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+/**
+ * Drives the "What's New" changelog dialog.
+ *
+ * `lastSeenVersion` is persisted to localStorage so a release's notes auto-open
+ * exactly once — the first time a player runs that build. `open` is ephemeral
+ * UI state: the dialog flips it on automatically after an update, and the footer
+ * version chip can flip it on manually to re-read the latest notes any time.
+ *
+ * `null` for `lastSeenVersion` means "this browser has never recorded a
+ * version" (a brand-new visitor). We intentionally don't pop the changelog at
+ * someone on their very first visit — `markSeen` is called silently in that
+ * case so they only ever see notes for genuine *updates*.
+ */
+interface ChangelogState {
+  open: boolean
+  lastSeenVersion: string | null
+  openChangelog: () => void
+  closeChangelog: () => void
+  markSeen: (version: string) => void
+}
+
+export const useChangelogStore = create<ChangelogState>()(
+  persist(
+    (set) => ({
+      open: false,
+      lastSeenVersion: null,
+      openChangelog: () => set({ open: true }),
+      closeChangelog: () => set({ open: false }),
+      markSeen: (version: string) =>
+        set({ open: false, lastSeenVersion: version }),
+    }),
+    {
+      name: 'the-box-changelog',
+      storage: createJSONStorage(() => localStorage),
+      // Only the seen marker needs to survive reloads; `open` is derived.
+      partialize: (state) => ({ lastSeenVersion: state.lastSeenVersion }),
+    },
+  ),
+)
+
+/** Selector hook that returns the imperative "open the changelog" action. */
+export function useOpenChangelog(): () => void {
+  return useChangelogStore((s) => s.openChangelog)
+}


### PR DESCRIPTION
## What & why

Instead of letting an app update slip by silently, the app now surfaces the **release notes of the new version in a dialog** (shadcn `Dialog`), fully localized (FR/EN).

This complements the existing `PWAUpdatePrompt` (which still handles the service-worker refresh): once a player is running a freshly-shipped build, a **"What's New"** dialog opens once to show what changed.

## How it works

- **`src/data/changelog.ts`** — registry (newest-first) of which releases get announced, with version + date. Single source of truth for *which* releases appear; the translatable bullet copy lives in the i18n bundles.
- **i18n content** — `changelog.releases.<version>` blocks in `public/locales/{en,fr}/translation.json` (features / improvements / fixes + summary). The dialog resolves the block in the player's active language, so notes follow the UI language and switch live on language change.
- **`src/stores/changelogStore.ts`** — Zustand + `persist`. `lastSeenVersion` survives reloads so notes auto-open **exactly once per upgrade**. Brand-new visitors are marked seen silently (no changelog on first-ever visit).
- **`ChangelogDialog.tsx`** — mounted in `App.tsx` next to the other PWA surfaces. Auto-opens after a version bump; renders sectioned, icon-tagged notes.
- **Footer** — the version chip (`v2.127.0`) is now a button that re-opens the changelog on demand.

## Adding notes for a future release

1. Prepend `{ version, date }` to `CHANGELOG` in `src/data/changelog.ts`.
2. Add a `changelog.releases.<version>` block to **both** `en` and `fr` translation files.

The dialog only auto-opens for the build whose version (`__APP_VERSION__`) matches the newest registry entry, so it won't fire in dev/preview where the version is `dev`.

## Validation

- `npm run build:frontend` ✅ (typecheck + production build + PWA)
- `npx eslint` on all touched files ✅ (0 errors/warnings)
- JSON validity of both locale files ✅

## Notes / open questions

- The 2.127.0 notes were seeded from recent `feat`/`fix` commits as illustrative content — happy to adjust wording.
- Scope is frontend-only; no backend `/version` endpoint needed since the changelog ships bundled with each build.

https://claude.ai/code/session_01TT2nqeUKKJCkWAQ6zhyccL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TT2nqeUKKJCkWAQ6zhyccL)_