### PR TITLE
fix(daily-login): keep reward modal open after claim

### DIFF
--- a/packages/frontend/src/components/daily-login/DailyRewardModal.tsx
+++ b/packages/frontend/src/components/daily-login/DailyRewardModal.tsx
@@ -60,11 +60,10 @@ export function DailyRewardModal() {
     const handleClaim = async () => {
         setIsAnimating(true)
         await claimReward()
-        // Brief delay to show success feedback, then auto-close
-        setTimeout(() => {
-            setIsAnimating(false)
-            handleClose()
-        }, 800)
+        // Keep the modal open after claiming so the player can read what they
+        // won. The success state renders a "Fermer" button for manual dismissal
+        // instead of auto-closing out from under them.
+        setIsAnimating(false)
     }
 
     // Closing the modal while a reward is still claimable would otherwise


### PR DESCRIPTION
## Problem

When claiming a daily login reward, the modal auto-closed ~800ms after the claim resolved. That's not enough time to read what you actually won (rarity, item, description) before it vanishes.

## Change

Removed the `setTimeout` auto-close in `handleClaim` (`DailyRewardModal.tsx`). After claiming, the modal now stays open in its success state, which already renders a **"Fermer"** button for manual dismissal. The player reads their reward at their own pace and closes when ready.

No behavior change to the claim itself or the close-on-dismiss logic — only the forced auto-close was removed.

## Testing

This is a small UI logic change in a single component. Note: a full `npm run build` could not be verified in this environment because dependencies/type definitions (`@types/node`, `vite/client`) are not installed in the fresh container — those errors are pre-existing and unrelated to this one-function change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNK6nmJCLx7cvpGxkxnhPs)_