### PR TITLE
feat(pricing): list what's included on each premium plan card

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -1753,6 +1753,7 @@
       "title": "What's included",
       "free": "Free",
       "premium": "Premium",
+      "everythingInFree": "Everything in Free, plus:",
       "items": {
         "dailyChallenge": "Daily challenge",
         "leaderboards": "Live leaderboards",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -1753,6 +1753,7 @@
       "title": "Ce qui est inclus",
       "free": "Gratuit",
       "premium": "Premium",
+      "everythingInFree": "Tout du Gratuit, et en plus :",
       "items": {
         "dailyChallenge": "Défi quotidien",
         "leaderboards": "Classements en temps réel",

--- a/packages/frontend/src/components/pricing/FreePricingCard.tsx
+++ b/packages/frontend/src/components/pricing/FreePricingCard.tsx
@@ -3,6 +3,8 @@ import { m } from 'framer-motion'
 import { Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { PlanFeatureList } from './PlanFeatureList'
+import { FREE_FEATURE_KEYS } from './planFeatures'
 
 interface FreePricingCardProps {
   isCurrentPlan: boolean
@@ -37,6 +39,7 @@ export function FreePricingCard({ isCurrentPlan, isLoggedIn, onSignUp }: FreePri
           <div className="flex items-baseline gap-1">
             <span className="text-4xl font-bold">{t('pricing.tiers.free.price')}</span>
           </div>
+          <PlanFeatureList featureKeys={FREE_FEATURE_KEYS} />
         </CardContent>
 
         <CardFooter>

--- a/packages/frontend/src/components/pricing/PlanFeatureList.tsx
+++ b/packages/frontend/src/components/pricing/PlanFeatureList.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next'
+import { Check } from 'lucide-react'
+
+interface PlanFeatureListProps {
+  /** i18n item keys resolved under `pricing.features.items.*`. */
+  featureKeys: readonly string[]
+  /** Optional lead line above the list, e.g. "Everything in Free, plus:". */
+  leadKey?: string
+}
+
+/** Bulleted "what's included" list shown inside a pricing card so each plan
+ *  states its benefits without the reader scrolling to the comparison table. */
+export function PlanFeatureList({ featureKeys, leadKey }: PlanFeatureListProps) {
+  const { t } = useTranslation()
+  return (
+    <ul className="space-y-2 text-sm">
+      {leadKey && <li className="font-medium text-muted-foreground">{t(leadKey)}</li>}
+      {featureKeys.map((key) => (
+        <li key={key} className="flex items-start gap-2">
+          <Check className="size-4 mt-0.5 shrink-0 text-success" aria-hidden="true" />
+          <span className="text-foreground/90">{t(`pricing.features.items.${key}`)}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/packages/frontend/src/components/pricing/PricingCard.tsx
+++ b/packages/frontend/src/components/pricing/PricingCard.tsx
@@ -7,6 +7,8 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import type { BillingPrice, BillingTier } from '@the-box/types'
+import { PlanFeatureList } from './PlanFeatureList'
+import { PREMIUM_TIER_FEATURE_KEYS } from './planFeatures'
 
 /** Per-card status flags, grouped so the component takes a single object prop
  *  instead of a wide row of booleans. */
@@ -99,6 +101,10 @@ export function PricingCard({
           {isOneTime && (
             <p className="text-xs text-neon-pink/80 font-medium">{t('pricing.supporterNote')}</p>
           )}
+          <PlanFeatureList
+            featureKeys={PREMIUM_TIER_FEATURE_KEYS[price.tier]}
+            leadKey="pricing.features.everythingInFree"
+          />
         </CardContent>
 
         <CardFooter>

--- a/packages/frontend/src/components/pricing/PricingTable.tsx
+++ b/packages/frontend/src/components/pricing/PricingTable.tsx
@@ -22,6 +22,11 @@ function PricingCardSkeleton() {
       </CardHeader>
       <CardContent className="flex-1 space-y-4">
         <Skeleton className="h-10 w-24" />
+        <div className="space-y-2 pt-2">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-36" />
+          <Skeleton className="h-4 w-44" />
+        </div>
       </CardContent>
       <CardFooter>
         <Skeleton className="h-10 w-full" />

--- a/packages/frontend/src/components/pricing/planFeatures.ts
+++ b/packages/frontend/src/components/pricing/planFeatures.ts
@@ -1,0 +1,33 @@
+import type { BillingTier } from '@the-box/types'
+
+/**
+ * Per-card "what's included" lists, expressed as i18n item keys under
+ * `pricing.features.items.*` so the copy stays in sync with the comparison
+ * `FeatureMatrix` instead of being duplicated.
+ *
+ * The Free card lists only what free players actually get; every paid tier
+ * shares the same premium highlights (the differences between paid tiers are
+ * price/cadence, not features), shown under an "everything in Free, plus:" lead.
+ */
+export const FREE_FEATURE_KEYS = [
+  'dailyChallenge',
+  'leaderboards',
+  'achievements',
+  'hintsBaseline',
+] as const
+
+export const PREMIUM_FEATURE_KEYS = [
+  'catchUpFull',
+  'hintsUnlimitedCatchUp',
+  'advancedStats',
+  'themes',
+  'cosmetics',
+  'earlyAccess',
+  'geoMode',
+] as const
+
+export const PREMIUM_TIER_FEATURE_KEYS: Record<BillingTier, readonly string[]> = {
+  premium_monthly: PREMIUM_FEATURE_KEYS,
+  premium_annual: PREMIUM_FEATURE_KEYS,
+  supporter_lifetime: PREMIUM_FEATURE_KEYS,
+}


### PR DESCRIPTION
## Problem

On the Premium page, the plan cards only showed a name, a one-line tagline, and a price + CTA. They **didn't describe what Premium actually unlocks** — a user scrolling through the cards (see the reported screenshot) has no idea what they're paying for. The benefit breakdown only existed in the `FeatureMatrix` comparison table *below* all four cards, which a buyer reading a single card never sees.

## Change

Add a per-card "what's included" benefit list inside every pricing card:

- **Free** card lists the baseline benefits (daily challenge, leaderboards, achievements, letter reveals).
- **Premium Monthly / Annual / Lifetime Supporter** share the premium highlights (full archive, unlimited catch-up hints, advanced stats, themes, cosmetics, early access, Geo mode) under an *"Everything in Free, plus:"* lead.

Copy is **not duplicated** — the lists reuse the existing `pricing.features.items.*` i18n strings that already power `FeatureMatrix.tsx`, so card copy and the comparison table stay in sync. One new key, `pricing.features.everythingInFree`, was added to both `en` and `fr`.

### Files
- `components/pricing/planFeatures.ts` (new) — tier → feature-key lists
- `components/pricing/PlanFeatureList.tsx` (new) — shared bulleted list
- `components/pricing/PricingCard.tsx`, `FreePricingCard.tsx` — render the list
- `components/pricing/PricingTable.tsx` — skeleton updated so the loading state mirrors the new layout
- `public/locales/{en,fr}/translation.json` — new `everythingInFree` key

## How it was built
A subagent workflow: parallel exploration of the frontend pricing UI and the backend billing/entitlement gating to confirm which features are genuinely premium-gated (catch-up archive, unlimited hints, advanced stats, premium themes), implementation, then a review subagent pass over the diff.

## Verification
- `npm run build:types` + `npm run build:frontend` — clean
- `npm run lint` — no new issues (one pre-existing unrelated warning)
- `npm test` — 264 + 25 passing
- Review subagent confirmed all referenced i18n keys exist in both locales and the card feature keys are a consistent subset of the premium-only matrix rows.

https://claude.ai/code/session_016XTWxmfkPRNwBoPRJcs7SX

---
_Generated by [Claude Code](https://claude.ai/code/session_016XTWxmfkPRNwBoPRJcs7SX)_