### PR TITLE
fix(game): show unfound games as 0 points instead of -50

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -424,7 +424,7 @@
       "speedMultiplier": "Speed multiplier: <3s = 2.0x (200pts), 3-5s = 1.75x (175pts), 5-10s = 1.5x (150pts), 10-20s = 1.25x (125pts), >20s = 1.0x (100pts)",
       "unlimitedTries": "Unlimited tries - wrong guesses don't affect score",
       "hints": "Revealing letters of the title costs -15% then -20% of the round's score (requires a Letter reveal power-up on today's challenge)",
-      "penalty": "-50 points per game not found when ending early"
+      "penalty": "Games left unfound when ending early score 0 points (no penalty)"
     },
     "navigation": {
       "previous": "Previous",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -424,7 +424,7 @@
       "speedMultiplier": "Multiplicateur de vitesse : <3s = 2.0x (200pts), 3-5s = 1.75x (175pts), 5-10s = 1.5x (150pts), 10-20s = 1.25x (125pts), >20s = 1.0x (100pts)",
       "unlimitedTries": "Essais illimités - les mauvaises réponses n'affectent pas le score",
       "hints": "Révéler des lettres du titre coûte -15 % puis -20 % du score de la manche (bonus Révélation de lettre requis sur le défi du jour)",
-      "penalty": "-50 points par jeu non trouvé lors de l'arrêt anticipé"
+      "penalty": "Les jeux non trouvés lors de l'arrêt anticipé rapportent 0 point (aucune pénalité)"
     },
     "navigation": {
       "previous": "Précédent",

--- a/packages/frontend/src/components/game/SessionResultsList.tsx
+++ b/packages/frontend/src/components/game/SessionResultsList.tsx
@@ -37,8 +37,9 @@ export function SessionResultsList({
   return (
     <ul className={isGrid ? 'list-none grid grid-cols-1 md:grid-cols-2 gap-2 sm:gap-3' : 'space-y-2 sm:space-y-3 list-none'}>
       {results.map((result, index) => {
-        const isUnguessed =
-          !result.isCorrect && result.userGuess === null && result.scoreEarned === -50
+        // Unfound games are folded in with no submitted guess; they score 0
+        // (the backend applies no unfound penalty) but still render as a miss.
+        const isUnguessed = !result.isCorrect && result.userGuess === null
         const attempts = result.attempts ?? []
         const multiplier =
           result.isCorrect && result.scoreEarned > 0
@@ -78,7 +79,7 @@ export function SessionResultsList({
                   </Badge>
                 ) : isUnguessed ? (
                   <Badge variant="destructive" className="text-xs sm:text-sm font-bold shrink-0">
-                    {result.scoreEarned}
+                    +{result.scoreEarned}
                   </Badge>
                 ) : (
                   <Badge variant="outline" className="text-xs sm:text-sm shrink-0">

--- a/packages/frontend/src/lib/sessionResults.ts
+++ b/packages/frontend/src/lib/sessionResults.ts
@@ -3,8 +3,10 @@ import type { GameSessionDetailsResponse, GuessResult, GuessAttempt } from '@/ty
 /**
  * Flatten a {@link GameSessionDetailsResponse} into a single, position-sorted
  * `GuessResult[]`. Unfound games (skipped / timed-out) are folded in as
- * incorrect entries with the `-50` miss penalty so they render alongside real
- * guesses.
+ * incorrect entries worth `0` points so they render alongside real guesses.
+ * They are still flagged as misses via `isCorrect: false` + `userGuess: null`;
+ * the score is `0` because the backend applies no unfound penalty
+ * (`UNFOUND_PENALTY = 0`).
  *
  * This is the one place the guesses + unfoundGames merge lives — ResultsPage,
  * GameHistoryDetailsPage and the leaderboard PlayerAnswersDialog all share it
@@ -30,7 +32,7 @@ export function mergeSessionResults(session: GameSessionDetailsResponse): GuessR
       correctGame: u.game,
       userGuess: null,
       timeTakenMs: 0,
-      scoreEarned: -50,
+      scoreEarned: 0,
       screenshot: u.screenshot,
       attempts: [] as GuessAttempt[],
     })),

--- a/packages/frontend/src/stores/gameStore.ts
+++ b/packages/frontend/src/stores/gameStore.ts
@@ -720,7 +720,7 @@ export const useGameStore = create<GameState>()(
                   correctGame: unfound.game,
                   userGuess: lastWrong,
                   timeTakenMs: 0,
-                  scoreEarned: -50, // Show -50 penalty
+                  scoreEarned: 0, // Unfound games score 0 — backend applies no penalty
                   screenshot: unfound.screenshot,
                   attempts,
                 }

--- a/packages/frontend/src/utils/scoringVerification.test.ts
+++ b/packages/frontend/src/utils/scoringVerification.test.ts
@@ -172,17 +172,17 @@ export function testEarlyEndGame(): {
     {
       screenshotsFound: 5,
       sessionScore: 500,
-      expectedFinalScore: 500 - (5 * UNFOUND_PENALTY), // 500 - 250 = 250
+      expectedFinalScore: 500 - (5 * UNFOUND_PENALTY), // 500 - 0 = 500
     },
     {
       screenshotsFound: 0,
       sessionScore: 0,
-      expectedFinalScore: 0 - (10 * UNFOUND_PENALTY), // 0 - 500 = -500
+      expectedFinalScore: 0 - (10 * UNFOUND_PENALTY), // 0 - 0 = 0
     },
     {
       screenshotsFound: 8,
       sessionScore: 1200,
-      expectedFinalScore: 1200 - (2 * UNFOUND_PENALTY), // 1200 - 100 = 1100
+      expectedFinalScore: 1200 - (2 * UNFOUND_PENALTY), // 1200 - 0 = 1200
     },
   ]
 


### PR DESCRIPTION
## Why

The session recap showed a **-50** score on "Jeu Introuvable" (game not found) rows, while wrong-guessed screenshots showed **+0**. This raised the question: why does an unfound game cost -50 but a timeout costs 0?

The answer: it shouldn't. The -50 was a **hardcoded display value that no longer matched the scoring engine**.

- The backend applies **no penalty** for unfound games: `UNFOUND_PENALTY = 0` (`game.service.ts:48`), so `endGame` computes `penaltyApplied = unfoundCount * 0 = 0`. Forfeiting never actually deducts points.
- Wrong guesses are also free: `WRONG_GUESS_PENALTY = 0`.
- But the frontend recap hardcoded `scoreEarned: -50` for every unfound game (in both `mergeSessionResults` and the live `gameStore` forfeit path), and the i18n strings promised "-50 points per game not found."

So the displayed -50 was cosmetic/stale — likely the penalty was 50 originally, later zeroed in the service without updating the UI.

The real split in the recap was never "skip vs timeout" — it was "position with no submitted guess (folded into `unfoundGames`)" vs "position with a guess record". This PR removes the misleading number.

## What changed

Aligned the display with reality (option: make the UI match the engine, not re-introduce a penalty):

- `lib/sessionResults.ts` — unfound games merge in at `scoreEarned: 0`
- `stores/gameStore.ts` — live forfeit path also uses `0`
- `components/game/SessionResultsList.tsx` — `isUnguessed` sentinel now keys off `userGuess === null` instead of the magic `-50`; the badge renders `+0`. The red "miss" styling and "not found" label are preserved.
- i18n `game.scoring.penalty` (en/fr) — no longer claims a -50 penalty
- `scoringVerification.test.ts` — fixed stale comments that still showed the old non-zero arithmetic

## Verification

- `npm run build` ✅ (types + frontend)
- `npm run lint` ✅ (only a pre-existing unrelated warning)
- `npm test` ✅ (25 frontend tests pass; full suite ran via pre-commit hook)

No behavior change to actual scoring — this is display/copy only.

https://claude.ai/code/session_01Qww8e8UzEopj9YaemgEVSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qww8e8UzEopj9YaemgEVSk)_