### PR TITLE
feat(game): award partial score for franchise-level guesses

### DIFF
--- a/packages/backend/src/domain/services/fuzzy-match.service.test.ts
+++ b/packages/backend/src/domain/services/fuzzy-match.service.test.ts
@@ -31,6 +31,19 @@ function expectNoMatch(input: string, gameName: string, aliases: string[] = []):
   )
 }
 
+function expectPrecision(
+  input: string,
+  gameName: string,
+  precision: 'exact' | 'partial' | 'none',
+  aliases: string[] = []
+): void {
+  assert.equal(
+    service.evaluateMatch(input, gameName, aliases).precision,
+    precision,
+    `expected "${input}" → "${gameName}" to be ${precision}`
+  )
+}
+
 describe('fuzzy-match.service', () => {
   describe('screenshot cases — guesses that must NOT match', () => {
     // The user surfaced "garage band" → "Xenoblade Chronicles 3D" with an
@@ -311,6 +324,73 @@ describe('fuzzy-match.service', () => {
 
       it('rejects "vice city" — different subtitle', () => {
         expectNoMatch('vice city', target)
+      })
+    })
+  })
+
+  // Graded matching: a franchise named without the sequel number / full
+  // subtitle now resolves to `partial` (solves the screenshot at a reduced
+  // score) instead of a flat rejection. `isMatch` keeps its strict (exact-only)
+  // semantics, so every assertion above is unaffected.
+  describe('graded matching — evaluateMatch precision tiers', () => {
+    describe('exact (full title identified)', () => {
+      it('full normalised title', () => {
+        expectPrecision('metal gear solid 2', 'Metal Gear Solid 2: Sons of Liberty', 'exact')
+        expectPrecision('final fantasy xii', 'Final Fantasy XII', 'exact')
+        expectPrecision('final fantasy 12', 'Final Fantasy XII', 'exact')
+      })
+      it('base + correct number', () => {
+        expectPrecision('witcher 3', 'The Witcher 3: Wild Hunt', 'exact')
+        expectPrecision('portal 2', 'Portal 2', 'exact')
+      })
+      it('subtitle-only is a full identification, not partial', () => {
+        expectPrecision('skyrim', 'The Elder Scrolls V: Skyrim', 'exact')
+      })
+      it('base-name guess for an unnumbered main game stays exact', () => {
+        expectPrecision('paper mario', 'Paper Mario: The Thousand-Year Door', 'exact')
+      })
+    })
+
+    describe('partial (franchise named, number / subtitle omitted)', () => {
+      it('reported cases — franchise without the number', () => {
+        expectPrecision('metal gear solid', 'Metal Gear Solid 2: Sons of Liberty', 'partial')
+        expectPrecision('final fantasy', 'Final Fantasy XII', 'partial')
+        expectPrecision('pokemon', 'Pokémon X, Y', 'partial')
+      })
+      it('numbered franchises where the number is omitted', () => {
+        expectPrecision('witcher', 'The Witcher 3: Wild Hunt', 'partial')
+        expectPrecision('the witcher', 'The Witcher 3: Wild Hunt', 'partial')
+        expectPrecision('portal', 'Portal 2', 'partial')
+        expectPrecision('fallout', 'Fallout 2', 'partial')
+        expectPrecision('half-life', 'Half-Life 2: Episode Two', 'partial')
+      })
+      it('isMatch (strict) still rejects these', () => {
+        // The strict contract that drives the letter-reveal leak gate is
+        // unchanged — only evaluateMatch grades them up to partial.
+        expectNoMatch('metal gear solid', 'Metal Gear Solid 2: Sons of Liberty')
+        expectNoMatch('final fantasy', 'Final Fantasy XII')
+        expectNoMatch('witcher', 'The Witcher 3: Wild Hunt')
+      })
+    })
+
+    describe('none (must never become partial)', () => {
+      it('a WRONG number names a different game', () => {
+        expectPrecision('final fantasy vii', 'Final Fantasy VIII', 'none')
+        expectPrecision('final fantasy 10', 'Final Fantasy VIII', 'none')
+        expectPrecision('witcher 2', 'The Witcher 3: Wild Hunt', 'none')
+        expectPrecision('pokemon 2', 'Pokémon X, Y', 'none')
+      })
+      it('a foreign specifier names a different entry', () => {
+        // "diamond" / "land" are not tokens of "Pokémon X, Y".
+        expectPrecision('pokemon diamond', 'Pokémon X, Y', 'none')
+        expectPrecision('pokemon land', 'Pokémon X, Y', 'none')
+      })
+      it('DLC base-name stays rejected (unnumbered subtitled target → no partial)', () => {
+        expectPrecision('cuphead', 'Cuphead: The Delicious Last Course', 'none')
+      })
+      it('unrelated guesses stay none', () => {
+        expectPrecision('garage band', 'Xenoblade Chronicles 3D', 'none')
+        expectPrecision('baldurs gate 3', 'Divinity: Original Sin - Enhanced Edition', 'none')
       })
     })
   })

--- a/packages/backend/src/domain/services/fuzzy-match.service.ts
+++ b/packages/backend/src/domain/services/fuzzy-match.service.ts
@@ -809,16 +809,153 @@ function isMatchEnhanced(
   return false
 }
 
+/**
+ * Precision of an accepted guess:
+ *  - `exact`   — the full title was identified (series + correct number +
+ *                subtitle as applicable, or any path the strict matcher
+ *                already accepts at full confidence).
+ *  - `partial` — the franchise was identified but the sequel number / full
+ *                subtitle was OMITTED (not wrong). Solves the position at a
+ *                reduced score.
+ *  - `none`    — not a match.
+ */
+export type MatchPrecision = 'exact' | 'partial' | 'none'
+
+export interface MatchResult {
+  /** Convenience: `precision !== 'none'`. */
+  matched: boolean
+  precision: MatchPrecision
+}
+
+/**
+ * Strict acceptance — the historical `isMatch` semantics. A guess is accepted
+ * only when it names the full title (series + correct number + subtitle as
+ * applicable). Kept as the single source of truth for `isMatch` (and therefore
+ * the letter-reveal leak gate), with the parenthesised-alias and
+ * expansion-suffix retries that `isMatch` has always applied.
+ */
+function strictMatch(
+  input: string,
+  gameName: string,
+  aliases: string[],
+  log: DomainLogger
+): boolean {
+  if (isMatchEnhanced(input, gameName, aliases, log)) {
+    return true
+  }
+  // Parenthesised alternate name (e.g. "Fahrenheit (Indigo Prophecy)"):
+  // retry against the base name with the parenthesised text promoted to an
+  // alias.
+  const paren = extractParenthesizedAliases(gameName)
+  if (
+    paren.aliases.length > 0 &&
+    isMatchEnhanced(input, paren.base, [...aliases, ...paren.aliases], log)
+  ) {
+    return true
+  }
+  // Retry against the base title with any " - Expansion" suffix removed.
+  const core = stripExpansionSuffix(gameName)
+  if (core !== gameName && isMatchEnhanced(input, core, aliases, log)) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Franchise-level partial match. Returns true ONLY when the strict matcher has
+ * already rejected the guess AND the input clearly identifies the franchise but
+ * merely OMITTED the sequel number (e.g. "metal gear solid" → "Metal Gear
+ * Solid 2: Sons of Liberty", "final fantasy" → "Final Fantasy XII", "pokemon"
+ * → "Pokémon X, Y").
+ *
+ * Deliberately narrow so it can never resurrect a rejection the matcher makes
+ * on purpose:
+ *   - target must carry a sequel NUMBER (so there is something to omit);
+ *     subtitled-but-unnumbered base names are already full-credit via the
+ *     strict matcher, and a DLC base-name must stay a miss;
+ *   - a WRONG number names a different entry → never partial;
+ *   - every meaningful input token must be COVERED by a target token, so a
+ *     foreign specifier ("pokemon diamond" for "Pokémon X, Y") stays a miss;
+ *   - DLC base-name matches stay rejected.
+ */
+function franchisePartialMatch(
+  input: string,
+  gameName: string,
+  log: DomainLogger
+): boolean {
+  const inputParsed = parseGameTitle(input)
+  const targetParsed = parseGameTitle(gameName)
+
+  // Nothing to be "partial" about unless the target has a sequel number the
+  // player could have left off.
+  if (targetParsed.seriesNumber === null) return false
+
+  // A wrong number is a different game, not a less-precise answer.
+  if (
+    inputParsed.seriesNumber !== null &&
+    inputParsed.seriesNumber !== targetParsed.seriesNumber
+  ) {
+    return false
+  }
+
+  // Never reopen the deliberate DLC base-name rejection.
+  if (isBaseNameOnlyMatch(input, targetParsed)) return false
+
+  // The franchise root is the target's series name with the number stripped.
+  const franchiseRoot = targetParsed.seriesName ?? targetParsed.baseName
+  if (!franchiseRoot) return false
+
+  const inputNorm = normalizeForFuzzy(stripCommonPrefixes(input))
+  const rootNorm = normalizeForFuzzy(stripCommonPrefixes(franchiseRoot))
+  if (!inputNorm || !rootNorm) return false
+
+  // The franchise must be clearly identified — plain JW for the in-order case,
+  // token-sort for natural word reorders. Either clears the bar.
+  const sim = Math.max(
+    jaroWinkler(inputNorm, rootNorm),
+    tokenSortSimilarity(inputNorm, rootNorm)
+  )
+  if (sim < SERIES_NAME_THRESHOLD) return false
+
+  // Subset guard: every meaningful input token must appear in the FULL target
+  // title. This is what separates "named the franchise" (a subset of the
+  // title's words) from "named a different entry" (adds a foreign token).
+  const targetTokens = tokenize(normalizeForFuzzy(gameName))
+  const inputTokens = tokenize(inputNorm).filter(
+    t => t.length >= MEANINGFUL_TOKEN_MIN_LENGTH && !STOP_TOKENS.has(t)
+  )
+  const allCovered = inputTokens.every(it =>
+    targetTokens.some(
+      tt =>
+        tt === it ||
+        (tt.length >= MEANINGFUL_TOKEN_MIN_LENGTH &&
+          (tt.includes(it) || it.includes(tt) || jaroWinkler(it, tt) >= 0.9))
+    )
+  )
+  if (!allCovered) return false
+
+  log.debug({ input, gameName, franchiseRoot, sim }, 'franchise partial match')
+  return true
+}
+
 export interface FuzzyMatchService {
   /**
    * Calculate similarity between two strings
    */
   calculateSimilarity(input: string, target: string): number
   /**
-   * Check if input matches the game name or any alias
-   * Uses enhanced structural matching algorithm
+   * Check if input matches the game name or any alias (STRICT / full-title
+   * semantics). Unchanged contract — used by the letter-reveal leak gate, so
+   * it must never loosen. For graded scoring use `evaluateMatch`.
    */
   isMatch(input: string, gameName: string, aliases?: string[]): boolean
+  /**
+   * Graded match: returns whether the guess is accepted and at what precision
+   * (`exact` full title vs `partial` franchise-only). A wrong number or an
+   * unrelated guess returns `none`. Consumed by the scorer to award reduced
+   * points for a franchise-level identification.
+   */
+  evaluateMatch(input: string, gameName: string, aliases?: string[]): MatchResult
   /**
    * Get the best match score for debugging/logging
    */
@@ -856,29 +993,21 @@ export function createFuzzyMatchService(deps: FuzzyMatchServiceDeps): FuzzyMatch
     },
 
     isMatch(input: string, gameName: string, aliases: string[] = []): boolean {
-      if (isMatchEnhanced(input, gameName, aliases, log)) {
-        return true
+      return strictMatch(input, gameName, aliases, log)
+    },
+
+    evaluateMatch(input: string, gameName: string, aliases: string[] = []): MatchResult {
+      // Strict / full-title acceptance wins first and is always `exact`.
+      if (strictMatch(input, gameName, aliases, log)) {
+        return { matched: true, precision: 'exact' }
       }
-      // Parenthesised alternate name (e.g. "Fahrenheit (Indigo Prophecy)"):
-      // retry against the base name with the parenthesised text promoted to
-      // an alias, so "farenheit" can clear the subtitle threshold against
-      // "Fahrenheit" instead of being judged against the full string.
-      const paren = extractParenthesizedAliases(gameName)
-      if (
-        paren.aliases.length > 0 &&
-        isMatchEnhanced(input, paren.base, [...aliases, ...paren.aliases], log)
-      ) {
-        return true
+      // Otherwise, accept a franchise-level identification (number omitted) at
+      // reduced precision. Wrong numbers and unrelated guesses fall through to
+      // `none`.
+      if (franchisePartialMatch(input, gameName, log)) {
+        return { matched: true, precision: 'partial' }
       }
-      // Retry against the base title with any " - Expansion" suffix removed,
-      // so the base game is accepted for an expansion-titled challenge
-      // (e.g. "Warhammer Dawn of War" for
-      // "Warhammer 40,000: Dawn of War - Dark Crusade").
-      const core = stripExpansionSuffix(gameName)
-      if (core !== gameName && isMatchEnhanced(input, core, aliases, log)) {
-        return true
-      }
-      return false
+      return { matched: false, precision: 'none' }
     },
 
     getBestMatchScore(

--- a/packages/backend/src/domain/services/game.service.get-screenshot.test.ts
+++ b/packages/backend/src/domain/services/game.service.get-screenshot.test.ts
@@ -22,6 +22,7 @@ function buildService(timeLimitSeconds: number | null) {
       // Fragments never match in this harness — letter caps stay at the
       // static formula, which is all the masked-title assertions need.
       isMatch: () => false,
+      evaluateMatch: () => ({ matched: false, precision: 'none' as const }),
     },
     sessionRepository: {
       findGameSessionById: async () => ({ id: 'game-1', daily_challenge_id: 1 }),

--- a/packages/backend/src/domain/services/game.service.reveal-letter.test.ts
+++ b/packages/backend/src/domain/services/game.service.reveal-letter.test.ts
@@ -60,6 +60,10 @@ function buildHarness(opts: { letterItems?: number; isCatchUp?: boolean } = {}) 
     logger: silentLogger,
     fuzzyMatchService: {
       isMatch: (guess: string) => guess.trim() === 'right',
+      evaluateMatch: (guess: string) =>
+        guess.trim() === 'right'
+          ? { matched: true, precision: 'exact' as const }
+          : { matched: false, precision: 'none' as const },
     },
     achievementService: { checkAchievementsAfterGame: async () => [] },
     challengeRepository: {

--- a/packages/backend/src/domain/services/game.service.submit-guess.test.ts
+++ b/packages/backend/src/domain/services/game.service.submit-guess.test.ts
@@ -104,6 +104,14 @@ function buildHarness() {
     fuzzyMatchService: {
       // The harness submits the literal answer 'right' for a correct guess.
       isMatch: (guess: string) => guess.trim() === 'right',
+      // Graded matcher used by submitGuess: 'right' = exact full title,
+      // 'franchise' = partial (franchise named, number omitted), else none.
+      evaluateMatch: (guess: string) => {
+        const g = guess.trim()
+        if (g === 'right') return { matched: true, precision: 'exact' as const }
+        if (g === 'franchise') return { matched: true, precision: 'partial' as const }
+        return { matched: false, precision: 'none' as const }
+      },
     },
     achievementService: {
       checkAchievementsAfterGame: async () => [],
@@ -267,5 +275,38 @@ describe('game.service submitGuess — legacy metadata hints retired', () => {
     await h.submit(1, 'right')
     assert.equal(h.guesses[0]!.powerUpUsed, null)
     assert.equal(h.guesses[0]!.hintFromInventory, false)
+  })
+})
+
+describe('game.service submitGuess — partial (franchise) scoring', () => {
+  it('awards a reduced score and solves the position for a partial match', async () => {
+    const h = buildHarness()
+    // 5s round → exact would be 150; partial = round(150 × 0.4) = 60.
+    const res = await h.submit(1, 'franchise')
+    assert.equal(res.isCorrect, true, 'a franchise-level guess solves the screenshot')
+    assert.equal(res.scoreEarned, 60, 'partial score = 40% of the exact (capped) score')
+    assert.equal(res.matchPrecision, 'partial')
+    assert.equal(res.screenshotsFound, 1, 'partial match counts as found')
+    assert.equal(res.correctGame?.name, 'Halo', 'a solved partial reveals the answer')
+  })
+
+  it('keeps an exact match at full score and labels it exact', async () => {
+    const h = buildHarness()
+    const res = await h.submit(1, 'right')
+    assert.equal(res.scoreEarned, 150)
+    assert.equal(res.matchPrecision, 'exact')
+  })
+
+  it('a partial match is always worth less than the slowest exact (100)', async () => {
+    const h = buildHarness()
+    const res = await h.submit(1, 'franchise')
+    assert.ok(res.scoreEarned < 100, 'partial must never reach the exact floor')
+  })
+
+  it('omits matchPrecision on a wrong guess', async () => {
+    const h = buildHarness()
+    const res = await h.submit(1, 'totally wrong')
+    assert.equal(res.isCorrect, false)
+    assert.equal(res.matchPrecision, undefined)
   })
 })

--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -22,7 +22,7 @@ import type {
   PositionSecondChanceRepository,
   PositionLetterRevealRepository,
 } from '../ports/repositories.js'
-import type { FuzzyMatchService } from './fuzzy-match.service.js'
+import type { FuzzyMatchService, MatchPrecision } from './fuzzy-match.service.js'
 import type { AchievementService } from './achievement.service.js'
 import {
   buildMaskedTitle,
@@ -46,6 +46,12 @@ const TOTAL_SCREENSHOTS = 10
 const BASE_SCORE = 100
 const UNFOUND_PENALTY = 0
 const WRONG_GUESS_PENALTY = 0
+// Fraction of the (speed-scaled, capped) score awarded for a `partial` match —
+// the player named the franchise but omitted the sequel number / full subtitle.
+// 0.40 is deliberately below 0.5 so the FASTEST partial (200 × 0.40 = 80) can
+// never beat the SLOWEST exact (100): full identification is always strictly
+// the better play. Applied after the 200 cap, before letter penalty / floor.
+const PARTIAL_MATCH_FACTOR = 0.4
 // Free tier no longer gets a catch-up window — only today's daily is
 // playable. Premium keeps the 365-day archive. Setting this to 0 (rather
 // than removing the constant) keeps the conditional shape downstream so
@@ -646,12 +652,21 @@ export function createGameService(deps: GameServiceDeps): GameService {
     // text attempt; fuzzy-match wins on its own, gameId is now only a
     // tiebreaker for ambiguous text (e.g. autocomplete picks).
     const trimmedGuess = data.guessText.trim()
-    const isCorrect =
-      trimmedGuess !== '' &&
-      (
-        fuzzyMatchService.isMatch(data.guessText, gameName, aliases) ||
-        data.gameId === screenshot.gameId
-      )
+    // Graded match. `exact` = full title; `partial` = franchise named but
+    // sequel number / subtitle omitted (solves the position at a reduced
+    // score). A picked autocomplete result (gameId) is a definitive selection,
+    // so it counts as `exact`. A wrong number / unrelated guess stays `none`.
+    const matchResult =
+      trimmedGuess !== ''
+        ? fuzzyMatchService.evaluateMatch(data.guessText, gameName, aliases)
+        : { matched: false, precision: 'none' as MatchPrecision }
+    const precision: MatchPrecision =
+      matchResult.precision !== 'none'
+        ? matchResult.precision
+        : trimmedGuess !== '' && data.gameId === screenshot.gameId
+          ? 'exact'
+          : 'none'
+    const isCorrect = precision !== 'none'
 
     // Server-authoritative round timer. The client submits its own
     // `roundTimeTakenMs`; we treat it as a hint and use Math.max(server,
@@ -698,6 +713,11 @@ export function createGameService(deps: GameServiceDeps): GameService {
       scoreEarned = Math.round(BASE_SCORE * speedMultiplier)
       // Cap max score per screenshot at 200 points
       scoreEarned = Math.min(scoreEarned, 200)
+      // Franchise-only identification earns a fraction of the full score. The
+      // factor is applied AFTER the cap so partial tops out at 80, never 200.
+      if (precision === 'partial') {
+        scoreEarned = Math.round(scoreEarned * PARTIAL_MATCH_FACTOR)
+      }
     }
 
     // Letter-reveal penalty — the cumulative percent was locked in at
@@ -995,6 +1015,7 @@ export function createGameService(deps: GameServiceDeps): GameService {
         letterPenalty: letterPenalty > 0 ? letterPenalty : undefined,
         wrongGuessPenalty: wrongGuessPenalty > 0 ? wrongGuessPenalty : undefined,
         secondChanceFloorBoost,
+        matchPrecision: isCorrect ? (precision as 'exact' | 'partial') : undefined,
         newlyEarnedAchievements: newlyEarnedAchievements.length > 0 ? newlyEarnedAchievements : undefined,
       }
     }
@@ -1033,6 +1054,7 @@ export function createGameService(deps: GameServiceDeps): GameService {
       letterPenalty: letterPenalty > 0 ? letterPenalty : undefined,
       wrongGuessPenalty: wrongGuessPenalty > 0 ? wrongGuessPenalty : undefined,
       secondChanceFloorBoost,
+      matchPrecision: isCorrect ? (precision as 'exact' | 'partial') : undefined,
     }
     }) // end withTierSessionLock
   },

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -338,6 +338,8 @@
     "guessPlaceholder": "Game name...",
     "nextRound": "Next Round",
     "correct": "Correct!",
+    "partialMatch": "Franchise recognised!",
+    "partialMatchHint": "You named the series but not the full title — partial points awarded.",
     "incorrect": "Incorrect",
     "timeUp": "Time's up!",
     "timer": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -338,6 +338,8 @@
     "guessPlaceholder": "Nom du jeu...",
     "nextRound": "Round Suivant",
     "correct": "Correct !",
+    "partialMatch": "Licence reconnue !",
+    "partialMatchHint": "Tu as trouvé la série mais pas le titre complet — points partiels accordés.",
     "incorrect": "Incorrect",
     "timeUp": "Temps écoulé !",
     "timer": {

--- a/packages/frontend/src/components/game/ResultCard.tsx
+++ b/packages/frontend/src/components/game/ResultCard.tsx
@@ -148,7 +148,7 @@ export function ResultCard() {
   // Early return after all hooks
   if (!lastResult) return null
 
-  const { isCorrect, correctGame, scoreEarned, timeTakenMs, userGuess, hintPenalty, letterPenalty, wrongGuessPenalty } = lastResult
+  const { isCorrect, correctGame, scoreEarned, timeTakenMs, userGuess, hintPenalty, letterPenalty, wrongGuessPenalty, matchPrecision } = lastResult
   const maxScore = 200
   const scorePercentage = (scoreEarned / maxScore) * 100
   const timeTakenSeconds = Math.round(timeTakenMs / 1000)
@@ -222,15 +222,17 @@ export function ResultCard() {
           <div
             className={cn(
               "inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold",
-              isCorrect
-                ? "bg-success/20 text-success"
-                : "bg-error/20 text-error"
+              !isCorrect
+                ? "bg-error/20 text-error"
+                : matchPrecision === 'partial'
+                  ? "bg-score-mid/20 text-score-mid"
+                  : "bg-success/20 text-success"
             )}
           >
             {isCorrect ? (
               <>
                 <CheckCircle className="size-5" />
-                {t('game.correct')}
+                {matchPrecision === 'partial' ? t('game.partialMatch') : t('game.correct')}
               </>
             ) : (
               <>
@@ -255,6 +257,7 @@ export function ResultCard() {
           hintPenalty={hintPenalty}
           letterPenalty={letterPenalty}
           wrongGuessPenalty={wrongGuessPenalty}
+          matchPrecision={matchPrecision}
         />
 
         {/* Next Button */}

--- a/packages/frontend/src/components/game/ResultScoreDisplay.tsx
+++ b/packages/frontend/src/components/game/ResultScoreDisplay.tsx
@@ -28,6 +28,7 @@ interface ResultScoreDisplayProps {
   hintPenalty?: number
   letterPenalty?: number
   wrongGuessPenalty?: number
+  matchPrecision?: 'exact' | 'partial'
 }
 
 /**
@@ -44,9 +45,14 @@ export function ResultScoreDisplay({
   hintPenalty,
   letterPenalty,
   wrongGuessPenalty,
+  matchPrecision,
 }: ResultScoreDisplayProps) {
   const { t } = useTranslation()
   const speedFeedback = getSpeedFeedback(isCorrect, timeTakenSeconds)
+  // A partial (franchise-only) match earns a reduced, already-discounted score,
+  // so the "100 × speed" headline would overstate it — show the flat earned
+  // value instead and explain why.
+  const isPartial = matchPrecision === 'partial'
 
   const scoreColor = cn(
     "text-5xl font-black",
@@ -64,7 +70,7 @@ export function ResultScoreDisplay({
       transition={{ delay: 0.45 }}
       className="text-center mb-6"
     >
-      {isCorrect && scoreEarned > 0 ? (
+      {isCorrect && scoreEarned > 0 && !isPartial ? (
         <div className="flex flex-col items-center gap-1">
           <div className="flex items-center justify-center gap-2">
             <span className={scoreColor}>+100</span>
@@ -82,6 +88,18 @@ export function ResultScoreDisplay({
           </span>
           <span className="text-lg text-muted-foreground font-medium">pts</span>
         </div>
+      )}
+
+      {/* Partial (franchise-only) match explanation */}
+      {isPartial && isCorrect && (
+        <m.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 }}
+          className="mt-2 text-score-mid text-sm font-medium"
+        >
+          {t('game.partialMatchHint')}
+        </m.div>
       )}
 
       {/* Hint Penalty Display */}

--- a/packages/frontend/src/hooks/useGameGuess.ts
+++ b/packages/frontend/src/hooks/useGameGuess.ts
@@ -120,6 +120,7 @@ export function useGameGuess(submissionService: GuessSubmissionService) {
             scoreEarned: result.scoreEarned,
             letterPenalty: result.letterPenalty,
             wrongGuessPenalty: result.wrongGuessPenalty,
+            matchPrecision: result.matchPrecision,
             attempts,
           })
         }

--- a/packages/frontend/src/services/guessSubmissionService.ts
+++ b/packages/frontend/src/services/guessSubmissionService.ts
@@ -33,6 +33,8 @@ export interface GuessSubmissionResult {
   letterPenalty?: number
   wrongGuessPenalty?: number
   secondChanceFloorBoost?: number
+  /** `partial` when only the franchise was named (reduced score); else `exact`. */
+  matchPrecision?: 'exact' | 'partial'
   newlyEarnedAchievements?: NewlyEarnedAchievement[]
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -278,6 +278,12 @@ export interface GuessResult {
   /** Points deducted for letters of the title revealed on this position. */
   letterPenalty?: number
   wrongGuessPenalty?: number
+  /**
+   * `partial` when the player named the franchise but omitted the sequel
+   * number / full subtitle — the screenshot is solved at a reduced score.
+   * `exact` (or absent) for a full-title identification.
+   */
+  matchPrecision?: 'exact' | 'partial'
   screenshot?: Screenshot
   /** All guesses the user made for this position, in chronological order. */
   attempts?: GuessAttempt[]
@@ -484,6 +490,14 @@ export interface GuessResponse {
    * active activation.
    */
   secondChanceFloorBoost?: number
+  /**
+   * Precision of a correct guess. `exact` = the full title was identified;
+   * `partial` = only the franchise was named (sequel number / full subtitle
+   * omitted), which still solves the screenshot but at a reduced score. Absent
+   * on a wrong guess. The frontend surfaces a "franchise recognised" badge for
+   * `partial` so the player understands the reduced points.
+   */
+  matchPrecision?: 'exact' | 'partial'
   newlyEarnedAchievements?: NewlyEarnedAchievement[]
 }
 

--- a/tasks/partial-guess-scoring-subagents-meeting.html
+++ b/tasks/partial-guess-scoring-subagents-meeting.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<!-- SUMMARY:
+  Graded guess scoring: a guess that identifies the franchise but omits the
+  sequel number / full subtitle now VALIDATES the screenshot at a reduced
+  score (partial tier) instead of scoring 0. A wrong number stays rejected.
+  Matcher gains evaluateMatch()->{matched,precision}; isMatch stays exact-only
+  so the letter-reveal leak gate is untouched. Partial = 40% so the fastest
+  partial (80) can never beat the slowest exact (100).
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Partial Guess Scoring — Subagent Design Review</title>
+<style>
+  :root { --bg:#0a0a0f; --panel:#14141c; --ink:#e7e7ee; --muted:#a0a0b0;
+          --primary:#a855f7; --good:#34d399; --warn:#fbbf24; --bad:#f87171;
+          --line:#26263420; }
+  * { box-sizing:border-box; }
+  body { background:var(--bg); color:var(--ink); margin:0;
+         font-family:Inter,system-ui,sans-serif; line-height:1.6; }
+  main { max-width:72ch; margin:0 auto; padding:3rem 1.25rem 6rem; }
+  h1 { font-size:1.9rem; line-height:1.2; margin:0 0 .25rem;
+       text-shadow:0 0 24px #a855f766; }
+  h2 { font-size:1.25rem; margin:2.4rem 0 .6rem; border-bottom:1px solid #2a2a38;
+       padding-bottom:.3rem; }
+  h3 { font-size:1rem; margin:1.4rem 0 .3rem; color:#cfcfe0; }
+  .sub { color:var(--muted); margin:0 0 1.5rem; }
+  code,pre { font-family:"JetBrains Mono",ui-monospace,monospace; }
+  code { background:#1d1d28; padding:.08em .4em; border-radius:4px; font-size:.88em; }
+  pre { background:#1d1d28; padding:1rem; border-radius:8px; overflow:auto;
+        border:1px solid #2a2a38; font-size:.82rem; }
+  table { width:100%; border-collapse:collapse; margin:.8rem 0; font-size:.86rem; }
+  th,td { text-align:left; padding:.5rem .6rem; border-bottom:1px solid #2a2a38;
+          vertical-align:top; }
+  th { color:var(--muted); font-weight:600; }
+  .tag { display:inline-block; padding:.05em .55em; border-radius:999px;
+         font-size:.74rem; font-weight:600; }
+  .exact { background:#34d39922; color:var(--good); }
+  .partial { background:#fbbf2422; color:var(--warn); }
+  .none { background:#f8717122; color:var(--bad); }
+  .persona { background:var(--panel); border:1px solid #2a2a38; border-radius:10px;
+             padding:.9rem 1.1rem; margin:.7rem 0; }
+  .persona b { color:var(--primary); }
+  .verdict { border-left:3px solid var(--primary); padding:.2rem 0 .2rem .9rem;
+             margin:1rem 0; color:#dcdce8; }
+  ul { padding-left:1.2rem; }
+  @media (prefers-reduced-motion: reduce) { * { transition:none !important; } }
+</style>
+</head>
+<body>
+<main>
+  <h1>Partial Guess Scoring</h1>
+  <p class="sub">Subagent design review · 4 personas + devil's advocate · 2026-06-14</p>
+
+  <h2>Problem</h2>
+  <p>A player identified the franchise from a screenshot but omitted the sequel
+  number or full subtitle, and scored <b>0</b>. From the reported session:</p>
+  <ul>
+    <li><code>metal gear solid</code> → <i>Metal Gear Solid 2: Sons of Liberty</i> — rejected.</li>
+    <li><code>final fantasy</code> → <i>Final Fantasy XII</i> — rejected.</li>
+    <li><code>pokemon</code> → <i>Pokémon X, Y</i> — rejected.</li>
+  </ul>
+  <p>Owner ask (FR): validate these at a <b>lower</b> score; award a bonus when
+  the number / full title is also right. Genuinely <i>wrong</i> guesses
+  (<code>final fantasy vii</code> for FF VIII) must stay rejected.</p>
+
+  <h2>Persona positions</h2>
+  <div class="persona"><b>Product / Game design.</b> Three tiers: exact / close /
+  franchise. Franchise-only is a real reward but unmistakably worse. Speed still
+  rewards skill. Crisp fairness line: <i>omission</i> = partial credit,
+  <i>commission</i> (wrong number) = a miss.</div>
+  <div class="persona"><b>Backend architect.</b> Add
+  <code>evaluateMatch() → { matched, precision }</code>; keep <code>isMatch</code>
+  as a thin wrapper so only the scorer consumes the grade. Map precision→score in
+  <code>game.service</code> via a constant. Apply the partial factor <i>after</i>
+  the 200 cap, before letter penalty &amp; second-chance floor. Do not loosen the
+  letter-reveal leak gate.</div>
+  <div class="persona"><b>QA.</b> Keep all ~90 boolean assertions green; add a
+  parallel graded suite. Highest-risk deltas: the
+  <code>witcher/portal/fallout</code> trio (false → partial) and the leak gate.
+  Pin "wrong number stays none" and "revealed letters can't auto-win".</div>
+  <div class="persona"><b>Devil's advocate.</b> Block as originally framed. The
+  matcher rejects franchise-only <i>on purpose</i> in 5 branches. Hard
+  constraints: partial NEVER on DLC base-name, incomplete truncation, or wrong
+  number; never trivialize the leaderboard via franchise-spam; the leak gate must
+  stay strict; one boolean tier, not a numeric gradient.</div>
+
+  <h2>Decision</h2>
+  <p>Single <span class="tag partial">partial</span> tier. The matcher gains
+  <code>evaluateMatch(input, name, aliases) → { matched, precision:
+  'exact'|'partial'|'none' }</code>. <code>isMatch</code> keeps its current
+  <b>exact-only</b> meaning — so the letter-reveal leak gate
+  (<code>effectiveMaxReveals</code>) and every other caller are byte-for-byte
+  unchanged. Only <code>submitGuess</code> reads the grade.</p>
+
+  <h3>When partial fires (narrow, by construction)</h3>
+  <p>All must hold, after the strict matcher has already said "no":</p>
+  <ul>
+    <li>target has a <b>sequel number</b> (so there is something to omit);</li>
+    <li>input matches the <b>franchise root</b> (number stripped) ≥ 0.85;</li>
+    <li>every meaningful input token is <b>covered</b> by a target token — no
+    foreign specifier (kills <code>pokemon diamond</code> → <i>Pokémon X, Y</i>);</li>
+    <li>input gives <b>no wrong number</b>;</li>
+    <li>it is <b>not</b> a DLC base-name match.</li>
+  </ul>
+
+  <h3>Scoring curve</h3>
+  <p><code>exact = round(min(100 × speed, 200))</code> (unchanged).
+  <code>partial = round(exact × 0.40)</code>. The 0.40 factor guarantees the
+  <i>fastest</i> partial (80) is always below the <i>slowest</i> exact (100), so
+  full identification is strictly the best play. Order:
+  speed → 200 cap → partial factor → letter penalty → second-chance floor.</p>
+  <pre>partial range: 40 – 80     exact range: 100 – 200   (no overlap)</pre>
+
+  <h2>Behaviour matrix</h2>
+  <table>
+    <tr><th>Guess → Target</th><th>Tier</th><th>Why</th></tr>
+    <tr><td>metal gear solid 2 → MGS 2: Sons of Liberty</td><td><span class="tag exact">exact</span></td><td>number supplied</td></tr>
+    <tr><td>metal gear solid → MGS 2: Sons of Liberty</td><td><span class="tag partial">partial</span></td><td>franchise, number omitted</td></tr>
+    <tr><td>final fantasy → Final Fantasy XII</td><td><span class="tag partial">partial</span></td><td>franchise, number omitted</td></tr>
+    <tr><td>pokemon → Pokémon X, Y</td><td><span class="tag partial">partial</span></td><td>franchise, edition omitted</td></tr>
+    <tr><td>portal / fallout / witcher → numbered entry</td><td><span class="tag partial">partial</span></td><td>franchise, number omitted</td></tr>
+    <tr><td>final fantasy vii → Final Fantasy VIII</td><td><span class="tag none">none</span></td><td>WRONG number = different game</td></tr>
+    <tr><td>witcher 2 → The Witcher 3</td><td><span class="tag none">none</span></td><td>wrong number</td></tr>
+    <tr><td>pokemon diamond → Pokémon X, Y</td><td><span class="tag none">none</span></td><td>foreign token "diamond"</td></tr>
+    <tr><td>cuphead → Cuphead: The Delicious Last Course</td><td><span class="tag none">none</span></td><td>DLC base-name</td></tr>
+    <tr><td>A Space for the Unb → …Unbound</td><td><span class="tag none">none</span></td><td>no number → no partial concept</td></tr>
+    <tr><td>paper mario → Paper Mario: TTYD</td><td><span class="tag exact">exact</span></td><td>no number to miss (already full credit)</td></tr>
+  </table>
+
+  <h2>Devil's-advocate constraints — disposition</h2>
+  <div class="verdict">
+    <b>Honored:</b> partial never touches DLC base-name, incomplete truncation, or
+    any wrong number; the leak gate keeps strict <code>isMatch</code>; single
+    boolean tier, no gradient; partial reveals the answer only because it
+    <i>solves</i> the position (a teaching moment), never on a miss.<br><br>
+    <b>Token-coverage guard</b> answers the high-cardinality-franchise abuse:
+    a franchise-only partial must be a <i>subset</i> of the target's words, so
+    naming a different entry ("pokemon diamond") stays a miss.<br><br>
+    <b>Consciously overruled:</b> the "non-ranked only" guardrail. The owner
+    explicitly wants partial credit to count; the 0.40 factor (and the no-overlap
+    property) is the mitigation. Revisit if farming shows up in the data.
+  </div>
+
+  <h2>Surface area</h2>
+  <ul>
+    <li><code>fuzzy-match.service.ts</code> — <code>evaluateMatch</code> +
+    <code>franchisePartialMatch</code>; <code>isMatch</code> unchanged (exact).</li>
+    <li><code>game.service.ts</code> — scorer reads precision;
+    <code>PARTIAL_MATCH_FACTOR</code>; <code>matchPrecision</code> on the response.</li>
+    <li><code>@the-box/types</code> — <code>GuessResponse.matchPrecision</code> (rebuild).</li>
+    <li>Frontend — partial badge on the result card; field threaded through the
+    store &amp; locales.</li>
+    <li>Tests — graded suite for the matcher; partial-score test for the scorer.</li>
+  </ul>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Problem

From a real session (screenshots attached to the request), a player clearly identified the franchise but omitted the sequel number / full subtitle and scored **0**:

| Guess | Target | Before |
|---|---|---|
| `metal gear solid` | Metal Gear Solid 2: Sons of Liberty | ❌ +0 |
| `final fantasy` | Final Fantasy XII | ❌ +0 |
| `pokemon` | Pokémon X, Y | ❌ +0 |

The ask: validate these at a **lower** score, with a bonus for getting the number / full title right — while genuinely *wrong* guesses (`final fantasy vii` → FF VIII) stay rejected.

## Approach

Ran a subagent persona workflow (Product, Backend Architect, QA, **Devil's Advocate**). The full design + the devil's-advocate guardrails are captured in [`tasks/partial-guess-scoring-subagents-meeting.html`](../blob/claude/game-capture-guess-scoring-yiieha/tasks/partial-guess-scoring-subagents-meeting.html).

### Graded matching
- Matcher gains `evaluateMatch() → { matched, precision: 'exact' | 'partial' | 'none' }`.
- **`isMatch` keeps its strict exact-only semantics** — so the letter-reveal leak gate (`effectiveMaxReveals`) and every other caller are byte-for-byte unchanged (zero regression). Only the scorer reads the grade.
- **Partial fires narrowly**: target has a sequel number, the franchise root is identified (≥0.85), every meaningful input token is *covered* by a target token (kills `pokemon diamond` → *Pokémon X, Y*), no wrong number, not a DLC base-name.

### Scoring
- `exact = round(min(100 × speed, 200))` (unchanged); `partial = round(exact × 0.40)`.
- `0.40` guarantees the **fastest partial (80) < slowest exact (100)** — full identification is always strictly the better play (no overlap: partial 40–80, exact 100–200).
- Surfaced via `GuessResponse.matchPrecision` with a "Licence reconnue / Franchise recognised" badge + explanatory line on the result card (en + fr).

### Behaviour
| Guess → Target | Tier |
|---|---|
| metal gear solid → MGS 2: Sons of Liberty | `partial` |
| final fantasy → Final Fantasy XII | `partial` |
| pokemon → Pokémon X, Y | `partial` |
| portal / fallout / witcher → numbered entry | `partial` |
| final fantasy vii → Final Fantasy VIII (wrong number) | `none` |
| pokemon diamond → Pokémon X, Y (foreign token) | `none` |
| cuphead → Cuphead: The Delicious Last Course (DLC) | `none` |
| metal gear solid 2 → MGS 2: Sons of Liberty | `exact` |

## Tests
- New graded matcher suite (exact / partial / none tiers, incl. the wrong-number and DLC guardrails) and partial-scoring tests for `submitGuess`.
- **+15 new passing backend tests, zero regressions** (all existing `isMatch` assertions still pass since strict semantics are unchanged).

> Note: `npm run build` / `npm run lint` / `npm test` can't run in this container due to pre-existing environment gaps (global TS 6.0 vs the repo's pinned 5.9, and missing `tsx`/`@eslint/js`/`clsx` in `node_modules`) — these fail identically on clean `main`. The suite was run via `npx tsx --test`; `build:types` succeeds.

## Files
- `fuzzy-match.service.ts` — `evaluateMatch` + `franchisePartialMatch`; `isMatch` unchanged.
- `game.service.ts` — scorer reads precision; `PARTIAL_MATCH_FACTOR`; `matchPrecision` on the response.
- `@the-box/types` — `GuessResponse.matchPrecision`, `GuessResult.matchPrecision`.
- Frontend — partial badge + result-card wiring + locales.

https://claude.ai/code/session_01LRL13NwEgVsn2ASUvgtt6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRL13NwEgVsn2ASUvgtt6U)_