### PR TITLE
feat(daily-login): add rarity tiers to daily rewards

### DIFF
--- a/packages/backend/migrations/20260614_daily_login_reward_rarity.ts
+++ b/packages/backend/migrations/20260614_daily_login_reward_rarity.ts
@@ -1,0 +1,45 @@
+import type { Knex } from 'knex'
+
+/**
+ * Add a `rarity` tier to daily-login rewards. Rarity is a purely cosmetic
+ * signal (colour + label + claim animation) layered on top of the existing
+ * 7-day cycle to make the rewards feel more rewarding. It is independent
+ * from `reward_type` (which describes the payload shape).
+ *
+ * Backfill follows the natural escalation of the 7-day cycle:
+ *   day 1-2 -> common, day 3-4 -> uncommon, day 5 -> rare,
+ *   day 6 -> epic, day 7 -> legendary.
+ */
+
+const RARITY_BY_DAY: Record<number, string> = {
+    1: 'common',
+    2: 'common',
+    3: 'uncommon',
+    4: 'uncommon',
+    5: 'rare',
+    6: 'epic',
+    7: 'legendary',
+}
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('daily_login_rewards', (table) => {
+        table
+            .string('rarity', 20)
+            .notNullable()
+            .defaultTo('common')
+            .comment('Cosmetic rarity tier: common, uncommon, rare, epic, legendary')
+    })
+
+    // Backfill the seeded 7-day cycle.
+    for (const [day, rarity] of Object.entries(RARITY_BY_DAY)) {
+        await knex('daily_login_rewards')
+            .where('day_number', Number(day))
+            .update({ rarity })
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('daily_login_rewards', (table) => {
+        table.dropColumn('rarity')
+    })
+}

--- a/packages/backend/src/infrastructure/repositories/daily-login.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/daily-login.repository.ts
@@ -1,6 +1,6 @@
 import { db } from '../database/connection.js'
 import { repoLogger } from '../logger/logger.js'
-import type { DailyReward } from '@the-box/types'
+import type { DailyReward, RewardRarity } from '@the-box/types'
 
 const log = repoLogger.child({ repository: 'daily-login' })
 
@@ -16,6 +16,7 @@ export interface DailyLoginRewardRow {
     id: number
     day_number: number
     reward_type: string
+    rarity: string | null
     reward_value: { items: Array<{ key: string; quantity: number }>; points: number }
     display_name: string
     description: string | null
@@ -44,11 +45,23 @@ export interface LoginRewardClaimRow {
     claimed_at: Date
 }
 
+const VALID_RARITIES: readonly RewardRarity[] = [
+    'common',
+    'uncommon',
+    'rare',
+    'epic',
+    'legendary',
+]
+
 function mapRewardRowToDailyReward(row: DailyLoginRewardRow): DailyReward {
+    const rarity = VALID_RARITIES.includes(row.rarity as RewardRarity)
+        ? (row.rarity as RewardRarity)
+        : 'common'
     return {
         id: row.id,
         dayNumber: row.day_number,
         rewardType: row.reward_type as 'powerup' | 'points' | 'legendary',
+        rarity,
         rewardValue: row.reward_value,
         displayName: row.display_name,
         description: row.description,

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2382,7 +2382,14 @@
         "description": "The ultimate chest: 2x letter reveal, 1x streak freeze + 500 points!"
       }
     },
-    "hintLetter": "Letter Reveal"
+    "hintLetter": "Letter Reveal",
+    "rarity": {
+      "common": "Common",
+      "uncommon": "Uncommon",
+      "rare": "Rare",
+      "epic": "Epic",
+      "legendary": "Legendary"
+    }
   },
   "onboarding": {
     "welcomeTitle": "Welcome to The Box!",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2382,7 +2382,14 @@
         "description": "Le coffre ultime : 2x révélation de lettre, 1x gel de série + 500 points !"
       }
     },
