### PR TITLE
feat(themes): add premium "Retro 80s" synthwave theme

### DIFF
--- a/packages/backend/src/config/themes.ts
+++ b/packages/backend/src/config/themes.ts
@@ -15,6 +15,7 @@ export const PREMIUM_THEME_KEYS = [
   'cyber_blue',
   'emerald_matrix',
   'sunset_blaze',
+  'retro_80s',
 ] as const
 
 export type PremiumThemeKey = (typeof PREMIUM_THEME_KEYS)[number]

--- a/packages/frontend/e2e/theme-switcher.spec.ts
+++ b/packages/frontend/e2e/theme-switcher.spec.ts
@@ -19,6 +19,7 @@ const EXPECTED: Record<string, { from: string; to: string }> = {
     cyber_blue: { from: '#3b82f6', to: '#06b6d4' },
     emerald_matrix: { from: '#22c55e', to: '#06b6d4' },
     sunset_blaze: { from: '#eab308', to: '#ef4444' },
+    retro_80s: { from: '#ff2e88', to: '#2de2e6' },
 }
 
 // Browsers normalize hex colors in computed `background-image` to `rgb()`,

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2717,7 +2717,8 @@
       "neonPink": "Neon pink",
       "cyberBlue": "Cyber blue",
       "emeraldMatrix": "Matrix green",
-      "sunsetBlaze": "Sunset blaze"
+      "sunsetBlaze": "Sunset blaze",
+      "retro80s": "Retro 80s"
     }
   },
   "premiumGate": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2717,7 +2717,8 @@
       "neonPink": "Rose néon",
       "cyberBlue": "Bleu cyber",
       "emeraldMatrix": "Vert matrix",
