### PR TITLE
fix(game): UX trust & a11y fixes for the guess loop (Wave C)

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -349,7 +349,9 @@
     },
     "timeUp": "Time's up!",
     "timer": {
-      "label": "Time remaining: {{seconds}} seconds"
+      "label": "Time remaining: {{seconds}} seconds",
+      "announceHalfway": "30 seconds left",
+      "announceLow": "10 seconds left"
     },
     "totalScore": "Total Score",
     "correctAnswers": "Correct Answers",
@@ -506,7 +508,16 @@
     "submit": "Submit guess",
     "guessCorrect": "Correct guess!",
     "guessIncorrect": "Incorrect guess. Try again.",
-    "wrongGuessPenalty": "Wrong guess penalty: -{{penalty}} pts"
+    "wrongGuessPenalty": "Wrong guess penalty: -{{penalty}} pts",
+    "resultDialogLabel": "Round result",
+    "resultAnnounce": "{{outcome}}. The answer was {{answer}}. You scored {{score}} points.",
+    "errors": {
+      "signIn": "Please sign in to continue",
+      "notFound": "This game session was not found or has expired",
+      "network": "Network connection failed. Check your connection and try again.",
+      "unexpected": "Something went wrong. Please try again.",
+      "sessionNotInitialized": "The game session isn't ready yet. Please reload the page."
+    }
   },
   "home": {
     "title": "The Box",
@@ -2382,6 +2393,7 @@
     "step1": "Look at the screenshot.",
     "step2": "Guess the game — the faster you are, the higher the score.",
     "step3": "Use a hint if you need to, then move to the next screenshot.",
+    "step4": "Watch the clock — each screenshot has 45 seconds. Run out and it's a permanent miss.",
     "skip": "Skip",
     "next": "Next",
     "start": "Let's go!"

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -349,7 +349,9 @@
     },
     "timeUp": "Temps écoulé !",
     "timer": {
-      "label": "Temps restant : {{seconds}} secondes"
+      "label": "Temps restant : {{seconds}} secondes",
+      "announceHalfway": "Plus que 30 secondes",
+      "announceLow": "Plus que 10 secondes"
     },
     "totalScore": "Score Total",
     "correctAnswers": "Bonnes Réponses",
@@ -506,7 +508,16 @@
     "submit": "Valider la proposition",
     "guessCorrect": "Bonne réponse !",
     "guessIncorrect": "Mauvaise réponse. Réessayez.",
