### PR TITLE
feat(game): surface letter-reveal cost in session results

### DIFF
--- a/packages/backend/migrations/20260614_add_letter_penalty_to_guesses.ts
+++ b/packages/backend/migrations/20260614_add_letter_penalty_to_guesses.ts
@@ -1,0 +1,25 @@
+import type { Knex } from 'knex'
+
+/**
+ * Persists the letter-reveal penalty (in points) that was deducted from a
+ * correct guess's score. The penalty is computed at submit time in
+ * game.service from the cumulative `penalty_pct` locked in at reveal time,
+ * then subtracted from `score_earned` — so the cost is baked into the stored
+ * score and can't be reconstructed afterwards (the second-chance floor and
+ * rounding make back-calculation lossy). Storing the points directly lets the
+ * session-details / history / leaderboard recap surface the cost the same way
+ * the live post-guess result already does.
+ *
+ * Historical rows predate the column and stay 0 — no backfill is possible.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('guesses', (table) => {
+    table.integer('letter_penalty').notNullable().defaultTo(0)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('guesses', (table) => {
+    table.dropColumn('letter_penalty')
+  })
+}

--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -199,6 +199,8 @@ export interface GuessWithGameRecord {
   scoreEarned: number
   powerUpUsed: string | null
   hintFromInventory: boolean
+  /** Letter-reveal cost (points) deducted from scoreEarned; 0 when none. */
+  letterPenalty: number
   correctGameId: number
   correctGameName: string
   correctGameSlug: string
@@ -256,6 +258,8 @@ export interface SessionRepository {
     scoreEarned: number
     powerUpUsed: string | null
     hintFromInventory: boolean
+    /** Letter-reveal cost (points) already deducted from scoreEarned. */
+    letterPenalty: number
   }): Promise<void>
   getCorrectAnswersCount(tierSessionId: string): Promise<number>
   hasCorrectGuessForPosition(tierSessionId: string, position: number): Promise<boolean>

