### PR TITLE
feat(game): smart-guess "warmer" proximity hints

### DIFF
--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -123,6 +123,14 @@ export interface GameRepository {
    * forfeit achievement check). Returns `[]` if no game is found.
    */
   getGenresByScreenshotIds(screenshotIds: number[]): Promise<string[]>
+  /**
+   * Catalogue games that plausibly match a free-text guess, pre-filtered by
+   * the significant word tokens in the guess (ILIKE on name). Used by the
+   * smart-guess proximity hint to resolve a wrong guess to a known game so it
+   * can be compared (franchise / developer / publisher) against the answer.
+   * Returns `[]` when the guess has no usable tokens.
+   */
+  findGuessMatchCandidates(guessText: string, limit?: number): Promise<Game[]>
 }
 
 // ---------- Session ----------

--- a/packages/backend/src/domain/services/game.service.submit-guess.test.ts
+++ b/packages/backend/src/domain/services/game.service.submit-guess.test.ts
@@ -132,7 +132,7 @@ function buildHarness() {
         return true
       },
     },
-    gameRepository: { getGenresById: async () => [] },
+    gameRepository: { getGenresById: async () => [], findGuessMatchCandidates: async () => [] },
     funnelEventRepository: { record: async () => {} },
     positionSecondChanceRepository: { findPending: async () => null },
     positionLetterRevealRepository: {

--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -30,6 +30,7 @@ import {
   nextPenaltyPct,
   LETTER_PENALTY_STEPS,
 } from './letter-reveal.service.js'
+import { computeGuessProximityHint } from './guess-proximity.service.js'
 
 export class GameError extends Error {
   constructor(
@@ -1018,6 +1019,35 @@ export function createGameService(deps: GameServiceDeps): GameService {
       correctGame.developer = fullGameData.developer ?? undefined
     }
 
+    // Smart-guess "warmer" hint. Only on a wrong, non-empty guess: resolve the
+    // guess to a known catalogue game and, if it shares a franchise / studio /
+    // publisher with the answer, surface that relation. The hint never carries
+    // the answer's title (anti-leak); it only echoes an attribute of the game
+    // the player named. Best-effort — a lookup failure must not fail the guess.
+    let proximityHint: GuessResponse['proximityHint']
+    if (!isCorrect && trimmedGuess !== '') {
+      try {
+        const candidates = await gameRepository.findGuessMatchCandidates(trimmedGuess)
+        proximityHint =
+          computeGuessProximityHint({
+            guessText: trimmedGuess,
+            answer: {
+              id: screenshot.gameId,
+              name: gameName,
+              developer: correctGame.developer,
+              publisher: correctGame.publisher,
+            },
+            candidates,
+            fuzzyMatch: fuzzyMatchService,
+          }) ?? undefined
+      } catch (error) {
+        log.warn(
+          { userId: data.userId, error: String(error) },
+          'proximity hint computation failed (non-fatal)'
+        )
+      }
+    }
+
     return {
       isCorrect,
       // Anti-leak gate: a wrong guess must not hand back the answer
@@ -1033,6 +1063,7 @@ export function createGameService(deps: GameServiceDeps): GameService {
       letterPenalty: letterPenalty > 0 ? letterPenalty : undefined,
       wrongGuessPenalty: wrongGuessPenalty > 0 ? wrongGuessPenalty : undefined,
       secondChanceFloorBoost,
+      proximityHint,
     }
     }) // end withTierSessionLock
   },

--- a/packages/backend/src/domain/services/guess-proximity.service.test.ts
+++ b/packages/backend/src/domain/services/guess-proximity.service.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { Game } from '@the-box/types'
+import { createFuzzyMatchService } from './fuzzy-match.service.js'
+import type { DomainLogger } from '../ports/logger.js'
+import {
+  computeGuessProximityHint,
+  type ProximityAnswer,
+} from './guess-proximity.service.js'
+
+const silentLogger: DomainLogger = {
+  child: () => silentLogger,
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+}
+
+const fuzzyMatch = createFuzzyMatchService({ logger: silentLogger })
+
+function game(partial: Partial<Game> & Pick<Game, 'id' | 'name'>): Game {
+  return {
+    slug: partial.name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+    aliases: [],
+    ...partial,
+  }
+}
+
+const divinity: ProximityAnswer = {
+  id: 1,
+  name: 'Divinity: Original Sin',
+  developer: 'Larian Studios',
+  publisher: 'Larian Studios',
+}
+
+describe('computeGuessProximityHint', () => {
+  it('flags a different game by the same studio (Larian)', () => {
+    const candidates = [
+      game({ id: 2, name: "Baldur's Gate 3", developer: 'Larian Studios', publisher: 'Larian Studios' }),
+    ]
+    const hint = computeGuessProximityHint({
+      guessText: "Baldur's Gate 3",
+      answer: divinity,
+      candidates,
+      fuzzyMatch,
+    })
+    assert.deepEqual(hint, { relation: 'same_developer', value: 'Larian Studios' })
+  })
+
+  it('prefers same_franchise over studio/publisher', () => {
+    const answer: ProximityAnswer = {
+      id: 10,
+      name: 'The Witcher 3: Wild Hunt',
+      developer: 'CD Projekt Red',
+      publisher: 'CD Projekt',
+    }
+    const candidates = [
+      game({ id: 11, name: 'The Witcher 2: Assassins of Kings', developer: 'CD Projekt Red', publisher: 'CD Projekt' }),
+    ]
+    const hint = computeGuessProximityHint({
+      guessText: 'The Witcher 2',
+      answer,
+      candidates,
+      fuzzyMatch,
+    })
+    assert.equal(hint?.relation, 'same_franchise')
+    assert.equal(hint?.value, 'The Witcher')
+  })
+
+  it('flags same publisher when developer differs', () => {
+    const answer: ProximityAnswer = {
+      id: 20,
+      name: 'Hades',
+      developer: 'Supergiant Games',
+      publisher: 'Private Division',
+    }
+    const candidates = [
+      game({ id: 21, name: 'Kerbal Space Program', developer: 'Squad', publisher: 'Private Division' }),
+    ]
+    const hint = computeGuessProximityHint({
+      guessText: 'Kerbal Space Program',
+      answer,
+      candidates,
+      fuzzyMatch,
+    })
+    assert.deepEqual(hint, { relation: 'same_publisher', value: 'Private Division' })
+  })
+
+  it('returns null when the guess shares nothing with the answer', () => {
+    const candidates = [
+      game({ id: 3, name: 'Doom', developer: 'id Software', publisher: 'Bethesda' }),
+    ]
+    const hint = computeGuessProximityHint({
+      guessText: 'Doom',
+      answer: divinity,
+      candidates,
+      fuzzyMatch,
+    })
+    assert.equal(hint, null)
+  })
+
+  it('never derives a hint from the answer’s own catalogue row', () => {
+    const candidates = [
+      game({ id: 1, name: 'Divinity: Original Sin', developer: 'Larian Studios', publisher: 'Larian Studios' }),
+    ]
+    const hint = computeGuessProximityHint({
+      guessText: 'Divinity Original Sin',
+      answer: divinity,
+      candidates,
+      fuzzyMatch,
+    })
+    assert.equal(hint, null)
+  })
+
+  it('returns null when no candidate fuzzy-matches the guess', () => {
+    const candidates = [
+      game({ id: 4, name: 'Stardew Valley', developer: 'ConcernedApe', publisher: 'ConcernedApe' }),
+    ]
+    const hint = computeGuessProximityHint({
+      guessText: 'completely unrelated text',
+      answer: divinity,
+      candidates,
+      fuzzyMatch,
+    })
+    assert.equal(hint, null)
+  })
+
+  it('returns null with no candidates', () => {
+    const hint = computeGuessProximityHint({
+      guessText: 'anything',
+      answer: divinity,
+      candidates: [],
+      fuzzyMatch,
+    })
+    assert.equal(hint, null)
+  })
+})

--- a/packages/backend/src/domain/services/guess-proximity.service.ts
+++ b/packages/backend/src/domain/services/guess-proximity.service.ts
@@ -1,0 +1,126 @@
+import type { Game, GuessProximityHint } from '@the-box/types'
+
+/**
+ * Smart-guess "warmer" hints.
+ *
+ * When a player misses, a raw "Incorrect" is a dead end — they learn nothing.
+ * But players very often miss with a *related* game: a different entry in the
+ * same franchise, or a different title by the same studio or publisher (a
+ * classic example: guessing "Baldur's Gate 3" when the answer is
+ * "Divinity: Original Sin" — both Larian Studios). This service resolves the
+ * wrong guess to a known catalogue game and, if it shares a franchise /
+ * developer / publisher with the answer, returns a hint so the UI can tell the
+ * player they are "warm".
+ *
+ * Anti-leak contract: the returned `value` is always an attribute of the game
+ * the player *named themselves* (its franchise / studio / publisher), never the
+ * answer's title. We also refuse to derive a hint from the answer's own row, so
+ * a near-miss can't be used to confirm the title.
+ *
+ * Pure domain logic: no DB / HTTP imports. Candidate games are supplied by the
+ * caller (the repository pre-filters the catalogue) and the fuzzy matcher is
+ * injected.
+ */
+
+/** Minimal shape of the answer we need — keeps this decoupled from `Game`. */
+export interface ProximityAnswer {
+  id: number
+  name: string
+  developer?: string
+  publisher?: string
+}
+
+/** Just the parts of the fuzzy-match service this computation depends on. */
+export interface ProximityFuzzyMatcher {
+  isMatch(input: string, gameName: string, aliases?: string[]): boolean
+  parseGameTitle(title: string): { seriesName: string | null; baseName: string | null }
+}
+
+export interface ComputeGuessProximityInput {
+  guessText: string
+  answer: ProximityAnswer
+  /** Catalogue games pre-filtered by the repository as plausible matches. */
+  candidates: Game[]
+  fuzzyMatch: ProximityFuzzyMatcher
+}
+
+/** Lowercase, strip diacritics + punctuation, collapse whitespace. */
+function normalizeText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+/** Compare two studio / publisher strings for a confident, non-empty match. */
+function sameOrg(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false
+  const na = normalizeText(a)
+  const nb = normalizeText(b)
+  return na.length > 0 && na === nb
+}
+
+/**
+ * Human-readable franchise label from a full title: the part before the first
+ * colon, or the title with a trailing series number removed. Used only for
+ * display — the comparison key comes from `parseGameTitle`.
+ */
+function franchiseLabel(name: string): string {
+  const colon = name.indexOf(':')
+  const base = colon > 0 ? name.slice(0, colon) : name
+  // Drop a trailing standalone number / roman numeral (e.g. "Diablo IV" -> "Diablo").
+  return base.replace(/\s+(\d+|[ivxlcdm]+)$/i, '').trim() || base.trim()
+}
+
+/** Normalized franchise key for a title, or null when it has no series root. */
+function franchiseKey(name: string, fuzzy: ProximityFuzzyMatcher): string | null {
+  const parsed = fuzzy.parseGameTitle(name)
+  const root = parsed.seriesName ?? parsed.baseName
+  if (!root) return null
+  const key = normalizeText(root)
+  // Guard against over-broad one/two-letter roots ("X", "Go") matching noise.
+  return key.length >= 3 ? key : null
+}
+
+/**
+ * Resolve `guessText` to a related catalogue game and describe how it relates
+ * to the answer. Returns `null` when the guess is unrecognised or shares
+ * nothing with the answer.
+ */
+export function computeGuessProximityHint(
+  input: ComputeGuessProximityInput
+): GuessProximityHint | null {
+  const { guessText, answer, candidates, fuzzyMatch } = input
+  if (!guessText.trim() || candidates.length === 0) return null
+
+  // Find the catalogue game the player most plausibly meant. Never resolve to
+  // the answer's own row — that would let a near-miss confirm the title.
+  let matched: Game | undefined
+  for (const candidate of candidates) {
+    if (candidate.id === answer.id) continue
+    if (fuzzyMatch.isMatch(guessText, candidate.name, candidate.aliases ?? [])) {
+      matched = candidate
+      break
+    }
+  }
+  if (!matched) return null
+
+  // Most specific signal first: same franchise > same developer > same publisher.
+  const answerFranchise = franchiseKey(answer.name, fuzzyMatch)
+  const guessFranchise = franchiseKey(matched.name, fuzzyMatch)
+  if (answerFranchise && guessFranchise && answerFranchise === guessFranchise) {
+    return { relation: 'same_franchise', value: franchiseLabel(matched.name) }
+  }
+
+  if (sameOrg(answer.developer, matched.developer)) {
+    return { relation: 'same_developer', value: matched.developer! }
+  }
+
+  if (sameOrg(answer.publisher, matched.publisher)) {
+    return { relation: 'same_publisher', value: matched.publisher! }
+  }
+
+  return null
+}

--- a/packages/backend/src/infrastructure/repositories/game.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/game.repository.ts
@@ -240,6 +240,42 @@ export const gameRepository = {
     return row ? mapRowToGame(row) : null
   },
 
+  /**
+   * Candidate catalogue games for a free-text guess, used by the smart-guess
+   * proximity hint. We tokenise the guess and ILIKE on `name` for each
+   * significant token (≥3 alphanumerics, minus a few stop-words). This narrows
+   * the catalogue to a small set the domain then confirms with the fuzzy
+   * matcher — far cheaper than loading every game. Returns `[]` when the guess
+   * yields no usable tokens (e.g. "di"), which the caller treats as "no hint".
+   */
+  async findGuessMatchCandidates(guessText: string, limit = 25): Promise<Game[]> {
+    const STOP_WORDS = new Set(['the', 'and', 'for', 'les', 'des', 'una', 'los'])
+    const tokens = guessText
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .split(/\s+/)
+      .filter((token) => token.length >= 3 && !STOP_WORDS.has(token))
+      .slice(0, 4)
+
+    if (tokens.length === 0) {
+      log.debug({ guessText }, 'findGuessMatchCandidates: no usable tokens')
+      return []
+    }
+
+    log.debug({ tokens, limit }, 'findGuessMatchCandidates')
+    const rows = await db('games')
+      .where(function () {
+        for (const token of tokens) {
+          this.orWhereILike('name', `%${token}%`)
+        }
+      })
+      .limit(limit)
+      .select<GameRow[]>('*')
+
+    log.debug({ tokens, resultCount: rows.length }, 'findGuessMatchCandidates result')
+    return rows.map(mapRowToGame)
+  },
+
   async getGenresById(gameId: number): Promise<string[]> {
     log.debug({ gameId }, 'getGenresById')
     const row = await db('games')

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -339,6 +339,12 @@
     "nextRound": "Next Round",
     "correct": "Correct!",
     "incorrect": "Incorrect",
+    "proximity": {
+      "warmer": "Warmer!",
+      "sameFranchise": "Same franchise as the answer · {{value}}",
+      "sameDeveloper": "Same studio as the answer · {{value}}",
+      "samePublisher": "Same publisher as the answer · {{value}}"
+    },
     "timeUp": "Time's up!",
     "timer": {
       "label": "Time remaining: {{seconds}} seconds"

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -339,6 +339,12 @@
     "nextRound": "Round Suivant",
     "correct": "Correct !",
     "incorrect": "Incorrect",
+    "proximity": {
+      "warmer": "Vous chauffez !",
+      "sameFranchise": "Même franchise que la réponse · {{value}}",
+      "sameDeveloper": "Même studio que la réponse · {{value}}",
+      "samePublisher": "Même éditeur que la réponse · {{value}}"
+    },
     "timeUp": "Temps écoulé !",
     "timer": {
       "label": "Temps restant : {{seconds}} secondes"

--- a/packages/frontend/src/components/game/GuessInput.tsx
+++ b/packages/frontend/src/components/game/GuessInput.tsx
@@ -8,6 +8,7 @@ import { useGameStore } from '@/stores/gameStore'
 import { SkipForward, SkipBack, Loader2, Send } from 'lucide-react'
 import { createGuessSubmissionService } from '@/services'
 import { LetterRevealBar } from '@/components/game/LetterRevealBar'
+import { ProximityHintBanner } from '@/components/game/ProximityHintBanner'
 import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe'
 import { useGameGuess } from '@/hooks/useGameGuess'
 import { useOnline } from '@/hooks/useOnline'
@@ -161,6 +162,10 @@ export function GuessInput() {
   // Hide skip button on last screenshot
   const isLastPosition = currentPosition === totalScreenshots
 
+  // Smart-guess "warmer" hint for the active screenshot, set by the backend
+  // after a related wrong guess (same franchise / studio / publisher).
+  const proximityHint = positionStates[currentPosition]?.proximityHint
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       e.preventDefault()
@@ -271,6 +276,10 @@ export function GuessInput() {
           </Tooltip>
         )}
       </div>
+
+      {gamePhase === 'playing' && proximityHint && (
+        <ProximityHintBanner hint={proximityHint} />
+      )}
     </div>
   )
 }

--- a/packages/frontend/src/components/game/ProximityHintBanner.tsx
+++ b/packages/frontend/src/components/game/ProximityHintBanner.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next'
+import { m } from 'framer-motion'
+import { Flame } from 'lucide-react'
+import type { GuessProximityHint } from '@the-box/types'
+import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe'
+
+const RELATION_KEY: Record<GuessProximityHint['relation'], string> = {
+  same_franchise: 'game.proximity.sameFranchise',
+  same_developer: 'game.proximity.sameDeveloper',
+  same_publisher: 'game.proximity.samePublisher',
+}
+
+/**
+ * "Warmer" banner shown under the guess input after a wrong guess that the
+ * server could relate to the answer (same franchise / studio / publisher). It
+ * teaches the player something from a near-miss without ever revealing the
+ * answer's title — `hint.value` is an attribute of the game they named.
+ */
+export function ProximityHintBanner({ hint }: { hint: GuessProximityHint }) {
+  const { t } = useTranslation()
+  const prefersReducedMotion = useReducedMotionSafe()
+
+  return (
+    <m.div
+      // `aria-live` so the clue is announced; matches the wrong-guess feedback.
+      role="status"
+      aria-live="polite"
+      initial={prefersReducedMotion ? false : { opacity: 0, y: -4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25 }}
+      className="mt-2 flex items-center gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-warning"
+    >
+      <Flame className="size-4 shrink-0 text-warning" aria-hidden="true" />
+      <span className="min-w-0 text-foreground">
+        <span className="font-semibold text-warning">{t('game.proximity.warmer')}</span>{' '}
+        <span className="text-foreground/90">
+          {t(RELATION_KEY[hint.relation], { value: hint.value })}
+        </span>
+      </span>
+    </m.div>
+  )
+}

--- a/packages/frontend/src/hooks/useGameGuess.ts
+++ b/packages/frontend/src/hooks/useGameGuess.ts
@@ -78,15 +78,20 @@ export function useGameGuess(submissionService: GuessSubmissionService) {
         const currentPos = store.currentPosition
 
         if (result.isCorrect) {
-          // Mark position as correct
+          // Mark position as correct and clear any lingering "warmer" hint.
           store.updatePositionState(currentPos, {
             status: 'correct',
             isCorrect: true,
+            proximityHint: undefined,
           })
         } else {
-          // Wrong guess - stay on current position and mark as having incorrect guess
+          // Wrong guess - stay on current position and mark as having incorrect
+          // guess. Surface the smart-guess "warmer" hint when the server could
+          // relate this guess to the answer; keep the previous one otherwise so
+          // an unrelated follow-up guess doesn't wipe a useful clue.
           store.updatePositionState(currentPos, {
             isCorrect: false,
+            ...(result.proximityHint ? { proximityHint: result.proximityHint } : {}),
           })
           store.markIncorrectGuess(currentPos)
 

--- a/packages/frontend/src/services/guessSubmissionService.ts
+++ b/packages/frontend/src/services/guessSubmissionService.ts
@@ -1,4 +1,4 @@
-import type { Game, NewlyEarnedAchievement } from '@the-box/types'
+import type { Game, GuessProximityHint, NewlyEarnedAchievement } from '@the-box/types'
 import {
   fetchWithRetry,
   parseApiError,
@@ -33,6 +33,8 @@ export interface GuessSubmissionResult {
   letterPenalty?: number
   wrongGuessPenalty?: number
   secondChanceFloorBoost?: number
+  /** "Warmer" hint after a wrong guess that relates to the answer. */
+  proximityHint?: GuessProximityHint
   newlyEarnedAchievements?: NewlyEarnedAchievement[]
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -315,6 +315,13 @@ export interface PositionState {
    * `positionStates`, so a refresh can't reset it either.
    */
   timeSpentMs?: number
+  /**
+   * Latest "warmer" hint for this position, set after a wrong guess that we
+   * could relate to the answer (same franchise / developer / publisher).
+   * Rendered under the guess input; kept across navigation so revisiting the
+   * screenshot still shows the last clue. Cleared once the position is solved.
+   */
+  proximityHint?: GuessProximityHint
 }
 
 // ============================================
@@ -451,6 +458,27 @@ export interface GuessRequest {
   roundTimeTakenMs: number
 }
 
+/**
+ * How a *wrong* guess relates to the hidden answer. Surfaced as a
+ * "warmer / colder" signal so the player learns something from a near-miss
+ * (e.g. they named a different game by the same studio) without the answer
+ * itself ever leaking. Ordered most-specific first.
+ */
+export type GuessProximityRelation =
+  | 'same_franchise'
+  | 'same_developer'
+  | 'same_publisher'
+
+export interface GuessProximityHint {
+  relation: GuessProximityRelation
+  /**
+   * The shared attribute to echo back — the franchise name, developer, or
+   * publisher. Safe to reveal because it is an attribute of the game the
+   * player *just named themselves*, so it never discloses the answer's title.
+   */
+  value: string
+}
+
 export interface GuessResponse {
   isCorrect: boolean
   /**
@@ -461,6 +489,13 @@ export interface GuessResponse {
    * defeats both the hint economy and the masked-title letter reveal.
    */
   correctGame?: Game
+  /**
+   * Present only on a *wrong* guess that we could resolve to a known game
+   * sharing a franchise / developer / publisher with the answer. Drives the
+   * in-game "warmer" banner. Absent when the guess was correct, empty, or
+   * unrecognised, or when it shares nothing with the answer.
+   */
+  proximityHint?: GuessProximityHint
   scoreEarned: number
   totalScore: number
   screenshotsFound: number


### PR DESCRIPTION
## What & why

When a player misses a screenshot, a bare **"Incorrect"** teaches them nothing — yet players very often miss with a *related* game. The motivating example (from the reported screenshot): the answer is **Divinity: Original Sin**, the player guesses **Baldur's Gate 3** / **Baldur's Gate 2** — all wrong, all from **Larian Studios**. The game should tell them they're *warm*.

This PR makes the guess system smarter: on a **wrong, non-empty** guess the backend resolves the guess to a known catalogue game and, when it shares a **franchise / developer / publisher** with the answer, returns a `proximityHint`. The frontend surfaces it as a **"Vous chauffez !"** banner under the input.

| Guess vs. answer | Hint shown |
|---|---|
| Baldur's Gate 3 → Divinity: Original Sin | **Même studio · Larian Studios** |
| The Witcher 2 → The Witcher 3 | **Même franchise · The Witcher** |
| Kerbal Space Program → Hades | **Même éditeur · Private Division** |
| Doom → Divinity: Original Sin | *(none — shares nothing)* |

## Anti-leak contract

- The hint only ever echoes an attribute of the game the **player named themselves** (its franchise / studio / publisher) — never the answer's title.
- It refuses to derive a hint from the **answer's own catalogue row**, so a near-miss can't be used to confirm the title.
- Lookups run **only on wrong guesses** and are **best-effort** — a lookup failure logs a warning and never fails the submission. The existing `correctGame`-omitted-on-miss gate is unchanged.

## Changes

**types** — `GuessProximityHint` / `GuessProximityRelation`, `GuessResponse.proximityHint`, `PositionState.proximityHint`.

**backend**
- New pure domain service `guess-proximity.service.ts` (priority: franchise → developer → publisher) + unit tests (7 cases).
- `gameRepository.findGuessMatchCandidates()` — tokenises the guess and `ILIKE`s the catalogue down to a small candidate set the domain confirms with the fuzzy matcher (no full-table scan; empty for un-tokenisable guesses like "di").
- Wired into `game.service.submitGuess`.

**frontend**
- `ProximityHintBanner` (semantic `warning` design tokens, `aria-live`, reduced-motion safe).
- `useGameGuess` persists the hint per position (keeps the last useful clue rather than wiping it on an unrelated follow-up); cleared on a correct guess.
- `GuessInput` renders the banner; en/fr copy.

## Validation

- `npm run build:types`, `npm run build:frontend` ✅
- Backend typecheck clean (only the repo's pre-existing `baseUrl` tsconfig deprecation remains, unrelated to this change).
- `npm run lint` ✅ (0 errors)
- Backend unit tests: **271 pass / 0 fail** (incl. the 7 new proximity tests).

## Follow-up (not in this PR)

The hint is **live in-game only**. Showing it in the history / leaderboard "Tentatives" breakdown would require recomputing proximity for stored guesses server-side — deliberately deferred to keep this PR focused.

https://claude.ai/code/session_01Jm4bby1wV6jEFWZHgJznSU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm4bby1wV6jEFWZHgJznSU)_