-    "wrongGuessPenalty": "Pénalité de mauvaise réponse : -{{penalty}} pts"
+    "wrongGuessPenalty": "Pénalité de mauvaise réponse : -{{penalty}} pts",
+    "resultDialogLabel": "Résultat du round",
+    "resultAnnounce": "{{outcome}}. La réponse était {{answer}}. Tu marques {{score}} points.",
+    "errors": {
+      "signIn": "Connecte-toi pour continuer",
+      "notFound": "Cette partie est introuvable ou a expiré",
+      "network": "Échec de la connexion réseau. Vérifie ta connexion et réessaie.",
+      "unexpected": "Une erreur est survenue. Réessaie.",
+      "sessionNotInitialized": "La partie n'est pas encore prête. Recharge la page."
+    }
   },
   "home": {
     "title": "The Box",
@@ -2382,6 +2393,7 @@
     "step1": "Regarde la capture d'écran.",
     "step2": "Devine le jeu — plus tu es rapide, plus le score grimpe.",
     "step3": "Utilise un indice si besoin, puis enchaîne la capture suivante.",
+    "step4": "Surveille le chrono — chaque capture dure 45 secondes. À zéro, c'est un échec définitif.",
     "skip": "Passer",
     "next": "Suivant",
     "start": "C'est parti !"

--- a/packages/frontend/src/components/game/CountdownTimer.tsx
+++ b/packages/frontend/src/components/game/CountdownTimer.tsx
@@ -34,7 +34,22 @@ export function CountdownTimer({ state }: { state: CountdownState }) {
   const styles = PHASE_STYLES[phase]
   const isCritical = phase === 'critical'
 
+  // `role="timer"` is an off live region — its ticking is silent to AT, so the
+  // permanent-miss clock is sighted-only. Announce coarse milestones (only at
+  // exact 30 s / 10 s thresholds) through a polite region; in-between seconds
+  // clear it so a screen reader isn't spammed every tick.
+  const milestone =
+    seconds === 30
+      ? t('game.timer.announceHalfway')
+      : seconds === 10
+        ? t('game.timer.announceLow')
+        : ''
+
   return (
+    <>
+      <div role="status" aria-live="polite" className="sr-only">
+        {milestone}
+      </div>
     <div
       role="timer"
       aria-label={t('game.timer.label', { seconds })}
@@ -74,5 +89,6 @@ export function CountdownTimer({ state }: { state: CountdownState }) {
         {formatCountdown(seconds)}
       </m.span>
     </div>
+    </>
   )
 }

--- a/packages/frontend/src/components/game/GuessInput.tsx
+++ b/packages/frontend/src/components/game/GuessInput.tsx
@@ -43,6 +43,10 @@ export function GuessInput() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isShaking, setIsShaking] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
+  // Drives the assertive screen-reader announcement for a wrong guess.
+  // Kept SEPARATE from `isShaking` (the shake animation) so reduced-motion
+  // users — who never get `isShaking` — still hear the miss.
+  const [announceIncorrect, setAnnounceIncorrect] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
   // Services (dependency injection via factory functions)
@@ -81,9 +85,11 @@ export function GuessInput() {
     try {
       const result = await submitGuess(null, query.trim())
 
-      // Show error toast if submission failed
+      // Show error toast if submission failed. `result.error` is an i18n key
+      // (or a server-provided message); translate it so the unhappy-path toast
+      // respects the user's locale. defaultValue keeps a non-key message as-is.
       if (!result.success && result.error) {
-        toast.error(result.error)
+        toast.error(t(result.error, { defaultValue: result.error }))
       }
 
       // Trigger animations based on result
@@ -93,6 +99,10 @@ export function GuessInput() {
           setTimeout(() => setIsSuccess(false), 800)
           vibrate(15)
         } else {
+          // Announce the miss to assistive tech regardless of motion
+          // preference (the shake below is the visual-only channel).
+          setAnnounceIncorrect(true)
+          setTimeout(() => setAnnounceIncorrect(false), 1000)
           // Skip the shake for users who prefer reduced motion; the colour
           // change on the border still signals the error.
           if (!prefersReducedMotion) {
@@ -180,7 +190,7 @@ export function GuessInput() {
         {isSuccess && t('game.guessCorrect', { defaultValue: 'Correct guess!' })}
       </div>
       <div aria-live="assertive" aria-atomic="true" className="sr-only">
-        {isShaking && t('game.guessIncorrect', { defaultValue: 'Incorrect guess. Try again.' })}
+        {announceIncorrect && t('game.guessIncorrect', { defaultValue: 'Incorrect guess. Try again.' })}
       </div>
 
       {/* Input with submit button. `items-end` keeps the nav buttons level

--- a/packages/frontend/src/components/game/ResultCard.tsx
+++ b/packages/frontend/src/components/game/ResultCard.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useEffectEvent } from 'react'
 import { m } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { useGameStore } from '@/stores/gameStore'
-import { CheckCircle, XCircle, ChevronRight } from 'lucide-react'
+import { CheckCircle, XCircle, ChevronRight, Target } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ResultGameInfo } from './ResultGameInfo'
 import { ResultScoreDisplay } from './ResultScoreDisplay'
@@ -39,6 +39,12 @@ export function ResultCard() {
 
   // Auto-close countdown state (must be before early return)
   const [countdown, setCountdown] = useState(AUTO_CLOSE_SECONDS)
+
+  // Move focus to the primary "Next" action when the result dialog opens so
+  // keyboard / screen-reader users land inside the dialog (and Enter-to-advance
+  // has a sensible focus target) instead of being stranded on the now-disabled
+  // guess input behind the overlay.
+  const nextButtonRef = useRef<HTMLButtonElement>(null)
 
   // Memoize nextPosition calculation
   const nextPosition = lastResult ? findNextUnfinished(currentPosition) : null
@@ -145,6 +151,12 @@ export function ResultCard() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [lastResult])
 
+  // Focus the primary action once the dialog has a result to show.
+  // `preventScroll` avoids yanking the screenshot on mobile.
+  useEffect(() => {
+    if (lastResult) nextButtonRef.current?.focus({ preventScroll: true })
+  }, [lastResult])
+
   // Early return after all hooks
   if (!lastResult) return null
 
@@ -192,12 +204,33 @@ export function ResultCard() {
       )}
 
       <m.div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('game.resultDialogLabel', 'Round result')}
         initial={{ scale: 0.9, opacity: 0, y: 20 }}
         animate={{ scale: 1, opacity: 1, y: 0 }}
         exit={{ scale: 0.9, opacity: 0 }}
         transition={{ type: 'spring', damping: 25, stiffness: 300 }}
         className="relative max-w-sm w-full mx-4"
       >
+        {/* Single concise outcome line for assistive tech — the visual card is
+            built from animated fragments that don't read as one coherent
+            announcement. Polite so it doesn't interrupt the miss/correct
+            announcement already fired by the guess input. */}
+        <div role="status" aria-live="polite" className="sr-only">
+          {t('game.resultAnnounce', {
+            outcome: isCorrect
+              ? matchPrecision === 'partial'
+                ? t('game.partialMatch')
+                : t('game.correct')
+              : t('game.incorrect'),
+            answer: correctGame?.name ?? '',
+            score: scoreEarned,
+            defaultValue: `${
+              isCorrect ? t('game.correct') : t('game.incorrect')
+            } ${correctGame?.name ?? ''} +${scoreEarned}`,
+          })}
+        </div>
         <Card
           variant={isCorrect ? 'success' : 'error'}
           className="relative border-2 rounded-2xl p-6 shadow-2xl"
@@ -230,10 +263,19 @@ export function ResultCard() {
             )}
           >
             {isCorrect ? (
-              <>
-                <CheckCircle className="size-5" />
-                {matchPrecision === 'partial' ? t('game.partialMatch') : t('game.correct')}
-              </>
+              matchPrecision === 'partial' ? (
+                <>
+                  {/* Distinct icon from the exact-match check so the partial
+                      state isn't differentiated by colour alone (WCAG 1.4.1). */}
+                  <Target className="size-5" />
+                  {t('game.partialMatch')}
+                </>
+              ) : (
+                <>
+                  <CheckCircle className="size-5" />
+                  {t('game.correct')}
+                </>
+              )
             ) : (
               <>
                 <XCircle className="size-5" />
@@ -268,6 +310,7 @@ export function ResultCard() {
           className="flex flex-col items-center gap-2"
         >
           <Button
+            ref={nextButtonRef}
             variant="secondary"
             size="lg"
             onClick={handleNext}

--- a/packages/frontend/src/components/onboarding/WelcomeModal.tsx
+++ b/packages/frontend/src/components/onboarding/WelcomeModal.tsx
@@ -94,6 +94,10 @@ export function WelcomeModal() {
                 <span className="flex items-center justify-center size-6 rounded-full bg-neon-pink/20 text-neon-pink font-bold text-xs shrink-0">3</span>
                 <span>{t('onboarding.step3')}</span>
               </li>
+              <li className="flex gap-3">
+                <span className="flex items-center justify-center size-6 rounded-full bg-warning/20 text-warning font-bold text-xs shrink-0">4</span>
+                <span>{t('onboarding.step4')}</span>
+              </li>
             </ol>
 
             <div className="flex justify-end">

--- a/packages/frontend/src/hooks/useGameGuess.ts
+++ b/packages/frontend/src/hooks/useGameGuess.ts
@@ -5,7 +5,7 @@ import { useAchievementStore } from '@/stores/achievementStore'
 import { useDailyLoginStore } from '@/stores/dailyLoginStore'
 import type { GuessSubmissionService } from '@/services/guessSubmissionService'
 import {
-  getUserFriendlyErrorMessage,
+  getErrorMessageKey,
   AuthenticationError,
   NotFoundError,
   logError,
@@ -33,7 +33,8 @@ export function useGameGuess(submissionService: GuessSubmissionService) {
           success: false,
           isCorrect: false,
           scoreEarned: 0,
-          error: 'Session not initialized',
+          // i18n key resolved at the toast site (GuessInput).
+          error: 'game.errors.sessionNotInitialized',
         }
       }
 
@@ -177,8 +178,9 @@ export function useGameGuess(submissionService: GuessSubmissionService) {
         // Log error with context
         logError(error, 'useGameGuess')
 
-        // Get user-friendly error message
-        const userMessage = getUserFriendlyErrorMessage(error)
+        // Resolve to an i18n key (or pass-through server message); the toast
+        // site translates it so French players don't see English copy.
+        const userMessage = getErrorMessageKey(error)
 
         // Handle specific error types
         if (error instanceof AuthenticationError) {

--- a/packages/frontend/src/lib/errors.ts
+++ b/packages/frontend/src/lib/errors.ts
@@ -230,6 +230,26 @@ export function getUserFriendlyErrorMessage(error: unknown): string {
 }
 
 /**
+ * Map an error to an i18n key (or a pass-through message) for display.
+ *
+ * The known transport/auth failures return stable `game.errors.*` keys so the
+ * toast site can translate them — fixing the previously hardcoded-English
+ * toasts on the unhappy path (default locale is French). ValidationError /
+ * ApiError carry a server-provided message (often already localized), so we
+ * return it verbatim; the toast site calls `t(key, { defaultValue: key })`, so
+ * a non-key string renders as-is rather than showing a raw key.
+ */
+export function getErrorMessageKey(error: unknown): string {
+  if (error instanceof AuthenticationError) return 'game.errors.signIn'
+  if (error instanceof NotFoundError) return 'game.errors.notFound'
+  if (error instanceof NetworkError) return 'game.errors.network'
+  if (error instanceof ValidationError) return error.message
+  if (error instanceof ApiError) return error.message
+  if (error instanceof Error && error.message) return error.message
+  return 'game.errors.unexpected'
+}
+
+/**
  * Log error for debugging
  */
 export function logError(error: unknown, context?: string): void {

--- a/packages/frontend/src/stores/gameStore.ts
+++ b/packages/frontend/src/stores/gameStore.ts
@@ -423,7 +423,9 @@ export const useGameStore = create<GameState>()(
           const { currentPosition, positionStates } = get()
           const currentState = positionStates[currentPosition]
 
-          // Mark current as skipped (only if not already correct)
+          // Mark current as skipped (only if not already correct). Also clear
+          // the transient "warmer" hint so it doesn't linger when the player
+          // returns to this position later without an active guess.
           if (currentState && currentState.status === 'in_progress') {
             set((state) => ({
               positionStates: {
@@ -431,6 +433,7 @@ export const useGameStore = create<GameState>()(
                 [currentPosition]: {
                   ...state.positionStates[currentPosition],
                   status: 'skipped',
+                  proximityHint: undefined,
                 },
               },
             }))
@@ -542,18 +545,30 @@ export const useGameStore = create<GameState>()(
         },
 
         navigateToPosition: (position) => {
-          const { positionStates } = get()
+          const { positionStates, currentPosition: leavingPosition } = get()
           const state = positionStates[position]
 
           if (!state) return
           // Timed-out positions are terminal — never navigable back into.
           if (state.status === 'timed_out') return
 
-          // Update current position
-          set({
+          // Update current position. Clear the transient "warmer" hint on the
+          // position we're leaving so it doesn't reappear on return without an
+          // active guess.
+          set((prev) => ({
             currentPosition: position,
             lastResult: null,
-          })
+            positionStates:
+              leavingPosition !== position && prev.positionStates[leavingPosition]
+                ? {
+                    ...prev.positionStates,
+                    [leavingPosition]: {
+                      ...prev.positionStates[leavingPosition],
+                      proximityHint: undefined,
+                    },
+                  }
+                : prev.positionStates,
+          }))
 
           // Mark as in_progress only if not already correct
           // Keep correct positions as correct (don't change to in_progress)
@@ -731,8 +746,17 @@ export const useGameStore = create<GameState>()(
           challengeId: state.challengeId,
           challengeDate: state.challengeDate,
           totalScore: state.totalScore,
-          // Persist position states for navigation on refresh
-          positionStates: state.positionStates,
+          // Persist position states for navigation on refresh, but strip the
+          // ephemeral "warmer" proximity hint: it's transient feedback for an
+          // active guess, not durable state. Persisting it made the banner
+          // reappear on PWA reopen / refresh with no active guess to justify
+          // it, growing the input dock and shoving the screenshot up.
+          positionStates: Object.fromEntries(
+            Object.entries(state.positionStates).map(([key, value]) => [
+              key,
+              { ...value, proximityHint: undefined },
+            ])
+          ),
           currentPosition: state.currentPosition,
           screenshotsFound: state.screenshotsFound,
           // Persist guess results for results page display


### PR DESCRIPTION
## Context

Wave C of the 12-persona guess-system review (`tasks/guess-system-personas-review.html`, on PR #311's branch) — **player-facing clarity & accessibility**. All changes here are **frontend-only**, low-risk, and "cheap, high-felt". Stacked logically after the Wave A integrity PR (#311) but independent of it (branches off `main`, no overlapping files).

## What's in this PR

| Fix | Finding | Detail |
|---|---|---|
| **Wrong-guess announce for reduced-motion users** | #10 / a11y #1 | The `aria-live` miss text only rendered while `isShaking`, which is gated behind `!prefersReducedMotion` — SR + reduced-motion users got **no** miss feedback. Split into a dedicated `announceIncorrect` state; the shake stays motion-gated, the announce doesn't. |
| **Result card is a dialog & is announced** | #10 / a11y #2 | Added `role="dialog" aria-modal`, focus moves to the **Next** button on open, and a `role="status"` line reads outcome + answer + score (the animated card fragments don't read as one announcement). |
| **Countdown milestones reach AT** | #10 / a11y #3 | `role="timer"` is an *off* live region, so the permanent-miss clock was sighted-only. Added a polite sr-only region announcing the **30s / 10s** thresholds (only at the exact boundary, so it isn't spammed each tick). |
| **i18n error toasts** | #12 / i18n #1 | Guess-path error toasts were hardcoded **English** on the default-**French** locale. New `getErrorMessageKey` → stable `game.errors.*` keys (auth / notFound / network / unexpected / sessionNotInitialized), translated at the toast site; server `ValidationError`/`ApiError` messages still pass through. en + fr strings added. |
| **Proximity banner persistence** | #7 / Mobile #1 | The ephemeral "warmer" hint was in `partialize` and only cleared on a correct guess → it reappeared on refresh / PWA reopen / revisit with no active guess, growing the dock and shoving the screenshot up. Stripped from the persisted snapshot + cleared when leaving a position (skip / navigate). |
| **Partial-badge icon** | P2 / a11y #4 | The partial state reused the green ✓ (colour-only differentiation). Now a distinct `Target` icon (WCAG 1.4.1). |
| **Onboarding clock line** | #3 (partial) | Added a "how to play" step about the 45s per-screenshot clock and that running out is a permanent miss. |

## Tests & checks
`build:frontend` ✅, `lint` ✅ (0 errors), frontend unit tests ✅ (25/25), both locale JSONs validate.

## Deliberately deferred — the rest of #3 needs a backend change
The marquee Wave C item is the **timeout ResultCard that reveals the answer**. The client never holds `correctGame` for an *unsolved* position (anti-leak — the server only returns it on a correct guess), so revealing it on timeout safely requires a **server-authoritative timeout-finalize endpoint**: mark the position terminal, gated on server-side `elapsed >= time_limit` (so a client can't call it early), *then* return the answer — otherwise it becomes a worse answer-oracle than the one Wave A just closed. That's a backend + anti-cheat change, so it's scoped out of this frontend-only PR. The onboarding line + the existing "Time's up!" toast partially cover the "silent & confusing" symptom in the meantime.

I also skipped the **subjective amber recolour** from the same P2 finding — `#eab308` text on the dark card measures ~9:1, so it clears 4.5:1; the real defect there was the colour-only icon, which this PR fixes.

https://claude.ai/code/session_01Jm4bby1wV6jEFWZHgJznSU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm4bby1wV6jEFWZHgJznSU)_