### PR TITLE
docs(changelog): announce daily reward rarity tiers (2.135.0)

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2764,6 +2764,13 @@
       "fixes": "Fixes"
     },
     "releases": {
+      "2.135.0": {
+        "summary": "Daily rewards now come in colors: each day reveals its rarity, with its own vibe and animation.",
+        "features": [
+          "Every daily reward now shows its rarity — from common to legendary — with a dedicated color.",
+          "Claiming a reward triggers an animation that escalates with its rarity, up to the legendary day-7 burst."
+        ]
+      },
       "2.130.0": {
         "summary": "Guessing gets smarter: proximity hints, partial credit and clearer premium plans.",
         "features": [

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2764,6 +2764,13 @@
       "fixes": "Corrections"
     },
     "releases": {
+      "2.135.0": {
+        "summary": "Les récompenses quotidiennes prennent des couleurs : chaque jour révèle sa rareté, avec son ambiance et son animation.",
+        "features": [
+          "Chaque récompense quotidienne affiche désormais sa rareté — du commun au légendaire — avec une couleur dédiée.",
+          "Récupérer une récompense déclenche une animation qui s'intensifie selon sa rareté, jusqu'à l'éclat légendaire du jour 7."
+        ]
+      },
       "2.130.0": {
         "summary": "Deviner devient plus malin : indices de proximité, points partiels et offres premium plus claires.",
         "features": [

--- a/packages/frontend/src/data/changelog.ts
+++ b/packages/frontend/src/data/changelog.ts
@@ -35,6 +35,7 @@ export interface ChangelogRelease {
  * manually from the footer.
  */
 export const CHANGELOG: ChangelogRelease[] = [
+  { version: '2.135.0', date: '2026-06-14' },
   { version: '2.130.0', date: '2026-06-14' },
   { version: '2.127.0', date: '2026-06-13' },
 ]


### PR DESCRIPTION
## Objectif

Annoncer aux joueurs la nouvelle fonctionnalité de **rareté des récompenses quotidiennes** (mergée en #317) via le dialogue « Nouveautés » in-app.

## Changements

- **`src/data/changelog.ts`** : nouvelle entrée `2.135.0` (version actuellement livrée) en tête du registre, qui devient la release « Nouveau » affichée après mise à jour.
- **i18n fr/en** (`changelog.releases.2.135.0`) : notes orientées joueur (non techniques) décrivant les couleurs de rareté et l'animation de récupération qui s'intensifie selon le palier.

## Notes

- L'entrée est calée sur `2.135.0` pour correspondre au `__APP_VERSION__` du build courant, afin que le dialogue auto-ouvre bien ces notes lors de la prochaine mise à jour des joueurs.
- Texte uniquement (registre + traductions) — aucun changement de logique applicative.

## Qualité

- JSON fr/en valides
- `npm run build:frontend` ✓
- `npm test` ✓ (relancé par le hook pre-commit)

https://claude.ai/code/session_018TM9z82GukzK9miz1GTMng

---
_Generated by [Claude Code](https://claude.ai/code/session_018TM9z82GukzK9miz1GTMng)_