-    "hintLetter": "Révélation de lettre"
+    "hintLetter": "Révélation de lettre",
+    "rarity": {
+      "common": "Commun",
+      "uncommon": "Peu commun",
+      "rare": "Rare",
+      "epic": "Épique",
+      "legendary": "Légendaire"
+    }
   },
   "onboarding": {
     "welcomeTitle": "Bienvenue dans The Box !",

--- a/packages/frontend/src/components/daily-login/DailyRewardModal.tsx
+++ b/packages/frontend/src/components/daily-login/DailyRewardModal.tsx
@@ -13,6 +13,11 @@ import { useDailyLoginStore } from '@/stores/dailyLoginStore'
 import { RewardCalendar } from './RewardCalendar'
 import { cn } from '@/lib/utils'
 import { Flame, Gift, Sparkles } from 'lucide-react'
+import {
+    getRarityStyle,
+    getRewardRarity,
+    RARITY_CLAIM_ANIMATION,
+} from '@/lib/rarity'
 
 // i18n key per item_key. Unknown keys (including the metadata hints
 // retired 2026-06, which can still appear on historical claims) fall
@@ -78,6 +83,9 @@ export function DailyRewardModal() {
     const reward = justClaimed?.reward || status.todayReward
     const showClaimSuccess = !!justClaimed
 
+    const rarity = reward ? getRewardRarity(reward) : 'common'
+    const rarityStyle = reward ? getRarityStyle(reward) : null
+
     return (
         <ResponsiveDialog open={isModalOpen} onOpenChange={(open) => { if (!open) handleClose() }}>
             <ResponsiveDialogContent className="sm:max-w-md">
@@ -111,26 +119,58 @@ export function DailyRewardModal() {
                 </div>
 
                 {/* Reward Display */}
-                {reward && (
-                    <div className={cn(
-                        'relative flex flex-col items-center p-6 rounded-lg border border-primary/30 bg-linear-to-b from-primary/10 to-transparent',
-                        isAnimating && 'animate-pulse',
-                        showClaimSuccess && 'border-success/50 bg-linear-to-b from-success/10 to-transparent'
-                    )}>
-                        {/* Sparkle effect on claim */}
+                {reward && rarityStyle && (
+                    <div
+                        style={
+                            showClaimSuccess
+                                ? { boxShadow: rarityStyle.glow }
+                                : undefined
+                        }
+                        className={cn(
+                            'relative flex flex-col items-center p-6 rounded-lg border bg-linear-to-b',
+                            // The card is always tinted by the reward's rarity so
+                            // the colour signals prestige before the claim.
+                            rarityStyle.border,
+                            rarityStyle.gradient,
+                            isAnimating && !showClaimSuccess && 'animate-pulse',
+                            // On claim, escalate the reveal animation with rarity.
+                            showClaimSuccess && RARITY_CLAIM_ANIMATION[rarity]
+                        )}
+                    >
+                        {/* Sparkle effect on claim, tinted by rarity */}
                         {showClaimSuccess && (
                             <div className="absolute inset-0 pointer-events-none">
-                                <Sparkles className="absolute top-2 left-4 size-4 text-warning animate-pulse" />
+                                <Sparkles className={cn('absolute top-2 left-4 size-4 animate-pulse', rarityStyle.sparkle)} />
                                 <Sparkles
-                                    className="absolute top-4 right-6 size-3 text-warning animate-pulse"
+                                    className={cn('absolute top-4 right-6 size-3 animate-pulse', rarityStyle.sparkle)}
                                     style={{ animationDelay: '100ms' }}
                                 />
                                 <Sparkles
-                                    className="absolute bottom-4 left-8 size-3 text-warning animate-pulse"
+                                    className={cn('absolute bottom-4 left-8 size-3 animate-pulse', rarityStyle.sparkle)}
                                     style={{ animationDelay: '200ms' }}
                                 />
+                                {(rarity === 'epic' || rarity === 'legendary') && (
+                                    <>
+                                        <Sparkles
+                                            className={cn('absolute bottom-3 right-5 size-4 animate-pulse', rarityStyle.sparkle)}
+                                            style={{ animationDelay: '150ms' }}
+                                        />
+                                        <Sparkles
+                                            className={cn('absolute top-1/2 left-2 size-3 animate-pulse', rarityStyle.sparkle)}
+                                            style={{ animationDelay: '250ms' }}
+                                        />
+                                    </>
+                                )}
                             </div>
                         )}
+
+                        {/* Rarity label */}
+                        <Badge
+                            variant="outline"
+                            className={cn('mb-2 uppercase tracking-wide text-[10px]', rarityStyle.badge, rarityStyle.border)}
+                        >
+                            {t(rarityStyle.labelKey)}
+                        </Badge>
 
                         <span className="text-4xl mb-2">{reward.iconUrl}</span>
                         <h3 className="font-bold text-lg text-center">

--- a/packages/frontend/src/components/daily-login/RewardCalendar.tsx
+++ b/packages/frontend/src/components/daily-login/RewardCalendar.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
 import { Check, Gift, Lock } from 'lucide-react'
 import type { DailyReward } from '@the-box/types'
+import { getRarityStyle, getRewardRarity } from '@/lib/rarity'
 
 interface RewardCalendarProps {
     rewards: DailyReward[]
@@ -60,23 +61,43 @@ export function RewardCalendar({
                     const isLocked = status === 'locked'
                     const isAvailable = status === 'available'
 
+                    const rarity = getRewardRarity(reward)
+                    const rarityStyle = getRarityStyle(reward)
+
                     return (
                         <div
                             key={reward.dayNumber}
+                            title={t(rarityStyle.labelKey)}
+                            style={
+                                isAvailable
+                                    ? { boxShadow: rarityStyle.glow }
+                                    : undefined
+                            }
                             className={cn(
                                 'relative flex flex-col items-center justify-center p-1 sm:p-2 rounded-lg border transition-all',
-                                isToday && 'ring-2 ring-primary ring-offset-2 ring-offset-background',
-                                isClaimed && 'bg-success/10 border-success/30',
-                                isAvailable && 'bg-primary/10 border-primary/30 animate-pulse',
-                                isLocked && 'bg-muted/20 border-muted/30 opacity-50'
+                                // Rarity tint is always present so the colour
+                                // reads as the day's prestige, not just its state.
+                                rarityStyle.cell,
+                                isToday && cn('ring-2 ring-offset-2 ring-offset-background', rarityStyle.ring),
+                                isAvailable && 'animate-pulse',
+                                isClaimed && 'opacity-70',
+                                isLocked && 'opacity-50'
                             )}
                         >
+                            {/* Rarity indicator dot */}
+                            <span
+                                className={cn(
+                                    'absolute top-1 right-1 size-1.5 rounded-full',
+                                    rarityStyle.text,
+                                    'bg-current'
+                                )}
+                                aria-hidden
+                            />
+
                             {/* Day number */}
                             <span className={cn(
                                 'text-[10px] sm:text-xs font-medium',
-                                isClaimed && 'text-success',
-                                isAvailable && 'text-primary',
-                                isLocked && 'text-muted-foreground'
+                                rarityStyle.text
                             )}>
                                 {t('dailyLogin.day')} {reward.dayNumber}
                             </span>
@@ -87,7 +108,7 @@ export function RewardCalendar({
                                 isLocked && 'grayscale'
                             )}>
                                 {isClaimed ? (
-                                    <Check className="size-4 sm:size-6 text-success" />
+                                    <Check className={cn('size-4 sm:size-6', rarityStyle.text)} />
                                 ) : isLocked ? (
                                     <Lock className="size-4 sm:size-5 text-muted-foreground" />
                                 ) : (
@@ -98,9 +119,7 @@ export function RewardCalendar({
                             {/* Reward preview */}
                             <span className={cn(
                                 'text-[8px] sm:text-[10px] text-center leading-tight truncate max-w-full px-0.5',
-                                isClaimed && 'text-success/70',
-                                isAvailable && 'text-primary/80',
-                                isLocked && 'text-muted-foreground/50'
+                                rarity === 'legendary' ? rarityStyle.text : 'text-muted-foreground'
                             )}>
                                 {reward.rewardType === 'legendary' ? (
                                     <Gift className="size-3 inline" />

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -498,3 +498,82 @@ html {
     transform-origin: center;
   }
 }
+
+/* Daily-reward rarity unlock celebrations. Intensity escalates with the
+   rarity tier (see RARITY_CLAIM_ANIMATION in src/lib/rarity.ts):
+   - soft:  a gentle scale settle for common/uncommon
+   - glow:  scale + a glow pulse for rare/epic
+   - burst: a bouncy reveal with a rotating shimmer for legendary
+   All three are gated on prefers-reduced-motion so vestibular-sensitive
+   players get the final, static state instead. The rarity glow itself is
+   applied inline (box-shadow) on the element; these keyframes pulse it. */
+@keyframes rarity-reveal-soft {
+  0% {
+    transform: scale(0.92);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes rarity-reveal-glow {
+  0% {
+    transform: scale(0.85);
+    opacity: 0;
+  }
+  55% {
+    transform: scale(1.06);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes rarity-reveal-burst {
+  0% {
+    transform: scale(0.7) rotate(-3deg);
+    opacity: 0;
+  }
+  45% {
+    transform: scale(1.14) rotate(2deg);
+    opacity: 1;
+  }
+  70% {
+    transform: scale(0.97) rotate(-1deg);
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+}
+
+@keyframes rarity-glow-pulse {
+  0%,
+  100% {
+    filter: brightness(1);
+  }
+  50% {
+    filter: brightness(1.18);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .rarity-reveal-soft {
+    animation: rarity-reveal-soft 360ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+    transform-origin: center;
+  }
+  .rarity-reveal-glow {
+    animation: rarity-reveal-glow 520ms cubic-bezier(0.34, 1.56, 0.64, 1) both,
+      rarity-glow-pulse 1.6s ease-in-out 520ms infinite;
+    transform-origin: center;
+  }
+  .rarity-reveal-burst {
+    animation: rarity-reveal-burst 620ms cubic-bezier(0.34, 1.56, 0.64, 1) both,
+      rarity-glow-pulse 1.4s ease-in-out 620ms infinite;
+    transform-origin: center;
+  }
+}

--- a/packages/frontend/src/lib/rarity.ts
+++ b/packages/frontend/src/lib/rarity.ts
@@ -1,0 +1,131 @@
+import type { DailyReward, RewardRarity } from '@the-box/types'
+
+/**
+ * Visual mapping for daily-login reward rarities. Centralised here so the
+ * calendar, the claim modal and any future surface share one source of
+ * truth for colours, labels and animations.
+ *
+ * IMPORTANT: every Tailwind class below is written as a complete literal
+ * string (never composed at runtime), so the Tailwind v4 scanner can see
+ * and emit them. Do not build these class names dynamically.
+ */
+
+export const RARITY_ORDER: readonly RewardRarity[] = [
+    'common',
+    'uncommon',
+    'rare',
+    'epic',
+    'legendary',
+]
+
+export interface RarityStyle {
+    /** i18n key for the human-readable rarity label. */
+    labelKey: string
+    /** Calendar cell tint (background + border) when the day is active/locked. */
+    cell: string
+    /** Ring colour used to highlight "today" in the calendar. */
+    ring: string
+    /** Text/icon accent colour. */
+    text: string
+    /** Border colour for the modal reward card + badges. */
+    border: string
+    /** Soft gradient backdrop for the modal reward card. */
+    gradient: string
+    /** Badge classes (bg + text) shown in the modal. */
+    badge: string
+    /** Sparkle / accent colour for the claim celebration. */
+    sparkle: string
+    /**
+     * Inline box-shadow used for the rarity "glow". Kept as a raw CSS value
+     * (consumed via `style`) so we can lean on the theme CSS variables and
+     * vary intensity per tier without bloating the Tailwind safelist.
+     */
+    glow: string
+}
+
+export const RARITY_STYLES: Record<RewardRarity, RarityStyle> = {
+    common: {
+        labelKey: 'dailyLogin.rarity.common',
+        cell: 'bg-muted/30 border-muted-foreground/30',
+        ring: 'ring-muted-foreground',
+        text: 'text-muted-foreground',
+        border: 'border-muted-foreground/30',
+        gradient: 'from-muted/20 to-transparent',
+        badge: 'bg-muted/40 text-muted-foreground',
+        sparkle: 'text-muted-foreground',
+        glow: '0 0 8px color-mix(in srgb, var(--muted-foreground) 45%, transparent)',
+    },
+    uncommon: {
+        labelKey: 'dailyLogin.rarity.uncommon',
+        cell: 'bg-success/10 border-success/40',
+        ring: 'ring-success',
+        text: 'text-success',
+        border: 'border-success/40',
+        gradient: 'from-success/10 to-transparent',
+        badge: 'bg-success/20 text-success',
+        sparkle: 'text-success',
+        glow: '0 0 10px color-mix(in srgb, var(--success) 50%, transparent)',
+    },
+    rare: {
+        labelKey: 'dailyLogin.rarity.rare',
+        cell: 'bg-neon-blue/10 border-neon-blue/40',
+        ring: 'ring-neon-blue',
+        text: 'text-neon-blue',
+        border: 'border-neon-blue/40',
+        gradient: 'from-neon-blue/15 to-transparent',
+        badge: 'bg-neon-blue/20 text-neon-blue',
+        sparkle: 'text-neon-blue',
+        glow: '0 0 14px color-mix(in srgb, var(--neon-blue) 55%, transparent)',
+    },
+    epic: {
+        labelKey: 'dailyLogin.rarity.epic',
+        cell: 'bg-neon-purple/10 border-neon-purple/50',
+        ring: 'ring-neon-purple',
+        text: 'text-neon-purple',
+        border: 'border-neon-purple/50',
+        gradient: 'from-neon-purple/20 to-transparent',
+        badge: 'bg-neon-purple/20 text-neon-purple',
+        sparkle: 'text-neon-purple',
+        glow: '0 0 18px color-mix(in srgb, var(--neon-purple) 60%, transparent)',
+    },
+    legendary: {
+        labelKey: 'dailyLogin.rarity.legendary',
+        cell: 'bg-warning/10 border-warning/50',
+        ring: 'ring-warning',
+        text: 'text-warning',
+        border: 'border-warning/50',
+        gradient: 'from-warning/20 to-transparent',
+        badge: 'bg-warning/20 text-warning',
+        sparkle: 'text-warning',
+        glow: '0 0 24px color-mix(in srgb, var(--warning) 70%, transparent)',
+    },
+}
+
+/**
+ * CSS keyframe animation name (defined in index.css) used for the unlock
+ * celebration, escalating with rarity. `prefers-reduced-motion` zeroes
+ * these out at the stylesheet level.
+ */
+export const RARITY_CLAIM_ANIMATION: Record<RewardRarity, string> = {
+    common: 'rarity-reveal-soft',
+    uncommon: 'rarity-reveal-soft',
+    rare: 'rarity-reveal-glow',
+    epic: 'rarity-reveal-glow',
+    legendary: 'rarity-reveal-burst',
+}
+
+/**
+ * Resolve a reward's rarity, falling back to a sensible derived value for
+ * historical rewards that predate the `rarity` column.
+ */
+export function getRewardRarity(reward: Pick<DailyReward, 'rarity' | 'rewardType'>): RewardRarity {
+    if (reward.rarity && RARITY_ORDER.includes(reward.rarity)) {
+        return reward.rarity
+    }
+    if (reward.rewardType === 'legendary') return 'legendary'
+    return 'common'
+}
+
+export function getRarityStyle(reward: Pick<DailyReward, 'rarity' | 'rewardType'>): RarityStyle {
+    return RARITY_STYLES[getRewardRarity(reward)]
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -829,10 +829,25 @@ export interface EmailLogQuery {
 // Daily Login Rewards Domain
 // ============================================
 
+/**
+ * Rarity tier for a daily-login reward. Drives the colour, label and
+ * unlock animation shown in the calendar + claim modal. Ordered from
+ * least to most prestigious; see `RARITY_STYLES` on the frontend for the
+ * visual mapping. Independent from `rewardType` (which only describes the
+ * payload shape) — a `points` reward can still be `epic`.
+ */
+export type RewardRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary'
+
 export interface DailyReward {
   id: number
   dayNumber: number
   rewardType: 'powerup' | 'points' | 'legendary'
+  /**
+   * Visual rarity tier. Optional for backward compatibility with historical
+   * claims; the backend always populates it and the frontend falls back to
+   * a derived value when absent.
+   */
+  rarity?: RewardRarity
   rewardValue: {
     items: Array<{ key: string; quantity: number }>
     points: number


### PR DESCRIPTION
## Objectif

Améliorer l'attractivité des récompenses quotidiennes en introduisant une **notion de rareté** : chaque récompense du cycle de 7 jours porte désormais un niveau de rareté, avec **une couleur** et **une animation** dédiées.

## Niveaux de rareté

5 paliers, escaladant le long du cycle de 7 jours :

| Jours | Rareté | Couleur (token) | Animation de récupération |
|-------|--------|-----------------|---------------------------|
| 1-2 | Commun | `muted` (gris) | révélation douce |
| 3-4 | Peu commun | `success` (vert) | révélation douce |
| 5 | Rare | `neon-blue` | révélation + pulsation lumineuse |
| 6 | Épique | `neon-purple` | révélation + pulsation lumineuse |
| 7 | Légendaire | `warning` (or) | éclat rebondissant + étincelles supplémentaires |

## Changements

**Types** (`@the-box/types`)
- Nouveau type `RewardRarity` + champ optionnel `rarity` sur `DailyReward` (optionnel pour rétro-compatibilité avec les anciens octrois).

**Backend**
- Migration `20260614_daily_login_reward_rarity.ts` : ajoute la colonne `rarity` (défaut `common`) et backfill le cycle de 7 jours.
- Le repository mappe la rareté (avec garde de validation → `common` par défaut).

**Frontend**
- `src/lib/rarity.ts` : configuration centralisée `RARITY_STYLES` (couleurs, libellés, lueur, animations) — uniquement des **tokens de design sémantiques** (conforme à la règle ESLint `no-raw-design-tokens`), plus un helper `getRewardRarity()` avec fallback.
- `RewardCalendar` : cases teintées par rareté + point indicateur + anneau « aujourd'hui » coloré + lueur sur la case disponible.
- `DailyRewardModal` : badge de rareté, carte teintée par rareté, étincelles colorées et animation de récupération qui s'intensifie selon le palier.
- Keyframes CSS (`rarity-reveal-soft/glow/burst`) **gated sur `prefers-reduced-motion`** pour l'accessibilité.
- Traductions fr/en des libellés de rareté.

## Tests & qualité

- `npm run build:types` ✓
- `npm run build:frontend` ✓
- `npm run lint` ✓ (0 erreur)
- `npm test` ✓ (288 tests backend, 25 frontend)

> Note : `npm run build:backend` échoue sur une dépréciation `baseUrl` de TypeScript **préexistante** (présente aussi sur `main` sans ces changements), sans rapport avec cette PR.

https://claude.ai/code/session_018TM9z82GukzK9miz1GTMng

---
_Generated by [Claude Code](https://claude.ai/code/session_018TM9z82GukzK9miz1GTMng)_