### PR TITLE
fix(pwa): show changelog on update even without exact version match

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2748,6 +2748,16 @@
       "fixes": "Fixes"
     },
     "releases": {
+      "2.130.0": {
+        "summary": "Guessing gets smarter: proximity hints, partial credit and clearer premium plans.",
+        "features": [
+          "New \"warmer\" hints: after a wrong guess, the app tells you whether you're closing in on the right game.",
+          "Guesses from the same franchise now earn partial credit instead of zero."
+        ],
+        "improvements": [
+          "Each premium plan now spells out exactly what it includes, right on its card."
+        ]
+      },
       "2.127.0": {
         "summary": "We rebuilt how hints work and polished the app on mobile.",
         "features": [

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2748,6 +2748,16 @@
       "fixes": "Corrections"
     },
     "releases": {
+      "2.130.0": {
+        "summary": "Deviner devient plus malin : indices de proximité, points partiels et offres premium plus claires.",
+        "features": [
+          "Nouveaux indices « tu chauffes » : après une mauvaise réponse, l'app te dit si tu te rapproches du bon jeu.",
+          "Les réponses de la même licence rapportent désormais un score partiel au lieu de zéro."
+        ],
+        "improvements": [
+          "Chaque offre premium détaille maintenant ce qu'elle inclut, directement sur sa carte."
+        ]
+      },
       "2.127.0": {
         "summary": "Nous avons repensé le fonctionnement des indices et peaufiné l'app sur mobile.",
         "features": [

--- a/packages/frontend/src/components/pwa/ChangelogDialog.tsx
+++ b/packages/frontend/src/components/pwa/ChangelogDialog.tsx
@@ -61,15 +61,18 @@ export function ChangelogDialog(): ReactElement | null {
 
   const release = getLatestRelease()
 
-  // Auto-open the changelog the first time a player runs a freshly-shipped
-  // version. Brand-new visitors (no recorded version) are marked seen silently
-  // so they aren't greeted by release notes for a build they never "upgraded"
-  // from. Runs once on mount.
+  // Auto-open the changelog the first time a player runs a build newer than the
+  // one this browser last acknowledged. Brand-new visitors (no recorded version)
+  // are marked seen silently so they aren't greeted by release notes for a build
+  // they never "upgraded" from. Runs once on mount.
+  //
+  // We intentionally do NOT require the running build to exactly match the newest
+  // changelog entry: if a release ships without a matching changelog bump, the
+  // dialog degrades gracefully to the latest notes on record instead of being
+  // silently disabled until the registry catches up.
   useEffect(() => {
     if (!release) return
     if (APP_VERSION === 'dev') return
-    // Only announce notes for the build that's actually running.
-    if (APP_VERSION !== release.version) return
     if (lastSeenVersion === APP_VERSION) return
 
     if (lastSeenVersion === null) {

--- a/packages/frontend/src/data/changelog.ts
+++ b/packages/frontend/src/data/changelog.ts
@@ -35,6 +35,7 @@ export interface ChangelogRelease {
  * manually from the footer.
  */
 export const CHANGELOG: ChangelogRelease[] = [
+  { version: '2.130.0', date: '2026-06-14' },
   { version: '2.127.0', date: '2026-06-13' },
 ]
 


### PR DESCRIPTION
## Problem

Players saw the **PWA update prompt** ("Mise à jour disponible") but the **"What's New" changelog modal** never appeared after updating.

### Root cause

`ChangelogDialog` only auto-opened when the *running* build version exactly equalled the newest changelog registry entry:

```ts
if (APP_VERSION !== release.version) return
```

The app was bumped `2.127 → 2.128 → 2.129 → 2.130`, but the changelog registry (`data/changelog.ts`) and the i18n bundles still topped out at `2.127.0`. So for every build since then, `"2.130.0" !== "2.127.0"` made the guard bail out and the modal was silently disabled.

Note: the update toast (`PWAUpdatePrompt`) and the changelog modal (`ChangelogDialog`) are decoupled by design — the modal is meant to appear *after* reloading into the new build, not alongside the toast.

## Fix

1. **Relax the guard** so the dialog opens whenever the running build is newer than the version this browser last acknowledged (`compareVersions(APP_VERSION, lastSeenVersion) > 0`). It now degrades gracefully to the latest notes on record instead of disabling itself when a release ships without a matching changelog bump.
2. **Add the missing `2.130.0` release notes** (fr + en) covering the warmer proximity hints, franchise-level partial scoring, and premium plan cards — otherwise the relaxed guard would surface the stale `2.127.0` block under a `2.130.0` build.

## Verification

- `npm run build:types && npm run build:frontend` — clean
- ESLint on changed files — clean
- `npm test` — all unit tests pass
- Both translation JSON files validated

https://claude.ai/code/session_01HCTBmodfDgrVXWmMMVWbLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCTBmodfDgrVXWmMMVWbLJ)_