--- a/packages/backend/src/domain/services/game.service.ts
+++ b/packages/backend/src/domain/services/game.service.ts
@@ -844,6 +844,9 @@ export function createGameService(deps: GameServiceDeps): GameService {
       // for history-display and recalculation paths.
       powerUpUsed: null,
       hintFromInventory: false,
+      // Persist the letter-reveal cost (already subtracted from scoreEarned)
+      // so the history/recap surfaces can show it without re-deriving it.
+      letterPenalty,
     })
 
     if (pendingSecondChanceActivationId !== null) {

--- a/packages/backend/src/domain/services/user.service.ts
+++ b/packages/backend/src/domain/services/user.service.ts
@@ -133,6 +133,9 @@ export function createUserService(deps: UserServiceDeps): UserService {
             timeTakenMs: correctGuess.timeTakenMs,
             scoreEarned: correctGuess.scoreEarned,
             hintPenalty,
+            // Letter-reveal cost deducted from this guess's score, when any.
+            // Persisted per-guess (game.service), so legacy rows stay 0.
+            letterPenalty: correctGuess.letterPenalty > 0 ? correctGuess.letterPenalty : undefined,
             tryNumber: correctGuess.tryNumber,
             screenshot: screenshotMap.get(position)!,
             attempts,

--- a/packages/backend/src/infrastructure/repositories/session.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/session.repository.ts
@@ -260,6 +260,7 @@ export const sessionRepository = {
     scoreEarned: number
     powerUpUsed: string | null
     hintFromInventory: boolean
+    letterPenalty: number
   }): Promise<void> {
     log.info(
       {
@@ -283,6 +284,7 @@ export const sessionRepository = {
       score_earned: data.scoreEarned,
       power_up_used: data.powerUpUsed,
       hint_from_inventory: data.hintFromInventory,
+      letter_penalty: data.letterPenalty,
     })
   },
 
@@ -447,6 +449,7 @@ export const sessionRepository = {
     scoreEarned: number
     powerUpUsed: string | null
     hintFromInventory: boolean
+    letterPenalty: number
     correctGameId: number
     correctGameName: string
     correctGameSlug: string
@@ -479,6 +482,7 @@ export const sessionRepository = {
           score_earned: number
           power_up_used: string | null
           hint_from_inventory: boolean
+          letter_penalty: number
           correct_game_id: number
           correct_game_name: string
           correct_game_slug: string
@@ -502,6 +506,7 @@ export const sessionRepository = {
         'guesses.score_earned',
         'guesses.power_up_used',
         'guesses.hint_from_inventory',
+        'guesses.letter_penalty',
         'correct_game.id as correct_game_id',
         'correct_game.name as correct_game_name',
         'correct_game.slug as correct_game_slug',
@@ -535,6 +540,7 @@ export const sessionRepository = {
         scoreEarned: row.score_earned,
         powerUpUsed: row.power_up_used,
         hintFromInventory: row.hint_from_inventory,
+        letterPenalty: row.letter_penalty,
         correctGameId: row.correct_game_id,
         correctGameName: row.correct_game_name,
         correctGameSlug: row.correct_game_slug,

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -383,6 +383,7 @@
     },
     "discoveryTime": "Found in {{time}}",
     "discoveryTimeShort": "{{time}}",
+    "letterPenaltyShort": "Letter −{{penalty}} pts",
     "powerUps": {
       "x2Timer": "Double Time",
       "hint": "Hint"

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -383,6 +383,7 @@
     },
     "discoveryTime": "Trouvé en {{time}}",
     "discoveryTimeShort": "{{time}}",
+    "letterPenaltyShort": "Lettre −{{penalty}} pts",
     "powerUps": {
       "x2Timer": "Temps Double",
       "hint": "Indice"

--- a/packages/frontend/src/components/game/SessionResultsList.tsx
+++ b/packages/frontend/src/components/game/SessionResultsList.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { m } from 'framer-motion'
-import { CheckCircle, XCircle, Clock } from 'lucide-react'
+import { CheckCircle, XCircle, Clock, Type } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { calculateSpeedMultiplier, formatDiscoveryTime } from '@/lib/utils'
 import { GuessAttemptsList } from '@/components/game/GuessAttemptsList'
@@ -107,6 +107,14 @@ export function SessionResultsList({
                     {result.scoreEarned > 0 && multiplier > 1.0 && (
                       <> · 100 × {multiplier.toFixed(1)}x {t('game.speed.label')}</>
                     )}
+                  </span>
+                </div>
+              )}
+              {result.isCorrect && (result.letterPenalty ?? 0) > 0 && (
+                <div className="flex items-center gap-1 sm:gap-1.5 text-xs text-score-low mt-1">
+                  <Type className="size-3 sm:size-3.5 shrink-0" aria-hidden="true" />
+                  <span className="whitespace-nowrap">
+                    {t('game.letterPenaltyShort', { penalty: result.letterPenalty })}
                   </span>
                 </div>
               )}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -632,6 +632,7 @@ export interface GameSessionDetailsResponse {
     timeTakenMs: number
     scoreEarned: number
     hintPenalty?: number
+    letterPenalty?: number
     wrongGuessPenalty?: number
     tryNumber: number
     screenshot: Screenshot


### PR DESCRIPTION
## What

The session results recap — the per-screenshot list shared by the **post-game results page**, the **History detail page**, and the **leaderboard answers dialog** (`SessionResultsList`) — showed the **Vitesse** speed multiplier but nothing about **letter reveals**. So after a game you couldn't tell whether, or how much, a letter reveal cost you on a given screenshot.

This adds a per-row indicator next to the Vitesse badge:

> 🔤 **Lettre −53 pts**  (fr) / **Letter −53 pts** (en)

…shown only on correct guesses that actually paid a letter-reveal penalty.

## Why a DB column instead of re-deriving it

The penalty is computed at submit time from the cumulative `penalty_pct` locked in at reveal time, then **subtracted from `score_earned`** before persisting. Because the second-chance floor and integer rounding both run after that subtraction, the points can't be reliably back-calculated from the stored score. So the cost is now persisted directly.

## Changes

- **Migration** `20260614_add_letter_penalty_to_guesses.ts` — adds `guesses.letter_penalty` (int, default 0). Historical rows stay `0` (no backfill possible) and show no badge — same convention as `hint_from_inventory`.
- **Backend** — `saveGuess` persists `letterPenalty`; `findGuessesByGameSession` + `GuessWithGameRecord` carry it; `user.service` surfaces it on correct-guess results (`> 0` only). Covers all three surfaces via the shared `buildSessionDetailsResponse`.
- **Types** — `letterPenalty?` added to `GameSessionDetailsResponse.guesses` (`GuessResult` already had it).
- **Frontend** — `SessionResultsList` renders the cost; `game.letterPenaltyShort` added for `fr` + `en`.

## Verification

- `npm run build:types` / `build:backend` / `build:frontend` — clean
- `npm run lint` — clean (one pre-existing unrelated warning)
- `npm test` — backend **288/288** pass, frontend **25/25** pass

## Note

The live post-guess result (`ResultScoreDisplay`) already displayed this penalty; this change brings the *recap* surfaces to parity.

https://claude.ai/code/session_016mGGp8NZ2t4LyBu8QDegi6

---
_Generated by [Claude Code](https://claude.ai/code/session_016mGGp8NZ2t4LyBu8QDegi6)_