### PR TITLE
fix(achievements): align descriptions with evaluator logic

### DIFF
--- a/packages/backend/migrations/20260614_fix_achievement_descriptions.ts
+++ b/packages/backend/migrations/20260614_fix_achievement_descriptions.ts
@@ -1,0 +1,61 @@
+import type { Knex } from 'knex'
+
+// Align achievement descriptions with what the evaluator actually rewards.
+// No criteria/threshold changes — wording only — so already-earned rows stay
+// valid. Three classes of mismatch were corrected:
+//
+//   1. game_collector_10/50/100 advertised "<n> jeux différents" (distinct
+//      games) but the criteria is `total_correct_guesses` — a cumulative
+//      count of correct guesses that does NOT de-duplicate by game. Reworded
+//      to "<n> bonnes réponses au total".
+//   2. high_roller said "plus de 1800 points" (strictly more than) but
+//      `min_score` fires at score >= 1800, so 1800 itself qualifies.
+//   3. acharne said "plus de 10 fois" (strictly more than) but
+//      `attempts_in_game` fires at attempts >= 10. Brought in line with its
+//      sibling tete_de_mule, which already reads "20 fois ou plus".
+
+interface DescriptionEdit {
+  key: string
+  to: string
+  from: string
+}
+
+const EDITS: DescriptionEdit[] = [
+  {
+    key: 'game_collector_10',
+    from: 'Identifiez correctement 10 jeux différents',
+    to: 'Trouvez 10 bonnes réponses au total',
+  },
+  {
+    key: 'game_collector_50',
+    from: 'Identifiez correctement 50 jeux différents',
+    to: 'Trouvez 50 bonnes réponses au total',
+  },
+  {
+    key: 'game_collector_100',
+    from: 'Identifiez correctement 100 jeux différents',
+    to: 'Trouvez 100 bonnes réponses au total',
+  },
+  {
+    key: 'high_roller',
+    from: 'Obtenez plus de 1800 points dans un seul défi',
+    to: 'Obtenez au moins 1800 points dans un seul défi',
+  },
+  {
+    key: 'acharne',
+    from: 'Tente ta chance plus de 10 fois sur une seule capture',
+    to: 'Tente ta chance 10 fois ou plus sur une seule capture',
+  },
+]
+
+export async function up(knex: Knex): Promise<void> {
+  for (const edit of EDITS) {
+    await knex('achievements').where('key', edit.key).update({ description: edit.to })
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  for (const edit of EDITS) {
+    await knex('achievements').where('key', edit.key).update({ description: edit.from })
+  }
+}

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -128,7 +128,7 @@
       },
       "high_roller": {
         "name": "High Roller",
-        "description": "Score over 1800 points in a single challenge"
+        "description": "Score at least 1800 points in a single challenge"
       },
       "dedicated_player": {
         "name": "Dedicated Player",
@@ -228,15 +228,15 @@
       },
       "game_collector_10": {
         "name": "Collector",
-        "description": "Correctly identify 10 different games"
+        "description": "Make 10 correct guesses in total"
       },
       "game_collector_50": {
         "name": "Game Expert",
-        "description": "Correctly identify 50 different games"
+        "description": "Make 50 correct guesses in total"
       },
       "game_collector_100": {
         "name": "Walking Encyclopedia",
-        "description": "Correctly identify 100 different games"
+        "description": "Make 100 correct guesses in total"
       },
       "comeback_kid": {
         "name": "Back Again",
@@ -268,7 +268,7 @@
       },
       "acharne": {
         "name": "Relentless",
-        "description": "Make more than 10 attempts on a single screenshot"
+        "description": "Make 10 or more attempts on a single screenshot"
       },
       "tete_de_mule": {
         "name": "Stubborn",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -128,7 +128,7 @@
       },
       "high_roller": {
         "name": "Gros Joueur",
-        "description": "Obtenez plus de 1800 points dans un seul défi"
+        "description": "Obtenez au moins 1800 points dans un seul défi"
       },
       "dedicated_player": {
         "name": "Joueur Dévoué",
@@ -228,15 +228,15 @@
       },
       "game_collector_10": {
         "name": "Collectionneur",
-        "description": "Identifiez correctement 10 jeux différents"
+        "description": "Trouvez 10 bonnes réponses au total"
       },
       "game_collector_50": {
         "name": "Expert en Jeux",
-        "description": "Identifiez correctement 50 jeux différents"
+        "description": "Trouvez 50 bonnes réponses au total"
       },
       "game_collector_100": {
         "name": "Encyclopédie Vivante",
-        "description": "Identifiez correctement 100 jeux différents"
+        "description": "Trouvez 100 bonnes réponses au total"
       },
       "comeback_kid": {
         "name": "De Retour",
@@ -268,7 +268,7 @@
       },
       "acharne": {
         "name": "Acharné",
-        "description": "Tente ta chance plus de 10 fois sur une seule capture"
+        "description": "Tente ta chance 10 fois ou plus sur une seule capture"
       },
       "tete_de_mule": {
         "name": "Tête de mule",


### PR DESCRIPTION
## Summary

Audited all **58 achievements ("succès")** to find any that don't link to an actual feature in code, running the investigation as a workflow (full catalog pass + a parallel feature-verification agent).

**Result: every achievement maps to a real, implemented feature.** Every `criteria.type` in the DB has a matching handler in `achievement.service.ts`, and every backing feature is live:

| Feature | Verdict |
|---|---|
| Genre (`games.genres`, RAWG ingestion) | ✅ wired |
| Speed (`guesses.time_taken_ms`) | ✅ wired |
| Streak (`current_streak`) | ✅ wired |
| Leaderboard rank | ✅ wired |
| Perfect score (2000 = 10×200) | ✅ wired |
| Account age (daily BullMQ worker) | ✅ wired |
| Attempts / comeback / first-try / flawless | ✅ wired |
| `no_hints` | ✅ re-pointed at the live letter-reveal feature when legacy power-ups were retired (2026-06) |

So **nothing was orphaned** — removing achievements would have deleted working features (and CASCADE-deleted users' earned rows). The genuine discrepancies were **misleading descriptions**, which this PR corrects instead.

## Changes (wording only — thresholds & earned rows untouched)

- **`game_collector_10/50/100`** — claimed *"&lt;n&gt; distinct games"* but the `total_correct_guesses` criteria counts *all* correct guesses, not distinct titles → reworded to *"&lt;n&gt; correct guesses in total"*.
- **`high_roller`** — said *"over 1800 points"* but `min_score` fires at `>= 1800` → *"at least 1800 points"*.
- **`acharne`** — said *"more than 10 attempts"* but `attempts_in_game` fires at `>= 10` → *"10 or more attempts"* (now consistent with its sibling `tete_de_mule`).

Applied in three places that must stay in sync:
- `packages/backend/migrations/20260614_fix_achievement_descriptions.ts` (DB source / fallback, with a reverting `down`)
- `packages/frontend/public/locales/fr/translation.json` (UI render source)
- `packages/frontend/public/locales/en/translation.json`

## Testing

- `npm test` — 288 backend tests pass
- Both locale JSON files validated

https://claude.ai/code/session_01Qmj4rtkroBv9pnW7Vavr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmj4rtkroBv9pnW7Vavr8s)_