-      "sunsetBlaze": "Coucher embrasé"
+      "sunsetBlaze": "Coucher embrasé",
+      "retro80s": "Rétro 80s"
     }
   },
   "premiumGate": {

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -91,6 +91,8 @@
   --theme-swatch-emerald-matrix-to: #06b6d4;
   --theme-swatch-sunset-blaze-from: #eab308;
   --theme-swatch-sunset-blaze-to: #ef4444;
+  --theme-swatch-retro-80s-from: #ff2e88;
+  --theme-swatch-retro-80s-to: #2de2e6;
 }
 
 @theme inline {
@@ -404,6 +406,58 @@ html {
   --neon-purple: #fb923c;
   --neon-pink: #ef4444;
   --border-interactive: oklch(0.74 0.18 40 / 0.55);
+}
+
+/* Retro 80s — full synthwave/outrun re-skin.
+   Unlike the accent-only themes above, this one repaints the core
+   surfaces (background, cards, popovers, borders) and the hero glow so
+   the whole app reads as a neon 1980s arcade. Surfaces stay dark enough
+   that the unchanged light `--foreground` keeps WCAG AA contrast; the
+   magenta/cyan accents are bright (high L in oklch) for the same reason.
+   The static horizon-grid backdrop lives on `[data-theme] body` below
+   (no animation, so nothing to disable under prefers-reduced-motion). */
+[data-theme="retro_80s"] {
+  --background: oklch(0.13 0.07 305);
+  --card: oklch(0.2 0.08 308);
+  --card-foreground: oklch(0.985 0.01 320);
+  --popover: oklch(0.18 0.08 308);
+  --popover-foreground: oklch(0.985 0.01 320);
+  --secondary: oklch(0.26 0.08 320);
+  --muted: oklch(0.26 0.07 308);
+  --muted-foreground: oklch(0.82 0.07 320);
+  --accent: oklch(0.3 0.12 200);
+  --primary: oklch(0.72 0.26 350);
+  --ring: oklch(0.8 0.18 200);
+  --border: oklch(0.75 0.2 340 / 22%);
+  --input: oklch(0.75 0.2 340 / 28%);
+  --neon-purple: #ff2e88;
+  --neon-pink: #2de2e6;
+  --neon-blue: #5b6bff;
+  --neon-cyan: #2de2e6;
+  --border-interactive: oklch(0.72 0.26 350 / 0.6);
+  --glow-sm: 0 0 10px oklch(0.7 0.26 350 / 0.4);
+  --glow-md: 0 0 22px oklch(0.7 0.26 350 / 0.5);
+  --glow-lg: 0 0 34px oklch(0.7 0.26 350 / 0.6);
+  --text-shadow-neon:
+    0 0 10px oklch(0.7 0.26 350 / 0.85),
+    0 0 22px oklch(0.72 0.2 200 / 0.6),
+    0 0 34px oklch(0.7 0.26 350 / 0.45),
+    0 0 46px oklch(0.72 0.2 200 / 0.25);
+}
+
+/* Neon horizon backdrop: a magenta/cyan perspective grid fading up into a
+   cyan "sun" glow on the horizon, painted behind the app shell. Fixed so
+   it doesn't scroll, low-alpha so card text contrast is unaffected. */
+[data-theme="retro_80s"] body {
+  background-color: var(--color-background);
+  background-image:
+    radial-gradient(120% 80% at 50% 116%, oklch(0.72 0.2 200 / 0.28) 0%, transparent 55%),
+    radial-gradient(90% 60% at 50% 0%, oklch(0.6 0.24 330 / 0.22) 0%, transparent 60%),
+    linear-gradient(oklch(0.7 0.26 350 / 0.07) 1px, transparent 1px),
+    linear-gradient(90deg, oklch(0.72 0.2 200 / 0.07) 1px, transparent 1px);
+  background-size: 100% 100%, 100% 100%, 44px 44px, 44px 44px;
+  background-position: center, center, center bottom, center bottom;
+  background-attachment: fixed;
 }
 
 /* =====================================================================

--- a/packages/frontend/src/lib/themes.ts
+++ b/packages/frontend/src/lib/themes.ts
@@ -12,6 +12,7 @@ export type ThemeKey =
   | 'cyber_blue'
   | 'emerald_matrix'
   | 'sunset_blaze'
+  | 'retro_80s'
 
 export interface ThemeMeta {
   key: ThemeKey
@@ -76,6 +77,18 @@ export const THEMES: ReadonlyArray<ThemeMeta> = [
     swatch: {
       from: 'var(--theme-swatch-sunset-blaze-from)',
       to: 'var(--theme-swatch-sunset-blaze-to)',
+    },
+  },
+  {
+    // Synthwave / outrun re-skin: the most dramatic premium theme — it
+    // repaints the whole shell (background, cards, neon accents, hero
+    // glow + grid backdrop), not just the accent like the others.
+    key: 'retro_80s',
+    i18nKey: 'retro80s',
+    premium: true,
+    swatch: {
+      from: 'var(--theme-swatch-retro-80s-from)',
+      to: 'var(--theme-swatch-retro-80s-to)',
     },
   },
 ]


### PR DESCRIPTION
## What

Adds a sixth **premium** UI theme — `retro_80s`, an 80s **synthwave / outrun** re-skin — to the theme selector (Profile → Customize). Premium-gated like the other accent themes; free users see it locked and routed to `/pricing`.

Unlike the existing accent-only premium themes (which only swap `--primary`/`--neon-*`), this one is a **full shell repaint**:
- Deep indigo-night `--background` / `--card` / `--popover` / `--border`
- Magenta `--primary` + cyan `--ring`/accents (`--neon-purple` → magenta, `--neon-pink`/`--neon-cyan` → cyan)
- Re-skinned neon glows + hero `--text-shadow-neon`
- A static magenta/cyan **horizon-grid backdrop** with a cyan "sun" glow on the body

Swatch preview gradient: `#ff2e88` → `#2de2e6`.

## Coupled surfaces changed in lockstep

| Surface | File |
|---|---|
| Backend keyset | `packages/backend/src/config/themes.ts` (`PREMIUM_THEME_KEYS`) |
| Frontend registry | `packages/frontend/src/lib/themes.ts` (`ThemeKey` + `THEMES` + swatch tokens) |
| CSS | `packages/frontend/src/index.css` (`:root` swatch vars + `[data-theme="retro_80s"]` block + body backdrop) |
| i18n | `public/locales/{en,fr}/translation.json` (`themes.options.retro80s`) |
| e2e contract | `e2e/theme-switcher.spec.ts` (swatch hex `#ff2e88` / `#2de2e6`) |

## Workflow

Implemented atomically (the e2e test enforces a lockstep hex contract), then reviewed via two parallel subagents:
- **Correctness/lockstep** review → PASS (all 5 surfaces consistent, no other theme enumeration missed).
- **Visual + a11y** review → PASS: every active token pair clears WCAG AA — `--foreground` on bg **19.4:1**, on card **17.6:1**, `--muted-foreground` on card **10.3:1**, dark `--primary-foreground` on magenta button **5.75:1**. Backdrop is static → reduced-motion safe.

## Validation

- `npm run build` — types + backend + frontend all clean
- `npm test` — 313 unit tests pass
- `npm run lint` — clean (1 pre-existing unrelated warning)

https://claude.ai/code/session_015Vzb294mE4jcdzPS1UkcQP

---
_Generated by [Claude Code](https://claude.ai/code/session_015Vzb294mE4jcdzPS1UkcQP)_