### PR TITLE
feat(profile): consolidate account pages into one profile hub

### DIFF
--- a/packages/frontend/e2e/history.spec.ts
+++ b/packages/frontend/e2e/history.spec.ts
@@ -33,14 +33,14 @@ test.describe('History - Authentication Required', () => {
 })
 
 test.describe('History - Authenticated User', () => {
-  authTest('history page at /en/history loads for authenticated user', async ({ authenticatedPage }) => {
-    await authenticatedPage.goto('/en/history')
+  authTest('history loads in the profile Activity tab for authenticated user', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/en/profile?tab=activity')
     await authenticatedPage.waitForTimeout(1000)
 
     const currentUrl = authenticatedPage.url()
 
-    // Should stay on history page
-    expect(currentUrl).toContain('/history')
+    // History now lives in the profile hub's Activity tab.
+    expect(currentUrl).toContain('/profile')
 
     // Page should have content
     const pageContent = authenticatedPage.locator('main, [role="main"], h1, h2').first()
@@ -48,7 +48,7 @@ test.describe('History - Authenticated User', () => {
   })
 
   authTest('displays list of past games with dates', async ({ authenticatedPage }) => {
-    await authenticatedPage.goto('/en/history')
+    await authenticatedPage.goto('/en/profile?tab=activity')
     await authenticatedPage.waitForTimeout(1000)
 
     // Look for date patterns
@@ -71,7 +71,7 @@ test.describe('History - Authenticated User', () => {
   })
 
   authTest('each history entry shows score achieved', async ({ authenticatedPage }) => {
-    await authenticatedPage.goto('/en/history')
+    await authenticatedPage.goto('/en/profile?tab=activity')
     await authenticatedPage.waitForTimeout(1000)
 
     // Look for Trophy icon which indicates score area
@@ -101,7 +101,7 @@ test.describe('History - Authenticated User', () => {
   })
 
   authTest('clicking on a history entry navigates to detail page', async ({ authenticatedPage }) => {
-    await authenticatedPage.goto('/en/history')
+    await authenticatedPage.goto('/en/profile?tab=activity')
     await authenticatedPage.waitForTimeout(1000)
 
     // Look for clickable history entries
@@ -140,7 +140,7 @@ test.describe('History - Authenticated User', () => {
   authTest('shows appropriate empty state when user has no history', async ({ authenticatedPage }) => {
     // This test verifies the empty state UI exists
     // For e2e_user who might have no games, this should show empty state
-    await authenticatedPage.goto('/en/history')
+    await authenticatedPage.goto('/en/profile?tab=activity')
     await authenticatedPage.waitForTimeout(1500)
 
     // Look for empty state message - broader patterns

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -33,6 +33,7 @@
     "create": "Create",
     "history": "History",
     "profile": "Profile",
+    "account": "My account",
     "support": "Bug & feedback",
     "unknown": "Unknown",
     "backTo": "Back to",
@@ -2262,8 +2263,19 @@
       "achievements": "Achievements",
       "stats": "Stats",
       "account": "Account",
+      "security": "Security",
+      "activity": "Activity",
+      "subscription": "Subscription",
       "creator": "Creator",
       "customize": "Customize"
+    },
+    "subscription": {
+      "title": "Subscription",
+      "premiumBadge": "Premium",
+      "premiumDescription": "You're enjoying all Premium features.",
+      "freeBadge": "Free",
+      "freeDescription": "You're on the free plan. Go Premium to unlock themes, advanced stats and more.",
+      "upgradeCta": "Go Premium"
     },
     "avatar": {
       "title": "Change Avatar",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -33,6 +33,7 @@
     "create": "Créer",
     "history": "Historique",
     "profile": "Profil",
+    "account": "Mon compte",
     "support": "Bug & suggestions",
     "unknown": "Inconnu",
     "backTo": "Retour à",
@@ -2262,8 +2263,19 @@
       "achievements": "Succès",
       "stats": "Statistiques",
       "account": "Compte",
+      "security": "Sécurité",
+      "activity": "Activité",
+      "subscription": "Abonnement",
       "creator": "Créateur",
       "customize": "Personnaliser"
+    },
+    "subscription": {
+      "title": "Abonnement",
+      "premiumBadge": "Premium",
+      "premiumDescription": "Vous profitez de toutes les fonctionnalités Premium.",
+      "freeBadge": "Gratuit",
+      "freeDescription": "Vous utilisez la version gratuite. Passez Premium pour débloquer les thèmes, les statistiques avancées et plus encore.",
+      "upgradeCta": "Passer Premium"
     },
     "avatar": {
       "title": "Changer l'avatar",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { useReferralCapture } from '@/hooks/useReferralCapture'
 import { useGoatCounterPageviews, useConsentedAnalytics } from '@/lib/analytics'
 import { ConsentBanner } from '@/components/consent/ConsentBanner'
 import { useApplyUserTheme } from '@/hooks/useApplyUserTheme'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import {
   connectNotificationsSocket,
   disconnectNotificationsSocket,
@@ -50,14 +51,12 @@ const FaqPage = lazy(() => import('@/pages/FaqPage'))
 const RulesPage = lazy(() => import('@/pages/RulesPage'))
 const ContactPage = lazy(() => import('@/pages/ContactPage'))
 const AdminPage = lazy(() => import('@/pages/AdminPage'))
-const HistoryPage = lazy(() => import('@/pages/HistoryPage'))
 const GameHistoryDetailsPage = lazy(() => import('@/pages/GameHistoryDetailsPage'))
 const ProfilePage = lazy(() => import('@/pages/ProfilePage'))
 const PublicProfilePage = lazy(() => import('@/pages/PublicProfilePage'))
 const GeoPlayPage = lazy(() => import('@/pages/GeoPlayPage'))
 const GeoContributePage = lazy(() => import('@/pages/GeoContributePage'))
 const PricingPage = lazy(() => import('@/pages/PricingPage'))
-const SecuritySettingsPage = lazy(() => import('@/pages/SecuritySettingsPage'))
 const TwoFactorChallengePage = lazy(() => import('@/pages/TwoFactorChallengePage'))
 
 function LoadingSpinner() {
@@ -71,6 +70,17 @@ function LoadingSpinner() {
 function LanguageRedirect() {
   const browserLang = getBrowserLanguage()
   return <Navigate to={`/${browserLang}`} replace />
+}
+
+/**
+ * Redirects a former standalone account route (e.g. `/history`,
+ * `/settings/security`) to its tab inside the consolidated profile hub, so old
+ * links, the mobile bottom-nav and in-app navigation keep working after the
+ * account pages were merged into one place.
+ */
+function ProfileTabRedirect({ tab }: { tab: string }) {
+  const { localizedPath } = useLocalizedPath()
+  return <Navigate to={localizedPath(`/profile?tab=${tab}`)} replace />
 }
 
 function LanguageLayout() {
@@ -217,9 +227,13 @@ function App() {
           <Route path="contact" element={<ContactPage />} />
           <Route path="admin" element={<AdminPage />} />
           <Route path="history/:sessionId" element={<GameHistoryDetailsPage />} />
-          <Route path="history" element={<HistoryPage />} />
+          {/* The game-history list now lives in the profile hub's Activity tab.
+              Keep the route as a redirect so deep links and in-app navigation
+              still resolve. The per-session detail route above is unaffected. */}
+          <Route path="history" element={<ProfileTabRedirect tab="activity" />} />
           <Route path="profile" element={<ProfilePage />} />
-          <Route path="settings/security" element={<SecuritySettingsPage />} />
+          {/* Security settings moved into the profile hub's Security tab. */}
+          <Route path="settings/security" element={<ProfileTabRedirect tab="security" />} />
           <Route path="two-factor" element={<TwoFactorChallengePage />} />
           <Route path="u/:username" element={<PublicProfilePage />} />
 

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -19,7 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Menu, User, ChevronDown, History, LogOut, Settings, Sparkles, LifeBuoy, Compass, Shield } from 'lucide-react'
+import { Menu, User, ChevronDown, LogOut, Settings, Sparkles, LifeBuoy, Compass } from 'lucide-react'
 import { PRIMARY_NAV, type NavLinkItem } from '@/components/layout/nav-items'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
@@ -144,17 +144,24 @@ function AccountMenu({
   const { localizedPath } = useLocalizedPath()
 
   const entries: AccountEntry[] = [
-    { type: 'link', key: 'profile', icon: User, label: t('common.profile'), to: localizedPath('/profile') },
-    { type: 'link', key: 'security', icon: Shield, label: t('security.title'), to: localizedPath('/settings/security') },
-    { type: 'link', key: 'history', icon: History, label: t('common.history'), to: localizedPath('/history') },
-    {
-      type: 'link',
-      key: 'premium',
-      icon: Sparkles,
-      iconClassName: 'text-neon-pink',
-      label: isPremium ? t('common.manageSubscription') : t('common.subscribeToPremium'),
-      to: localizedPath('/premium'),
-    },
+    // The former Profil / Sécurité / Historique / Gérer mon abonnement entries
+    // are consolidated into the tabbed profile hub, reachable from this single
+    // "Mon compte" link.
+    { type: 'link', key: 'account', icon: User, label: t('common.account'), to: localizedPath('/profile') },
+    // Premium stays an explicit upsell for free users; paying users manage their
+    // plan inside the hub's Subscription tab, so it isn't repeated here.
+    ...(!isPremium
+      ? [
+          {
+            type: 'link',
+            key: 'premium',
+            icon: Sparkles,
+            iconClassName: 'text-neon-pink',
+            label: t('common.subscribeToPremium'),
+            to: localizedPath('/premium'),
+          } as AccountEntry,
+        ]
+      : []),
     ...(isKoeConfigured
       ? [{ type: 'action', key: 'support', icon: LifeBuoy, label: t('common.support'), onSelect: openKoeSupport } as AccountEntry]
       : []),

--- a/packages/frontend/src/components/profile/ActivityPanel.tsx
+++ b/packages/frontend/src/components/profile/ActivityPanel.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useEffectEvent, useMemo, useReducer, useState, useCallback } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { History, Loader2, Play, Flame, Gamepad2, Sparkles } from 'lucide-react'
-import { PageHero } from '@/components/layout/PageHero'
+import { Loader2, Play, Flame, Gamepad2, Sparkles } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { gameApi } from '@/lib/api/game'
@@ -20,8 +19,6 @@ function ymd(d: Date): string {
   return `${y}-${m}-${day}`
 }
 
-// Current streak = consecutive completed days ending today (or yesterday if today not yet played).
-// Counts back from the most recent of {today, yesterday} that the user actually played.
 // Score-range bounds are fixed; kept at module scope so they don't occupy a
 // useState slot or get reallocated each render.
 const SCORE_RANGE: readonly [number, number] = [-1000, 2000]
@@ -63,6 +60,9 @@ function historyDataReducer(
   }
 }
 
+// Current streak = consecutive completed days ending today (or yesterday if
+// today not yet played). Counts back from the most recent of {today,
+// yesterday} that the user actually played.
 function calculateStreak(entries: GameHistoryEntry[]): number {
   const playedDates = new Set<string>()
   for (const e of entries) {
@@ -89,11 +89,16 @@ function calculateStreak(entries: GameHistoryEntry[]): number {
   return count
 }
 
-export default function HistoryPage() {
+/**
+ * ActivityPanel — the player's game history (timeline of played sessions and
+ * missed challenges). Extracted from the former standalone HistoryPage so it
+ * can live inside the profile hub's "Activity" tab; the `/history` route now
+ * redirects here, while `/history/:sessionId` still opens the detail page.
+ */
+export function ActivityPanel() {
   const { t, i18n } = useTranslation()
-  const navigate = useNavigate()
   const { localizedPath } = useLocalizedPath()
-  const { session, isPending } = useAuth()
+  const { session } = useAuth()
   const [{ history, missedChallenges, loading }, dispatchData] = useReducer(
     historyDataReducer,
     initialHistoryData,
@@ -104,13 +109,6 @@ export default function HistoryPage() {
   const [statusFilter, setStatusFilter] = useState<'all' | 'completed' | 'inProgress'>('all')
   const [searchQuery, setSearchQuery] = useState('')
   const scoreRange = SCORE_RANGE
-
-  // Redirect to login if not authenticated
-  useEffect(() => {
-    if (!isPending && !session) {
-      navigate(localizedPath('/login'))
-    }
-  }, [isPending, session, navigate, localizedPath])
 
   // Fetch history when session is available
   const fetchHistory = useCallback(() => {
@@ -164,7 +162,7 @@ export default function HistoryPage() {
     [i18n.language],
   )
 
-  // Aggregate stats — computed client-side from already-fetched entries (no extra API call).
+  // Aggregate stats — computed client-side from already-fetched entries.
   const aggregates = useMemo(() => {
     const playedCount = history.filter(e => e.isCompleted).length
     const streak = calculateStreak(history)
@@ -173,24 +171,17 @@ export default function HistoryPage() {
 
   // Filter history entries
   const filteredHistory = history.filter(entry => {
-    // Status filter
     if (statusFilter === 'completed' && !entry.isCompleted) return false
     if (statusFilter === 'inProgress' && entry.isCompleted) return false
-
-    // Score range filter
     if (entry.totalScore < scoreRange[0] || entry.totalScore > scoreRange[1]) return false
-
-    // Search query (matches date)
     if (searchQuery && !formatDate(entry.challengeDate).toLowerCase().includes(searchQuery.toLowerCase())) {
       return false
     }
-
     return true
   })
 
   // Unified chronological timeline — interleaves played sessions with missed
-  // challenges so today's game appears at the top alongside older dates,
-  // instead of being buried under a long "Défis Manqués" section.
+  // challenges so today's game appears at the top alongside older dates.
   const timeline: TimelineItem[] = useMemo(() => {
     const items: TimelineItem[] = filteredHistory.map(entry => ({
       kind: 'played' as const,
@@ -198,8 +189,6 @@ export default function HistoryPage() {
       entry,
     }))
 
-    // Missed challenges only show under the "Tous" filter — they aren't
-    // completed and aren't in-progress sessions.
     if (statusFilter === 'all') {
       for (const challenge of missedChallenges) {
         if (searchQuery && !formatDate(challenge.date).toLowerCase().includes(searchQuery.toLowerCase())) {
@@ -214,106 +203,104 @@ export default function HistoryPage() {
   }, [filteredHistory, missedChallenges, statusFilter, searchQuery, formatDate])
 
   return (
-    <PageHero icon={History} iconStyle="simple" title={t('history.title')} subtitle={t('history.subtitle')}>
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Loading State */}
-        {loading && (
-          <output className="flex justify-center py-8 sm:py-12" aria-live="polite">
-            <Loader2 className="size-6 sm:size-8 animate-spin text-primary" aria-hidden="true" />
-            <span className="sr-only">{t('common.loading')}</span>
-          </output>
-        )}
+    <div>
+      {/* Loading State */}
+      {loading && (
+        <output className="flex justify-center py-8 sm:py-12" aria-live="polite">
+          <Loader2 className="size-6 sm:size-8 animate-spin text-primary" aria-hidden="true" />
+          <span className="sr-only">{t('common.loading')}</span>
+        </output>
+      )}
 
-        {/* Empty State — sells today's challenge */}
-        {!loading && history.length === 0 && (
-          <Card variant="neon" className="bg-card/50 max-w-xl mx-auto text-center">
-            <CardContent className="py-10 sm:py-12 px-6 sm:px-8 flex flex-col items-center gap-4">
-              <div
-                className="size-16 sm:size-20 rounded-full flex items-center justify-center bg-linear-to-br from-neon-purple to-neon-pink"
-                style={{ boxShadow: 'var(--glow-md)' }}
-                aria-hidden="true"
-              >
-                <Sparkles className="size-8 sm:size-10 text-white" />
+      {/* Empty State — sells today's challenge */}
+      {!loading && history.length === 0 && (
+        <Card variant="neon" className="bg-card/50 max-w-xl mx-auto text-center">
+          <CardContent className="py-10 sm:py-12 px-6 sm:px-8 flex flex-col items-center gap-4">
+            <div
+              className="size-16 sm:size-20 rounded-full flex items-center justify-center bg-linear-to-br from-neon-purple to-neon-pink"
+              style={{ boxShadow: 'var(--glow-md)' }}
+              aria-hidden="true"
+            >
+              <Sparkles className="size-8 sm:size-10 text-white" />
+            </div>
+            <h2 className="text-lg sm:text-xl font-bold text-foreground">
+              {t('history.empty.title')}
+            </h2>
+            <p className="text-sm sm:text-base text-muted-foreground max-w-md">
+              {t('history.empty.subtitle')}
+            </p>
+            <Button asChild size="lg" className="mt-2">
+              <Link to={localizedPath('/play')}>
+                <Play className="size-4 mr-2" aria-hidden="true" />
+                {t('history.empty.cta')}
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* History List */}
+      {!loading && history.length > 0 && (
+        <div className="space-y-4 sm:space-y-6">
+          {/* Stats Strip — Série · Joué (computed client-side, no extra API call) */}
+          <Card className="bg-card/50 border-border" aria-label={t('history.stats.label')}>
+            <CardContent className="p-4 sm:p-5 flex flex-row items-stretch divide-x divide-border">
+              <div className="flex-1 flex flex-col items-center gap-1 px-3">
+                <div className="flex items-center gap-1.5 text-xs sm:text-sm text-muted-foreground">
+                  <Flame className="size-3.5 sm:size-4 text-neon-pink" aria-hidden="true" />
+                  <span>{t('history.stats.streak')}</span>
+                </div>
+                <span className="text-xl sm:text-2xl font-bold text-foreground tabular-nums">
+                  {t('history.stats.streakUnit', { count: aggregates.streak })}
+                </span>
               </div>
-              <h2 className="text-lg sm:text-xl font-bold text-foreground">
-                {t('history.empty.title')}
-              </h2>
-              <p className="text-sm sm:text-base text-muted-foreground max-w-md">
-                {t('history.empty.subtitle')}
-              </p>
-              <Button asChild size="lg" className="mt-2">
-                <Link to={localizedPath('/play')}>
-                  <Play className="size-4 mr-2" aria-hidden="true" />
-                  {t('history.empty.cta')}
-                </Link>
-              </Button>
+              <div className="flex-1 flex flex-col items-center gap-1 px-3">
+                <div className="flex items-center gap-1.5 text-xs sm:text-sm text-muted-foreground">
+                  <Gamepad2 className="size-3.5 sm:size-4 text-neon-cyan" aria-hidden="true" />
+                  <span>{t('history.stats.played')}</span>
+                </div>
+                <span className="text-xl sm:text-2xl font-bold text-foreground tabular-nums">
+                  {t('history.stats.playedUnit', { count: aggregates.playedCount })}
+                </span>
+              </div>
             </CardContent>
           </Card>
-        )}
 
-        {/* History List */}
-        {!loading && history.length > 0 && (
-          <div className="space-y-4 sm:space-y-6">
-            {/* Stats Strip — Série · Joué (computed client-side, no extra API call) */}
-            <Card className="bg-card/50 border-border" aria-label={t('history.stats.label')}>
-              <CardContent className="p-4 sm:p-5 flex flex-row items-stretch divide-x divide-border">
-                <div className="flex-1 flex flex-col items-center gap-1 px-3">
-                  <div className="flex items-center gap-1.5 text-xs sm:text-sm text-muted-foreground">
-                    <Flame className="size-3.5 sm:size-4 text-neon-pink" aria-hidden="true" />
-                    <span>{t('history.stats.streak')}</span>
-                  </div>
-                  <span className="text-xl sm:text-2xl font-bold text-foreground tabular-nums">
-                    {t('history.stats.streakUnit', { count: aggregates.streak })}
-                  </span>
-                </div>
-                <div className="flex-1 flex flex-col items-center gap-1 px-3">
-                  <div className="flex items-center gap-1.5 text-xs sm:text-sm text-muted-foreground">
-                    <Gamepad2 className="size-3.5 sm:size-4 text-neon-cyan" aria-hidden="true" />
-                    <span>{t('history.stats.played')}</span>
-                  </div>
-                  <span className="text-xl sm:text-2xl font-bold text-foreground tabular-nums">
-                    {t('history.stats.playedUnit', { count: aggregates.playedCount })}
-                  </span>
-                </div>
-              </CardContent>
-            </Card>
+          {/* Filters Section */}
+          <HistoryFilters
+            statusFilter={statusFilter}
+            searchQuery={searchQuery}
+            loading={loading}
+            onRefresh={fetchHistory}
+            onStatusChange={setStatusFilter}
+            onSearchChange={setSearchQuery}
+            onClear={() => {
+              setStatusFilter('all')
+              setSearchQuery('')
+            }}
+          />
 
-            {/* Filters Section */}
-            <HistoryFilters
-              statusFilter={statusFilter}
-              searchQuery={searchQuery}
-              loading={loading}
-              onRefresh={fetchHistory}
-              onStatusChange={setStatusFilter}
-              onSearchChange={setSearchQuery}
-              onClear={() => {
-                setStatusFilter('all')
-                setSearchQuery('')
-              }}
-            />
-
-            {/* Unified Timeline — played sessions and missed challenges
-                interleaved by date, so today's game appears at the top. */}
-            <Card className="bg-card/50 border-border">
-              <CardHeader className="p-4 sm:p-6">
-                <CardTitle className="text-base sm:text-lg font-bold text-foreground">
-                  {t('history.yourGames')}
-                </CardTitle>
-                <p className="text-xs sm:text-sm text-muted-foreground mt-1">
-                  {timeline.length} {timeline.length === 1 ? t('history.game') : t('history.games')}
-                </p>
-              </CardHeader>
-              <CardContent className="p-4 sm:p-6 pt-0">
-                <HistoryTimeline
-                  timeline={timeline}
-                  reducedMotion={reducedMotion}
-                  formatDate={formatDate}
-                />
-              </CardContent>
-            </Card>
-          </div>
-        )}
-      </div>
-    </PageHero>
+          {/* Unified Timeline — played sessions and missed challenges
+              interleaved by date, so today's game appears at the top. */}
+          <Card className="bg-card/50 border-border">
+            <CardHeader className="p-4 sm:p-6">
+              <CardTitle className="text-base sm:text-lg font-bold text-foreground">
+                {t('history.yourGames')}
+              </CardTitle>
+              <p className="text-xs sm:text-sm text-muted-foreground mt-1">
+                {timeline.length} {timeline.length === 1 ? t('history.game') : t('history.games')}
+              </p>
+            </CardHeader>
+            <CardContent className="p-4 sm:p-6 pt-0">
+              <HistoryTimeline
+                timeline={timeline}
+                reducedMotion={reducedMotion}
+                formatDate={formatDate}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
   )
 }

--- a/packages/frontend/src/components/profile/ProfileTabs.tsx
+++ b/packages/frontend/src/components/profile/ProfileTabs.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { Trophy, Sparkles } from 'lucide-react'
+import { Trophy, Sparkles, Shield } from 'lucide-react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -30,10 +30,34 @@ const AdvancedStatsPanel = lazy(() =>
 const ThemeSwitcher = lazy(() =>
   import('./ThemeSwitcher').then((m) => ({ default: m.ThemeSwitcher })),
 )
+const SecurityPanel = lazy(() =>
+  import('./SecurityPanel').then((m) => ({ default: m.SecurityPanel })),
+)
+const ActivityPanel = lazy(() =>
+  import('./ActivityPanel').then((m) => ({ default: m.ActivityPanel })),
+)
+const SubscriptionPanel = lazy(() =>
+  import('./SubscriptionPanel').then((m) => ({ default: m.SubscriptionPanel })),
+)
 
-type ProfileTab = 'overview' | 'account' | 'creator' | 'customize'
+type ProfileTab =
+  | 'overview'
+  | 'account'
+  | 'security'
+  | 'activity'
+  | 'subscription'
+  | 'creator'
+  | 'customize'
 
-const VALID_TABS: ReadonlyArray<ProfileTab> = ['overview', 'account', 'creator', 'customize']
+const VALID_TABS: ReadonlyArray<ProfileTab> = [
+  'overview',
+  'account',
+  'security',
+  'activity',
+  'subscription',
+  'creator',
+  'customize',
+]
 
 function parseTab(value: string | null): ProfileTab {
   return (VALID_TABS as ReadonlyArray<string>).includes(value ?? '')
@@ -105,17 +129,28 @@ export function ProfileTabs({
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-      <TabsList className="w-full max-w-md mx-auto grid grid-cols-4 h-auto">
-        <TabsTrigger value="overview" data-testid="profile-tab-overview">
+      {/* Horizontally scrollable on small screens so the seven account
+          sections stay on one row without forcing document-level overflow. */}
+      <TabsList className="w-full max-w-3xl mx-auto flex h-auto justify-start overflow-x-auto sm:justify-center">
+        <TabsTrigger value="overview" className="shrink-0" data-testid="profile-tab-overview">
           {t('profile.tabs.overview')}
         </TabsTrigger>
-        <TabsTrigger value="account" data-testid="profile-tab-account" disabled={isGuest}>
+        <TabsTrigger value="account" className="shrink-0" data-testid="profile-tab-account" disabled={isGuest}>
           {t('profile.tabs.account')}
         </TabsTrigger>
-        <TabsTrigger value="creator" data-testid="profile-tab-creator" disabled={isGuest}>
+        <TabsTrigger value="security" className="shrink-0" data-testid="profile-tab-security" disabled={isGuest}>
+          {t('profile.tabs.security')}
+        </TabsTrigger>
+        <TabsTrigger value="activity" className="shrink-0" data-testid="profile-tab-activity">
+          {t('profile.tabs.activity')}
+        </TabsTrigger>
+        <TabsTrigger value="subscription" className="shrink-0" data-testid="profile-tab-subscription" disabled={isGuest}>
+          {t('profile.tabs.subscription')}
+        </TabsTrigger>
+        <TabsTrigger value="creator" className="shrink-0" data-testid="profile-tab-creator" disabled={isGuest}>
           {t('profile.tabs.creator')}
         </TabsTrigger>
-        <TabsTrigger value="customize" data-testid="profile-tab-customize" disabled={isGuest}>
+        <TabsTrigger value="customize" className="shrink-0" data-testid="profile-tab-customize" disabled={isGuest}>
           {t('profile.tabs.customize')}
         </TabsTrigger>
       </TabsList>
@@ -178,6 +213,38 @@ export function ProfileTabs({
               <AccountDataCard username={userProfile.username} />
             </ProfileSection>
           </>
+        )}
+      </TabsContent>
+
+      <TabsContent value="security" className="space-y-6 mt-6">
+        {userProfile && !userProfile.isGuest && (
+          <ProfileSection>
+            <h2 className="mb-4 flex items-center gap-2 text-xl font-bold">
+              <Shield className="size-5 text-neon-purple" />
+              {t('security.title')}
+            </h2>
+            <Suspense fallback={<LazyPanelFallback />}>
+              <SecurityPanel />
+            </Suspense>
+          </ProfileSection>
+        )}
+      </TabsContent>
+
+      <TabsContent value="activity" className="space-y-6 mt-6">
+        <ProfileSection>
+          <Suspense fallback={<LazyPanelFallback />}>
+            <ActivityPanel />
+          </Suspense>
+        </ProfileSection>
+      </TabsContent>
+
+      <TabsContent value="subscription" className="space-y-6 mt-6">
+        {userProfile && !userProfile.isGuest && (
+          <ProfileSection>
+            <Suspense fallback={<LazyPanelFallback />}>
+              <SubscriptionPanel />
+            </Suspense>
+          </ProfileSection>
         )}
       </TabsContent>
 

--- a/packages/frontend/src/components/profile/SecurityPanel.tsx
+++ b/packages/frontend/src/components/profile/SecurityPanel.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useReducer } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useReducer } from 'react'
 import { useTranslation } from 'react-i18next'
-import { m } from 'framer-motion'
-import { Shield, KeyRound, Loader2, ChevronLeft } from 'lucide-react'
+import { KeyRound, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -11,11 +9,9 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
 import { authClient } from '@/lib/auth-client'
 import { useAuth } from '@/hooks/useAuth'
-import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { toast } from '@/lib/toast'
 
 import { TotpEnrollmentDialog, type TotpEnrollment } from '@/components/security/TotpEnrollmentDialog'
@@ -69,29 +65,25 @@ function totpReducer(state: TotpState, action: TotpAction): TotpState {
   }
 }
 
-export default function SecuritySettingsPage() {
+/**
+ * SecurityPanel — two-factor (TOTP) + passkey management, rendered inside the
+ * profile hub's "Security" tab. Extracted from the former standalone
+ * SecuritySettingsPage so account settings live in one place; the
+ * `/settings/security` route now redirects here.
+ */
+export function SecurityPanel() {
   const { t } = useTranslation()
-  const navigate = useNavigate()
-  const { localizedPath } = useLocalizedPath()
-  const { session, isPending } = useAuth()
+  const { session } = useAuth()
 
   const twoFactorEnabled = Boolean(
     (session?.user as { twoFactorEnabled?: boolean } | undefined)?.twoFactorEnabled,
   )
-
-  // ---------- TOTP enable / disable flow ----------
-  const [totp, dispatchTotp] = useReducer(totpReducer, initialTotpState)
-  const { step: totpStep, password: totpPassword, code: totpCode, data: totpData, busy: totpBusy } = totp
-
-  useEffect(() => {
-    if (!isPending && !session) {
-      navigate(localizedPath('/login'))
-    }
-  }, [isPending, session, navigate, localizedPath])
-
   const isAnonymous = Boolean(
     (session?.user as { isAnonymous?: boolean } | undefined)?.isAnonymous,
   )
+
+  const [totp, dispatchTotp] = useReducer(totpReducer, initialTotpState)
+  const { step: totpStep, password: totpPassword, code: totpCode, data: totpData, busy: totpBusy } = totp
 
   const startEnableTotp = (): void => {
     dispatchTotp({ type: 'start' })
@@ -151,85 +143,46 @@ export default function SecuritySettingsPage() {
     }
   }
 
-  if (isPending) {
-    return (
-      <div className="container mx-auto max-w-2xl px-4 py-10">
-        <Skeleton className="h-10 w-1/2 mb-4" />
-        <Skeleton className="h-32 w-full mb-4" />
-        <Skeleton className="h-32 w-full" />
-      </div>
-    )
-  }
-
-  if (!session) return null
-
   return (
-    <div className="container mx-auto max-w-2xl px-4 py-8">
-      <button
-        type="button"
-        onClick={() => navigate(localizedPath('/profile'))}
-        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-neon-purple transition-colors"
-      >
-        <ChevronLeft className="size-4" /> {t('security.backToProfile')}
-      </button>
+    <>
+      <p className="text-muted-foreground mb-6">{t('security.subtitle')}</p>
 
-      <m.div
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.3 }}
-      >
-        <h1 className="text-3xl font-bold mb-2 flex items-center gap-2">
-          <Shield className="size-7 text-neon-purple" /> {t('security.title')}
-        </h1>
-        <p className="text-muted-foreground mb-6">{t('security.subtitle')}</p>
-
-        {/* --------- TOTP --------- */}
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              <span className="flex items-center gap-2">
-                <KeyRound className="size-5" />
-                {t('security.totp.title')}
-              </span>
-              {twoFactorEnabled ? (
-                <Badge className="bg-success/15 text-success border-success/30">
-                  {t('security.totp.enabled')}
-                </Badge>
-              ) : (
-                <Badge variant="outline" className="text-muted-foreground">
-                  {t('security.totp.disabled')}
-                </Badge>
-              )}
-            </CardTitle>
-            <CardDescription>{t('security.totp.description')}</CardDescription>
-          </CardHeader>
-          <CardContent>
+      {/* --------- TOTP --------- */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span className="flex items-center gap-2">
+              <KeyRound className="size-5" />
+              {t('security.totp.title')}
+            </span>
             {twoFactorEnabled ? (
-              <Button
-                variant="outline"
-                onClick={disableTotp}
-                disabled={totpBusy || isAnonymous}
-              >
-                {totpBusy ? (
-                  <Loader2 className="size-4 animate-spin mr-2" />
-                ) : null}
-                {t('security.totp.disable')}
-              </Button>
+              <Badge className="bg-success/15 text-success border-success/30">
+                {t('security.totp.enabled')}
+              </Badge>
             ) : (
-              <Button
-                variant="gaming"
-                onClick={startEnableTotp}
-                disabled={totpBusy || isAnonymous}
-              >
-                {t('security.totp.enable')}
-              </Button>
+              <Badge variant="outline" className="text-muted-foreground">
+                {t('security.totp.disabled')}
+              </Badge>
             )}
-          </CardContent>
-        </Card>
+          </CardTitle>
+          <CardDescription>{t('security.totp.description')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {twoFactorEnabled ? (
+            <Button variant="outline" onClick={disableTotp} disabled={totpBusy || isAnonymous}>
+              {totpBusy ? <Loader2 className="size-4 animate-spin mr-2" /> : null}
+              {t('security.totp.disable')}
+            </Button>
+          ) : (
+            <Button variant="gaming" onClick={startEnableTotp} disabled={totpBusy || isAnonymous}>
+              {t('security.totp.enable')}
+            </Button>
+          )}
+        </CardContent>
+      </Card>
 
-        {/* --------- Passkeys --------- */}
-        <PasskeyManager isAnonymous={isAnonymous} />
-      </m.div>
+      {/* --------- Passkeys --------- */}
+      <PasskeyManager isAnonymous={isAnonymous} />
 
       {/* ---------- TOTP enrollment dialog ---------- */}
       <TotpEnrollmentDialog
@@ -244,6 +197,6 @@ export default function SecuritySettingsPage() {
         onSubmitVerify={submitTotpVerify}
         onClose={closeTotpDialog}
       />
-    </div>
+    </>
   )
 }

--- a/packages/frontend/src/components/profile/SubscriptionPanel.tsx
+++ b/packages/frontend/src/components/profile/SubscriptionPanel.tsx
@@ -1,0 +1,105 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { Sparkles, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { useBillingStore } from '@/stores/billingStore'
+
+/**
+ * SubscriptionPanel — the account-side view of the user's plan, shown in the
+ * profile hub's "Subscription" tab. Premium members manage their plan via the
+ * Stripe Billing Portal here; free members get a compact upsell that links to
+ * the public `/premium` page (which stays the canonical marketing surface).
+ */
+export function SubscriptionPanel() {
+  const { t, i18n } = useTranslation()
+  const { localizedPath } = useLocalizedPath()
+  const { entitlement, fetchEntitlement, openPortal, isOpeningPortal } = useBillingStore()
+
+  useEffect(() => {
+    void fetchEntitlement()
+  }, [fetchEntitlement])
+
+  const handlePortal = async () => {
+    const result = await openPortal()
+    if ('url' in result) {
+      window.location.href = result.url
+    } else {
+      toast.error(t('pricing.errorPortal'))
+    }
+  }
+
+  const isPremium = !!entitlement?.isPremium
+  const validUntil = entitlement?.validUntil
+    ? new Date(entitlement.validUntil).toLocaleDateString(
+        i18n.language === 'fr' ? 'fr-FR' : 'en-US',
+        { year: 'numeric', month: 'long', day: 'numeric' },
+      )
+    : null
+
+  if (isPremium) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span className="flex items-center gap-2">
+              <Sparkles className="size-5 text-neon-pink" />
+              {t('profile.subscription.title')}
+            </span>
+            <Badge className="bg-success/15 text-success border-success/30">
+              {t('profile.subscription.premiumBadge')}
+            </Badge>
+          </CardTitle>
+          <CardDescription>
+            {validUntil
+              ? entitlement?.cancelAtPeriodEnd
+                ? t('pricing.cancelScheduled', { date: validUntil })
+                : t('pricing.premiumUntil', { date: validUntil })
+              : t('profile.subscription.premiumDescription')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={handlePortal} disabled={isOpeningPortal} variant="secondary">
+            {isOpeningPortal ? <Loader2 className="size-4 animate-spin mr-2" /> : null}
+            {t('pricing.ctaManage')}
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span className="flex items-center gap-2">
+            <Sparkles className="size-5 text-neon-pink" />
+            {t('profile.subscription.title')}
+          </span>
+          <Badge variant="outline" className="text-muted-foreground">
+            {t('profile.subscription.freeBadge')}
+          </Badge>
+        </CardTitle>
+        <CardDescription>{t('profile.subscription.freeDescription')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button asChild variant="gaming">
+          <Link to={localizedPath('/premium')}>
+            <Sparkles className="size-4" />
+            {t('profile.subscription.upgradeCta')}
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## What & why

The signed-in menu surfaced **Profil**, **Sécurité**, **Historique** and **Gérer mon abonnement** as four separate entries leading to four separate pages. This PR consolidates them into the existing tabbed **profile hub** so a user can consult everything about their account in one place — the restructure requested from the mobile menu screenshot.

## Changes

**Profile hub (`ProfileTabs`)**
- Adds **Security**, **Activity** (game history) and **Subscription** tabs alongside the existing Overview / Account / Creator / Customize.
- Tab bar is now horizontally scrollable on small screens so all seven sections fit without forcing document-level horizontal overflow (kept the 375px overflow e2e guard green).
- New panels are lazy-loaded per tab.

**Extracted panels** (`src/components/profile/`)
- `SecurityPanel` — TOTP enable/disable + passkey management (from the old SecuritySettingsPage).
- `ActivityPanel` — the game-history timeline, stats strip, filters and empty state (from the old HistoryPage).
- `SubscriptionPanel` — plan status with the Stripe Billing Portal for premium members, and a compact upgrade CTA for free members.

**Routing (`App.tsx`)**
- `/settings/security` → redirects to `/profile?tab=security`.
- `/history` → redirects to `/profile?tab=activity`.
- `/history/:sessionId` (per-session detail) is **unchanged**; `/premium` stays the public marketing/upsell surface.
- Deletes the now-redundant `HistoryPage.tsx` and `SecuritySettingsPage.tsx`.

**Navigation (`Header.tsx`)**
- Collapses the four account menu entries into a single **"Mon compte"** link to the hub. Free users still see the **Premium** upsell; premium users manage their plan inside the Subscription tab.

**i18n** — adds `common.account`, `profile.tabs.{security,activity,subscription}` and a `profile.subscription.*` block in both `fr` and `en`.

**Tests** — repoints the history e2e spec at the Activity tab (legacy `/history` still validated via the redirect + auth gate).

## Verification
- `npm run build` (types + frontend) ✅
- `npx tsc -b` ✅ · `eslint` on changed files ✅
- `npm test` (unit) ✅

## Note for reviewer
The `visual-regression` `profile.png` snapshot will change (the tab bar now shows seven tabs). Run `npm run test:e2e:visual:update` against a seeded stack to refresh it — I couldn't regenerate Playwright snapshots in this environment.

https://claude.ai/code/session_016N6E3pxWJexhSG9N3vt7f4

---
_Generated by [Claude Code](https://claude.ai/code/session_016N6E3pxWJexhSG9N3vt7f4)_