### PR TITLE
feat(geogamers): GeoGamers mode — Phases 0–4 (schema, backend, frontend, season, party)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -139,6 +139,10 @@ the-box/
 - **Geo Contribute**: Eligible players place/confirm pins; consensus service resolves ground truth
 - **Ingestion pipeline**: BullMQ workers import maps & screenshots from many sources (RAWG, Steam, Fandom, Fextralife, StrategyWiki, MapGenie/Wand, Wikidata, registry); admin Geo-Fetch panel drives it (`docs/geo-mode.md`)
 
+**GeoGamers Mode** (behind `GEOGAMERS_ENABLED`)
+- **Daily two-phase run**: identify the hidden game (fuzzy match, 3 attempts, 100/66/33/0, hint-free) then pin its location (0–100), 200/day; once-per-season joker; guests play unranked with claim-on-signup (`docs/geogamers.md`)
+- **Monthly season**: separate ranking, season = sum minus 3 worst days (≥10 days played); month-close payout worker grants a season frame
+
 **Account & monetization**
 - **Premium / Lifetime Supporter**: Stripe Checkout + Billing Portal, premium-only features (`docs/billing-stripe.md`)
 - **Referrals**: Invite codes, capture on signup, reward announcements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,10 @@ the-box/
 - **Geo Contribute** – eligible players (min days played) place/confirm pins; consensus service resolves ground truth
 - **Ingestion pipeline** – BullMQ workers import maps & screenshots from many sources (RAWG, Steam, Fandom, Fextralife, StrategyWiki, MapGenie/Wand, Wikidata, registry); admin Geo-Fetch panel drives it. See `docs/geo-mode.md`
 
+**GeoGamers Mode** (behind `GEOGAMERS_ENABLED`)
+- **Daily two-phase run** – identify the hidden game (fuzzy match, 3 attempts, 100/66/33/0, hint-free) then pin its location (0–100), 200/day. Once-per-season joker; guests play unranked with claim-on-signup. See `docs/geogamers.md`
+- **Monthly season** – separate ranking, season score = sum minus 3 worst days (≥10 days played); month-close payout worker grants a season frame
+
 **Account & monetization**
 - **Premium / Lifetime Supporter** – Stripe Checkout + Billing Portal, premium-only features. See `docs/billing-stripe.md`
 - **Referrals** – invite codes, capture on signup, reward announcements
@@ -327,6 +331,7 @@ Detailed docs live in `docs/`:
 - `authentication.md`, `better-auth-setup.md` – Auth flow (incl. 2FA / passkeys)
 - `game-flow.md` – Scoring, tiers, challenge mechanics
 - `geo-mode.md` – Geo mode mechanics + ingestion pipeline
+- `geogamers.md` – GeoGamers mode (guess-the-game + geolocate, season ranking)
 - `billing-stripe.md` – Premium subscription + lifetime supporter
 - `push.md` – Web Push lifecycle (VAPID, fan-out, service worker)
 - `public-api.md` (+ `public-api.openapi.yaml`), `streamer-kit.html` – Public API / streamer kit

--- a/docs/geogamers.md
+++ b/docs/geogamers.md
@@ -1,0 +1,127 @@
+# GeoGamers Mode
+
+"GeoGuessr for video games" — a daily challenge that fuses the two existing
+modes: **identify the game** from a screenshot (classic mode's skill) then
+**pin where it was captured** on that game's map (geo mode's skill). Inspired by
+Red Bull GeoGamers. Tracking issue: #325.
+
+Ships **dark** behind `GEOGAMERS_ENABLED`; the API 404s and the daily scheduler
+doesn't register until it's turned on.
+
+## The daily run
+
+One challenge per UTC day. A run walks two phases then terminates:
+
+1. **identify** — the player names the hidden game (fuzzy-matched, reusing the
+   classic `fuzzy-match.service`). Up to **3 attempts**, scored **100 / 66 / 33
+   / 0** by the attempt that lands. No hints — the ranked run is deliberately
+   hint-free (the game identity *is* the puzzle, so metadata hints would be far
+   too strong). Near-miss proximity feedback on the player's own guess only.
+2. **locate** — the game + its maps are revealed; the player drops a pin.
+   Scored **0–100** by precision, reusing geo mode's exponential-decay curve
+   (`GEO_SCORE_DECAY`) rescaled from 2000 → 100. Wrong-map picks are floored to
+   ~0, same rule as geo mode.
+3. **done** — both phases scored. **Daily max = 200.**
+
+### Joker
+
+A once-per-**season** "swap panorama" re-roll (account only, no premium second
+one). Allowed only in the identify phase before any attempt is spent — it
+replaces the puzzle, it is not a retry. Enforced by the `geogamers_joker`
+composite primary key `(user_id, season_month)`.
+
+### Anonymous play & claim-on-signup
+
+Guests (logged-out / anonymous sessions) play **today's actual run unranked**,
+see their score and a **ghost rank** ("you'd be #N today"). Signing up in the
+same browser session **claims** that one day's score into the season — it does
+NOT grant a fresh attempt (the anonymous run *is* the ranked score), which
+closes the "scout in incognito then replay ranked" hole. A timing-plausibility
+floor (`GEOGAMERS_MIN_RUN_SECONDS`) rejects impossibly fast runs at claim time.
+All season mechanics stay account-only.
+
+### Anti-leak
+
+Game/map identity is never serialized before phase 1 resolves — the run view is
+built from an explicit whitelist, never by spreading the run row. The screenshot
+is served through an **opaque proxy** (`GET /api/geogamers/image/:runToken`) that
+streams the source server-side, so the client never sees an asset path that
+could carry a game slug.
+
+## Season & ranking
+
+Season = **calendar month**. A player's **season score = sum of daily totals
+minus their 3 worst days**, but only once they've played **≥ 10 days**
+(`provisional` until then, raw total stands). Fully **separate** from the
+classic/geo leaderboards — no points cross modes; cross-mode links are
+recognition-only (planned achievements/badges).
+
+The ranking lives in `geogamers-season.repository` (a windowed SQL CTE) behind a
+reusable `SeasonRanking` port, so future modes plug into the same payout loop.
+
+At month close the **payout worker** (`geogamers-season-payout-logic`, 1st @
+00:35 UTC) grants a season-frame cosmetic to eligible **non-provisional** top
+finishers, idempotent via the `reward_grants` unique `(userId, sourceRef =
+geogamers_payout:season:YYYY-MM)`. Full first-attempt-correct anomaly screening
++ admin review is a documented follow-up; the days-played floor is the enforced
+integrity gate today.
+
+## Content pipeline
+
+A challenge needs a geo screenshot with a **consensus/admin canonical pin**, an
+active map, and an active game — and one that has **never** been a GeoGamers
+challenge before. The daily scheduler (`geogamers-challenge-logic`, 00:05 UTC):
+
+- **gates** on `GEOGAMERS_MIN_ELIGIBLE_GAMES` distinct eligible games (a
+  "guess the game" round is meaningless with too small a pool) — skips + warns
+  when starved;
+- applies a per-game **cooldown** (`GEOGAMERS_GAME_COOLDOWN_DAYS`) so the same
+  game isn't reused too soon;
+- is idempotent per date and sets the new challenge current in a transaction
+  (partial-unique `is_current`).
+
+## Schema
+
+| Table | Purpose |
+|---|---|
+| `geogamers_challenge` | one per UTC day; partial-unique `is_current` |
+| `geogamers_run` | one row per user\|guest per challenge. No hint columns. Nullable `user_id` + `run_token` + claim columns; nullable `geo_screenshot_meta_id` overrides the challenge meta on a joker re-roll |
+| `geogamers_joker` | once-per-season ledger (composite PK) |
+| `geogamers_season` | month-close finalization + frozen standings snapshot |
+
+## API (`/api/geogamers`, mounted only when enabled)
+
+| Method & path | Auth | Purpose |
+|---|---|---|
+| `POST /run` | optional | start or resume today's run |
+| `GET /run/:runToken` | optional | fetch a run (reload) |
+| `POST /run/guess-game` | optional | phase 1 attempt |
+| `POST /run/guess-location` | optional | phase 2 pin |
+| `POST /run/joker` | required | re-roll (once/season) |
+| `POST /run/claim` | required | claim a completed guest run into the account |
+| `GET /image/:runToken` | optional | opaque screenshot proxy |
+| `GET /season` | optional | top 100 standings + player count |
+| `GET /season/me` | required | own standing + per-day breakdown |
+
+## Realtime
+
+`geogamers:season:updated` broadcasts finalized/updated top standings on the
+`/geo` namespace (see `docs/realtime.md`).
+
+## Config
+
+| Var | Default | Purpose |
+|---|---|---|
+| `GEOGAMERS_ENABLED` | `false` | mount routes + register the scheduler |
+| `GEOGAMERS_MIN_ELIGIBLE_GAMES` | `10` | content gate for challenge creation |
+| `GEOGAMERS_GAME_COOLDOWN_DAYS` | `14` | per-game reuse cooldown |
+
+## Status
+
+Implemented: Phase 0 (types + schema), Phase 1 (backend core — scoring,
+orchestration, repos, worker, routes), Phase 2 (frontend play flow), Phase 3
+core (season ranking + standings API + payout worker + socket broadcast).
+
+Follow-ups (tracked on #325): GeoGamers achievements, web-push fan-out, public
+API / SSE / webhooks, admin health & anomaly-review panels, leaderboard-page
+season tab, party mode (Phase 4), immersive panoramas (Phase 5).

--- a/docs/geogamers.md
+++ b/docs/geogamers.md
@@ -108,6 +108,20 @@ challenge before. The daily scheduler (`geogamers-challenge-logic`, 00:05 UTC):
 `geogamers:season:updated` broadcasts finalized/updated top standings on the
 `/geo` namespace (see `docs/realtime.md`).
 
+## Public API
+
+`GET /api/public/v1/geogamers/season?limit=N` (key-authenticated, same tree as
+the streamer kit) returns current-month standings for overlays/bots:
+`{ month, standings: [{ rank, slug, displayName, seasonScore, daysPlayed,
+provisional }] }`. Public-safe (no user ids; slug only for opted-in public
+profiles). Returns an empty list when the feature is disabled so integrators
+can poll unconditionally. Documented in `docs/public-api.openapi.yaml`.
+
+## Web push
+
+A "today's panorama is live" notification (`type: geogamers_daily`) fans out to
+active, non-anonymous subscribers on the day's first challenge creation.
+
 ## Config
 
 | Var | Default | Purpose |
@@ -124,6 +138,9 @@ orchestration, repos, worker, routes), Phase 2 (frontend play flow), Phase 3
 leaderboard season tab + recognition-only achievements — `geogamers_first_run`,
 `geogamers_perfect_day`, awarded on ranked completion).
 
-Follow-ups (tracked on #325): web-push fan-out, public API / SSE / webhooks,
-admin health & anomaly-review panels, more cross-mode achievements (season
-top-10, dual-podium), party mode (Phase 4), immersive panoramas (Phase 5).
+Plus: daily web-push fan-out and a read-only public-API season endpoint.
+
+Follow-ups (tracked on #325): public-API SSE / outbound webhooks for GeoGamers
+events, admin health & anomaly-review panels, more cross-mode achievements
+(season top-10, dual-podium), party mode (Phase 4), immersive panoramas
+(Phase 5).

--- a/docs/geogamers.md
+++ b/docs/geogamers.md
@@ -122,6 +122,22 @@ can poll unconditionally. Documented in `docs/public-api.openapi.yaml`.
 A "today's panorama is live" notification (`type: geogamers_daily`) fans out to
 active, non-anonymous subscribers on the day's first challenge creation.
 
+## Party mode (1–4 players)
+
+A casual, **unranked** variant: 1–4 players in a private lobby play the same
+server-seeded round sequence (3/5/10 rounds), each on their own screen, with a
+synchronized reveal between rounds and a live scoreboard. Draws from the same
+eligible pool as the daily (which excludes every screenshot ever used as a
+challenge), so it never touches the season and can't scout the ranked daily.
+Guests may join.
+
+State is ephemeral (Redis, 2h TTL). Play runs over the Socket.io
+`/geogamers-party` namespace; the pure state machine (`geogamers-party.service`)
+is the source of truth and is fully unit-tested. Views are spectator-safe — the
+game identity and canonical pin are withheld until a player resolves phase 1 or
+the round reveals. Screenshots stream through a party image proxy. Frontend:
+`GeoGamersPartyPage` (route `/:lang/geogamers/party`).
+
 ## Config
 
 | Var | Default | Purpose |
@@ -142,7 +158,10 @@ Plus: daily web-push fan-out, a read-only public-API season endpoint, and an
 admin content-health panel (`GET /api/admin/geogamers/health` + a Géo-tab card
 that flags content starvation before a day silently skips).
 
+Plus Phase 4 party mode (1–4 player lobbies).
+
 Follow-ups (tracked on #325): public-API SSE / outbound webhooks for GeoGamers
 events, admin anomaly-review (first-attempt-correct screening at payout), more
-cross-mode achievements (season top-10, dual-podium), party mode (Phase 4),
-immersive panoramas (Phase 5).
+cross-mode achievements (season top-10, dual-podium), immersive panoramas
+(Phase 5). Party mode's live multiplayer path (Redis + Socket.io + multiple
+clients) still needs end-to-end verification in a real environment.

--- a/docs/geogamers.md
+++ b/docs/geogamers.md
@@ -120,8 +120,10 @@ challenge before. The daily scheduler (`geogamers-challenge-logic`, 00:05 UTC):
 
 Implemented: Phase 0 (types + schema), Phase 1 (backend core — scoring,
 orchestration, repos, worker, routes), Phase 2 (frontend play flow), Phase 3
-core (season ranking + standings API + payout worker + socket broadcast).
+(season ranking + standings API + payout worker + socket broadcast +
+leaderboard season tab + recognition-only achievements — `geogamers_first_run`,
+`geogamers_perfect_day`, awarded on ranked completion).
 
-Follow-ups (tracked on #325): GeoGamers achievements, web-push fan-out, public
-API / SSE / webhooks, admin health & anomaly-review panels, leaderboard-page
-season tab, party mode (Phase 4), immersive panoramas (Phase 5).
+Follow-ups (tracked on #325): web-push fan-out, public API / SSE / webhooks,
+admin health & anomaly-review panels, more cross-mode achievements (season
+top-10, dual-podium), party mode (Phase 4), immersive panoramas (Phase 5).

--- a/docs/geogamers.md
+++ b/docs/geogamers.md
@@ -138,9 +138,11 @@ orchestration, repos, worker, routes), Phase 2 (frontend play flow), Phase 3
 leaderboard season tab + recognition-only achievements — `geogamers_first_run`,
 `geogamers_perfect_day`, awarded on ranked completion).
 
-Plus: daily web-push fan-out and a read-only public-API season endpoint.
+Plus: daily web-push fan-out, a read-only public-API season endpoint, and an
+admin content-health panel (`GET /api/admin/geogamers/health` + a Géo-tab card
+that flags content starvation before a day silently skips).
 
 Follow-ups (tracked on #325): public-API SSE / outbound webhooks for GeoGamers
-events, admin health & anomaly-review panels, more cross-mode achievements
-(season top-10, dual-podium), party mode (Phase 4), immersive panoramas
-(Phase 5).
+events, admin anomaly-review (first-attempt-correct screening at payout), more
+cross-mode achievements (season top-10, dual-podium), party mode (Phase 4),
+immersive panoramas (Phase 5).

--- a/docs/public-api.openapi.yaml
+++ b/docs/public-api.openapi.yaml
@@ -170,6 +170,46 @@ paths:
         "429":
           $ref: "#/components/responses/RateLimited"
 
+  /geogamers/season:
+    get:
+      tags: [leaderboard]
+      summary: GeoGamers season standings (current month)
+      description: >
+        Read-only GeoGamers season leaderboard. Returns an empty list when the
+        feature is disabled. Season score drops each player's 3 worst days once
+        they have played at least 10 (provisional until then).
+      operationId: getGeoGamersSeason
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 100, default: 10 }
+      responses:
+        "200":
+          description: Season standings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      month: { type: string, nullable: true }
+                      standings:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            rank: { type: integer }
+                            slug: { type: string, nullable: true }
+                            displayName: { type: string }
+                            seasonScore: { type: integer }
+                            daysPlayed: { type: integer }
+                            provisional: { type: boolean }
+        "429":
+          $ref: "#/components/responses/RateLimited"
+
   /webhooks:
     get:
       tags: [webhooks]

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -113,6 +113,16 @@ socket.on('job_completed', (data) => console.log('OK', data.result))
 socket.on('job_failed', (data) => console.error('KO', data.error))
 ```
 
+## Événements GeoGamers (namespace `/geo`)
+
+| Événement | Description | Charge utile |
+|-----------|-------------|--------------|
+| `geogamers:season:updated` | Diffusion des classements de saison finalisés / mis à jour (top 10) | `{ month: 'YYYY-MM', topN: GeoGamersSeasonStanding[] }` |
+
+Émis par le worker de clôture de saison (`geogamers-season-payout`). Non ciblé
+par utilisateur — tout client sur le namespace `/geo` le reçoit et peut
+rafraîchir un classement ouvert.
+
 ## Gestion des salles
 
 > **Détail technique.** Les joueurs sont placés dans une salle nommée `challenge_<id>`. Les admins dans la salle `admin`.

--- a/packages/backend/migrations/20260710_add_geogamers_mode.ts
+++ b/packages/backend/migrations/20260710_add_geogamers_mode.ts
@@ -1,0 +1,145 @@
+import type { Knex } from 'knex'
+
+// Additive "GeoGamers" mode: a daily run that fuses classic (guess the game
+// from a screenshot) with geo (pin the spot on its map). All tables are
+// prefixed `geogamers_` and reference existing tables (geo_screenshot_meta,
+// user) read-only. No existing schema is modified.
+//
+// Design decisions baked into this schema (see the tracking issue):
+//  - Ranked runs are hint-free -> geogamers_run carries NO hint columns.
+//  - Season ranking is fully separate from the classic/geo leaderboards.
+//  - Guests play unranked; a run can be claimed into an account on signup ->
+//    user_id is nullable, plus anonymous_session_id + claim columns.
+//  - The joker is once per season, no premium second -> geogamers_joker's
+//    (user_id, season_month) primary key enforces it at the DB level.
+
+export async function up(knex: Knex): Promise<void> {
+  // One challenge per UTC day (no tier concept — GeoGamers runs a single
+  // daily). A partial unique index enforces "at most one current" without
+  // NULL-juggling, mirroring geo_challenge's is_current model.
+  await knex.schema.createTable('geogamers_challenge', (table) => {
+    table.increments('id').primary()
+    table.date('challenge_date').notNullable().unique()
+    table
+      .integer('geo_screenshot_meta_id')
+      .notNullable()
+      .references('id')
+      .inTable('geo_screenshot_meta')
+      .onDelete('RESTRICT')
+    table.boolean('is_current').notNullable().defaultTo(false)
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+
+    table.index('challenge_date')
+  })
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX geogamers_challenge_one_current
+    ON geogamers_challenge (is_current)
+    WHERE is_current = true
+  `)
+
+  // One run per (user | guest) per challenge. NO hint columns by design —
+  // the ranked run is hint-free. Guest rows carry a null user_id and ride the
+  // existing 24h anonymous-session cleanup; the TTL doubles as the claim
+  // window. Coordinates are normalized [0..1], same as geo_guess.
+  await knex.schema.createTable('geogamers_run', (table) => {
+    table.increments('id').primary()
+    table
+      .integer('geogamers_challenge_id')
+      .notNullable()
+      .references('id')
+      .inTable('geogamers_challenge')
+      .onDelete('CASCADE')
+    // Nullable: guests play unranked. Ranked runs set user_id.
+    table.text('user_id').nullable().references('id').inTable('user').onDelete('CASCADE')
+    table.text('anonymous_session_id').nullable().comment('Set for guest runs; null once claimed into an account')
+    table.uuid('run_token').notNullable().unique().comment('Single-use, server-issued; addresses a run without leaking meta id')
+    table.jsonb('game_attempts').notNullable().defaultTo('[]').comment('GeoGamersGameAttempt[]')
+    table.integer('game_points').nullable().comment('100 / 66 / 33 / 0, locked at phase-1 resolve')
+    table.float('guess_x').nullable()
+    table.float('guess_y').nullable()
+    table.float('distance').nullable().comment('Normalized [0..1] distance to canonical')
+    table.integer('location_points').nullable().comment('0..100')
+    table.integer('total_points').nullable().comment('game_points + location_points, 0..200')
+    table.integer('score_version').nullable().comment('Bump on formula retune for fairness')
+    table.integer('time_spent_ms').notNullable().defaultTo(0)
+    table.timestamp('started_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+    table.timestamp('completed_at', { useTz: true }).nullable().comment('Set once both phases scored; used for claim timing-plausibility')
+    table.boolean('joker_used').notNullable().defaultTo(false)
+    table.timestamp('claimed_at', { useTz: true }).nullable()
+    table.text('claimed_by_user_id').nullable().references('id').inTable('user').onDelete('SET NULL')
+
+    table.index('geogamers_challenge_id')
+    table.index('run_token')
+    table.index('anonymous_session_id')
+  })
+
+  // At most one ranked run per user per challenge. Guests (user_id null) are
+  // excluded from the constraint — their one-per-device cap is soft (client
+  // localStorage + run token), per the anonymous-play decision.
+  await knex.raw(`
+    CREATE UNIQUE INDEX geogamers_run_user_challenge
+    ON geogamers_run (user_id, geogamers_challenge_id)
+    WHERE user_id IS NOT NULL
+  `)
+
+  // Drives the season aggregation query (drop-3-worst over the month).
+  await knex.raw(`
+    CREATE INDEX geogamers_run_season
+    ON geogamers_run (user_id, completed_at)
+    WHERE user_id IS NOT NULL AND completed_at IS NOT NULL
+  `)
+
+  // A guest run may be claimed by at most one account, once per challenge.
+  await knex.raw(`
+    CREATE UNIQUE INDEX geogamers_run_claim_once
+    ON geogamers_run (claimed_by_user_id, geogamers_challenge_id)
+    WHERE claimed_by_user_id IS NOT NULL
+  `)
+
+  // The joker: exactly one re-roll per user per season. The composite primary
+  // key is the enforcement — a second INSERT trips a unique violation, which
+  // the service maps to JOKER_ALREADY_USED. No premium second joker.
+  await knex.schema.createTable('geogamers_joker', (table) => {
+    table.text('user_id').notNullable().references('id').inTable('user').onDelete('CASCADE')
+    table.string('season_month', 7).notNullable().comment('YYYY-MM (UTC)')
+    table
+      .integer('geogamers_challenge_id')
+      .notNullable()
+      .references('id')
+      .inTable('geogamers_challenge')
+      .onDelete('CASCADE')
+    table
+      .integer('rerolled_geo_screenshot_meta_id')
+      .notNullable()
+      .references('id')
+      .inTable('geo_screenshot_meta')
+      .onDelete('RESTRICT')
+    table.timestamp('used_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+
+    table.primary(['user_id', 'season_month'])
+  })
+
+  // Finalization record. Written when the payout worker closes a month;
+  // final_standings freezes a snapshot for history / OG pages so it survives
+  // later run mutations.
+  await knex.schema.createTable('geogamers_season', (table) => {
+    table.string('month', 7).primary().comment('YYYY-MM')
+    table.integer('dropped_worst_count').notNullable().defaultTo(3)
+    table.integer('min_days_for_drop').notNullable().defaultTo(10)
+    table.timestamp('finalized_at', { useTz: true }).nullable()
+    table.jsonb('final_standings').nullable().comment('Frozen GeoGamersSeasonStanding[] snapshot')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('geogamers_season')
+  await knex.schema.dropTableIfExists('geogamers_joker')
+  // Raw partial indexes drop with their table, but be explicit for clarity.
+  await knex.raw('DROP INDEX IF EXISTS geogamers_run_claim_once')
+  await knex.raw('DROP INDEX IF EXISTS geogamers_run_season')
+  await knex.raw('DROP INDEX IF EXISTS geogamers_run_user_challenge')
+  await knex.schema.dropTableIfExists('geogamers_run')
+  await knex.raw('DROP INDEX IF EXISTS geogamers_challenge_one_current')
+  await knex.schema.dropTableIfExists('geogamers_challenge')
+}

--- a/packages/backend/migrations/20260710_add_geogamers_mode.ts
+++ b/packages/backend/migrations/20260710_add_geogamers_mode.ts
@@ -53,6 +53,15 @@ export async function up(knex: Knex): Promise<void> {
     // Nullable: guests play unranked. Ranked runs set user_id.
     table.text('user_id').nullable().references('id').inTable('user').onDelete('CASCADE')
     table.text('anonymous_session_id').nullable().comment('Set for guest runs; null once claimed into an account')
+    // Overrides the challenge's screenshot when the joker re-rolled THIS run.
+    // Null = play the shared daily meta; set = this player's re-rolled meta.
+    // The joker is per-player, so it cannot live on the shared challenge row.
+    table
+      .integer('geo_screenshot_meta_id')
+      .nullable()
+      .references('id')
+      .inTable('geo_screenshot_meta')
+      .onDelete('RESTRICT')
     table.uuid('run_token').notNullable().unique().comment('Single-use, server-issued; addresses a run without leaking meta id')
     table.jsonb('game_attempts').notNullable().defaultTo('[]').comment('GeoGamersGameAttempt[]')
     table.integer('game_points').nullable().comment('100 / 66 / 33 / 0, locked at phase-1 resolve')

--- a/packages/backend/migrations/20260710_geogamers_achievements.ts
+++ b/packages/backend/migrations/20260710_geogamers_achievements.ts
@@ -1,0 +1,51 @@
+import type { Knex } from 'knex'
+
+// Recognition-only GeoGamers achievements. Points feed the existing
+// achievement-points leaderboard (that's a recognition tier, not GeoGamers
+// season score — no points cross into the season ranking). Awarded on a
+// completed RANKED run; see geogamers.routes.
+//
+// French copy to match the app's default locale (like the other achievement
+// seed migrations).
+
+const ACHIEVEMENTS = [
+  {
+    key: 'geogamers_first_run',
+    name: 'GeoGamers : première partie',
+    description: 'Terminez votre première partie de GeoGamers',
+    category: 'geogamers',
+    icon_url: 'crosshair',
+    points: 10,
+    criteria: JSON.stringify({ type: 'geogamers_runs_completed', count: 1 }),
+    tier: 1,
+    is_hidden: false,
+  },
+  {
+    key: 'geogamers_perfect_day',
+    name: 'GeoGamers : sans-faute',
+    description: 'Marquez 200 points sur une partie de GeoGamers',
+    category: 'geogamers',
+    icon_url: 'target',
+    points: 30,
+    criteria: JSON.stringify({ type: 'geogamers_perfect_run', score: 200 }),
+    tier: 3,
+    is_hidden: false,
+  },
+]
+
+export async function up(knex: Knex): Promise<void> {
+  for (const a of ACHIEVEMENTS) {
+    // Idempotent: skip if the key already exists (re-run / partial apply safe).
+    const exists = await knex('achievements').where({ key: a.key }).first()
+    if (!exists) await knex('achievements').insert(a)
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex('achievements')
+    .whereIn(
+      'key',
+      ACHIEVEMENTS.map((a) => a.key),
+    )
+    .del()
+}

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -40,6 +40,16 @@ export const env = {
   // Public-facing frontend URL (used in marketing email CTAs)
   FRONTEND_URL: process.env['FRONTEND_URL'] || 'https://the-box.battistella.ovh',
 
+  // GeoGamers mode (guess-the-game + geolocate). Off by default: the routes
+  // 404 and the daily-challenge scheduler doesn't register until enabled, so
+  // the feature can ship dark and be turned on once enough consensus-confirmed
+  // content exists. MIN_ELIGIBLE_GAMES gates challenge creation (the "guess
+  // the game" step is meaningless with too few distinct games); a featured
+  // game is then on cooldown for COOLDOWN_DAYS before it can be reused.
+  GEOGAMERS_ENABLED: process.env['GEOGAMERS_ENABLED'] || 'false',
+  GEOGAMERS_MIN_ELIGIBLE_GAMES: process.env['GEOGAMERS_MIN_ELIGIBLE_GAMES'] || '10',
+  GEOGAMERS_GAME_COOLDOWN_DAYS: process.env['GEOGAMERS_GAME_COOLDOWN_DAYS'] || '14',
+
   // RAWG API (for fetching game screenshots)
   RAWG_API_KEY: process.env['RAWG_API_KEY'] || '',
 

--- a/packages/backend/src/domain/services/geogamers-daily-push-copy.test.ts
+++ b/packages/backend/src/domain/services/geogamers-daily-push-copy.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildGeoGamersDailyCopy } from './geogamers-daily-push-copy.js'
+
+describe('buildGeoGamersDailyCopy', () => {
+  it('returns French copy by default', () => {
+    const { title, body } = buildGeoGamersDailyCopy('fr')
+    assert.match(title, /GeoGamers/)
+    assert.match(title, /panorama/i)
+    assert.ok(body.includes('200'))
+  })
+
+  it('returns English copy for en', () => {
+    const { title, body } = buildGeoGamersDailyCopy('en')
+    assert.match(title, /GeoGamers/)
+    assert.match(body, /200 points/)
+  })
+})

--- a/packages/backend/src/domain/services/geogamers-daily-push-copy.ts
+++ b/packages/backend/src/domain/services/geogamers-daily-push-copy.ts
@@ -1,0 +1,16 @@
+// Pure copy builder for the GeoGamers daily push. Kept infra-free (like
+// evening-nudge-copy) so it's unit-testable without pulling in the Redis-backed
+// services barrel.
+
+export function buildGeoGamersDailyCopy(locale: 'fr' | 'en'): { title: string; body: string } {
+  if (locale === 'en') {
+    return {
+      title: 'GeoGamers — new panorama!',
+      body: "Today's game is live. Guess it and pin the spot — 200 points up for grabs.",
+    }
+  }
+  return {
+    title: 'GeoGamers — nouveau panorama !',
+    body: 'Le jeu du jour est en ligne. Devine-le et place le marqueur — 200 points à prendre.',
+  }
+}

--- a/packages/backend/src/domain/services/geogamers-party.service.test.ts
+++ b/packages/backend/src/domain/services/geogamers-party.service.test.ts
@@ -1,0 +1,216 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createParty,
+  joinParty,
+  leaveParty,
+  startParty,
+  submitGameGuess,
+  submitLocation,
+  allConnectedDone,
+  revealRound,
+  advanceRound,
+  scoreboard,
+  PartyError,
+  PARTY_MAX_PLAYERS,
+  type PartyRoundContent,
+} from './geogamers-party.service.js'
+import type { GeoGamersPartyConfig } from '@the-box/types'
+
+const CONFIG: GeoGamersPartyConfig = { rounds: 3, timerSeconds: 45 }
+
+function content(i: number): PartyRoundContent {
+  return {
+    geoScreenshotMetaId: 100 + i,
+    gameId: 10 + i,
+    gameName: `Game ${i}`,
+    geoMapId: 900 + i,
+    canonical: { x: 0.5, y: 0.5 },
+  }
+}
+const CONTENTS = [content(0), content(1), content(2)]
+
+function lobbyOf2() {
+  let p = createParty({ code: 'ABCDEF', host: { id: 'h', name: 'Host' }, config: CONFIG, nowMs: 0 })
+  p = joinParty(p, { id: 'p2', name: 'Bob' })
+  return p
+}
+
+describe('party lobby', () => {
+  it('creates a lobby with the host', () => {
+    const p = createParty({ code: 'ABCDEF', host: { id: 'h', name: 'Host' }, config: CONFIG, nowMs: 0 })
+    assert.equal(p.status, 'lobby')
+    assert.equal(p.players.length, 1)
+    assert.equal(p.players[0]!.isHost, true)
+    assert.equal(p.currentRound, -1)
+  })
+
+  it('normalizes an invalid config', () => {
+    const p = createParty({ code: 'X', host: { id: 'h', name: 'H' }, config: { rounds: 7, timerSeconds: 99 }, nowMs: 0 })
+    assert.equal(p.config.rounds, 5)
+    assert.equal(p.config.timerSeconds, 45)
+  })
+
+  it('caps the lobby at 4 players', () => {
+    let p = createParty({ code: 'X', host: { id: 'h', name: 'H' }, config: CONFIG, nowMs: 0 })
+    p = joinParty(p, { id: 'a', name: 'A' })
+    p = joinParty(p, { id: 'b', name: 'B' })
+    p = joinParty(p, { id: 'c', name: 'C' })
+    assert.equal(p.players.length, PARTY_MAX_PLAYERS)
+    assert.throws(() => joinParty(p, { id: 'd', name: 'D' }), (e) => e instanceof PartyError && e.code === 'LOBBY_FULL')
+  })
+
+  it('treats a re-join by same id as reconnect (no duplicate)', () => {
+    let p = lobbyOf2()
+    p = joinParty(p, { id: 'p2', name: 'Bob2' })
+    assert.equal(p.players.length, 2)
+    assert.equal(p.players.find((x) => x.id === 'p2')!.name, 'Bob2')
+  })
+
+  it('removes a leaver in the lobby and migrates host', () => {
+    let p = lobbyOf2()
+    p = leaveParty(p, 'h')
+    assert.equal(p.players.length, 1)
+    assert.equal(p.hostId, 'p2')
+    assert.equal(p.players[0]!.isHost, true)
+  })
+})
+
+describe('party start', () => {
+  it('requires content count to equal configured rounds', () => {
+    const p = lobbyOf2()
+    assert.throws(() => startParty(p, [content(0)]), (e) => e instanceof PartyError && e.code === 'ROUND_COUNT_MISMATCH')
+  })
+
+  it('loads round 0 and seeds results for all players', () => {
+    const p = startParty(lobbyOf2(), CONTENTS)
+    assert.equal(p.status, 'in_round')
+    assert.equal(p.currentRound, 0)
+    assert.equal(p.rounds.length, 3)
+    assert.ok(p.rounds[0]!.results['h'])
+    assert.ok(p.rounds[0]!.results['p2'])
+    assert.equal(p.rounds[0]!.results['h']!.done, false)
+  })
+})
+
+describe('party round play', () => {
+  it('correct first guess locks 100 game points then a perfect pin → 200', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    p = submitGameGuess(p, 'h', true)
+    assert.equal(p.rounds[0]!.results['h']!.gamePoints, 100)
+    assert.equal(p.rounds[0]!.results['h']!.solvedGame, true)
+    p = submitLocation(p, 'h', 0, false)
+    const r = p.rounds[0]!.results['h']!
+    assert.equal(r.locationPoints, 100)
+    assert.equal(r.totalPoints, 200)
+    assert.equal(r.done, true)
+  })
+
+  it('rejects a location before phase 1 resolves', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    assert.throws(() => submitLocation(p, 'h', 0, false), (e) => e instanceof PartyError && e.code === 'WRONG_PHASE')
+  })
+
+  it('three wrong guesses exhaust phase 1 to 0 but still allow a pin', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    p = submitGameGuess(p, 'h', false)
+    p = submitGameGuess(p, 'h', false)
+    p = submitGameGuess(p, 'h', false)
+    assert.equal(p.rounds[0]!.results['h']!.gamePoints, 0)
+    p = submitLocation(p, 'h', 0, false)
+    assert.equal(p.rounds[0]!.results['h']!.totalPoints, 100)
+  })
+
+  it('rejects a second phase-1 guess after solving', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    p = submitGameGuess(p, 'h', true)
+    assert.throws(() => submitGameGuess(p, 'h', false), (e) => e instanceof PartyError && e.code === 'WRONG_PHASE')
+  })
+
+  it('wrong map floors location to ~0', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    p = submitGameGuess(p, 'h', true)
+    p = submitLocation(p, 'h', 0, true)
+    assert.ok(p.rounds[0]!.results['h']!.locationPoints! <= 1)
+  })
+})
+
+describe('party round transitions', () => {
+  it('allConnectedDone flips only when every connected player is done', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    p = submitGameGuess(p, 'h', true)
+    p = submitLocation(p, 'h', 0, false)
+    assert.equal(allConnectedDone(p), false)
+    p = submitGameGuess(p, 'p2', true)
+    p = submitLocation(p, 'p2', 0.1, false)
+    assert.equal(allConnectedDone(p), true)
+  })
+
+  it('reveal force-times-out stragglers and marks the round revealed', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    p = submitGameGuess(p, 'h', true)
+    p = submitLocation(p, 'h', 0, false)
+    // p2 never played
+    p = revealRound(p)
+    assert.equal(p.status, 'reveal')
+    assert.equal(p.rounds[0]!.revealed, true)
+    assert.equal(p.rounds[0]!.results['p2']!.done, true)
+    assert.equal(p.rounds[0]!.results['p2']!.totalPoints, 0)
+  })
+
+  it('advances through all rounds then finishes', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    for (let i = 0; i < 3; i++) {
+      p = submitGameGuess(p, 'h', true)
+      p = submitLocation(p, 'h', 0, false)
+      p = submitGameGuess(p, 'p2', true)
+      p = submitLocation(p, 'p2', 0.5, false)
+      p = revealRound(p)
+      p = advanceRound(p)
+    }
+    assert.equal(p.status, 'finished')
+  })
+
+  it('advanceRound is rejected outside the reveal screen', () => {
+    const p = startParty(lobbyOf2(), CONTENTS)
+    assert.throws(() => advanceRound(p), (e) => e instanceof PartyError && e.code === 'NOT_REVEAL')
+  })
+})
+
+describe('party scoreboard', () => {
+  it('accumulates revealed-round totals and ranks players', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    // Round 0: host 200, p2 100
+    p = submitGameGuess(p, 'h', true)
+    p = submitLocation(p, 'h', 0, false)
+    p = submitGameGuess(p, 'p2', true)
+    p = submitLocation(p, 'p2', 1, false) // ~0 location → 100 total
+    p = revealRound(p)
+    const board = scoreboard(p)
+    assert.equal(board[0]!.playerId, 'h')
+    assert.equal(board[0]!.total, 200)
+    assert.equal(board[1]!.playerId, 'p2')
+    assert.equal(board[1]!.total, 100)
+  })
+
+  it('excludes an unrevealed in-progress round from the scoreboard', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    p = submitGameGuess(p, 'h', true)
+    p = submitLocation(p, 'h', 0, false)
+    // not revealed yet
+    assert.equal(scoreboard(p).find((s) => s.playerId === 'h')!.total, 0)
+  })
+})
+
+describe('party disconnect mid-game', () => {
+  it('keeps a disconnected player (scores persist) and lets the round close', () => {
+    let p = startParty(lobbyOf2(), CONTENTS)
+    p = submitGameGuess(p, 'h', true)
+    p = submitLocation(p, 'h', 0, false)
+    p = leaveParty(p, 'p2') // disconnect mid-round
+    assert.equal(p.players.length, 2)
+    assert.equal(p.players.find((x) => x.id === 'p2')!.connected, false)
+    // now all CONNECTED players (just host) are done
+    assert.equal(allConnectedDone(p), true)
+  })
+})

--- a/packages/backend/src/domain/services/geogamers-party.service.test.ts
+++ b/packages/backend/src/domain/services/geogamers-party.service.test.ts
@@ -99,7 +99,7 @@ describe('party round play', () => {
     p = submitGameGuess(p, 'h', true)
     assert.equal(p.rounds[0]!.results['h']!.gamePoints, 100)
     assert.equal(p.rounds[0]!.results['h']!.solvedGame, true)
-    p = submitLocation(p, 'h', 0, false)
+    p = submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, false)
     const r = p.rounds[0]!.results['h']!
     assert.equal(r.locationPoints, 100)
     assert.equal(r.totalPoints, 200)
@@ -108,7 +108,7 @@ describe('party round play', () => {
 
   it('rejects a location before phase 1 resolves', () => {
     let p = startParty(lobbyOf2(), CONTENTS)
-    assert.throws(() => submitLocation(p, 'h', 0, false), (e) => e instanceof PartyError && e.code === 'WRONG_PHASE')
+    assert.throws(() => submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, false), (e) => e instanceof PartyError && e.code === 'WRONG_PHASE')
   })
 
   it('three wrong guesses exhaust phase 1 to 0 but still allow a pin', () => {
@@ -117,7 +117,7 @@ describe('party round play', () => {
     p = submitGameGuess(p, 'h', false)
     p = submitGameGuess(p, 'h', false)
     assert.equal(p.rounds[0]!.results['h']!.gamePoints, 0)
-    p = submitLocation(p, 'h', 0, false)
+    p = submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, false)
     assert.equal(p.rounds[0]!.results['h']!.totalPoints, 100)
   })
 
@@ -130,7 +130,7 @@ describe('party round play', () => {
   it('wrong map floors location to ~0', () => {
     let p = startParty(lobbyOf2(), CONTENTS)
     p = submitGameGuess(p, 'h', true)
-    p = submitLocation(p, 'h', 0, true)
+    p = submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, true)
     assert.ok(p.rounds[0]!.results['h']!.locationPoints! <= 1)
   })
 })
@@ -139,17 +139,17 @@ describe('party round transitions', () => {
   it('allConnectedDone flips only when every connected player is done', () => {
     let p = startParty(lobbyOf2(), CONTENTS)
     p = submitGameGuess(p, 'h', true)
-    p = submitLocation(p, 'h', 0, false)
+    p = submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, false)
     assert.equal(allConnectedDone(p), false)
     p = submitGameGuess(p, 'p2', true)
-    p = submitLocation(p, 'p2', 0.1, false)
+    p = submitLocation(p, 'p2', { x: 0.5, y: 0.5 }, 0.1, false)
     assert.equal(allConnectedDone(p), true)
   })
 
   it('reveal force-times-out stragglers and marks the round revealed', () => {
     let p = startParty(lobbyOf2(), CONTENTS)
     p = submitGameGuess(p, 'h', true)
-    p = submitLocation(p, 'h', 0, false)
+    p = submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, false)
     // p2 never played
     p = revealRound(p)
     assert.equal(p.status, 'reveal')
@@ -162,9 +162,9 @@ describe('party round transitions', () => {
     let p = startParty(lobbyOf2(), CONTENTS)
     for (let i = 0; i < 3; i++) {
       p = submitGameGuess(p, 'h', true)
-      p = submitLocation(p, 'h', 0, false)
+      p = submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, false)
       p = submitGameGuess(p, 'p2', true)
-      p = submitLocation(p, 'p2', 0.5, false)
+      p = submitLocation(p, 'p2', { x: 0.5, y: 0.5 }, 0.5, false)
       p = revealRound(p)
       p = advanceRound(p)
     }
@@ -182,9 +182,9 @@ describe('party scoreboard', () => {
     let p = startParty(lobbyOf2(), CONTENTS)
     // Round 0: host 200, p2 100
     p = submitGameGuess(p, 'h', true)
-    p = submitLocation(p, 'h', 0, false)
+    p = submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, false)
     p = submitGameGuess(p, 'p2', true)
-    p = submitLocation(p, 'p2', 1, false) // ~0 location → 100 total
+    p = submitLocation(p, 'p2', { x: 0.5, y: 0.5 }, 1, false) // ~0 location → 100 total
     p = revealRound(p)
     const board = scoreboard(p)
     assert.equal(board[0]!.playerId, 'h')
@@ -196,7 +196,7 @@ describe('party scoreboard', () => {
   it('excludes an unrevealed in-progress round from the scoreboard', () => {
     let p = startParty(lobbyOf2(), CONTENTS)
     p = submitGameGuess(p, 'h', true)
-    p = submitLocation(p, 'h', 0, false)
+    p = submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, false)
     // not revealed yet
     assert.equal(scoreboard(p).find((s) => s.playerId === 'h')!.total, 0)
   })
@@ -206,7 +206,7 @@ describe('party disconnect mid-game', () => {
   it('keeps a disconnected player (scores persist) and lets the round close', () => {
     let p = startParty(lobbyOf2(), CONTENTS)
     p = submitGameGuess(p, 'h', true)
-    p = submitLocation(p, 'h', 0, false)
+    p = submitLocation(p, 'h', { x: 0.5, y: 0.5 }, 0, false)
     p = leaveParty(p, 'p2') // disconnect mid-round
     assert.equal(p.players.length, 2)
     assert.equal(p.players.find((x) => x.id === 'p2')!.connected, false)

--- a/packages/backend/src/domain/services/geogamers-party.service.ts
+++ b/packages/backend/src/domain/services/geogamers-party.service.ts
@@ -59,6 +59,7 @@ function emptyResult(playerId: string): GeoGamersPartyRoundResult {
     attemptsUsed: 0,
     gamePoints: null,
     solvedGame: false,
+    guess: null,
     locationPoints: null,
     totalPoints: null,
     done: false,
@@ -228,6 +229,7 @@ export function submitGameGuess(
 export function submitLocation(
   party: GeoGamersParty,
   playerId: string,
+  guess: GeoPoint,
   distance: number,
   wrongMap: boolean,
 ): GeoGamersParty {
@@ -242,6 +244,7 @@ export function submitLocation(
   const gamePoints = result.gamePoints ?? 0
   const updated: GeoGamersPartyRoundResult = {
     ...result,
+    guess,
     locationPoints,
     gamePoints,
     totalPoints: gamePoints + locationPoints,

--- a/packages/backend/src/domain/services/geogamers-party.service.ts
+++ b/packages/backend/src/domain/services/geogamers-party.service.ts
@@ -1,0 +1,322 @@
+import type {
+  GeoGamersParty,
+  GeoGamersPartyConfig,
+  GeoGamersPartyPlayer,
+  GeoGamersPartyRound,
+  GeoGamersPartyRoundResult,
+  GeoPoint,
+} from '@the-box/types'
+import {
+  gamePointsForAttempt,
+  locationPointsFromDistance,
+  GEOGAMERS_ATTEMPTS_MAX,
+} from './geogamers-scoring.service.js'
+
+// Pure state machine for GeoGamers party mode. All functions take a Party
+// snapshot and return a NEW snapshot (never mutate) so the Redis-backed store
+// can persist deterministically and the whole thing is unit-testable without
+// Redis or sockets. Content (which screenshot/game/canonical each round uses)
+// is injected by the caller — the domain stays infra-free.
+
+export const PARTY_MAX_PLAYERS = 4
+export const PARTY_MIN_PLAYERS = 1
+export const PARTY_ALLOWED_ROUNDS = [3, 5, 10] as const
+export const PARTY_ALLOWED_TIMERS = [30, 45, 60] as const
+
+export class PartyError extends Error {
+  constructor(
+    message: string,
+    public code:
+      | 'LOBBY_FULL'
+      | 'NOT_LOBBY'
+      | 'NOT_IN_ROUND'
+      | 'NOT_REVEAL'
+      | 'PLAYER_NOT_FOUND'
+      | 'ALREADY_DONE'
+      | 'WRONG_PHASE'
+      | 'NO_PLAYERS'
+      | 'NO_CONTENT'
+      | 'ROUND_COUNT_MISMATCH'
+      | 'INVALID_CONFIG',
+  ) {
+    super(message)
+    this.name = 'PartyError'
+  }
+}
+
+// Content for one round, resolved by the infra layer (retired/free-play pool).
+export interface PartyRoundContent {
+  geoScreenshotMetaId: number
+  gameId: number
+  gameName: string
+  geoMapId: number
+  canonical: GeoPoint
+}
+
+function emptyResult(playerId: string): GeoGamersPartyRoundResult {
+  return {
+    playerId,
+    attemptsUsed: 0,
+    gamePoints: null,
+    solvedGame: false,
+    locationPoints: null,
+    totalPoints: null,
+    done: false,
+  }
+}
+
+function roundFromContent(index: number, content: PartyRoundContent): GeoGamersPartyRound {
+  return {
+    index,
+    geoScreenshotMetaId: content.geoScreenshotMetaId,
+    gameId: content.gameId,
+    gameName: content.gameName,
+    geoMapId: content.geoMapId,
+    canonical: content.canonical,
+    results: {},
+    revealed: false,
+  }
+}
+
+function normalizeConfig(config: GeoGamersPartyConfig): GeoGamersPartyConfig {
+  const rounds = (PARTY_ALLOWED_ROUNDS as readonly number[]).includes(config.rounds)
+    ? config.rounds
+    : 5
+  const timerSeconds = (PARTY_ALLOWED_TIMERS as readonly number[]).includes(config.timerSeconds)
+    ? config.timerSeconds
+    : 45
+  return { rounds, timerSeconds }
+}
+
+export function createParty(input: {
+  code: string
+  host: { id: string; name: string }
+  config: GeoGamersPartyConfig
+  nowMs: number
+}): GeoGamersParty {
+  return {
+    code: input.code,
+    status: 'lobby',
+    config: normalizeConfig(input.config),
+    hostId: input.host.id,
+    players: [{ id: input.host.id, name: input.host.name, isHost: true, connected: true }],
+    currentRound: -1,
+    rounds: [],
+    createdAtMs: input.nowMs,
+  }
+}
+
+export function joinParty(
+  party: GeoGamersParty,
+  player: { id: string; name: string },
+): GeoGamersParty {
+  // Reconnect: an existing player id just flips back to connected (allowed in
+  // any status so a dropped player can rejoin mid-game).
+  const existing = party.players.find((p) => p.id === player.id)
+  if (existing) {
+    return {
+      ...party,
+      players: party.players.map((p) =>
+        p.id === player.id ? { ...p, connected: true, name: player.name } : p,
+      ),
+    }
+  }
+  if (party.status !== 'lobby') throw new PartyError('game already started', 'NOT_LOBBY')
+  if (party.players.length >= PARTY_MAX_PLAYERS) throw new PartyError('lobby full', 'LOBBY_FULL')
+  const newPlayer: GeoGamersPartyPlayer = {
+    id: player.id,
+    name: player.name,
+    isHost: false,
+    connected: true,
+  }
+  return { ...party, players: [...party.players, newPlayer] }
+}
+
+// Mark a player disconnected. In the lobby they're removed outright; mid-game
+// they stay (so their scores persist) but flip to disconnected. Host migrates
+// to the oldest remaining connected player.
+export function leaveParty(party: GeoGamersParty, playerId: string): GeoGamersParty {
+  const leaving = party.players.find((p) => p.id === playerId)
+  if (!leaving) return party
+
+  let players: GeoGamersPartyPlayer[]
+  if (party.status === 'lobby') {
+    players = party.players.filter((p) => p.id !== playerId)
+  } else {
+    players = party.players.map((p) => (p.id === playerId ? { ...p, connected: false } : p))
+  }
+
+  // Host migration.
+  let hostId = party.hostId
+  if (leaving.isHost) {
+    const nextHost = players.find((p) => p.connected) ?? players[0]
+    if (nextHost) {
+      hostId = nextHost.id
+      players = players.map((p) => ({ ...p, isHost: p.id === nextHost.id }))
+    }
+  }
+  return { ...party, players, hostId }
+}
+
+export function startParty(party: GeoGamersParty, contents: PartyRoundContent[]): GeoGamersParty {
+  if (party.status !== 'lobby') throw new PartyError('already started', 'NOT_LOBBY')
+  if (party.players.length < PARTY_MIN_PLAYERS) throw new PartyError('no players', 'NO_PLAYERS')
+  if (contents.length === 0) throw new PartyError('no round content', 'NO_CONTENT')
+  if (contents.length !== party.config.rounds) {
+    throw new PartyError('content count must equal configured rounds', 'ROUND_COUNT_MISMATCH')
+  }
+  const rounds = contents.map((c, i) => {
+    const round = roundFromContent(i, c)
+    // Seed results only for round 0; later rounds seed on advance so late
+    // reconnects still get an entry via ensureResult.
+    return round
+  })
+  const first = seedResults(rounds[0]!, party.players)
+  rounds[0] = first
+  return { ...party, status: 'in_round', currentRound: 0, rounds }
+}
+
+function seedResults(round: GeoGamersPartyRound, players: GeoGamersPartyPlayer[]): GeoGamersPartyRound {
+  const results = { ...round.results }
+  for (const p of players) {
+    if (!results[p.id]) results[p.id] = emptyResult(p.id)
+  }
+  return { ...round, results }
+}
+
+function currentRound(party: GeoGamersParty): GeoGamersPartyRound {
+  if (party.status !== 'in_round') throw new PartyError('not in a round', 'NOT_IN_ROUND')
+  const r = party.rounds[party.currentRound]
+  if (!r) throw new PartyError('not in a round', 'NOT_IN_ROUND')
+  return r
+}
+
+function withRound(party: GeoGamersParty, round: GeoGamersPartyRound): GeoGamersParty {
+  const rounds = party.rounds.map((r) => (r.index === round.index ? round : r))
+  return { ...party, rounds }
+}
+
+// Phase 1: a player names the game. `correct` is decided by the caller (fuzzy
+// match). Returns the updated party.
+export function submitGameGuess(
+  party: GeoGamersParty,
+  playerId: string,
+  correct: boolean,
+): GeoGamersParty {
+  const round = currentRound(party)
+  const result = round.results[playerId]
+  if (!result) throw new PartyError('player not in round', 'PLAYER_NOT_FOUND')
+  if (result.done) throw new PartyError('already done this round', 'ALREADY_DONE')
+  if (result.solvedGame || result.gamePoints !== null) {
+    throw new PartyError('phase 1 already resolved', 'WRONG_PHASE')
+  }
+  const attemptsUsed = result.attemptsUsed + 1
+  let gamePoints: number | null = result.gamePoints
+  let solvedGame = result.solvedGame as boolean
+  if (correct) {
+    solvedGame = true
+    gamePoints = gamePointsForAttempt(attemptsUsed)
+  } else if (attemptsUsed >= GEOGAMERS_ATTEMPTS_MAX) {
+    gamePoints = 0 // exhausted; still must place a pin
+  }
+  const updated: GeoGamersPartyRoundResult = { ...result, attemptsUsed, gamePoints, solvedGame }
+  return withRound(party, { ...round, results: { ...round.results, [playerId]: updated } })
+}
+
+// Phase 2: a player places a pin. Requires phase 1 to have resolved (solved or
+// 3 attempts spent). Completes the player's round.
+export function submitLocation(
+  party: GeoGamersParty,
+  playerId: string,
+  distance: number,
+  wrongMap: boolean,
+): GeoGamersParty {
+  const round = currentRound(party)
+  const result = round.results[playerId]
+  if (!result) throw new PartyError('player not in round', 'PLAYER_NOT_FOUND')
+  if (result.done) throw new PartyError('already done this round', 'ALREADY_DONE')
+  const phase1Resolved = result.solvedGame || result.attemptsUsed >= GEOGAMERS_ATTEMPTS_MAX
+  if (!phase1Resolved) throw new PartyError('identify the game first', 'WRONG_PHASE')
+
+  const locationPoints = locationPointsFromDistance(wrongMap ? 1 : distance)
+  const gamePoints = result.gamePoints ?? 0
+  const updated: GeoGamersPartyRoundResult = {
+    ...result,
+    locationPoints,
+    gamePoints,
+    totalPoints: gamePoints + locationPoints,
+    done: true,
+  }
+  return withRound(party, { ...round, results: { ...round.results, [playerId]: updated } })
+}
+
+// Force-complete a player's round (timer lapse): whatever they have becomes
+// final; unreached phases score 0.
+export function timeoutPlayer(party: GeoGamersParty, playerId: string): GeoGamersParty {
+  const round = currentRound(party)
+  const result = round.results[playerId]
+  if (!result || result.done) return party
+  const gamePoints = result.gamePoints ?? 0
+  const locationPoints = result.locationPoints ?? 0
+  const updated: GeoGamersPartyRoundResult = {
+    ...result,
+    gamePoints,
+    locationPoints,
+    totalPoints: gamePoints + locationPoints,
+    done: true,
+  }
+  return withRound(party, { ...round, results: { ...round.results, [playerId]: updated } })
+}
+
+// True when every CONNECTED player has finished the current round.
+export function allConnectedDone(party: GeoGamersParty): boolean {
+  if (party.status !== 'in_round') return false
+  const round = party.rounds[party.currentRound]
+  if (!round) return false
+  const connected = party.players.filter((p) => p.connected)
+  if (connected.length === 0) return false
+  return connected.every((p) => round.results[p.id]?.done)
+}
+
+// Close the current round: force-timeout any stragglers, mark revealed, move to
+// the reveal screen.
+export function revealRound(party: GeoGamersParty): GeoGamersParty {
+  if (party.status !== 'in_round') throw new PartyError('not in a round', 'NOT_IN_ROUND')
+  let next = party
+  const round = party.rounds[party.currentRound]!
+  for (const p of party.players) {
+    if (!round.results[p.id]?.done) next = timeoutPlayer(next, p.id)
+  }
+  const closed = next.rounds.map((r) =>
+    r.index === party.currentRound ? { ...r, revealed: true } : r,
+  )
+  return { ...next, rounds: closed, status: 'reveal' }
+}
+
+// From the reveal screen, advance: load the next round (in_round) or finish.
+export function advanceRound(party: GeoGamersParty): GeoGamersParty {
+  if (party.status !== 'reveal') throw new PartyError('not on the reveal screen', 'NOT_REVEAL')
+  const nextIndex = party.currentRound + 1
+  if (nextIndex >= party.rounds.length) {
+    return { ...party, status: 'finished' }
+  }
+  const seeded = seedResults(party.rounds[nextIndex]!, party.players)
+  const rounds = party.rounds.map((r) => (r.index === nextIndex ? seeded : r))
+  return { ...party, status: 'in_round', currentRound: nextIndex, rounds }
+}
+
+// Cumulative total per player across all revealed rounds.
+export function scoreboard(
+  party: GeoGamersParty,
+): Array<{ playerId: string; name: string; total: number }> {
+  const totals = new Map<string, number>()
+  for (const round of party.rounds) {
+    if (!round.revealed) continue
+    for (const r of Object.values(round.results)) {
+      totals.set(r.playerId, (totals.get(r.playerId) ?? 0) + (r.totalPoints ?? 0))
+    }
+  }
+  return party.players
+    .map((p) => ({ playerId: p.id, name: p.name, total: totals.get(p.id) ?? 0 }))
+    .sort((a, b) => b.total - a.total)
+}

--- a/packages/backend/src/domain/services/geogamers-scoring.service.test.ts
+++ b/packages/backend/src/domain/services/geogamers-scoring.service.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { DomainLogger } from '../ports/logger.js'
+import {
+  createGeoGamersScoringService,
+  gamePointsForAttempt,
+  locationPointsFromDistance,
+  GEOGAMERS_GAME_POINTS,
+  GEOGAMERS_LOCATION_MAX,
+  GEOGAMERS_SCORE_VERSION,
+} from './geogamers-scoring.service.js'
+
+// Minimal no-op logger satisfying the DomainLogger port.
+const noopLogger: DomainLogger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+  fatal() {},
+  trace() {},
+  child() {
+    return noopLogger
+  },
+}
+
+describe('gamePointsForAttempt', () => {
+  it('awards 100 / 66 / 33 on attempts 1..3', () => {
+    assert.equal(gamePointsForAttempt(1), 100)
+    assert.equal(gamePointsForAttempt(2), 66)
+    assert.equal(gamePointsForAttempt(3), 33)
+  })
+
+  it('awards 0 once attempts are exhausted or invalid', () => {
+    assert.equal(gamePointsForAttempt(4), 0)
+    assert.equal(gamePointsForAttempt(0), 0)
+    assert.equal(gamePointsForAttempt(-1), 0)
+    assert.equal(gamePointsForAttempt(1.5), 0)
+  })
+
+  it('matches the exported band table', () => {
+    assert.deepEqual([...GEOGAMERS_GAME_POINTS], [100, 66, 33])
+  })
+})
+
+describe('locationPointsFromDistance', () => {
+  it('awards the full ceiling for a perfect pin', () => {
+    assert.equal(locationPointsFromDistance(0), GEOGAMERS_LOCATION_MAX)
+    assert.equal(locationPointsFromDistance(0), 100)
+  })
+
+  it('decays toward zero as distance grows', () => {
+    const near = locationPointsFromDistance(0.1)
+    const mid = locationPointsFromDistance(0.5)
+    const far = locationPointsFromDistance(1)
+    assert.ok(near > mid, `near (${near}) should beat mid (${mid})`)
+    assert.ok(mid > far, `mid (${mid}) should beat far (${far})`)
+    assert.ok(far <= 1, `far (${far}) should be ~0`)
+  })
+
+  it('clamps out-of-range distances', () => {
+    assert.equal(locationPointsFromDistance(-5), 100)
+    assert.equal(locationPointsFromDistance(5), locationPointsFromDistance(1))
+  })
+
+  it('never exceeds the ceiling', () => {
+    for (const d of [0, 0.01, 0.2, 0.7, 1]) {
+      const p = locationPointsFromDistance(d)
+      assert.ok(p >= 0 && p <= GEOGAMERS_LOCATION_MAX, `d=${d} -> ${p} out of range`)
+    }
+  })
+})
+
+describe('createGeoGamersScoringService', () => {
+  const svc = createGeoGamersScoringService({ logger: noopLogger })
+
+  it('scoreLocation gives full points for an exact pin', () => {
+    const r = svc.scoreLocation({ x: 0.5, y: 0.5 }, { x: 0.5, y: 0.5 })
+    assert.equal(r.distance, 0)
+    assert.equal(r.locationPoints, 100)
+    assert.equal(r.wrongMap, false)
+    assert.equal(r.scoreVersion, GEOGAMERS_SCORE_VERSION)
+  })
+
+  it('scoreLocation floors distance to 1.0 on wrong map (≈0 points)', () => {
+    const r = svc.scoreLocation({ x: 0.5, y: 0.5 }, { x: 0.5, y: 0.5 }, { wrongMap: true })
+    // Same pin, but wrongMap overrides distance to the maximum.
+    assert.equal(r.distance, 1)
+    assert.equal(r.wrongMap, true)
+    assert.equal(r.locationPoints, locationPointsFromDistance(1))
+    assert.ok(r.locationPoints <= 1)
+  })
+
+  it('gamePoints delegates to the band table', () => {
+    assert.equal(svc.gamePoints(1), 100)
+    assert.equal(svc.gamePoints(3), 33)
+    assert.equal(svc.gamePoints(4), 0)
+  })
+})

--- a/packages/backend/src/domain/services/geogamers-scoring.service.ts
+++ b/packages/backend/src/domain/services/geogamers-scoring.service.ts
@@ -1,0 +1,102 @@
+import type { DomainLogger } from '../ports/logger.js'
+import type { GeoPoint } from '@the-box/types'
+import { geoDistance, GEO_SCORE_DECAY } from './geo-scoring.service.js'
+
+// GeoGamers scoring. A run has two independently-scored phases whose points
+// sum to a 200/day headline:
+//   phase 1 (identify the game) -> 100 / 66 / 33 / 0 by the attempt that lands
+//   phase 2 (pin the location)  -> 0..100 by pin accuracy
+//
+// Location scoring deliberately REUSES the geo mode decay curve
+// (`GEO_SCORE_DECAY`) so the two modes feel identical to place a pin in — only
+// the ceiling differs (2000 -> 100). Because we reuse the exact curve and only
+// rescale linearly, this starts at version 1; bump it whenever a constant here
+// changes so historical `geogamers_run.score_version` stays comparable.
+export const GEOGAMERS_SCORE_VERSION = 1
+
+// Points for identifying the game, indexed by attempt number (1-based). A 4th+
+// attempt (shouldn't happen — the run locks at 3) scores 0.
+export const GEOGAMERS_GAME_POINTS = [100, 66, 33] as const
+
+export const GEOGAMERS_ATTEMPTS_MAX = 3
+
+// Ceiling for the location phase. Rescales the geo curve's 2000 down to 100 so
+// the two phases sum to a clean 200.
+export const GEOGAMERS_LOCATION_MAX = 100
+
+/**
+ * Points awarded for identifying the game on a given attempt (1-based).
+ * Attempt 1 -> 100, 2 -> 66, 3 -> 33, anything else (exhausted / invalid) -> 0.
+ */
+export function gamePointsForAttempt(attemptNumber: number): number {
+  if (!Number.isInteger(attemptNumber) || attemptNumber < 1) return 0
+  return GEOGAMERS_GAME_POINTS[attemptNumber - 1] ?? 0
+}
+
+function clamp01(n: number): number {
+  return Math.max(0, Math.min(1, n))
+}
+
+/**
+ * Map a normalized distance in [0..1] to a location score in
+ * [0..GEOGAMERS_LOCATION_MAX], using the same exponential decay as geo mode.
+ * distance 0 -> 100, ~0.1 across -> ~45, halfway -> ~2, 1 -> ~0.
+ */
+export function locationPointsFromDistance(distance: number): number {
+  return Math.round(GEOGAMERS_LOCATION_MAX * Math.exp(-GEO_SCORE_DECAY * clamp01(distance)))
+}
+
+export interface GeoGamersLocationResult {
+  distance: number
+  locationPoints: number
+  scoreVersion: number
+  // True when the player pinned on a map the screenshot doesn't belong to.
+  // Distance is floored to 1.0 (→ ~0 points), matching geo mode's wrong-map
+  // rule, without a new formula version.
+  wrongMap: boolean
+}
+
+export interface GeoGamersLocationOptions {
+  wrongMap?: boolean
+}
+
+export interface GeoGamersScoringService {
+  /** Points for the game-identification phase given the landing attempt. */
+  gamePoints(attemptNumber: number): number
+  /** Score the location phase from a guess pin against the canonical pin. */
+  scoreLocation(
+    guess: GeoPoint,
+    canonical: GeoPoint,
+    opts?: GeoGamersLocationOptions,
+  ): GeoGamersLocationResult
+}
+
+export interface GeoGamersScoringServiceDeps {
+  logger: DomainLogger
+}
+
+export function createGeoGamersScoringService(
+  deps: GeoGamersScoringServiceDeps,
+): GeoGamersScoringService {
+  const log = deps.logger.child({ service: 'geogamers-scoring' })
+
+  return {
+    gamePoints(attemptNumber) {
+      return gamePointsForAttempt(attemptNumber)
+    },
+
+    scoreLocation(guess, canonical, opts) {
+      const wrongMap = !!opts?.wrongMap
+      const rawDistance = geoDistance(guess, canonical)
+      const distance = wrongMap ? 1 : rawDistance
+      const locationPoints = locationPointsFromDistance(distance)
+      log.debug({ guess, canonical, distance, locationPoints, wrongMap }, 'scored location')
+      return {
+        distance,
+        locationPoints,
+        scoreVersion: GEOGAMERS_SCORE_VERSION,
+        wrongMap,
+      }
+    },
+  }
+}

--- a/packages/backend/src/domain/services/geogamers-season.service.ts
+++ b/packages/backend/src/domain/services/geogamers-season.service.ts
@@ -1,0 +1,50 @@
+import type { DomainLogger } from '../ports/logger.js'
+import type { GeoGamersSeasonStanding, GeoGamersSeasonMe } from '@the-box/types'
+
+// Reusable ranking port. Each mode owns a season ranking that plugs into the
+// shared payout loop (leaderboard-payout worker) instead of copy-pasting the
+// aggregation. Future modes implement this same shape.
+export interface SeasonRanking {
+  findBySeason(month: string, limit?: number, offset?: number): Promise<GeoGamersSeasonStanding[]>
+  findUserSeason(month: string, userId: string): Promise<GeoGamersSeasonMe | null>
+  playerCount(month: string): Promise<number>
+  currentSeasonMonth(referenceMs?: number): string
+}
+
+export interface GeoGamersSeasonService {
+  currentMonth(): string
+  standings(month?: string, limit?: number, offset?: number): Promise<GeoGamersSeasonStanding[]>
+  myStanding(userId: string, month?: string): Promise<GeoGamersSeasonMe | null>
+  playerCount(month?: string): Promise<number>
+}
+
+export interface GeoGamersSeasonServiceDeps {
+  logger: DomainLogger
+  ranking: SeasonRanking
+}
+
+export function createGeoGamersSeasonService(
+  deps: GeoGamersSeasonServiceDeps,
+): GeoGamersSeasonService {
+  const log = deps.logger.child({ service: 'geogamers-season' })
+  const month = () => deps.ranking.currentSeasonMonth()
+
+  return {
+    currentMonth: month,
+
+    async standings(m, limit = 100, offset = 0) {
+      const season = m ?? month()
+      const rows = await deps.ranking.findBySeason(season, limit, offset)
+      log.debug({ season, count: rows.length }, 'season standings')
+      return rows
+    },
+
+    async myStanding(userId, m) {
+      return deps.ranking.findUserSeason(m ?? month(), userId)
+    },
+
+    async playerCount(m) {
+      return deps.ranking.playerCount(m ?? month())
+    },
+  }
+}

--- a/packages/backend/src/domain/services/geogamers.service.test.ts
+++ b/packages/backend/src/domain/services/geogamers.service.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import type { DomainLogger } from '../ports/logger.js'
+import { createGeoGamersScoringService } from './geogamers-scoring.service.js'
+import {
+  createGeoGamersService,
+  GeoGamersError,
+  type GeoGamersChallengeRecord,
+  type GeoGamersChallengeRepository,
+  type GeoGamersRunRecord,
+  type GeoGamersRunRepository,
+  type GeoGamersJokerRepository,
+  type GeoGamersAlternatePicker,
+  type CreateRunInput,
+  type UpdateRunInput,
+} from './geogamers.service.js'
+
+const noopLogger: DomainLogger = {
+  info() {}, warn() {}, error() {}, debug() {}, fatal() {}, trace() {},
+  child() { return noopLogger },
+}
+
+// ---- in-memory fakes ----
+const CHALLENGE: GeoGamersChallengeRecord = {
+  id: 1,
+  challengeDate: '2026-07-10',
+  geoScreenshotMetaId: 100,
+}
+
+const META = {
+  id: 100,
+  geoScreenshotCandidateId: 500,
+  geoMapId: 900,
+  canonical: { x: 0.5, y: 0.5 },
+  confidence: 1,
+  consensusVersion: 1,
+  promotedVia: 'admin' as const,
+}
+const ALT_META = { ...META, id: 101, geoScreenshotCandidateId: 501, geoMapId: 900 }
+const CANDIDATE = { id: 500, gameId: 42, geoMapId: 900, imageUrl: 'file:///uploads/eldenring-xyz.jpg', source: 'manual' as const, status: 'promoted' as const, pinCount: 3 }
+const ALT_CANDIDATE = { ...CANDIDATE, id: 501, imageUrl: 'file:///uploads/witcher-abc.jpg' }
+const GAME = { id: 42, name: 'Elden Ring', aliases: [] as string[] }
+const MAP = { id: 900, gameId: 42, source: 'manual', imageUrl: 'm.png', widthPx: 1000, heightPx: 1000, kind: 'image', consensusRadius: 0.03, license: 'CC' }
+const OTHER_MAP = { ...MAP, id: 901 }
+
+function makeDeps(overrides: { jokerUsed?: boolean } = {}) {
+  const runs = new Map<string, GeoGamersRunRecord>()
+  let seq = 1
+  const completedScores: number[] = []
+
+  const challengeRepo: GeoGamersChallengeRepository = {
+    async findCurrent() { return CHALLENGE },
+    async findByDate(d) { return d === CHALLENGE.challengeDate ? CHALLENGE : null },
+  }
+
+  const runRepo: GeoGamersRunRepository = {
+    async findByToken(t) { return runs.get(t) ?? null },
+    async findRankedForUser(cid, uid) {
+      for (const r of runs.values()) if (r.challengeId === cid && r.userId === uid) return r
+      return null
+    },
+    async create(input: CreateRunInput) {
+      const r: GeoGamersRunRecord = {
+        id: seq++, challengeId: input.challengeId, userId: input.userId,
+        anonymousSessionId: input.anonymousSessionId, runToken: input.runToken,
+        geoScreenshotMetaId: null, gameAttempts: [], gamePoints: null, guess: null,
+        distance: null, locationPoints: null, totalPoints: null, scoreVersion: null,
+        timeSpentMs: 0, startedAt: new Date(0).toISOString(), completedAt: null,
+        jokerUsed: false, claimedAt: null, claimedByUserId: null,
+      }
+      runs.set(r.runToken, r)
+      return r
+    },
+    async update(runId: number, patch: UpdateRunInput) {
+      const r = [...runs.values()].find((x) => x.id === runId)!
+      Object.assign(r, patch)
+      if (patch.completedAt && r.totalPoints != null) completedScores.push(r.totalPoints)
+      return r
+    },
+    async countCompletedBetter(_cid, points) {
+      return completedScores.filter((s) => s > points).length
+    },
+    async claimGuestRun({ guestRunId, userId }) {
+      const guest = [...runs.values()].find((x) => x.id === guestRunId)!
+      guest.claimedAt = new Date(1).toISOString()
+      guest.claimedByUserId = userId
+      const copy: GeoGamersRunRecord = { ...guest, id: seq++, userId, anonymousSessionId: null, runToken: 'claimed-token' }
+      runs.set(copy.runToken, copy)
+      return copy
+    },
+  }
+
+  const jokerRepo: GeoGamersJokerRepository = {
+    async hasUsed() { return !!overrides.jokerUsed },
+    async record() {},
+  }
+  const alternatePicker: GeoGamersAlternatePicker = {
+    async pickAlternate() { return ALT_META.id },
+  }
+
+  const screenshotRepo = {
+    async findMetaById(id: number) { return id === META.id ? META : id === ALT_META.id ? ALT_META : null },
+    async findCandidateById(id: number) { return id === CANDIDATE.id ? CANDIDATE : id === ALT_CANDIDATE.id ? ALT_CANDIDATE : null },
+  } as never
+
+  const mapRepo = {
+    async listEnabledByGameId() { return [MAP, OTHER_MAP] },
+    async findEnabledById(_g: number, mapId: number) { return mapId === MAP.id ? MAP : mapId === OTHER_MAP.id ? OTHER_MAP : null },
+  } as never
+
+  const gameRepo = { async findById(id: number) { return id === GAME.id ? GAME : null } } as never
+  const fuzzyMatch = {
+    evaluateMatch(input: string) {
+      return { matched: input.trim().toLowerCase() === 'elden ring', precision: 'exact' as const }
+    },
+  } as never
+
+  const scoring = createGeoGamersScoringService({ logger: noopLogger })
+
+  const svc = createGeoGamersService({
+    logger: noopLogger, challengeRepo, runRepo, jokerRepo, alternatePicker,
+    screenshotRepo, mapRepo, gameRepo, fuzzyMatch, scoring,
+    screenshotUrlFor: (t) => `/api/geogamers/image/${t}`,
+    now: () => 60_000, // 60s after epoch — well past the min-run floor
+  })
+  return { svc, runs }
+}
+
+describe('geogamers.service anti-leak', () => {
+  it('identify-phase view exposes NO game or map identity', async () => {
+    const { svc } = makeDeps()
+    const view = await svc.startOrResumeRun({ userId: 'u1', anonymousSessionId: null })
+    assert.equal(view.phase, 'identify')
+    assert.equal(view.game, undefined)
+    assert.equal(view.maps, undefined)
+    assert.equal(view.gamePoints, undefined)
+    // screenshot url is opaque (no game slug)
+    assert.match(view.screenshotUrl, /^\/api\/geogamers\/image\//)
+    assert.doesNotMatch(view.screenshotUrl, /elden|uploads/i)
+  })
+})
+
+describe('geogamers.service phase 1', () => {
+  it('correct guess reveals game + maps and locks 100 points on attempt 1', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: 'u1', anonymousSessionId: null })
+    const res = await svc.guessGame({ runToken: start.runToken, guess: 'Elden Ring' })
+    assert.equal(res.correct, true)
+    assert.equal(res.gamePoints, 100)
+    assert.equal(res.run.phase, 'locate')
+    assert.equal(res.run.game?.name, 'Elden Ring')
+    assert.ok((res.run.maps?.length ?? 0) >= 1)
+  })
+
+  it('three wrong guesses exhaust to locate with 0 game points', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: 'u1', anonymousSessionId: null })
+    await svc.guessGame({ runToken: start.runToken, guess: 'Dark Souls' })
+    await svc.guessGame({ runToken: start.runToken, guess: 'Sekiro' })
+    const third = await svc.guessGame({ runToken: start.runToken, guess: 'Bloodborne' })
+    assert.equal(third.correct, false)
+    assert.equal(third.attemptsRemaining, 0)
+    assert.equal(third.gamePoints, 0)
+    assert.equal(third.run.phase, 'locate')
+    assert.equal(third.run.gamePoints, 0)
+  })
+
+  it('rejects a game guess once past the identify phase', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: 'u1', anonymousSessionId: null })
+    await svc.guessGame({ runToken: start.runToken, guess: 'Elden Ring' })
+    await assert.rejects(
+      svc.guessGame({ runToken: start.runToken, guess: 'again' }),
+      (e) => e instanceof GeoGamersError && e.code === 'WRONG_PHASE',
+    )
+  })
+})
+
+describe('geogamers.service phase 2', () => {
+  it('exact pin completes the run at 200 and returns a live rank', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: 'u1', anonymousSessionId: null })
+    await svc.guessGame({ runToken: start.runToken, guess: 'Elden Ring' })
+    const loc = await svc.guessLocation({ runToken: start.runToken, geoMapId: MAP.id, guess: { x: 0.5, y: 0.5 } })
+    assert.equal(loc.gamePoints, 100)
+    assert.equal(loc.locationPoints, 100)
+    assert.equal(loc.totalPoints, 200)
+    assert.equal(loc.rank, 1)
+    assert.equal(loc.ghostRank, undefined)
+  })
+
+  it('wrong map floors location points to ~0', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: 'u1', anonymousSessionId: null })
+    await svc.guessGame({ runToken: start.runToken, guess: 'Elden Ring' })
+    const loc = await svc.guessLocation({ runToken: start.runToken, geoMapId: OTHER_MAP.id, guess: { x: 0.5, y: 0.5 } })
+    assert.ok(loc.locationPoints <= 1)
+    assert.equal(loc.distance, 1)
+  })
+
+  it('guest gets a ghostRank, not a rank', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: null, anonymousSessionId: 'guest-1' })
+    await svc.guessGame({ runToken: start.runToken, guess: 'Elden Ring' })
+    const loc = await svc.guessLocation({ runToken: start.runToken, geoMapId: MAP.id, guess: { x: 0.51, y: 0.5 } })
+    assert.equal(typeof loc.ghostRank, 'number')
+    assert.equal(loc.rank, undefined)
+  })
+})
+
+describe('geogamers.service joker', () => {
+  it('re-rolls when in identify with no attempts', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: 'u1', anonymousSessionId: null })
+    const view = await svc.useJoker({ userId: 'u1', runToken: start.runToken })
+    assert.equal(view.phase, 'identify')
+    assert.equal(view.attemptsUsed, 0)
+  })
+
+  it('is refused after an attempt has been spent', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: 'u1', anonymousSessionId: null })
+    await svc.guessGame({ runToken: start.runToken, guess: 'Dark Souls' })
+    await assert.rejects(
+      svc.useJoker({ userId: 'u1', runToken: start.runToken }),
+      (e) => e instanceof GeoGamersError && e.code === 'JOKER_NOT_ALLOWED',
+    )
+  })
+
+  it('is refused when already used this season', async () => {
+    const { svc } = makeDeps({ jokerUsed: true })
+    const start = await svc.startOrResumeRun({ userId: 'u1', anonymousSessionId: null })
+    await assert.rejects(
+      svc.useJoker({ userId: 'u1', runToken: start.runToken }),
+      (e) => e instanceof GeoGamersError && e.code === 'JOKER_ALREADY_USED',
+    )
+  })
+})
+
+describe('geogamers.service claim', () => {
+  it('rejects claiming a run that is not completed', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: null, anonymousSessionId: 'guest-1' })
+    await assert.rejects(
+      svc.claimRun({ userId: 'u9', runToken: start.runToken }),
+      (e) => e instanceof GeoGamersError && e.code === 'CLAIM_INVALID',
+    )
+  })
+
+  it('claims a completed guest run into an account', async () => {
+    const { svc } = makeDeps()
+    const start = await svc.startOrResumeRun({ userId: null, anonymousSessionId: 'guest-1' })
+    await svc.guessGame({ runToken: start.runToken, guess: 'Elden Ring' })
+    await svc.guessLocation({ runToken: start.runToken, geoMapId: MAP.id, guess: { x: 0.5, y: 0.5 } })
+    const claimed = await svc.claimRun({ userId: 'u9', runToken: start.runToken })
+    assert.equal(claimed.phase, 'done')
+  })
+})

--- a/packages/backend/src/domain/services/geogamers.service.test.ts
+++ b/packages/backend/src/domain/services/geogamers.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import type { DomainLogger } from '../ports/logger.js'
 import { createGeoGamersScoringService } from './geogamers-scoring.service.js'

--- a/packages/backend/src/domain/services/geogamers.service.ts
+++ b/packages/backend/src/domain/services/geogamers.service.ts
@@ -1,0 +1,526 @@
+import type { DomainLogger } from '../ports/logger.js'
+import type {
+  GeoGamersGameAttempt,
+  GeoGamersGuessGameResult,
+  GeoGamersGuessLocationResult,
+  GeoGamersRunView,
+  GeoMap,
+  GeoMapOption,
+  GeoPoint,
+  GeoScreenshotMeta,
+} from '@the-box/types'
+import type {
+  GameRepository,
+  GeoMapRepository,
+  GeoScreenshotRepository,
+} from '../ports/repositories.js'
+import type { FuzzyMatchService } from './fuzzy-match.service.js'
+import {
+  GEOGAMERS_ATTEMPTS_MAX,
+  gamePointsForAttempt,
+  type GeoGamersScoringService,
+} from './geogamers-scoring.service.js'
+
+// Per-phase active-time budget, mirroring the classic 45s-per-screenshot rule.
+export const GEOGAMERS_PHASE_TIME_LIMIT_SECONDS = 60
+
+// A run cannot legitimately complete faster than this. Used by claim() to
+// reject implausibly fast guest runs before folding them into a season.
+export const GEOGAMERS_MIN_RUN_SECONDS = 10
+
+export class GeoGamersError extends Error {
+  constructor(
+    message: string,
+    public code:
+      | 'NO_CHALLENGE'
+      | 'RUN_NOT_FOUND'
+      | 'WRONG_PHASE'
+      | 'ATTEMPTS_EXHAUSTED'
+      | 'ALREADY_PLAYED'
+      | 'JOKER_ALREADY_USED'
+      | 'JOKER_NOT_ALLOWED'
+      | 'NO_ALTERNATE'
+      | 'CLAIM_INVALID'
+      | 'INVALID_POINT'
+      | 'INVALID_MAP'
+      | 'NOT_AUTHENTICATED',
+  ) {
+    super(message)
+    this.name = 'GeoGamersError'
+  }
+}
+
+// ---------- Domain records + repository ports ----------
+// Ports are co-located (as guess-proximity does with its fuzzy matcher) and
+// implemented by the infrastructure repositories in the next phase.
+
+export interface GeoGamersChallengeRecord {
+  id: number
+  challengeDate: string // YYYY-MM-DD
+  geoScreenshotMetaId: number
+}
+
+export interface GeoGamersRunRecord {
+  id: number
+  challengeId: number
+  userId: string | null
+  anonymousSessionId: string | null
+  runToken: string
+  // Overrides the challenge meta when the joker re-rolled this run.
+  geoScreenshotMetaId: number | null
+  gameAttempts: GeoGamersGameAttempt[]
+  gamePoints: number | null
+  guess: GeoPoint | null
+  distance: number | null
+  locationPoints: number | null
+  totalPoints: number | null
+  scoreVersion: number | null
+  timeSpentMs: number
+  startedAt: string
+  completedAt: string | null
+  jokerUsed: boolean
+  claimedAt: string | null
+  claimedByUserId: string | null
+}
+
+export interface GeoGamersChallengeRepository {
+  findCurrent(): Promise<GeoGamersChallengeRecord | null>
+  findByDate(date: string): Promise<GeoGamersChallengeRecord | null>
+}
+
+export interface CreateRunInput {
+  challengeId: number
+  userId: string | null
+  anonymousSessionId: string | null
+  runToken: string
+}
+
+export interface UpdateRunInput {
+  gameAttempts?: GeoGamersGameAttempt[]
+  gamePoints?: number | null
+  geoScreenshotMetaId?: number | null
+  guess?: GeoPoint | null
+  distance?: number | null
+  locationPoints?: number | null
+  totalPoints?: number | null
+  scoreVersion?: number | null
+  timeSpentMs?: number
+  completedAt?: string | null
+  jokerUsed?: boolean
+}
+
+export interface GeoGamersRunRepository {
+  findByToken(runToken: string): Promise<GeoGamersRunRecord | null>
+  findRankedForUser(challengeId: number, userId: string): Promise<GeoGamersRunRecord | null>
+  create(input: CreateRunInput): Promise<GeoGamersRunRecord>
+  update(runId: number, patch: UpdateRunInput): Promise<GeoGamersRunRecord>
+  // Rank support: how many completed ranked runs beat `points` today.
+  countCompletedBetter(challengeId: number, points: number): Promise<number>
+  // Claim: copy a completed guest run into a new user-owned row and mark the
+  // guest row claimed. Idempotent at the DB layer via the claim-once index.
+  claimGuestRun(input: {
+    guestRunId: number
+    userId: string
+    challengeId: number
+  }): Promise<GeoGamersRunRecord | null>
+}
+
+// Records a season joker and re-rolls the run's screenshot. Enforced
+// once-per-season by the (user_id, season_month) primary key.
+export interface GeoGamersJokerRepository {
+  hasUsed(userId: string, seasonMonth: string): Promise<boolean>
+  record(input: {
+    userId: string
+    seasonMonth: string
+    challengeId: number
+    rerolledMetaId: number
+  }): Promise<void>
+}
+
+// Picks an alternate eligible screenshot for a joker re-roll, excluding the
+// current meta and the recent-games cooldown pool.
+export interface GeoGamersAlternatePicker {
+  pickAlternate(input: { excludeMetaId: number }): Promise<number | null>
+}
+
+export interface GeoGamersServiceDeps {
+  logger: DomainLogger
+  challengeRepo: GeoGamersChallengeRepository
+  runRepo: GeoGamersRunRepository
+  jokerRepo: GeoGamersJokerRepository
+  alternatePicker: GeoGamersAlternatePicker
+  screenshotRepo: GeoScreenshotRepository
+  mapRepo: GeoMapRepository
+  gameRepo: GameRepository
+  fuzzyMatch: FuzzyMatchService
+  scoring: GeoGamersScoringService
+  // Builds the opaque proxy URL the client uses to fetch the screenshot
+  // without ever seeing the underlying asset path (which can carry a slug).
+  screenshotUrlFor: (runToken: string) => string
+  // Injectable clock so tests are deterministic; defaults to Date.now.
+  now?: () => number
+}
+
+export type GeoGamersRunPhaseComputed = 'identify' | 'locate' | 'done'
+
+function mapToOption(map: GeoMap): GeoMapOption {
+  return {
+    id: map.id,
+    region: map.region,
+    imageUrl: map.imageUrl,
+    widthPx: map.widthPx,
+    heightPx: map.heightPx,
+    kind: map.kind,
+    tiles: map.tiles,
+  }
+}
+
+function isValidPoint(p: GeoPoint): boolean {
+  return (
+    typeof p?.x === 'number' &&
+    typeof p?.y === 'number' &&
+    p.x >= 0 &&
+    p.x <= 1 &&
+    p.y >= 0 &&
+    p.y <= 1
+  )
+}
+
+/** Derive the run phase from its persisted state. */
+export function computeRunPhase(run: GeoGamersRunRecord): GeoGamersRunPhaseComputed {
+  if (run.completedAt) return 'done'
+  const solved = run.gameAttempts.some((a) => a.correct)
+  const exhausted = run.gameAttempts.length >= GEOGAMERS_ATTEMPTS_MAX
+  return solved || exhausted ? 'locate' : 'identify'
+}
+
+export interface GeoGamersService {
+  startOrResumeRun(input: {
+    userId: string | null
+    anonymousSessionId: string | null
+  }): Promise<GeoGamersRunView>
+  getRunByToken(runToken: string): Promise<GeoGamersRunView>
+  guessGame(input: {
+    runToken: string
+    guess: string
+    timeSpentMsDelta?: number
+  }): Promise<GeoGamersGuessGameResult>
+  guessLocation(input: {
+    runToken: string
+    geoMapId: number
+    guess: GeoPoint
+    timeSpentMsDelta?: number
+  }): Promise<GeoGamersGuessLocationResult>
+  useJoker(input: { userId: string; runToken: string }): Promise<GeoGamersRunView>
+  claimRun(input: { userId: string; runToken: string }): Promise<GeoGamersRunView>
+  // Raw underlying image URL for the opaque proxy route (server-side only).
+  resolveScreenshotSource(runToken: string): Promise<{ imageUrl: string } | null>
+}
+
+export function createGeoGamersService(deps: GeoGamersServiceDeps): GeoGamersService {
+  const log = deps.logger.child({ service: 'geogamers' })
+  const now = deps.now ?? (() => Date.now())
+
+  function seasonMonth(challengeDate: string): string {
+    return challengeDate.slice(0, 7) // YYYY-MM
+  }
+
+  async function effectiveMetaId(run: GeoGamersRunRecord, challenge: GeoGamersChallengeRecord) {
+    return run.geoScreenshotMetaId ?? challenge.geoScreenshotMetaId
+  }
+
+  async function loadChallengeForRun(run: GeoGamersRunRecord): Promise<GeoGamersChallengeRecord> {
+    // The run references a challenge by id; the current challenge is the common
+    // case, but resume/claim may target a past one — resolve by the run's own
+    // challenge via the "current or by date" repos. We only expose findCurrent
+    // / findByDate, so resolve current first and fall back to identity.
+    const current = await deps.challengeRepo.findCurrent()
+    if (current && current.id === run.challengeId) return current
+    // A run should always match the current challenge in the MVP (one live
+    // challenge). If not, treat as no-challenge to avoid leaking a stale meta.
+    throw new GeoGamersError('challenge for run not found', 'NO_CHALLENGE')
+  }
+
+  // Build the client view, enforcing anti-leak: game/map identity is attached
+  // ONLY once phase 1 has resolved (game solved or attempts exhausted).
+  async function buildView(
+    run: GeoGamersRunRecord,
+    challenge: GeoGamersChallengeRecord,
+  ): Promise<GeoGamersRunView> {
+    const phase = computeRunPhase(run)
+    const view: GeoGamersRunView = {
+      runToken: run.runToken,
+      challengeDate: challenge.challengeDate,
+      phase,
+      screenshotUrl: deps.screenshotUrlFor(run.runToken),
+      attemptsUsed: run.gameAttempts.length,
+      attemptsMax: GEOGAMERS_ATTEMPTS_MAX,
+      timeLimitSeconds: GEOGAMERS_PHASE_TIME_LIMIT_SECONDS,
+      timeSpentMs: run.timeSpentMs,
+      jokerAvailable: false,
+    }
+
+    // Joker offer: account-only, once per season, and only before any attempt
+    // is spent (a re-roll replaces the puzzle, it is not a retry).
+    if (run.userId && phase === 'identify' && run.gameAttempts.length === 0 && !run.jokerUsed) {
+      const used = await deps.jokerRepo.hasUsed(run.userId, seasonMonth(challenge.challengeDate))
+      view.jokerAvailable = !used
+    }
+
+    if (phase !== 'identify') {
+      const metaId = await effectiveMetaId(run, challenge)
+      const meta = await deps.screenshotRepo.findMetaById(metaId)
+      if (meta) {
+        const candidate = await deps.screenshotRepo.findCandidateById(meta.geoScreenshotCandidateId)
+        if (candidate) {
+          const game = await deps.gameRepo.findById(candidate.gameId)
+          if (game) {
+            const maps = await deps.mapRepo.listEnabledByGameId(candidate.gameId)
+            view.game = { id: game.id, name: game.name }
+            view.maps = maps.map(mapToOption)
+          }
+        }
+      }
+      view.gamePoints = run.gamePoints ?? 0
+    }
+
+    return view
+  }
+
+  async function requireRun(runToken: string): Promise<GeoGamersRunRecord> {
+    const run = await deps.runRepo.findByToken(runToken)
+    if (!run) throw new GeoGamersError('run not found', 'RUN_NOT_FOUND')
+    return run
+  }
+
+  return {
+    async startOrResumeRun({ userId, anonymousSessionId }) {
+      const challenge = await deps.challengeRepo.findCurrent()
+      if (!challenge) throw new GeoGamersError('no current challenge', 'NO_CHALLENGE')
+
+      // Ranked resume: an authenticated user has at most one run per challenge.
+      if (userId) {
+        const existing = await deps.runRepo.findRankedForUser(challenge.id, userId)
+        if (existing) return buildView(existing, challenge)
+      }
+
+      const runToken = globalThis.crypto.randomUUID()
+      const run = await deps.runRepo.create({
+        challengeId: challenge.id,
+        userId,
+        anonymousSessionId: userId ? null : anonymousSessionId,
+        runToken,
+      })
+      log.info({ runId: run.id, ranked: !!userId }, 'started geogamers run')
+      return buildView(run, challenge)
+    },
+
+    async getRunByToken(runToken) {
+      const run = await requireRun(runToken)
+      const challenge = await loadChallengeForRun(run)
+      return buildView(run, challenge)
+    },
+
+    async guessGame({ runToken, guess, timeSpentMsDelta }) {
+      const run = await requireRun(runToken)
+      const challenge = await loadChallengeForRun(run)
+      const phase = computeRunPhase(run)
+      if (phase !== 'identify') {
+        throw new GeoGamersError('game already identified or run over', 'WRONG_PHASE')
+      }
+
+      const metaId = await effectiveMetaId(run, challenge)
+      const meta = await deps.screenshotRepo.findMetaById(metaId)
+      if (!meta) throw new GeoGamersError('challenge screenshot missing', 'NO_CHALLENGE')
+      const candidate = await deps.screenshotRepo.findCandidateById(meta.geoScreenshotCandidateId)
+      const game = candidate ? await deps.gameRepo.findById(candidate.gameId) : null
+      if (!candidate || !game) throw new GeoGamersError('challenge game missing', 'NO_CHALLENGE')
+
+      const evaluation = deps.fuzzyMatch.evaluateMatch(guess, game.name, game.aliases ?? [])
+      const correct = evaluation.matched
+      const attempts: GeoGamersGameAttempt[] = [
+        ...run.gameAttempts,
+        {
+          guess,
+          normalized: guess.trim().toLowerCase(),
+          correct,
+          at: new Date(now()).toISOString(),
+        },
+      ]
+
+      // gamePoints locks when phase 1 resolves (correct guess or 3rd miss).
+      const attemptNumber = attempts.length
+      const exhausted = attempts.length >= GEOGAMERS_ATTEMPTS_MAX
+      let gamePoints: number | null = null
+      if (correct) gamePoints = gamePointsForAttempt(attemptNumber)
+      else if (exhausted) gamePoints = 0
+
+      const patch: UpdateRunInput = { gameAttempts: attempts }
+      if (gamePoints !== null) patch.gamePoints = gamePoints
+      if (typeof timeSpentMsDelta === 'number' && timeSpentMsDelta > 0) {
+        patch.timeSpentMs = run.timeSpentMs + Math.min(timeSpentMsDelta, 5 * 60_000)
+      }
+      const updated = await deps.runRepo.update(run.id, patch)
+
+      const result: GeoGamersGuessGameResult = {
+        correct,
+        attemptsUsed: attempts.length,
+        attemptsRemaining: Math.max(0, GEOGAMERS_ATTEMPTS_MAX - attempts.length),
+        run: await buildView(updated, challenge),
+      }
+      if (gamePoints !== null) result.gamePoints = gamePoints
+      return result
+    },
+
+    async guessLocation({ runToken, geoMapId, guess, timeSpentMsDelta }) {
+      const run = await requireRun(runToken)
+      const challenge = await loadChallengeForRun(run)
+      if (computeRunPhase(run) !== 'locate') {
+        throw new GeoGamersError('not in the locate phase', 'WRONG_PHASE')
+      }
+      if (!isValidPoint(guess)) throw new GeoGamersError('invalid point', 'INVALID_POINT')
+
+      const metaId = await effectiveMetaId(run, challenge)
+      const meta = await deps.screenshotRepo.findMetaById(metaId)
+      if (!meta) throw new GeoGamersError('challenge screenshot missing', 'NO_CHALLENGE')
+      const candidate = await deps.screenshotRepo.findCandidateById(meta.geoScreenshotCandidateId)
+      if (!candidate) throw new GeoGamersError('challenge screenshot missing', 'NO_CHALLENGE')
+
+      // The chosen map must be an enabled map for this game.
+      const chosenMap = await deps.mapRepo.findEnabledById(candidate.gameId, geoMapId)
+      if (!chosenMap) throw new GeoGamersError('invalid map for game', 'INVALID_MAP')
+      const wrongMap = chosenMap.id !== meta.geoMapId
+
+      const scored = deps.scoring.scoreLocation(guess, meta.canonical, { wrongMap })
+      const gamePoints = run.gamePoints ?? 0
+      const totalPoints = gamePoints + scored.locationPoints
+
+      let timeSpentMs = run.timeSpentMs
+      if (typeof timeSpentMsDelta === 'number' && timeSpentMsDelta > 0) {
+        timeSpentMs += Math.min(timeSpentMsDelta, 5 * 60_000)
+      }
+
+      const completedAt = new Date(now()).toISOString()
+      const updated = await deps.runRepo.update(run.id, {
+        guess,
+        distance: scored.distance,
+        locationPoints: scored.locationPoints,
+        totalPoints,
+        scoreVersion: scored.scoreVersion,
+        timeSpentMs,
+        completedAt,
+      })
+
+      const result: GeoGamersGuessLocationResult = {
+        guess,
+        canonical: meta.canonical,
+        distance: scored.distance,
+        locationPoints: scored.locationPoints,
+        gamePoints,
+        totalPoints,
+        scoreVersion: scored.scoreVersion,
+      }
+
+      if (updated.userId) {
+        // Live daily rank = (# completed ranked runs strictly better) + 1.
+        const better = await deps.runRepo.countCompletedBetter(challenge.id, totalPoints)
+        result.rank = better + 1
+      } else {
+        // Guests get a ghost rank instead — same computation, framed as a
+        // hypothetical since the run isn't persisted into the season.
+        const better = await deps.runRepo.countCompletedBetter(challenge.id, totalPoints)
+        result.ghostRank = better + 1
+      }
+      return result
+    },
+
+    async useJoker({ userId, runToken }) {
+      const run = await requireRun(runToken)
+      if (!run.userId || run.userId !== userId) {
+        throw new GeoGamersError('joker requires the run owner', 'NOT_AUTHENTICATED')
+      }
+      const challenge = await loadChallengeForRun(run)
+      // A re-roll replaces the puzzle before it is engaged: identify phase,
+      // no attempts spent, not already jokered on this run.
+      if (
+        computeRunPhase(run) !== 'identify' ||
+        run.gameAttempts.length > 0 ||
+        run.jokerUsed
+      ) {
+        throw new GeoGamersError('joker not allowed now', 'JOKER_NOT_ALLOWED')
+      }
+      const month = seasonMonth(challenge.challengeDate)
+      if (await deps.jokerRepo.hasUsed(userId, month)) {
+        throw new GeoGamersError('joker already used this season', 'JOKER_ALREADY_USED')
+      }
+
+      const currentMetaId = await effectiveMetaId(run, challenge)
+      const alternate = await deps.alternatePicker.pickAlternate({ excludeMetaId: currentMetaId })
+      if (!alternate) throw new GeoGamersError('no alternate screenshot available', 'NO_ALTERNATE')
+
+      // Record first (DB PK enforces once-per-season; a race trips a unique
+      // violation which the route maps to JOKER_ALREADY_USED).
+      await deps.jokerRepo.record({
+        userId,
+        seasonMonth: month,
+        challengeId: challenge.id,
+        rerolledMetaId: alternate,
+      })
+      const updated = await deps.runRepo.update(run.id, {
+        geoScreenshotMetaId: alternate,
+        jokerUsed: true,
+        gameAttempts: [],
+      })
+      log.info({ runId: run.id, alternate }, 'joker re-rolled run')
+      return buildView(updated, challenge)
+    },
+
+    async claimRun({ userId, runToken }) {
+      const run = await requireRun(runToken)
+      const challenge = await loadChallengeForRun(run)
+      // Only a completed, unclaimed GUEST run is claimable.
+      if (run.userId || !run.completedAt || run.claimedAt) {
+        throw new GeoGamersError('run is not claimable', 'CLAIM_INVALID')
+      }
+      // Timing plausibility: a run completed impossibly fast is rejected.
+      const started = Date.parse(run.startedAt)
+      const completed = Date.parse(run.completedAt)
+      if (
+        Number.isFinite(started) &&
+        Number.isFinite(completed) &&
+        completed - started < GEOGAMERS_MIN_RUN_SECONDS * 1000
+      ) {
+        throw new GeoGamersError('run completed implausibly fast', 'CLAIM_INVALID')
+      }
+      // The claiming account must not already have a ranked run today.
+      const existing = await deps.runRepo.findRankedForUser(challenge.id, userId)
+      if (existing) throw new GeoGamersError('account already played today', 'ALREADY_PLAYED')
+
+      const claimed = await deps.runRepo.claimGuestRun({
+        guestRunId: run.id,
+        userId,
+        challengeId: challenge.id,
+      })
+      if (!claimed) throw new GeoGamersError('claim failed', 'CLAIM_INVALID')
+      log.info({ guestRunId: run.id, userId }, 'claimed guest run into account')
+      return buildView(claimed, challenge)
+    },
+
+    async resolveScreenshotSource(runToken) {
+      const run = await deps.runRepo.findByToken(runToken)
+      if (!run) return null
+      const challenge = await deps.challengeRepo.findCurrent()
+      const metaId =
+        run.geoScreenshotMetaId ?? (challenge?.id === run.challengeId ? challenge.geoScreenshotMetaId : null)
+      if (metaId == null) return null
+      const meta = await deps.screenshotRepo.findMetaById(metaId)
+      if (!meta) return null
+      const candidate = await deps.screenshotRepo.findCandidateById(meta.geoScreenshotCandidateId)
+      if (!candidate) return null
+      return { imageUrl: candidate.imageUrl }
+    },
+  }
+}
+
+// Re-export a helper used by tests / callers to check leak-safety.
+export type { GeoScreenshotMeta }

--- a/packages/backend/src/domain/services/index.ts
+++ b/packages/backend/src/domain/services/index.ts
@@ -77,6 +77,11 @@ export {
   GEOGAMERS_PHASE_TIME_LIMIT_SECONDS,
 } from './geogamers.service.js'
 export {
+  createGeoGamersSeasonService,
+  type GeoGamersSeasonService,
+  type SeasonRanking,
+} from './geogamers-season.service.js'
+export {
   createBillingService,
   toSubscriptionStatus,
   type BillingService,
@@ -135,6 +140,7 @@ import { createGeoContributorService } from './geo-contributor.service.js'
 import { createGeoGameService } from './geo-game.service.js'
 import { createGeoGamersScoringService } from './geogamers-scoring.service.js'
 import { createGeoGamersService } from './geogamers.service.js'
+import { createGeoGamersSeasonService } from './geogamers-season.service.js'
 import { createWebhookDispatchService } from './webhook-dispatch.service.js'
 import { createPushService } from './push.service.js'
 import { serviceLogger } from '../../infrastructure/logger/logger.js'
@@ -162,6 +168,7 @@ import {
   geoGamersChallengeRepository,
   geoGamersRunRepository,
   geoGamersJokerRepository,
+  geoGamersSeasonRepository,
   webhookRepository,
   webhookDeliveryRepository,
 } from '../../infrastructure/repositories/index.js'
@@ -416,4 +423,9 @@ export const geoGamersService = createGeoGamersService({
   fuzzyMatch: fuzzyMatchService,
   scoring: geoGamersScoringService,
   screenshotUrlFor: (runToken) => `/api/geogamers/image/${runToken}`,
+})
+
+export const geoGamersSeasonService = createGeoGamersSeasonService({
+  logger: serviceLogger,
+  ranking: geoGamersSeasonRepository,
 })

--- a/packages/backend/src/domain/services/index.ts
+++ b/packages/backend/src/domain/services/index.ts
@@ -64,6 +64,19 @@ export {
   GEO_CONTRIBUTE_MIN_DAYS_PLAYED,
 } from './geo-game.service.js'
 export {
+  createGeoGamersScoringService,
+  type GeoGamersScoringService,
+  GEOGAMERS_SCORE_VERSION,
+  GEOGAMERS_ATTEMPTS_MAX,
+} from './geogamers-scoring.service.js'
+export {
+  createGeoGamersService,
+  type GeoGamersService,
+  GeoGamersError,
+  GEOGAMERS_MIN_RUN_SECONDS,
+  GEOGAMERS_PHASE_TIME_LIMIT_SECONDS,
+} from './geogamers.service.js'
+export {
   createBillingService,
   toSubscriptionStatus,
   type BillingService,
@@ -120,6 +133,8 @@ import { createGeoConsensusService } from './geo-consensus.service.js'
 import { createGeoRewardService } from './geo-reward.service.js'
 import { createGeoContributorService } from './geo-contributor.service.js'
 import { createGeoGameService } from './geo-game.service.js'
+import { createGeoGamersScoringService } from './geogamers-scoring.service.js'
+import { createGeoGamersService } from './geogamers.service.js'
 import { createWebhookDispatchService } from './webhook-dispatch.service.js'
 import { createPushService } from './push.service.js'
 import { serviceLogger } from '../../infrastructure/logger/logger.js'
@@ -144,6 +159,9 @@ import {
   geoMapRepository,
   geoPinRepository,
   geoScreenshotRepository,
+  geoGamersChallengeRepository,
+  geoGamersRunRepository,
+  geoGamersJokerRepository,
   webhookRepository,
   webhookDeliveryRepository,
 } from '../../infrastructure/repositories/index.js'
@@ -375,4 +393,27 @@ export const geoGameService = createGeoGameService({
   geoPinRepository,
   geoMapRepository,
   sessionRepository,
+})
+
+// GeoGamers mode. Scoring is pure; the orchestration service is wired here
+// from the concrete repos, the fuzzy matcher, and a repo-backed alternate
+// picker for joker re-rolls. `screenshotUrlFor` builds the opaque proxy URL so
+// the domain never emits a raw asset path (anti-leak).
+export const geoGamersScoringService = createGeoGamersScoringService({ logger: serviceLogger })
+
+export const geoGamersService = createGeoGamersService({
+  logger: serviceLogger,
+  challengeRepo: geoGamersChallengeRepository,
+  runRepo: geoGamersRunRepository,
+  jokerRepo: geoGamersJokerRepository,
+  alternatePicker: {
+    pickAlternate: ({ excludeMetaId }) =>
+      geoGamersChallengeRepository.pickAlternateMeta(excludeMetaId),
+  },
+  screenshotRepo: geoScreenshotRepository,
+  mapRepo: geoMapRepository,
+  gameRepo: gameRepository,
+  fuzzyMatch: fuzzyMatchService,
+  scoring: geoGamersScoringService,
+  screenshotUrlFor: (runToken) => `/api/geogamers/image/${runToken}`,
 })

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -449,6 +449,23 @@ async function start(): Promise<void> {
       } catch (error) {
         logger.warn({ error: String(error) }, 'failed to schedule recurring geogamers challenge job')
       }
+
+      // Close the prior season on the 1st at 00:35 UTC (after the classic
+      // leaderboard payout at 00:30) and grant season frames to eligible
+      // top finishers. Idempotent via reward_grants.
+      try {
+        await importQueue.add(
+          'geogamers-season-payout',
+          {},
+          {
+            repeat: { pattern: '35 0 1 * *', tz: 'UTC' },
+            jobId: 'geogamers-season-payout-recurring',
+          }
+        )
+        logger.info('scheduled recurring geogamers-season-payout job (1st @ 00:35 UTC)')
+      } catch (error) {
+        logger.warn({ error: String(error) }, 'failed to schedule recurring geogamers season payout job')
+      }
     }
 
     // Schedule recurring sync-all-games job (weekly on Sundays at 2 AM UTC)

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -23,6 +23,7 @@ import rewardsRoutes from './presentation/routes/rewards.routes.js'
 import referralRoutes from './presentation/routes/referral.routes.js'
 import ogRoutes from './presentation/routes/og.routes.js'
 import geoRoutes from './presentation/routes/geo.routes.js'
+import geoGamersRoutes from './presentation/routes/geogamers.routes.js'
 import screenshotReportRoutes from './presentation/routes/screenshot-report.routes.js'
 import pushRoutes from './presentation/routes/push.routes.js'
 import billingRoutes from './presentation/routes/billing.routes.js'
@@ -240,6 +241,11 @@ app.use('/api/rewards', rewardsRoutes)
 app.use('/api/referral', referralRoutes)
 app.use('/api/og', ogRoutes)
 app.use('/api/geo', geoRoutes)
+// GeoGamers mode — mounted only when enabled so the API surface stays dark
+// until there's enough consensus-confirmed content to schedule challenges.
+if (env.GEOGAMERS_ENABLED === 'true') {
+  app.use('/api/geogamers', geoGamersRoutes)
+}
 app.use('/api/screenshot-reports', screenshotReportRoutes)
 app.use('/api/push', pushRoutes)
 app.use('/api/billing', billingRoutes)
@@ -425,6 +431,24 @@ async function start(): Promise<void> {
       logger.info('scheduled recurring create-daily-challenge job (daily at midnight UTC)')
     } catch (error) {
       logger.warn({ error: String(error) }, 'failed to schedule recurring daily challenge job')
+    }
+
+    // Schedule recurring GeoGamers challenge creation (00:05 UTC, just after
+    // the classic daily job to spread load). Only when the feature is enabled.
+    if (env.GEOGAMERS_ENABLED === 'true') {
+      try {
+        await importQueue.add(
+          'create-geogamers-challenge',
+          {},
+          {
+            repeat: { pattern: '5 0 * * *', tz: 'UTC' }, // Cron: 00:05 UTC daily
+            jobId: 'create-geogamers-challenge-recurring',
+          }
+        )
+        logger.info('scheduled recurring create-geogamers-challenge job (daily at 00:05 UTC)')
+      } catch (error) {
+        logger.warn({ error: String(error) }, 'failed to schedule recurring geogamers challenge job')
+      }
     }
 
     // Schedule recurring sync-all-games job (weekly on Sundays at 2 AM UTC)

--- a/packages/backend/src/infrastructure/queue/workers/geogamers-challenge-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geogamers-challenge-logic.ts
@@ -1,0 +1,105 @@
+/**
+ * GeoGamers Daily Challenge Creation Logic
+ *
+ * Recurring job that picks one eligible geo screenshot per UTC day and marks
+ * it the current GeoGamers challenge. Idempotent per date.
+ *
+ * Eligibility (all must hold):
+ *   - the screenshot has a consensus/admin canonical pin (it's a geo_screenshot_meta)
+ *   - its map is active and its game is present
+ *   - the screenshot has never been a GeoGamers challenge before
+ *   - its game hasn't been featured within the cooldown window
+ *
+ * Content gate: if fewer than GEOGAMERS_MIN_ELIGIBLE_GAMES distinct games are
+ * eligible, creation is SKIPPED (a "guess the game" round is meaningless with
+ * too small a pool) and a warning is logged for admins.
+ */
+
+import { queueLogger } from '../../logger/logger.js'
+import { env } from '../../../config/env.js'
+import { geoGamersChallengeRepository } from '../../repositories/geogamers-challenge.repository.js'
+
+const log = queueLogger.child({ module: 'geogamers-challenge' })
+
+export interface GeoGamersChallengeResult {
+  created: boolean
+  skipped?: 'ALREADY_EXISTS' | 'INSUFFICIENT_CONTENT'
+  challengeId?: number
+  challengeDate: string
+  geoScreenshotMetaId?: number
+  eligibleGames?: number
+  message: string
+}
+
+/** Today's date in YYYY-MM-DD (UTC). Accepts the job's scheduled-fire ms so a
+ *  near-midnight container restart doesn't skip a day (same guard as the
+ *  classic daily-challenge worker). */
+function getTodayDateUTC(referenceMs?: number): string {
+  const ref = typeof referenceMs === 'number' ? new Date(referenceMs) : new Date()
+  return ref.toISOString().split('T')[0]!
+}
+
+/**
+ * Create today's GeoGamers challenge. Idempotent — skips if one exists for the
+ * date. Gated on eligible-game count.
+ */
+export async function createGeoGamersChallenge(options?: {
+  referenceMs?: number
+  targetDate?: string
+}): Promise<GeoGamersChallengeResult> {
+  const challengeDate = options?.targetDate ?? getTodayDateUTC(options?.referenceMs)
+  log.info({ challengeDate }, 'creating geogamers challenge')
+
+  const existing = await geoGamersChallengeRepository.findByDate(challengeDate)
+  if (existing) {
+    log.info({ challengeId: existing.id, challengeDate }, 'challenge already exists, skipping')
+    return {
+      created: false,
+      skipped: 'ALREADY_EXISTS',
+      challengeId: existing.id,
+      challengeDate,
+      message: `GeoGamers challenge already exists for ${challengeDate}`,
+    }
+  }
+
+  const cooldownDays = Number(env.GEOGAMERS_GAME_COOLDOWN_DAYS) || 14
+  const minGames = Number(env.GEOGAMERS_MIN_ELIGIBLE_GAMES) || 10
+  const cooldownGameIds = await geoGamersChallengeRepository.gameIdsUsedSince(cooldownDays)
+
+  const eligible = await geoGamersChallengeRepository.listEligibleMetas({ cooldownGameIds })
+  const distinctGames = new Set(eligible.map((r) => r.gameId)).size
+
+  if (distinctGames < minGames) {
+    log.warn(
+      { challengeDate, distinctGames, minGames, cooldownDays },
+      'GeoGamers content starved: not enough eligible games — skipping challenge creation',
+    )
+    return {
+      created: false,
+      skipped: 'INSUFFICIENT_CONTENT',
+      challengeDate,
+      eligibleGames: distinctGames,
+      message: `Only ${distinctGames} eligible games (need ${minGames}); skipped ${challengeDate}`,
+    }
+  }
+
+  const pick = eligible[Math.floor(Math.random() * eligible.length)]!
+  const challenge = await geoGamersChallengeRepository.create({
+    challengeDate,
+    geoScreenshotMetaId: pick.metaId,
+  })
+  await geoGamersChallengeRepository.setCurrent(challenge.id)
+
+  log.info(
+    { challengeId: challenge.id, challengeDate, metaId: pick.metaId, eligibleGames: distinctGames },
+    'geogamers challenge created and set current',
+  )
+  return {
+    created: true,
+    challengeId: challenge.id,
+    challengeDate,
+    geoScreenshotMetaId: pick.metaId,
+    eligibleGames: distinctGames,
+    message: `Created GeoGamers challenge for ${challengeDate}`,
+  }
+}

--- a/packages/backend/src/infrastructure/queue/workers/geogamers-daily-push-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geogamers-daily-push-logic.ts
@@ -1,0 +1,81 @@
+/**
+ * GeoGamers daily push fan-out.
+ *
+ * Fired once, right after a new GeoGamers challenge is created, to tell
+ * subscribed players "today's panorama is live". Enumerates active,
+ * non-anonymous push subscribers and enqueues a per-user send (the push
+ * worker handles the per-device fan-out, retries, and 410-pruning).
+ *
+ * Best-effort and idempotent-enough: it runs only on the day's first
+ * successful challenge creation (the scheduler is idempotent per date), so a
+ * container restart that re-runs the already-created challenge won't re-notify.
+ */
+
+import { db } from '../../database/connection.js'
+import { queueLogger } from '../../logger/logger.js'
+import { pushService } from '../../../domain/services/index.js'
+import { buildGeoGamersDailyCopy } from '../../../domain/services/geogamers-daily-push-copy.js'
+
+const log = queueLogger.child({ module: 'geogamers-daily-push' })
+
+export { buildGeoGamersDailyCopy }
+
+interface Subscriber {
+  id: string
+}
+
+export interface GeoGamersDailyPushResult {
+  candidates: number
+  enqueued: number
+  failed: number
+  skipped: boolean
+  message: string
+}
+
+// Exported for testing: active, non-anonymous push subscribers (deduped).
+// Note: the `user` table stores no per-user locale, so copy defaults to French
+// (the app's default locale); the deep-link uses the same.
+export async function findSubscribers(): Promise<Subscriber[]> {
+  return db('user')
+    .join('push_subscriptions', 'push_subscriptions.user_id', 'user.id')
+    .where('push_subscriptions.is_active', true)
+    .whereRaw('"user"."isAnonymous" = ?', [false])
+    .distinct<Subscriber[]>('user.id as id')
+}
+
+export async function sendGeoGamersDailyPush(
+  onProgress?: (current: number, total: number) => void,
+): Promise<GeoGamersDailyPushResult> {
+  if (!pushService.isConfigured()) {
+    log.info('push not configured; skipping geogamers daily fan-out')
+    return { candidates: 0, enqueued: 0, failed: 0, skipped: true, message: 'push not configured' }
+  }
+
+  const subscribers = await findSubscribers()
+  let enqueued = 0
+  let failed = 0
+
+  // No stored per-user locale → default to French (app default).
+  const { title, body } = buildGeoGamersDailyCopy('fr')
+
+  for (let i = 0; i < subscribers.length; i++) {
+    const sub = subscribers[i]!
+    onProgress?.(i + 1, subscribers.length)
+    try {
+      await pushService.sendToUser(sub.id, {
+        type: 'geogamers_daily',
+        title,
+        body,
+        url: '/fr/geogamers',
+      })
+      enqueued++
+    } catch (err) {
+      failed++
+      log.warn({ userId: sub.id, err: String(err) }, 'geogamers daily push enqueue failed')
+    }
+  }
+
+  const message = `geogamers-daily-push: candidates=${subscribers.length} enqueued=${enqueued} failed=${failed}`
+  log.info({ enqueued, failed, candidates: subscribers.length }, message)
+  return { candidates: subscribers.length, enqueued, failed, skipped: false, message }
+}

--- a/packages/backend/src/infrastructure/queue/workers/geogamers-season-payout-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geogamers-season-payout-logic.ts
@@ -1,0 +1,94 @@
+/**
+ * GeoGamers Season Payout Logic
+ *
+ * Runs on the 1st of the month to close the season that just ended: ranks the
+ * final standings and grants a season-frame cosmetic to the top finishers.
+ *
+ * Integrity gate (per the anonymous-play/season decision): only NON-provisional
+ * finishers (>= min days played) are eligible for a payout — a handful of days
+ * can't win a season. Full first-attempt-correct anomaly screening + admin
+ * review is a documented follow-up; this worker enforces the days-played floor,
+ * which is the cheap, high-value half.
+ *
+ * Idempotent via the reward_grants unique (userId, sourceRef); a re-run grants
+ * nothing new.
+ */
+
+import { queueLogger } from '../../logger/logger.js'
+import { rewardsService, geoGamersSeasonService } from '../../../domain/services/index.js'
+import { emitRewardGranted, emitGeoGamersSeasonUpdated } from '../../socket/socket.js'
+import { priorMonthLabel } from './leaderboard-payout-period.js'
+import type { RewardGrantedEvent } from '@the-box/types'
+
+const log = queueLogger.child({ module: 'geogamers-season-payout' })
+
+// Top N finishers receive the season frame. Mirrors the classic monthly
+// leaderboard's recognition tier size.
+const SEASON_PAYOUT_TOP_N = 100
+
+function seasonFrameItemKey(label: string): string {
+  return `geogamers_season_frame_${label.replace('-', '_')}`
+}
+
+export interface GeoGamersSeasonPayoutResult {
+  month: string
+  candidates: number
+  granted: number
+  failures: number
+  message: string
+}
+
+export async function grantGeoGamersSeasonPayout(
+  onProgress?: (current: number, total: number) => void,
+  now: Date = new Date(),
+): Promise<GeoGamersSeasonPayoutResult> {
+  const period = priorMonthLabel(now)
+  const sourceRef = `geogamers_payout:season:${period.label}`
+  const itemKey = seasonFrameItemKey(period.label)
+  log.info({ month: period.label, sourceRef, itemKey }, 'geogamers season payout starting')
+
+  const standings = await geoGamersSeasonService.standings(period.label, SEASON_PAYOUT_TOP_N)
+  // Eligibility gate: non-provisional finishers only.
+  const eligible = standings.filter((s) => !s.provisional)
+
+  let granted = 0
+  let failures = 0
+  for (let i = 0; i < eligible.length; i++) {
+    const entry = eligible[i]!
+    onProgress?.(i + 1, eligible.length)
+    try {
+      const result = await rewardsService.grant({
+        userId: entry.userId,
+        source: 'leaderboard_payout',
+        sourceRef,
+        items: [{ itemType: 'cosmetic', itemKey, quantity: 1 }],
+      })
+      if (result.wasNew) {
+        granted++
+        const event: RewardGrantedEvent = {
+          rewardId: result.grant.id,
+          source: result.grant.source,
+          sourceRef: result.grant.sourceRef,
+          items: result.grant.payload.items,
+          grantedAt: result.grant.grantedAt,
+          unlockedAt: result.grant.unlockedAt,
+        }
+        emitRewardGranted(entry.userId, event)
+      }
+    } catch (error) {
+      failures++
+      log.error({ userId: entry.userId, error: String(error) }, 'geogamers payout grant failed')
+    }
+  }
+
+  // Broadcast the finalized top standings so any open leaderboard refreshes.
+  try {
+    emitGeoGamersSeasonUpdated({ month: period.label, topN: eligible.slice(0, 10) })
+  } catch (error) {
+    log.warn({ error: String(error) }, 'failed to emit season updated')
+  }
+
+  const message = `geogamers-payout: month=${period.label} candidates=${eligible.length} granted=${granted} failures=${failures}`
+  log.info({ month: period.label, granted, failures }, message)
+  return { month: period.label, candidates: eligible.length, granted, failures, message }
+}

--- a/packages/backend/src/infrastructure/queue/workers/import.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/import.worker.ts
@@ -6,6 +6,7 @@ import { fetchGamesFromRAWG, saveData, downloadAllScreenshots } from './import-l
 import { processBatch, scheduleNextBatch } from './batch-import-logic.js'
 import { processSyncAllBatch, scheduleSyncAllNextBatch } from './sync-all-logic.js'
 import { createDailyChallenge } from './daily-challenge-logic.js'
+import { createGeoGamersChallenge } from './geogamers-challenge-logic.js'
 import { cleanupAnonymousUsers } from './cleanup-anonymous-logic.js'
 import { processRecalculateScoresJob } from './recalculate-scores-logic.js'
 import { clearDailyData } from './clear-daily-data-logic.js'
@@ -152,6 +153,19 @@ export const importWorker = new Worker<JobData, JobResult>(
 
         log.info({ jobId: id, result: jobResult }, 'create-daily-challenge job completed')
         return jobResult
+      }
+
+      if (name === 'create-geogamers-challenge') {
+        // Same repeat-id -> scheduled-fire-time decoding as the classic daily
+        // challenge, so a near-midnight restart computes the right date.
+        let referenceMs = Date.now()
+        if (typeof id === 'string' && id.startsWith('repeat:')) {
+          const parsed = Number(id.split(':').pop())
+          if (Number.isFinite(parsed)) referenceMs = parsed
+        }
+        const result = await createGeoGamersChallenge({ referenceMs })
+        log.info({ jobId: id, result }, 'create-geogamers-challenge job completed')
+        return { message: result.message }
       }
 
       if (name === 'sync-all-games') {

--- a/packages/backend/src/infrastructure/queue/workers/import.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/import.worker.ts
@@ -7,6 +7,7 @@ import { processBatch, scheduleNextBatch } from './batch-import-logic.js'
 import { processSyncAllBatch, scheduleSyncAllNextBatch } from './sync-all-logic.js'
 import { createDailyChallenge } from './daily-challenge-logic.js'
 import { createGeoGamersChallenge } from './geogamers-challenge-logic.js'
+import { grantGeoGamersSeasonPayout } from './geogamers-season-payout-logic.js'
 import { cleanupAnonymousUsers } from './cleanup-anonymous-logic.js'
 import { processRecalculateScoresJob } from './recalculate-scores-logic.js'
 import { clearDailyData } from './clear-daily-data-logic.js'
@@ -153,6 +154,14 @@ export const importWorker = new Worker<JobData, JobResult>(
 
         log.info({ jobId: id, result: jobResult }, 'create-daily-challenge job completed')
         return jobResult
+      }
+
+      if (name === 'geogamers-season-payout') {
+        const result = await grantGeoGamersSeasonPayout((current, total) => {
+          job.updateProgress(Math.round((current / Math.max(1, total)) * 100))
+        })
+        log.info({ jobId: id, result }, 'geogamers-season-payout job completed')
+        return { message: result.message }
       }
 
       if (name === 'create-geogamers-challenge') {

--- a/packages/backend/src/infrastructure/queue/workers/import.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/import.worker.ts
@@ -8,6 +8,7 @@ import { processSyncAllBatch, scheduleSyncAllNextBatch } from './sync-all-logic.
 import { createDailyChallenge } from './daily-challenge-logic.js'
 import { createGeoGamersChallenge } from './geogamers-challenge-logic.js'
 import { grantGeoGamersSeasonPayout } from './geogamers-season-payout-logic.js'
+import { sendGeoGamersDailyPush } from './geogamers-daily-push-logic.js'
 import { cleanupAnonymousUsers } from './cleanup-anonymous-logic.js'
 import { processRecalculateScoresJob } from './recalculate-scores-logic.js'
 import { clearDailyData } from './clear-daily-data-logic.js'
@@ -173,6 +174,16 @@ export const importWorker = new Worker<JobData, JobResult>(
           if (Number.isFinite(parsed)) referenceMs = parsed
         }
         const result = await createGeoGamersChallenge({ referenceMs })
+        // Notify subscribers only on the day's first successful creation, so a
+        // restart re-running the (idempotent) challenge job won't re-notify.
+        if (result.created) {
+          try {
+            const push = await sendGeoGamersDailyPush()
+            log.info({ push }, 'geogamers daily push fan-out complete')
+          } catch (err) {
+            log.warn({ err: String(err) }, 'geogamers daily push fan-out failed')
+          }
+        }
         log.info({ jobId: id, result }, 'create-geogamers-challenge job completed')
         return { message: result.message }
       }

--- a/packages/backend/src/infrastructure/repositories/geogamers-challenge.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geogamers-challenge.repository.ts
@@ -1,0 +1,93 @@
+import { db } from '../database/connection.js'
+import { repoLogger } from '../logger/logger.js'
+import type {
+  GeoGamersChallengeRecord,
+  GeoGamersChallengeRepository,
+} from '../../domain/services/geogamers.service.js'
+
+const log = repoLogger.child({ repository: 'geogamers-challenge' })
+
+interface GeoGamersChallengeRow {
+  id: number
+  challenge_date: Date | string
+  geo_screenshot_meta_id: number
+  is_current: boolean
+  created_at: Date
+}
+
+function mapChallenge(row: GeoGamersChallengeRow): GeoGamersChallengeRecord {
+  return {
+    id: row.id,
+    challengeDate:
+      row.challenge_date instanceof Date
+        ? row.challenge_date.toISOString().slice(0, 10)
+        : String(row.challenge_date).slice(0, 10),
+    geoScreenshotMetaId: row.geo_screenshot_meta_id,
+  }
+}
+
+// Concrete repository. Implements the domain port plus the create/setCurrent
+// helpers the daily-scheduler worker needs.
+export const geoGamersChallengeRepository: GeoGamersChallengeRepository & {
+  create(data: { challengeDate: string; geoScreenshotMetaId: number }): Promise<GeoGamersChallengeRecord>
+  setCurrent(challengeId: number): Promise<void>
+  gameIdsUsedSince(days: number): Promise<number[]>
+} = {
+  async findCurrent(): Promise<GeoGamersChallengeRecord | null> {
+    const row = await db('geogamers_challenge')
+      .where({ is_current: true })
+      .first<GeoGamersChallengeRow>()
+    return row ? mapChallenge(row) : null
+  },
+
+  async findByDate(date: string): Promise<GeoGamersChallengeRecord | null> {
+    const row = await db('geogamers_challenge')
+      .where({ challenge_date: date })
+      .first<GeoGamersChallengeRow>()
+    return row ? mapChallenge(row) : null
+  },
+
+  async create(data): Promise<GeoGamersChallengeRecord> {
+    log.info({ date: data.challengeDate }, 'create geogamers challenge')
+    const [row] = await db('geogamers_challenge')
+      .insert({
+        challenge_date: data.challengeDate,
+        geo_screenshot_meta_id: data.geoScreenshotMetaId,
+      })
+      .onConflict('challenge_date')
+      .ignore()
+      .returning<GeoGamersChallengeRow[]>('*')
+    // onConflict().ignore() returns nothing when the row already exists —
+    // fall back to a read so the caller always gets the canonical record.
+    if (row) return mapChallenge(row)
+    const existing = await db('geogamers_challenge')
+      .where({ challenge_date: data.challengeDate })
+      .first<GeoGamersChallengeRow>()
+    return mapChallenge(existing!)
+  },
+
+  // Atomically promote `challengeId` to current, demoting any prior current
+  // row. The partial unique index geogamers_challenge_one_current rejects two
+  // current rows, so both statements must share a transaction.
+  async setCurrent(challengeId: number): Promise<void> {
+    await db.transaction(async (trx) => {
+      await trx('geogamers_challenge')
+        .where({ is_current: true })
+        .whereNot('id', challengeId)
+        .update({ is_current: false })
+      await trx('geogamers_challenge').where({ id: challengeId }).update({ is_current: true })
+    })
+  },
+
+  // Game-cooldown support: which game ids have been featured in the last
+  // `days` days. The worker excludes these so the same game isn't reused too
+  // soon. Joins meta -> candidate to reach game_id.
+  async gameIdsUsedSince(days: number): Promise<number[]> {
+    const rows = await db('geogamers_challenge as gc')
+      .join('geo_screenshot_meta as m', 'm.id', 'gc.geo_screenshot_meta_id')
+      .join('geo_screenshot_candidate as c', 'c.id', 'm.geo_screenshot_candidate_id')
+      .where('gc.challenge_date', '>=', db.raw(`CURRENT_DATE - INTERVAL '${days} days'`))
+      .distinct<{ game_id: number }[]>('c.game_id')
+    return rows.map((r) => r.game_id)
+  },
+}

--- a/packages/backend/src/infrastructure/repositories/geogamers-challenge.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geogamers-challenge.repository.ts
@@ -26,12 +26,20 @@ function mapChallenge(row: GeoGamersChallengeRow): GeoGamersChallengeRecord {
   }
 }
 
+export interface EligibleMeta {
+  metaId: number
+  gameId: number
+}
+
 // Concrete repository. Implements the domain port plus the create/setCurrent
-// helpers the daily-scheduler worker needs.
+// helpers the daily-scheduler worker needs and the eligibility queries shared
+// by the scheduler (daily pick) and the joker re-roll.
 export const geoGamersChallengeRepository: GeoGamersChallengeRepository & {
   create(data: { challengeDate: string; geoScreenshotMetaId: number }): Promise<GeoGamersChallengeRecord>
   setCurrent(challengeId: number): Promise<void>
   gameIdsUsedSince(days: number): Promise<number[]>
+  listEligibleMetas(opts: { cooldownGameIds?: number[]; excludeMetaId?: number }): Promise<EligibleMeta[]>
+  pickAlternateMeta(excludeMetaId: number): Promise<number | null>
 } = {
   async findCurrent(): Promise<GeoGamersChallengeRecord | null> {
     const row = await db('geogamers_challenge')
@@ -89,5 +97,38 @@ export const geoGamersChallengeRepository: GeoGamersChallengeRepository & {
       .where('gc.challenge_date', '>=', db.raw(`CURRENT_DATE - INTERVAL '${days} days'`))
       .distinct<{ game_id: number }[]>('c.game_id')
     return rows.map((r) => r.game_id)
+  },
+
+  // Metas eligible to be a challenge: canonical pin (it's a meta), active map,
+  // present game, and NEVER previously used as a GeoGamers challenge. Optional
+  // game cooldown + single-meta exclusion (for joker re-rolls).
+  async listEligibleMetas({ cooldownGameIds = [], excludeMetaId }): Promise<EligibleMeta[]> {
+    const q = db('geo_screenshot_meta as m')
+      .join('geo_screenshot_candidate as c', 'c.id', 'm.geo_screenshot_candidate_id')
+      .join('geo_map as map', function joinMap() {
+        this.on('map.id', '=', 'm.geo_map_id').andOn('map.is_active', '=', db.raw('true'))
+      })
+      .join('games as g', 'g.id', 'c.game_id')
+      .whereNotExists(function usedBefore() {
+        this.select(db.raw('1'))
+          .from('geogamers_challenge as gc')
+          .whereRaw('gc.geo_screenshot_meta_id = m.id')
+      })
+    if (cooldownGameIds.length > 0) q.whereNotIn('c.game_id', cooldownGameIds)
+    if (excludeMetaId != null) q.whereNot('m.id', excludeMetaId)
+    const rows = await q.select<Array<{ meta_id: number; game_id: number }>>(
+      'm.id as meta_id',
+      'c.game_id',
+    )
+    return rows.map((r) => ({ metaId: r.meta_id, gameId: r.game_id }))
+  },
+
+  // Joker re-roll: any eligible meta other than the current one. No cooldown
+  // (variety for one player, not the day-to-day rotation). Null when none.
+  async pickAlternateMeta(excludeMetaId: number): Promise<number | null> {
+    const eligible = await this.listEligibleMetas({ excludeMetaId })
+    if (eligible.length === 0) return null
+    const pick = eligible[Math.floor(Math.random() * eligible.length)]!
+    return pick.metaId
   },
 }

--- a/packages/backend/src/infrastructure/repositories/geogamers-joker.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geogamers-joker.repository.ts
@@ -1,0 +1,27 @@
+import { db } from '../database/connection.js'
+import { repoLogger } from '../logger/logger.js'
+import type { GeoGamersJokerRepository } from '../../domain/services/geogamers.service.js'
+
+const log = repoLogger.child({ repository: 'geogamers-joker' })
+
+// Once-per-season joker ledger. The (user_id, season_month) primary key is the
+// real enforcement; `record` lets a unique violation propagate so the service
+// can map a race to JOKER_ALREADY_USED.
+export const geoGamersJokerRepository: GeoGamersJokerRepository = {
+  async hasUsed(userId: string, seasonMonth: string): Promise<boolean> {
+    const row = await db('geogamers_joker')
+      .where({ user_id: userId, season_month: seasonMonth })
+      .first<{ user_id: string }>()
+    return !!row
+  },
+
+  async record({ userId, seasonMonth, challengeId, rerolledMetaId }): Promise<void> {
+    log.info({ userId, seasonMonth, rerolledMetaId }, 'record joker')
+    await db('geogamers_joker').insert({
+      user_id: userId,
+      season_month: seasonMonth,
+      geogamers_challenge_id: challengeId,
+      rerolled_geo_screenshot_meta_id: rerolledMetaId,
+    })
+  },
+}

--- a/packages/backend/src/infrastructure/repositories/geogamers-party.store.ts
+++ b/packages/backend/src/infrastructure/repositories/geogamers-party.store.ts
@@ -1,0 +1,106 @@
+import { randomBytes } from 'node:crypto'
+import { getRedis } from '../redis/redis.client.js'
+import { repoLogger } from '../logger/logger.js'
+import { geoGamersChallengeRepository } from './geogamers-challenge.repository.js'
+import { geoScreenshotRepository } from './geo-screenshot.repository.js'
+import { gameRepository } from './game.repository.js'
+import type { GeoGamersParty } from '@the-box/types'
+import type { PartyRoundContent } from '../../domain/services/geogamers-party.service.js'
+
+const log = repoLogger.child({ repository: 'geogamers-party' })
+
+// Party state is ephemeral — a 2h TTL is plenty for a session and keeps stale
+// lobbies from accumulating (no cron needed; Redis expires them).
+const PARTY_TTL_SECONDS = 2 * 60 * 60
+const KEY = (code: string) => `geogamers:party:${code}`
+
+// Unambiguous invite-code alphabet (no 0/O/1/I).
+const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+
+export function generatePartyCode(): string {
+  const bytes = randomBytes(6)
+  let code = ''
+  for (let i = 0; i < 6; i++) code += CODE_ALPHABET[bytes[i]! % CODE_ALPHABET.length]
+  return code
+}
+
+export const geoGamersPartyStore = {
+  async get(code: string): Promise<GeoGamersParty | null> {
+    const raw = await getRedis().get(KEY(code))
+    return raw ? (JSON.parse(raw) as GeoGamersParty) : null
+  },
+
+  // Persist and refresh the TTL. Party mutations always go through the pure
+  // state machine, then save() writes the new snapshot.
+  async save(party: GeoGamersParty): Promise<void> {
+    await getRedis().set(KEY(party.code), JSON.stringify(party), 'EX', PARTY_TTL_SECONDS)
+  },
+
+  // Reserve a fresh, unused code and persist the initial party.
+  async create(party: Omit<GeoGamersParty, 'code'>): Promise<GeoGamersParty> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const code = generatePartyCode()
+      // NX: only set if the code is free, so two hosts can't collide.
+      const ok = await getRedis().set(
+        KEY(code),
+        JSON.stringify({ ...party, code }),
+        'EX',
+        PARTY_TTL_SECONDS,
+        'NX',
+      )
+      if (ok) return { ...party, code }
+    }
+    throw new Error('could not allocate a unique party code')
+  },
+
+  async delete(code: string): Promise<void> {
+    await getRedis().del(KEY(code))
+  },
+}
+
+/**
+ * Resolve `count` round contents from the eligible pool. `listEligibleMetas`
+ * excludes every screenshot that has EVER been a daily challenge, so party
+ * content can never leak (or be used to scout) the ranked daily. Returns fewer
+ * than `count` only if the pool is too small.
+ */
+export async function resolvePartyRoundContents(count: number): Promise<PartyRoundContent[]> {
+  const eligible = await geoGamersChallengeRepository.listEligibleMetas({})
+  if (eligible.length === 0) return []
+
+  // Shuffle (Fisher–Yates) and take up to `count` distinct metas.
+  const pool = [...eligible]
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[pool[i], pool[j]] = [pool[j]!, pool[i]!]
+  }
+  const chosen = pool.slice(0, count)
+
+  const contents: PartyRoundContent[] = []
+  for (const { metaId } of chosen) {
+    const meta = await geoScreenshotRepository.findMetaById(metaId)
+    if (!meta) continue
+    const candidate = await geoScreenshotRepository.findCandidateById(meta.geoScreenshotCandidateId)
+    if (!candidate) continue
+    const game = await gameRepository.findById(candidate.gameId)
+    if (!game) continue
+    contents.push({
+      geoScreenshotMetaId: meta.id,
+      gameId: candidate.gameId,
+      gameName: game.name,
+      geoMapId: meta.geoMapId,
+      canonical: meta.canonical,
+    })
+  }
+  log.debug({ requested: count, resolved: contents.length }, 'resolved party round contents')
+  return contents
+}
+
+// Server-only lookup for the party image proxy: the underlying asset URL for a
+// round's screenshot (never sent to clients — streamed through the proxy).
+export async function resolvePartyRoundImage(metaId: number): Promise<string | null> {
+  const meta = await geoScreenshotRepository.findMetaById(metaId)
+  if (!meta) return null
+  const candidate = await geoScreenshotRepository.findCandidateById(meta.geoScreenshotCandidateId)
+  return candidate?.imageUrl ?? null
+}

--- a/packages/backend/src/infrastructure/repositories/geogamers-run.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geogamers-run.repository.ts
@@ -1,0 +1,190 @@
+import { db } from '../database/connection.js'
+import { repoLogger } from '../logger/logger.js'
+import type { Knex } from 'knex'
+import type {
+  CreateRunInput,
+  GeoGamersRunRecord,
+  GeoGamersRunRepository,
+  UpdateRunInput,
+} from '../../domain/services/geogamers.service.js'
+import type { GeoGamersGameAttempt } from '@the-box/types'
+
+const log = repoLogger.child({ repository: 'geogamers-run' })
+
+interface GeoGamersRunRow {
+  id: number
+  geogamers_challenge_id: number
+  user_id: string | null
+  anonymous_session_id: string | null
+  run_token: string
+  geo_screenshot_meta_id: number | null
+  game_attempts: GeoGamersGameAttempt[] | string
+  game_points: number | null
+  guess_x: number | null
+  guess_y: number | null
+  distance: number | null
+  location_points: number | null
+  total_points: number | null
+  score_version: number | null
+  time_spent_ms: number
+  started_at: Date | string
+  completed_at: Date | string | null
+  joker_used: boolean
+  claimed_at: Date | string | null
+  claimed_by_user_id: string | null
+}
+
+function toIso(v: Date | string | null): string | null {
+  if (v == null) return null
+  return v instanceof Date ? v.toISOString() : String(v)
+}
+
+function mapRun(row: GeoGamersRunRow): GeoGamersRunRecord {
+  // jsonb comes back parsed under pg, but guard for string just in case a
+  // driver hands us raw text.
+  const attempts =
+    typeof row.game_attempts === 'string'
+      ? (JSON.parse(row.game_attempts) as GeoGamersGameAttempt[])
+      : row.game_attempts
+  const guess =
+    row.guess_x != null && row.guess_y != null ? { x: row.guess_x, y: row.guess_y } : null
+  return {
+    id: row.id,
+    challengeId: row.geogamers_challenge_id,
+    userId: row.user_id,
+    anonymousSessionId: row.anonymous_session_id,
+    runToken: row.run_token,
+    geoScreenshotMetaId: row.geo_screenshot_meta_id,
+    gameAttempts: attempts ?? [],
+    gamePoints: row.game_points,
+    guess,
+    distance: row.distance,
+    locationPoints: row.location_points,
+    totalPoints: row.total_points,
+    scoreVersion: row.score_version,
+    timeSpentMs: row.time_spent_ms,
+    startedAt: toIso(row.started_at)!,
+    completedAt: toIso(row.completed_at),
+    jokerUsed: row.joker_used,
+    claimedAt: toIso(row.claimed_at),
+    claimedByUserId: row.claimed_by_user_id,
+  }
+}
+
+// Translate a domain UpdateRunInput into a snake_case DB patch, only touching
+// the columns actually provided.
+function toDbPatch(patch: UpdateRunInput): Record<string, unknown> {
+  const db_: Record<string, unknown> = {}
+  if (patch.gameAttempts !== undefined) db_['game_attempts'] = JSON.stringify(patch.gameAttempts)
+  if (patch.gamePoints !== undefined) db_['game_points'] = patch.gamePoints
+  if (patch.geoScreenshotMetaId !== undefined) db_['geo_screenshot_meta_id'] = patch.geoScreenshotMetaId
+  if (patch.guess !== undefined) {
+    db_['guess_x'] = patch.guess?.x ?? null
+    db_['guess_y'] = patch.guess?.y ?? null
+  }
+  if (patch.distance !== undefined) db_['distance'] = patch.distance
+  if (patch.locationPoints !== undefined) db_['location_points'] = patch.locationPoints
+  if (patch.totalPoints !== undefined) db_['total_points'] = patch.totalPoints
+  if (patch.scoreVersion !== undefined) db_['score_version'] = patch.scoreVersion
+  if (patch.timeSpentMs !== undefined) db_['time_spent_ms'] = patch.timeSpentMs
+  if (patch.completedAt !== undefined) db_['completed_at'] = patch.completedAt
+  if (patch.jokerUsed !== undefined) db_['joker_used'] = patch.jokerUsed
+  return db_
+}
+
+export const geoGamersRunRepository: GeoGamersRunRepository = {
+  async findByToken(runToken: string): Promise<GeoGamersRunRecord | null> {
+    const row = await db('geogamers_run').where({ run_token: runToken }).first<GeoGamersRunRow>()
+    return row ? mapRun(row) : null
+  },
+
+  async findRankedForUser(challengeId: number, userId: string): Promise<GeoGamersRunRecord | null> {
+    const row = await db('geogamers_run')
+      .where({ geogamers_challenge_id: challengeId, user_id: userId })
+      .first<GeoGamersRunRow>()
+    return row ? mapRun(row) : null
+  },
+
+  async create(input: CreateRunInput): Promise<GeoGamersRunRecord> {
+    const [row] = await db('geogamers_run')
+      .insert({
+        geogamers_challenge_id: input.challengeId,
+        user_id: input.userId,
+        anonymous_session_id: input.anonymousSessionId,
+        run_token: input.runToken,
+        game_attempts: JSON.stringify([]),
+      })
+      .returning<GeoGamersRunRow[]>('*')
+    return mapRun(row!)
+  },
+
+  async update(runId: number, patch: UpdateRunInput): Promise<GeoGamersRunRecord> {
+    const [row] = await db('geogamers_run')
+      .where({ id: runId })
+      .update(toDbPatch(patch))
+      .returning<GeoGamersRunRow[]>('*')
+    return mapRun(row!)
+  },
+
+  async countCompletedBetter(challengeId: number, points: number): Promise<number> {
+    const res = await db('geogamers_run')
+      .where({ geogamers_challenge_id: challengeId })
+      .whereNotNull('completed_at')
+      .whereNotNull('user_id')
+      .where('total_points', '>', points)
+      .count<{ count: string }>('id as count')
+      .first()
+    return Number(res?.count ?? 0)
+  },
+
+  // Copy a completed guest run into a NEW user-owned row and mark the guest
+  // row claimed. The unique claim index (claimed_by_user_id, challenge) plus
+  // the ranked-run unique index make a double-claim/double-play trip a unique
+  // violation, which surfaces as null (caller maps to CLAIM_INVALID/ALREADY).
+  async claimGuestRun({ guestRunId, userId, challengeId }): Promise<GeoGamersRunRecord | null> {
+    try {
+      return await db.transaction(async (trx: Knex.Transaction) => {
+        const guest = await trx('geogamers_run')
+          .where({ id: guestRunId })
+          .whereNull('user_id')
+          .whereNull('claimed_at')
+          .first<GeoGamersRunRow>()
+        if (!guest) return null
+
+        await trx('geogamers_run')
+          .where({ id: guestRunId })
+          .update({ claimed_at: new Date().toISOString(), claimed_by_user_id: userId })
+
+        const [copy] = await trx('geogamers_run')
+          .insert({
+            geogamers_challenge_id: challengeId,
+            user_id: userId,
+            anonymous_session_id: null,
+            run_token: globalThis.crypto.randomUUID(),
+            geo_screenshot_meta_id: guest.geo_screenshot_meta_id,
+            game_attempts:
+              typeof guest.game_attempts === 'string'
+                ? guest.game_attempts
+                : JSON.stringify(guest.game_attempts),
+            game_points: guest.game_points,
+            guess_x: guest.guess_x,
+            guess_y: guest.guess_y,
+            distance: guest.distance,
+            location_points: guest.location_points,
+            total_points: guest.total_points,
+            score_version: guest.score_version,
+            time_spent_ms: guest.time_spent_ms,
+            started_at: guest.started_at,
+            completed_at: guest.completed_at,
+            joker_used: guest.joker_used,
+          })
+          .returning<GeoGamersRunRow[]>('*')
+        return mapRun(copy!)
+      })
+    } catch (err) {
+      // Unique-violation on claim-once or ranked-run index → not claimable.
+      log.warn({ err, guestRunId, userId }, 'claimGuestRun conflict')
+      return null
+    }
+  },
+}

--- a/packages/backend/src/infrastructure/repositories/geogamers-season.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geogamers-season.repository.ts
@@ -1,0 +1,196 @@
+import { db } from '../database/connection.js'
+import { repoLogger } from '../logger/logger.js'
+import type { GeoGamersSeasonStanding, GeoGamersSeasonMe } from '@the-box/types'
+
+const log = repoLogger.child({ repository: 'geogamers-season' })
+
+// Season parameters. A player's season score drops their N worst days, but
+// ONLY once they've played at least MIN_DAYS (until then the raw total stands
+// and they're flagged provisional).
+export const SEASON_DROP_WORST = 3
+export const SEASON_MIN_DAYS_FOR_DROP = 10
+
+/** Current season month (YYYY-MM, UTC). */
+export function currentSeasonMonth(referenceMs?: number): string {
+  const ref = typeof referenceMs === 'number' ? new Date(referenceMs) : new Date()
+  return ref.toISOString().slice(0, 7)
+}
+
+/** [start, end) date bounds for a YYYY-MM season, as YYYY-MM-DD strings. */
+export function seasonBounds(month: string): { start: string; end: string } {
+  const [y, m] = month.split('-').map(Number) as [number, number]
+  const start = `${month}-01`
+  const nextMonth = m === 12 ? 1 : m + 1
+  const nextYear = m === 12 ? y + 1 : y
+  const end = `${String(nextYear).padStart(4, '0')}-${String(nextMonth).padStart(2, '0')}-01`
+  return { start, end }
+}
+
+interface StandingRow {
+  user_id: string
+  username: string | null
+  days_played: string | number
+  joker_used: boolean
+  raw_total: string | number
+  season_score: string | number
+  rank: string | number
+}
+
+// The shared ranking CTE. Computes each day's rank-from-worst per user, folds
+// them into a season score that drops the N worst days once MIN_DAYS is hit,
+// then ranks users. Bound parameters keep it injection-safe.
+function rankingCte(month: string) {
+  const { start, end } = seasonBounds(month)
+  return db.raw(
+    `
+    WITH daily AS (
+      SELECT
+        r.user_id,
+        r.total_points,
+        r.joker_used,
+        ROW_NUMBER() OVER (
+          PARTITION BY r.user_id
+          ORDER BY r.total_points ASC, c.challenge_date ASC
+        ) AS worst_rank,
+        COUNT(*) OVER (PARTITION BY r.user_id) AS days_played
+      FROM geogamers_run r
+      JOIN geogamers_challenge c ON c.id = r.geogamers_challenge_id
+      WHERE r.user_id IS NOT NULL
+        AND r.completed_at IS NOT NULL
+        AND c.challenge_date >= ? AND c.challenge_date < ?
+    ),
+    agg AS (
+      SELECT
+        d.user_id,
+        MAX(d.days_played) AS days_played,
+        bool_or(d.joker_used) AS joker_used,
+        SUM(d.total_points) AS raw_total,
+        SUM(d.total_points) FILTER (
+          WHERE d.days_played < ? OR d.worst_rank > ?
+        ) AS season_score
+      FROM daily d
+      GROUP BY d.user_id
+    ),
+    ranked AS (
+      SELECT
+        a.*,
+        ROW_NUMBER() OVER (
+          ORDER BY a.season_score DESC, a.raw_total DESC, a.user_id ASC
+        ) AS rank
+      FROM agg a
+    )
+    SELECT
+      r.user_id,
+      COALESCE(u.display_name, u.username, 'Player') AS username,
+      r.days_played, r.joker_used, r.raw_total, r.season_score, r.rank
+    FROM ranked r
+    JOIN "user" u ON u.id = r.user_id
+    `,
+    [start, end, SEASON_MIN_DAYS_FOR_DROP, SEASON_DROP_WORST],
+  )
+}
+
+function mapStanding(row: StandingRow): GeoGamersSeasonStanding {
+  const daysPlayed = Number(row.days_played)
+  const provisional = daysPlayed < SEASON_MIN_DAYS_FOR_DROP
+  return {
+    userId: row.user_id,
+    username: row.username ?? 'Player',
+    daysPlayed,
+    jokerUsed: !!row.joker_used,
+    rawTotal: Number(row.raw_total),
+    seasonScore: Number(row.season_score),
+    droppedDays: provisional ? 0 : SEASON_DROP_WORST,
+    provisional,
+    rank: Number(row.rank),
+  }
+}
+
+export const geoGamersSeasonRepository = {
+  currentSeasonMonth,
+
+  async findBySeason(month: string, limit = 100, offset = 0): Promise<GeoGamersSeasonStanding[]> {
+    const cte = rankingCte(month)
+    const rows = (await db
+      .with('leaderboard', cte)
+      .select<StandingRow[]>('*')
+      .from('leaderboard')
+      .orderBy('rank', 'asc')
+      .limit(limit)
+      .offset(offset)) as StandingRow[]
+    return rows.map(mapStanding)
+  },
+
+  async findUserSeason(month: string, userId: string): Promise<GeoGamersSeasonMe | null> {
+    const cte = rankingCte(month)
+    const row = (await db
+      .with('leaderboard', cte)
+      .select<StandingRow[]>('*')
+      .from('leaderboard')
+      .where('user_id', userId)
+      .first()) as StandingRow | undefined
+    if (!row) return null
+
+    const { start, end } = seasonBounds(month)
+    const dailyRows = await db('geogamers_run as r')
+      .join('geogamers_challenge as c', 'c.id', 'r.geogamers_challenge_id')
+      .where('r.user_id', userId)
+      .whereNotNull('r.completed_at')
+      .andWhere('c.challenge_date', '>=', start)
+      .andWhere('c.challenge_date', '<', end)
+      .orderBy('c.challenge_date', 'asc')
+      .select<
+        Array<{
+          challenge_date: Date | string
+          game_points: number | null
+          location_points: number | null
+          total_points: number | null
+          joker_used: boolean
+        }>
+      >(
+        'c.challenge_date',
+        'r.game_points',
+        'r.location_points',
+        'r.total_points',
+        'r.joker_used',
+      )
+
+    // Mark the N worst days as dropped (only when past the min-days gate).
+    const base = mapStanding(row)
+    const sortedByWorst = [...dailyRows]
+      .map((d, idx) => ({ d, idx, total: Number(d.total_points ?? 0) }))
+      .sort((a, b) => a.total - b.total || a.idx - b.idx)
+    const droppedIdx = new Set(
+      base.provisional ? [] : sortedByWorst.slice(0, SEASON_DROP_WORST).map((x) => x.idx),
+    )
+
+    const dailyBreakdown = dailyRows.map((d, idx) => ({
+      date:
+        d.challenge_date instanceof Date
+          ? d.challenge_date.toISOString().slice(0, 10)
+          : String(d.challenge_date).slice(0, 10),
+      gamePoints: Number(d.game_points ?? 0),
+      locationPoints: Number(d.location_points ?? 0),
+      total: Number(d.total_points ?? 0),
+      dropped: droppedIdx.has(idx),
+      jokerUsed: !!d.joker_used,
+    }))
+
+    return { ...base, dailyBreakdown }
+  },
+
+  async playerCount(month: string): Promise<number> {
+    const { start, end } = seasonBounds(month)
+    const res = await db('geogamers_run as r')
+      .join('geogamers_challenge as c', 'c.id', 'r.geogamers_challenge_id')
+      .whereNotNull('r.user_id')
+      .whereNotNull('r.completed_at')
+      .andWhere('c.challenge_date', '>=', start)
+      .andWhere('c.challenge_date', '<', end)
+      .countDistinct<{ count: string }>('r.user_id as count')
+      .first()
+    return Number(res?.count ?? 0)
+  },
+}
+
+log.debug('geogamers-season repository initialized')

--- a/packages/backend/src/infrastructure/repositories/index.ts
+++ b/packages/backend/src/infrastructure/repositories/index.ts
@@ -26,6 +26,9 @@ export { geoScreenshotRepository } from './geo-screenshot.repository.js'
 export { geoChallengeRepository } from './geo-challenge.repository.js'
 export { geoPinRepository } from './geo-pin.repository.js'
 export { geoContributorRepository } from './geo-contributor.repository.js'
+export { geoGamersChallengeRepository } from './geogamers-challenge.repository.js'
+export { geoGamersRunRepository } from './geogamers-run.repository.js'
+export { geoGamersJokerRepository } from './geogamers-joker.repository.js'
 export {
   screenshotReportRepository,
   REPORT_DEACTIVATION_THRESHOLD,

--- a/packages/backend/src/infrastructure/repositories/index.ts
+++ b/packages/backend/src/infrastructure/repositories/index.ts
@@ -29,6 +29,7 @@ export { geoContributorRepository } from './geo-contributor.repository.js'
 export { geoGamersChallengeRepository } from './geogamers-challenge.repository.js'
 export { geoGamersRunRepository } from './geogamers-run.repository.js'
 export { geoGamersJokerRepository } from './geogamers-joker.repository.js'
+export { geoGamersSeasonRepository } from './geogamers-season.repository.js'
 export {
   screenshotReportRepository,
   REPORT_DEACTIVATION_THRESHOLD,

--- a/packages/backend/src/infrastructure/socket/geogamers-party.socket.ts
+++ b/packages/backend/src/infrastructure/socket/geogamers-party.socket.ts
@@ -1,0 +1,253 @@
+import type { Server as SocketIOServer, Socket } from 'socket.io'
+import type { GeoGamersParty, GeoGamersPartyView, GeoPoint } from '@the-box/types'
+import { logger } from '../logger/logger.js'
+import { getSocketSession } from './socket.js'
+import {
+  geoGamersPartyStore,
+  resolvePartyRoundContents,
+} from '../repositories/geogamers-party.store.js'
+import { geoMapRepository } from '../repositories/geo-map.repository.js'
+import { createFuzzyMatchService } from '../../domain/services/fuzzy-match.service.js'
+import { geoDistance } from '../../domain/services/geo-scoring.service.js'
+import {
+  createParty,
+  joinParty,
+  leaveParty,
+  startParty,
+  submitGameGuess,
+  submitLocation,
+  revealRound,
+  advanceRound,
+  allConnectedDone,
+  scoreboard,
+  PartyError,
+  PARTY_MAX_PLAYERS,
+} from '../../domain/services/geogamers-party.service.js'
+
+const log = logger.child({ module: 'geogamers-party-socket' })
+// Local fuzzy matcher (avoids importing the queue-backed services barrel).
+const fuzzyMatch = createFuzzyMatchService({ logger: log })
+
+const NS = '/geogamers-party'
+const room = (code: string) => `party:${code}`
+
+// Party clients may be guests. Identity: authed user id, else a stable
+// per-socket guest id. Name comes from the join payload or the account.
+interface PartyIdentity {
+  playerId: string
+  name: string
+}
+
+function isPoint(p: unknown): p is GeoPoint {
+  const q = p as GeoPoint
+  return !!q && typeof q.x === 'number' && typeof q.y === 'number' &&
+    q.x >= 0 && q.x <= 1 && q.y >= 0 && q.y <= 1
+}
+
+// Build the spectator-safe view for a specific player. Answers (game identity,
+// canonical pin) are withheld while a round is in progress; the locate-phase
+// map + game name are revealed only once THIS player has resolved phase 1.
+async function buildView(party: GeoGamersParty, playerId: string): Promise<GeoGamersPartyView> {
+  const view: GeoGamersPartyView = {
+    code: party.code,
+    status: party.status,
+    config: party.config,
+    hostId: party.hostId,
+    players: party.players,
+    currentRound: party.currentRound,
+    totalRounds: party.rounds.length,
+    scoreboard: scoreboard(party).map((s) => ({ playerId: s.playerId, name: s.name, total: s.total })),
+  }
+
+  if (party.status === 'in_round') {
+    const round = party.rounds[party.currentRound]
+    if (round) {
+      const result = round.results[playerId]
+      const resolved = !!result && (result.solvedGame || result.attemptsUsed >= 3)
+      view.round = {
+        index: round.index,
+        screenshotUrl: `/api/geogamers/party/${party.code}/round/${round.index}/image`,
+      }
+      if (resolved) {
+        view.round.gameName = round.gameName
+        const maps = await geoMapRepository.listEnabledByGameId(round.gameId)
+        view.round.maps = maps.map((m) => ({
+          id: m.id,
+          region: m.region,
+          imageUrl: m.imageUrl,
+          widthPx: m.widthPx,
+          heightPx: m.heightPx,
+          kind: m.kind,
+          tiles: m.tiles,
+        }))
+      }
+    }
+  }
+
+  if (party.status === 'reveal' || party.status === 'finished') {
+    const round = party.rounds[party.currentRound]
+    if (round) {
+      view.reveal = {
+        index: round.index,
+        gameName: round.gameName,
+        canonical: round.canonical,
+        pins: party.players.map((p) => {
+          const r = round.results[p.id]
+          return { playerId: p.id, name: p.name, guess: r?.guess ?? null, points: r?.totalPoints ?? 0 }
+        }),
+      }
+    }
+  }
+
+  return view
+}
+
+// Broadcast a per-player tailored view to each socket in the room (each may see
+// a different locate-phase reveal state), so we emit individually.
+async function broadcast(io: SocketIOServer, party: GeoGamersParty): Promise<void> {
+  await geoGamersPartyStore.save(party)
+  const ns = io.of(NS)
+  const sockets = await ns.in(room(party.code)).fetchSockets()
+  for (const s of sockets) {
+    const pid = (s.data as { playerId?: string }).playerId
+    if (!pid) continue
+    s.emit('party:state', await buildView(party, pid))
+  }
+}
+
+export function ensureGeoGamersPartyNamespace(io: SocketIOServer): void {
+  const ns = io.of(NS)
+  if ((ns as unknown as { _wired?: boolean })._wired) return
+
+  ns.use(async (socket, next) => {
+    // Resolve identity once. Guests allowed: fall back to a per-socket id.
+    const session = await getSocketSession(socket)
+    const playerId = session?.user?.id ?? `guest_${socket.id}`
+    const name = session?.user?.name ?? 'Invité'
+    socket.data = { ...(socket.data ?? {}), playerId, name } satisfies PartyIdentity & Record<string, unknown>
+    next()
+  })
+
+  ns.on('connection', (socket: Socket) => {
+    const id = () => socket.data as PartyIdentity
+
+    const safe = (fn: () => Promise<void>) =>
+      fn().catch((err) => {
+        const code = err instanceof PartyError ? err.code : 'ERROR'
+        socket.emit('party:error', { code, message: String(err instanceof Error ? err.message : err) })
+      })
+
+    socket.on('party:create', (payload: { rounds?: number; timerSeconds?: number; name?: string }) =>
+      safe(async () => {
+        const { playerId, name } = id()
+        const created = await geoGamersPartyStore.create(
+          createParty({
+            code: '', // replaced by the store's reserved code
+            host: { id: playerId, name: payload.name || name },
+            config: { rounds: payload.rounds ?? 5, timerSeconds: payload.timerSeconds ?? 45 },
+            nowMs: Date.now(),
+          }),
+        )
+        socket.join(room(created.code))
+        socket.emit('party:created', { code: created.code })
+        await broadcast(io, created)
+      }),
+    )
+
+    socket.on('party:join', (payload: { code: string; name?: string }) =>
+      safe(async () => {
+        const { playerId, name } = id()
+        const party = await geoGamersPartyStore.get(payload.code)
+        if (!party) {
+          socket.emit('party:error', { code: 'NOT_FOUND', message: 'party not found' })
+          return
+        }
+        if (party.players.length >= PARTY_MAX_PLAYERS && !party.players.some((p) => p.id === playerId)) {
+          socket.emit('party:error', { code: 'LOBBY_FULL', message: 'lobby full' })
+          return
+        }
+        const next = joinParty(party, { id: playerId, name: payload.name || name })
+        socket.join(room(payload.code))
+        await broadcast(io, next)
+      }),
+    )
+
+    socket.on('party:start', (payload: { code: string }) =>
+      safe(async () => {
+        const { playerId } = id()
+        const party = await geoGamersPartyStore.get(payload.code)
+        if (!party) return
+        if (party.hostId !== playerId) {
+          socket.emit('party:error', { code: 'NOT_HOST', message: 'only the host can start' })
+          return
+        }
+        const contents = await resolvePartyRoundContents(party.config.rounds)
+        if (contents.length < party.config.rounds) {
+          socket.emit('party:error', { code: 'NOT_ENOUGH_CONTENT', message: 'not enough content' })
+          return
+        }
+        await broadcast(io, startParty(party, contents))
+      }),
+    )
+
+    socket.on('party:guess_game', (payload: { code: string; guess: string }) =>
+      safe(async () => {
+        const { playerId } = id()
+        const party = await geoGamersPartyStore.get(payload.code)
+        if (!party || party.status !== 'in_round') return
+        const round = party.rounds[party.currentRound]
+        if (!round) return
+        const correct = fuzzyMatch.evaluateMatch(String(payload.guess ?? ''), round.gameName).matched
+        const next = submitGameGuess(party, playerId, correct)
+        socket.emit('party:guess_result', { correct })
+        await maybeAdvanceAndBroadcast(io, next)
+      }),
+    )
+
+    socket.on('party:guess_location', (payload: { code: string; geoMapId: number; guess: GeoPoint }) =>
+      safe(async () => {
+        const { playerId } = id()
+        const party = await geoGamersPartyStore.get(payload.code)
+        if (!party || party.status !== 'in_round') return
+        const round = party.rounds[party.currentRound]
+        if (!round || !isPoint(payload.guess)) return
+        const wrongMap = payload.geoMapId !== round.geoMapId
+        const distance = wrongMap ? 1 : geoDistance(payload.guess, round.canonical)
+        const next = submitLocation(party, playerId, payload.guess, distance, wrongMap)
+        await maybeAdvanceAndBroadcast(io, next)
+      }),
+    )
+
+    // Host advances from the reveal screen to the next round / finish.
+    socket.on('party:advance', (payload: { code: string }) =>
+      safe(async () => {
+        const { playerId } = id()
+        const party = await geoGamersPartyStore.get(payload.code)
+        if (!party || party.status !== 'reveal') return
+        if (party.hostId !== playerId) return
+        await broadcast(io, advanceRound(party))
+      }),
+    )
+
+    socket.on('party:leave', (payload: { code: string }) =>
+      safe(async () => {
+        const { playerId } = id()
+        const party = await geoGamersPartyStore.get(payload.code)
+        if (!party) return
+        socket.leave(room(payload.code))
+        await broadcast(io, leaveParty(party, playerId))
+      }),
+    )
+
+    socket.on('disconnect', () => {
+      log.debug({ socketId: socket.id }, 'party client disconnected')
+    })
+  })
+  ;(ns as unknown as { _wired?: boolean })._wired = true
+}
+
+// After a play action, auto-close the round when everyone connected is done.
+async function maybeAdvanceAndBroadcast(io: SocketIOServer, party: GeoGamersParty): Promise<void> {
+  const next = allConnectedDone(party) ? revealRound(party) : party
+  await broadcast(io, next)
+}

--- a/packages/backend/src/infrastructure/socket/geogamers-party.socket.ts
+++ b/packages/backend/src/infrastructure/socket/geogamers-party.socket.ts
@@ -64,6 +64,11 @@ async function buildView(party: GeoGamersParty, playerId: string): Promise<GeoGa
     if (round) {
       const result = round.results[playerId]
       const resolved = !!result && (result.solvedGame || result.attemptsUsed >= 3)
+      view.you = {
+        attemptsUsed: result?.attemptsUsed ?? 0,
+        resolvedPhase1: resolved,
+        done: result?.done ?? false,
+      }
       view.round = {
         index: round.index,
         screenshotUrl: `/api/geogamers/party/${party.code}/round/${round.index}/image`,

--- a/packages/backend/src/infrastructure/socket/socket.ts
+++ b/packages/backend/src/infrastructure/socket/socket.ts
@@ -5,6 +5,7 @@ import { env } from '../../config/env.js'
 import { logger } from '../logger/logger.js'
 import { auth } from '../auth/auth.js'
 import { importQueueEvents } from '../queue/queues.js'
+import { ensureGeoGamersPartyNamespace } from './geogamers-party.socket.js'
 import type {
     AchievementUnlockedEvent,
     GeoRewardedEvent,
@@ -19,7 +20,7 @@ let io: SocketIOServer | null = null
 
 // Resolve the Better Auth session from a socket handshake. Returns null on
 // missing / invalid session; the caller decides how to react.
-async function getSocketSession(socket: Socket) {
+export async function getSocketSession(socket: Socket) {
     try {
         return await auth.api.getSession({
             headers: socket.handshake.headers as Record<string, string>,
@@ -94,6 +95,7 @@ export function initializeSocketIO(httpServer: HTTPServer): SocketIOServer {
 
     ensureGeoNamespace()
     ensureUserNotificationsNamespace()
+    ensureGeoGamersPartyNamespace(io)
 
     logger.info('Socket.IO server initialized')
     return io

--- a/packages/backend/src/infrastructure/socket/socket.ts
+++ b/packages/backend/src/infrastructure/socket/socket.ts
@@ -8,6 +8,7 @@ import { importQueueEvents } from '../queue/queues.js'
 import type {
     AchievementUnlockedEvent,
     GeoRewardedEvent,
+    GeoGamersSeasonUpdatedEvent,
     GeoTierUpEvent,
     NewlyEarnedAchievement,
     RewardGrantedEvent,
@@ -300,6 +301,14 @@ export function emitGeoTierUp(event: GeoTierUpEvent): void {
     const ns = geoNamespace()
     if (!ns) return
     ns.to(`user:${event.userId}`).emit('geo:contributor:tier_up', event)
+}
+
+// Broadcast finalized/updated GeoGamers season standings to everyone on the
+// geo namespace so an open leaderboard refreshes. Not user-targeted.
+export function emitGeoGamersSeasonUpdated(event: GeoGamersSeasonUpdatedEvent): void {
+    const ns = geoNamespace()
+    if (!ns) return
+    ns.emit('geogamers:season:updated', event)
 }
 
 // ---------- User-targeted notifications ----------

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 import { adminService, jobService } from '../../domain/services/index.js'
 import { billingService } from '../../domain/services/index.js'
 import { userRepository } from '../../infrastructure/repositories/user.repository.js'
+import { geoGamersChallengeRepository } from '../../infrastructure/repositories/geogamers-challenge.repository.js'
+import { geoGamersSeasonRepository } from '../../infrastructure/repositories/geogamers-season.repository.js'
 import { adminMiddleware } from '../middleware/auth.middleware.js'
 import { recordAdminGeoAudit } from '../middleware/admin-audit.js'
 import {
@@ -3590,6 +3592,50 @@ router.post('/scraping/reset', async (req, res, next) => {
       'admin reset scraping state from zero',
     )
     res.json({ success: true, data: result })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// GET /api/admin/geogamers/health — content-readiness dashboard for the
+// GeoGamers daily scheduler. Surfaces the same eligibility the worker gates on
+// so an admin can see "starved" before a day silently skips, plus today's
+// challenge and the current season's player count.
+router.get('/geogamers/health', async (_req, res, next) => {
+  try {
+    const enabled = env.GEOGAMERS_ENABLED === 'true'
+    const minRequired = Number(env.GEOGAMERS_MIN_ELIGIBLE_GAMES) || 10
+    const cooldownDays = Number(env.GEOGAMERS_GAME_COOLDOWN_DAYS) || 14
+
+    const today = new Date().toISOString().slice(0, 10)
+    const [todayChallenge, current, cooldownGameIds] = await Promise.all([
+      geoGamersChallengeRepository.findByDate(today),
+      geoGamersChallengeRepository.findCurrent(),
+      geoGamersChallengeRepository.gameIdsUsedSince(cooldownDays),
+    ])
+
+    const eligible = await geoGamersChallengeRepository.listEligibleMetas({ cooldownGameIds })
+    const eligibleGames = new Set(eligible.map((e) => e.gameId)).size
+    const eligibleScreenshots = eligible.length
+
+    const month = geoGamersSeasonRepository.currentSeasonMonth()
+    const seasonPlayers = await geoGamersSeasonRepository.playerCount(month)
+
+    res.json({
+      success: true,
+      data: {
+        enabled,
+        minRequired,
+        cooldownDays,
+        eligibleGames,
+        eligibleScreenshots,
+        gamesOnCooldown: cooldownGameIds.length,
+        starved: eligibleGames < minRequired,
+        todayChallengeExists: !!todayChallenge,
+        currentChallengeDate: current?.challengeDate ?? null,
+        season: { month, players: seasonPlayers },
+      },
+    })
   } catch (err) {
     next(err)
   }

--- a/packages/backend/src/presentation/routes/geogamers.routes.ts
+++ b/packages/backend/src/presentation/routes/geogamers.routes.ts
@@ -6,6 +6,7 @@ import { validateBody, validateParams } from '../middleware/validation.middlewar
 import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
 import { achievementRepository } from '../../infrastructure/repositories/index.js'
+import { geoGamersPartyStore, resolvePartyRoundImage } from '../../infrastructure/repositories/geogamers-party.store.js'
 import { emitAchievementUnlocked } from '../../infrastructure/socket/socket.js'
 import type { NewlyEarnedAchievement } from '@the-box/types'
 
@@ -291,5 +292,47 @@ router.get(
     }
   },
 )
+
+// Party image proxy. Streams a party round's screenshot server-side so the
+// client never sees the asset path (same anti-leak posture as the daily
+// proxy). Guests allowed. Only the current or a revealed round is fetchable.
+router.get('/party/:code/round/:index/image', optionalAuthMiddleware, async (req, res, next) => {
+  try {
+    const { code } = req.params as { code: string; index: string }
+    const index = Number(req.params['index'])
+    const party = await geoGamersPartyStore.get(code)
+    if (!party || !Number.isInteger(index)) {
+      res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'party round not found' } })
+      return
+    }
+    const round = party.rounds[index]
+    // Only expose the active round (or an already-revealed one) — never a
+    // future round's screenshot.
+    const exposable = round && (index === party.currentRound || round.revealed)
+    if (!round || !exposable) {
+      res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'round not available' } })
+      return
+    }
+    const imageUrl = await resolvePartyRoundImage(round.geoScreenshotMetaId)
+    if (!imageUrl) {
+      res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'image missing' } })
+      return
+    }
+    if (/^https?:\/\//i.test(imageUrl)) {
+      const upstream = await fetch(imageUrl)
+      if (!upstream.ok || !upstream.body) {
+        res.status(502).json({ success: false, error: { code: 'UPSTREAM', message: 'image fetch failed' } })
+        return
+      }
+      res.setHeader('Content-Type', upstream.headers.get('content-type') ?? 'image/jpeg')
+      res.setHeader('Cache-Control', 'private, max-age=300')
+      res.end(Buffer.from(await upstream.arrayBuffer()))
+      return
+    }
+    res.redirect(imageUrl)
+  } catch (err) {
+    handleError(err, res, next)
+  }
+})
 
 export default router

--- a/packages/backend/src/presentation/routes/geogamers.routes.ts
+++ b/packages/backend/src/presentation/routes/geogamers.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import { z } from 'zod'
-import { geoGamersService, GeoGamersError } from '../../domain/services/index.js'
+import { geoGamersService, geoGamersSeasonService, GeoGamersError } from '../../domain/services/index.js'
 import { authMiddleware, optionalAuthMiddleware } from '../middleware/auth.middleware.js'
 import { validateBody, validateParams } from '../middleware/validation.middleware.js'
 import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
@@ -183,6 +183,32 @@ router.post(
     }
   },
 )
+
+// ---------- Season standings ----------
+
+// Public season leaderboard (top N + player count).
+router.get('/season', optionalAuthMiddleware, async (_req, res, next) => {
+  try {
+    const month = geoGamersSeasonService.currentMonth()
+    const [standings, players] = await Promise.all([
+      geoGamersSeasonService.standings(month, 100),
+      geoGamersSeasonService.playerCount(month),
+    ])
+    res.json({ success: true, data: { month, players, standings } })
+  } catch (err) {
+    handleError(err, res, next)
+  }
+})
+
+// The signed-in user's own standing + per-day breakdown (dropped-days flagged).
+router.get('/season/me', authMiddleware, async (req, res, next) => {
+  try {
+    const me = await geoGamersSeasonService.myStanding(req.userId!)
+    res.json({ success: true, data: me })
+  } catch (err) {
+    handleError(err, res, next)
+  }
+})
 
 // Opaque screenshot proxy. The client only ever sees /api/geogamers/image/:token,
 // never the underlying asset URL (which can carry a game slug). We fetch the

--- a/packages/backend/src/presentation/routes/geogamers.routes.ts
+++ b/packages/backend/src/presentation/routes/geogamers.routes.ts
@@ -1,0 +1,225 @@
+import { Router } from 'express'
+import { z } from 'zod'
+import { geoGamersService, GeoGamersError } from '../../domain/services/index.js'
+import { authMiddleware, optionalAuthMiddleware } from '../middleware/auth.middleware.js'
+import { validateBody, validateParams } from '../middleware/validation.middleware.js'
+import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
+import { routeLogger } from '../../infrastructure/logger/logger.js'
+
+const log = routeLogger.child({ route: 'geogamers' })
+
+const router = Router()
+
+// ---------- Schemas ----------
+
+const pointSchema = z.object({
+  x: z.number().min(0).max(1),
+  y: z.number().min(0).max(1),
+})
+
+const runTokenBody = z.object({ runToken: z.string().uuid() })
+
+const guessGameBody = z.object({
+  runToken: z.string().uuid(),
+  guess: z.string().min(1).max(200),
+  timeSpentMsDelta: z.number().int().nonnegative().max(600_000).optional(),
+})
+
+const guessLocationBody = z.object({
+  runToken: z.string().uuid(),
+  geoMapId: z.number().int().positive(),
+  guess: pointSchema,
+  timeSpentMsDelta: z.number().int().nonnegative().max(600_000).optional(),
+})
+
+const runTokenParam = z.object({ runToken: z.string().uuid() })
+
+// ---------- Identity helper ----------
+// Ranked play requires a non-anonymous account. Better-auth anonymous sessions
+// (isGuest) and fully logged-out callers are treated as guests: unranked, keyed
+// by the run token the client persists.
+function identity(req: { userId?: string; isGuest?: boolean }): {
+  userId: string | null
+  anonymousSessionId: string | null
+} {
+  const isGuest = req.isGuest === true || !req.userId
+  return {
+    userId: isGuest ? null : req.userId!,
+    anonymousSessionId: isGuest ? (req.userId ?? null) : null,
+  }
+}
+
+// Map a GeoGamersError code to an HTTP status.
+function statusForCode(code: GeoGamersError['code']): number {
+  switch (code) {
+    case 'RUN_NOT_FOUND':
+    case 'NO_CHALLENGE':
+      return 404
+    case 'INVALID_POINT':
+    case 'INVALID_MAP':
+      return 400
+    case 'WRONG_PHASE':
+    case 'ATTEMPTS_EXHAUSTED':
+    case 'JOKER_NOT_ALLOWED':
+    case 'NO_ALTERNATE':
+      return 409
+    case 'ALREADY_PLAYED':
+    case 'JOKER_ALREADY_USED':
+      return 409
+    case 'CLAIM_INVALID':
+      return 422
+    case 'NOT_AUTHENTICATED':
+      return 401
+    default:
+      return 400
+  }
+}
+
+function handleError(err: unknown, res: import('express').Response, next: import('express').NextFunction) {
+  if (err instanceof GeoGamersError) {
+    res.status(statusForCode(err.code)).json({
+      success: false,
+      error: { code: err.code, message: err.message },
+    })
+    return
+  }
+  next(err)
+}
+
+const writeLimiter = createRateLimiter({ windowMs: 60_000, max: 30 })
+
+// ---------- Routes ----------
+
+// Start or resume today's run.
+router.post('/run', optionalAuthMiddleware, async (req, res, next) => {
+  try {
+    const view = await geoGamersService.startOrResumeRun(identity(req))
+    res.json({ success: true, data: view })
+  } catch (err) {
+    handleError(err, res, next)
+  }
+})
+
+// Fetch a run by its token (page reload).
+router.get(
+  '/run/:runToken',
+  optionalAuthMiddleware,
+  validateParams(runTokenParam),
+  async (req, res, next) => {
+    try {
+      const { runToken } = req.params as z.infer<typeof runTokenParam>
+      const view = await geoGamersService.getRunByToken(runToken)
+      res.json({ success: true, data: view })
+    } catch (err) {
+      handleError(err, res, next)
+    }
+  },
+)
+
+// Phase 1: name the game.
+router.post(
+  '/run/guess-game',
+  optionalAuthMiddleware,
+  writeLimiter,
+  validateBody(guessGameBody),
+  async (req, res, next) => {
+    try {
+      const body = req.body as z.infer<typeof guessGameBody>
+      const result = await geoGamersService.guessGame(body)
+      res.json({ success: true, data: result })
+    } catch (err) {
+      handleError(err, res, next)
+    }
+  },
+)
+
+// Phase 2: pin the location.
+router.post(
+  '/run/guess-location',
+  optionalAuthMiddleware,
+  writeLimiter,
+  validateBody(guessLocationBody),
+  async (req, res, next) => {
+    try {
+      const body = req.body as z.infer<typeof guessLocationBody>
+      const result = await geoGamersService.guessLocation(body)
+      res.json({ success: true, data: result })
+    } catch (err) {
+      handleError(err, res, next)
+    }
+  },
+)
+
+// Joker re-roll — account only.
+router.post(
+  '/run/joker',
+  authMiddleware,
+  writeLimiter,
+  validateBody(runTokenBody),
+  async (req, res, next) => {
+    try {
+      const { runToken } = req.body as z.infer<typeof runTokenBody>
+      const view = await geoGamersService.useJoker({ userId: req.userId!, runToken })
+      res.json({ success: true, data: view })
+    } catch (err) {
+      handleError(err, res, next)
+    }
+  },
+)
+
+// Claim a completed guest run into the signed-in account.
+router.post(
+  '/run/claim',
+  authMiddleware,
+  writeLimiter,
+  validateBody(runTokenBody),
+  async (req, res, next) => {
+    try {
+      const { runToken } = req.body as z.infer<typeof runTokenBody>
+      const view = await geoGamersService.claimRun({ userId: req.userId!, runToken })
+      res.json({ success: true, data: view })
+    } catch (err) {
+      handleError(err, res, next)
+    }
+  },
+)
+
+// Opaque screenshot proxy. The client only ever sees /api/geogamers/image/:token,
+// never the underlying asset URL (which can carry a game slug). We fetch the
+// source server-side and stream it back. Non-http(s) sources fall back to a
+// redirect (documented minor leak) — ingested content is overwhelmingly http(s).
+router.get(
+  '/image/:runToken',
+  optionalAuthMiddleware,
+  validateParams(runTokenParam),
+  async (req, res, next) => {
+    try {
+      const { runToken } = req.params as z.infer<typeof runTokenParam>
+      const src = await geoGamersService.resolveScreenshotSource(runToken)
+      if (!src) {
+        res.status(404).json({ success: false, error: { code: 'RUN_NOT_FOUND', message: 'run not found' } })
+        return
+      }
+      if (/^https?:\/\//i.test(src.imageUrl)) {
+        const upstream = await fetch(src.imageUrl)
+        if (!upstream.ok || !upstream.body) {
+          res.status(502).json({ success: false, error: { code: 'UPSTREAM', message: 'image fetch failed' } })
+          return
+        }
+        res.setHeader('Content-Type', upstream.headers.get('content-type') ?? 'image/jpeg')
+        res.setHeader('Cache-Control', 'private, max-age=300')
+        const buf = Buffer.from(await upstream.arrayBuffer())
+        res.end(buf)
+        return
+      }
+      // Same-origin relative uploads (e.g. /uploads/..): safe to redirect, the
+      // path itself is not identity-revealing.
+      res.redirect(src.imageUrl)
+    } catch (err) {
+      log.error({ err }, 'image proxy error')
+      handleError(err, res, next)
+    }
+  },
+)
+
+export default router

--- a/packages/backend/src/presentation/routes/geogamers.routes.ts
+++ b/packages/backend/src/presentation/routes/geogamers.routes.ts
@@ -5,6 +5,9 @@ import { authMiddleware, optionalAuthMiddleware } from '../middleware/auth.middl
 import { validateBody, validateParams } from '../middleware/validation.middleware.js'
 import { createRateLimiter } from '../middleware/rate-limit.middleware.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
+import { achievementRepository } from '../../infrastructure/repositories/index.js'
+import { emitAchievementUnlocked } from '../../infrastructure/socket/socket.js'
+import type { NewlyEarnedAchievement } from '@the-box/types'
 
 const log = routeLogger.child({ route: 'geogamers' })
 
@@ -88,6 +91,40 @@ function handleError(err: unknown, res: import('express').Response, next: import
 
 const writeLimiter = createRateLimiter({ windowMs: 60_000, max: 30 })
 
+// Award recognition-only GeoGamers achievements on a completed RANKED run.
+// Idempotent: guarded by hasAchievement + the user_achievements unique, so a
+// re-award is a no-op. Best-effort — never blocks the guess response.
+async function awardCompletionAchievements(
+  userId: string,
+  totalPoints: number,
+): Promise<NewlyEarnedAchievement[]> {
+  const candidates: string[] = ['geogamers_first_run']
+  if (totalPoints >= 200) candidates.push('geogamers_perfect_day')
+
+  const earned: NewlyEarnedAchievement[] = []
+  for (const key of candidates) {
+    try {
+      if (await achievementRepository.hasAchievement(userId, key)) continue
+      const ach = await achievementRepository.findByKey(key)
+      if (!ach) continue
+      await achievementRepository.awardAchievement(userId, key)
+      earned.push({
+        key: ach.key,
+        name: ach.name,
+        description: ach.description ?? '',
+        category: ach.category,
+        iconUrl: ach.icon_url ?? null,
+        points: ach.points,
+        tier: ach.tier,
+      })
+    } catch (err) {
+      // Unique race (already earned) or missing row — non-fatal.
+      log.debug({ err, userId, key }, 'geogamers achievement award skipped')
+    }
+  }
+  return earned
+}
+
 // ---------- Routes ----------
 
 // Start or resume today's run.
@@ -143,6 +180,13 @@ router.post(
     try {
       const body = req.body as z.infer<typeof guessLocationBody>
       const result = await geoGamersService.guessLocation(body)
+      // Ranked completion (result.rank set for account runs) → evaluate the
+      // recognition-only achievements and push a toast. Guests (ghostRank)
+      // earn nothing until they claim.
+      if (req.userId && !req.isGuest && result.rank != null) {
+        const earned = await awardCompletionAchievements(req.userId, result.totalPoints)
+        if (earned.length > 0) emitAchievementUnlocked(req.userId, earned)
+      }
       res.json({ success: true, data: result })
     } catch (err) {
       handleError(err, res, next)

--- a/packages/backend/src/presentation/routes/public.routes.ts
+++ b/packages/backend/src/presentation/routes/public.routes.ts
@@ -3,6 +3,9 @@ import { z } from 'zod'
 import { db } from '../../infrastructure/database/connection.js'
 import { challengeRepository } from '../../infrastructure/repositories/challenge.repository.js'
 import { leaderboardRepository } from '../../infrastructure/repositories/leaderboard.repository.js'
+import { geoGamersSeasonRepository } from '../../infrastructure/repositories/geogamers-season.repository.js'
+import { createGeoGamersSeasonService } from '../../domain/services/geogamers-season.service.js'
+import { serviceLogger } from '../../infrastructure/logger/logger.js'
 import {
   webhookRepository,
 } from '../../infrastructure/repositories/webhook.repository.js'
@@ -44,6 +47,15 @@ import type {
 //   2. Cross-account reads return the same data as anonymous reads — keys
 //      identify YOU, never elevate access to someone else's data.
 //   3. No screenshot bytes, no answers, no current-screenshot id leak.
+
+// Constructed locally (not from the services barrel) so this route module —
+// and public-api-spec.test.ts which introspects it — never transitively
+// imports queues.ts (whose eager QueueEvents would open a Redis connection and
+// hang the test process). The season service only needs its repository.
+const geoGamersSeasonService = createGeoGamersSeasonService({
+  logger: serviceLogger,
+  ranking: geoGamersSeasonRepository,
+})
 
 const router = Router()
 
@@ -420,6 +432,56 @@ router.get('/leaderboard/monthly', validateQuery(monthlyQuerySchema), async (req
     next(err)
   }
 })
+
+// GET /api/public/v1/geogamers/season — read-only GeoGamers season standings
+// for overlays/bots. Returns an empty list when the feature is disabled so
+// integrators can poll unconditionally. Public-safe: exposes rank, display
+// name, and public slug (only for opted-in public profiles), never user ids.
+const geogamersSeasonQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+})
+
+router.get(
+  '/geogamers/season',
+  validateQuery(geogamersSeasonQuerySchema),
+  async (req, res, next) => {
+    try {
+      if (env.GEOGAMERS_ENABLED !== 'true') {
+        res.json({ success: true, data: { month: null, standings: [] } })
+        return
+      }
+      const { limit } = req.query as unknown as z.infer<typeof geogamersSeasonQuerySchema>
+      const month = geoGamersSeasonService.currentMonth()
+      const standings = await geoGamersSeasonService.standings(month, limit)
+
+      const userIds = standings.map((s) => s.userId)
+      const slugRows = userIds.length
+        ? await db('user')
+            .whereIn('id', userIds)
+            .andWhere('public_profile_enabled', true)
+            .select<Array<{ id: string; public_slug: string | null }>>('id', 'public_slug')
+        : []
+      const slugById = new Map(slugRows.map((r) => [r.id, r.public_slug]))
+
+      res.json({
+        success: true,
+        data: {
+          month,
+          standings: standings.map((s) => ({
+            rank: s.rank,
+            slug: slugById.get(s.userId) ?? null,
+            displayName: s.username,
+            seasonScore: s.seasonScore,
+            daysPlayed: s.daysPlayed,
+            provisional: s.provisional,
+          })),
+        },
+      })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
 
 // ─────────────────────────────────────────────────────────────────────
 // M2 — SSE live channel

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -52,7 +52,9 @@
       "second": "2nd place",
       "third": "3rd place"
     },
-    "menuDescription": "Site navigation and account links"
+    "menuDescription": "Site navigation and account links",
+    "geogamers": "GeoGamers",
+    "new": "New"
   },
   "nav": {
     "primary": "Primary navigation",
@@ -2892,6 +2894,47 @@
     "geoContribute": {
       "title": "Contribute to Geo Mode — The Box",
       "description": "Help curate and verify Geo Mode challenges."
+    }
+  },
+  "geogamers": {
+    "error": "Something went wrong.",
+    "retry": "Try again",
+    "identify": {
+      "screenshotAlt": "Screenshot of the game to guess",
+      "prompt": "Which game do you recognize?",
+      "placeholder": "Game name…",
+      "submit": "Submit",
+      "attemptsLeft": "{{count}} attempt left",
+      "attemptsLeft_other": "{{count}} attempts left",
+      "proximity": {
+        "far": "Not close.",
+        "close": "Getting warmer…",
+        "very_close": "So close!"
+      }
+    },
+    "joker": {
+      "cta": "Swap panorama (joker)",
+      "guestHint": "Sign up to use the joker."
+    },
+    "locate": {
+      "banner": "Drop your marker on the map of",
+      "confirm": "Confirm location"
+    },
+    "result": {
+      "breakdown": "{{game}} (game) + {{location}} (precision)",
+      "rank": "You're #{{rank}} today.",
+      "ghostRank": "You'd be #{{rank}} today — save this score to the season.",
+      "claimCta": "Sign up and save",
+      "claimed": "Score saved to your season!",
+      "comeBack": "Come back tomorrow for a new panorama.",
+      "unranked": "Unranked score — sign in to join the season.",
+      "done": "Done"
+    },
+    "season": {
+      "link": "Season",
+      "provisional": "Provisional",
+      "daysPlayed": "Days played",
+      "droppedDays": "3 worst days dropped"
     }
   }
 }

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -637,7 +637,19 @@
     "clickToView": "Click to view this player's answers",
     "todayLocked": "Complete today's challenge to view other players' answers.",
     "capturesFound": "Captures found",
-    "avgCaptureTime": "Average time per capture"
+    "avgCaptureTime": "Average time per capture",
+    "geogamers": {
+      "tab": "GeoGamers",
+      "title": "Season {{month}}",
+      "players": "{{count}} player",
+      "players_other": "{{count}} players",
+      "empty": "No standings yet this season — be the first to play!",
+      "provisional": "Provisional",
+      "daysPlayed": "{{count}} day played",
+      "daysPlayed_other": "{{count}} days played",
+      "dropped": "3 worst days dropped",
+      "unavailable": "The GeoGamers leaderboard is unavailable."
+    }
   },
   "history": {
     "title": "Game History",

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2948,5 +2948,26 @@
       "daysPlayed": "Days played",
       "droppedDays": "3 worst days dropped"
     }
+  },
+  "geogamersParty": {
+    "title": "GeoGamers — Party",
+    "create": "Create a party",
+    "createCta": "Create",
+    "rounds": "Rounds",
+    "join": "Join",
+    "joinCta": "Join",
+    "codePlaceholder": "CODE",
+    "inviteCode": "Invite code:",
+    "playerCount": "{{count}}/{{max}} players",
+    "start": "Start game",
+    "waitingHost": "Waiting for the host…",
+    "leave": "Leave",
+    "round": "Round {{n}} / {{total}}",
+    "waitingOthers": "Waiting for other players…",
+    "wrongGuess": "Missed — {{left}} attempt(s) left",
+    "answer": "Answer:",
+    "finished": "Game over!",
+    "nextRound": "Next round",
+    "seeResults": "See results"
   }
 }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -637,7 +637,19 @@
     "clickToView": "Cliquez pour voir les réponses de ce joueur",
     "todayLocked": "Termine le défi du jour pour voir les réponses des autres joueurs.",
     "capturesFound": "Captures découvertes",
-    "avgCaptureTime": "Temps moyen par capture"
+    "avgCaptureTime": "Temps moyen par capture",
+    "geogamers": {
+      "tab": "GeoGamers",
+      "title": "Saison {{month}}",
+      "players": "{{count}} joueur",
+      "players_other": "{{count}} joueurs",
+      "empty": "Aucun classement pour cette saison — sois le premier à jouer !",
+      "provisional": "Provisoire",
+      "daysPlayed": "{{count}} jour joué",
+      "daysPlayed_other": "{{count}} jours joués",
+      "dropped": "3 pires jours retirés",
+      "unavailable": "Le classement GeoGamers n'est pas disponible."
+    }
   },
   "history": {
     "title": "Historique des Parties",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -52,7 +52,9 @@
       "second": "2e place",
       "third": "3e place"
     },
-    "menuDescription": "Navigation du site et liens du compte"
+    "menuDescription": "Navigation du site et liens du compte",
+    "geogamers": "GeoGamers",
+    "new": "Nouveau"
   },
   "nav": {
     "primary": "Navigation principale",
@@ -2892,6 +2894,47 @@
     "geoContribute": {
       "title": "Contribuer au mode Geo — The Box",
       "description": "Aidez à curer et vérifier les défis du mode Geo."
+    }
+  },
+  "geogamers": {
+    "error": "Une erreur est survenue.",
+    "retry": "Réessayer",
+    "identify": {
+      "screenshotAlt": "Capture d'écran du jeu à deviner",
+      "prompt": "Quel jeu reconnais-tu ?",
+      "placeholder": "Nom du jeu…",
+      "submit": "Valider",
+      "attemptsLeft": "{{count}} essai restant",
+      "attemptsLeft_other": "{{count}} essais restants",
+      "proximity": {
+        "far": "Loin du compte.",
+        "close": "Tu chauffes…",
+        "very_close": "Tout proche !"
+      }
+    },
+    "joker": {
+      "cta": "Changer de panorama (joker)",
+      "guestHint": "Crée un compte pour utiliser le joker."
+    },
+    "locate": {
+      "banner": "Place ton marqueur sur la carte de",
+      "confirm": "Confirmer l'emplacement"
+    },
+    "result": {
+      "breakdown": "{{game}} (jeu) + {{location}} (précision)",
+      "rank": "Tu es {{rank}}e aujourd'hui.",
+      "ghostRank": "Tu serais {{rank}}e aujourd'hui — enregistre ce score dans la saison.",
+      "claimCta": "Créer un compte et enregistrer",
+      "claimed": "Score enregistré dans ta saison !",
+      "comeBack": "Reviens demain pour un nouveau panorama.",
+      "unranked": "Score non classé — connecte-toi pour participer à la saison.",
+      "done": "Terminé"
+    },
+    "season": {
+      "link": "Saison",
+      "provisional": "Provisoire",
+      "daysPlayed": "Jours joués",
+      "droppedDays": "3 pires jours retirés"
     }
   }
 }

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2948,5 +2948,26 @@
       "daysPlayed": "Jours joués",
       "droppedDays": "3 pires jours retirés"
     }
+  },
+  "geogamersParty": {
+    "title": "GeoGamers — Partie à plusieurs",
+    "create": "Créer une partie",
+    "createCta": "Créer",
+    "rounds": "Nombre de manches",
+    "join": "Rejoindre",
+    "joinCta": "Rejoindre",
+    "codePlaceholder": "CODE",
+    "inviteCode": "Code d'invitation :",
+    "playerCount": "{{count}}/{{max}} joueurs",
+    "start": "Lancer la partie",
+    "waitingHost": "En attente de l'hôte…",
+    "leave": "Quitter",
+    "round": "Manche {{n}} / {{total}}",
+    "waitingOthers": "En attente des autres joueurs…",
+    "wrongGuess": "Raté — {{left}} essai(s) restant(s)",
+    "answer": "Réponse :",
+    "finished": "Partie terminée !",
+    "nextRound": "Manche suivante",
+    "seeResults": "Voir les résultats"
   }
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -55,6 +55,7 @@ const GameHistoryDetailsPage = lazy(() => import('@/pages/GameHistoryDetailsPage
 const ProfilePage = lazy(() => import('@/pages/ProfilePage'))
 const PublicProfilePage = lazy(() => import('@/pages/PublicProfilePage'))
 const GeoPlayPage = lazy(() => import('@/pages/GeoPlayPage'))
+const GeoGamersPlayPage = lazy(() => import('@/pages/GeoGamersPlayPage'))
 const GeoContributePage = lazy(() => import('@/pages/GeoContributePage'))
 const PricingPage = lazy(() => import('@/pages/PricingPage'))
 const TwoFactorChallengePage = lazy(() => import('@/pages/TwoFactorChallengePage'))
@@ -239,6 +240,7 @@ function App() {
 
           <Route path="geo" element={<GeoPlayPage />} />
           <Route path="geo/play" element={<GeoPlayPage />} />
+          <Route path="geogamers" element={<GeoGamersPlayPage />} />
           <Route path="geo/contribute" element={<GeoContributePage />} />
 
           <Route path="premium" element={<PricingPage />} />

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -56,6 +56,7 @@ const ProfilePage = lazy(() => import('@/pages/ProfilePage'))
 const PublicProfilePage = lazy(() => import('@/pages/PublicProfilePage'))
 const GeoPlayPage = lazy(() => import('@/pages/GeoPlayPage'))
 const GeoGamersPlayPage = lazy(() => import('@/pages/GeoGamersPlayPage'))
+const GeoGamersPartyPage = lazy(() => import('@/pages/GeoGamersPartyPage'))
 const GeoContributePage = lazy(() => import('@/pages/GeoContributePage'))
 const PricingPage = lazy(() => import('@/pages/PricingPage'))
 const TwoFactorChallengePage = lazy(() => import('@/pages/TwoFactorChallengePage'))
@@ -241,6 +242,7 @@ function App() {
           <Route path="geo" element={<GeoPlayPage />} />
           <Route path="geo/play" element={<GeoPlayPage />} />
           <Route path="geogamers" element={<GeoGamersPlayPage />} />
+          <Route path="geogamers/party" element={<GeoGamersPartyPage />} />
           <Route path="geo/contribute" element={<GeoContributePage />} />
 
           <Route path="premium" element={<PricingPage />} />

--- a/packages/frontend/src/components/admin/GeoGamersHealthCard.tsx
+++ b/packages/frontend/src/components/admin/GeoGamersHealthCard.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react'
+import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react'
+import { fetchAdminJson } from '@/lib/api/admin'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+interface GeoGamersHealth {
+    enabled: boolean
+    minRequired: number
+    cooldownDays: number
+    eligibleGames: number
+    eligibleScreenshots: number
+    gamesOnCooldown: number
+    starved: boolean
+    todayChallengeExists: boolean
+    currentChallengeDate: string | null
+    season: { month: string; players: number }
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+    return (
+        <div className="rounded-lg bg-muted/40 px-3 py-2">
+            <div className="text-xs text-muted-foreground">{label}</div>
+            <div className="text-lg font-semibold">{value}</div>
+        </div>
+    )
+}
+
+export function GeoGamersHealthCard() {
+    const [health, setHealth] = useState<GeoGamersHealth | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        let cancelled = false
+        fetchAdminJson<GeoGamersHealth>('/api/admin/geogamers/health')
+            .then((d) => !cancelled && setHealth(d))
+            .catch((e) => !cancelled && setError(String(e)))
+            .finally(() => !cancelled && setLoading(false))
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    if (loading) {
+        return (
+            <div className="flex justify-center py-6">
+                <Loader2 className="size-6 animate-spin text-primary" />
+            </div>
+        )
+    }
+    if (error || !health) {
+        return <p className="py-4 text-sm text-muted-foreground">GeoGamers: {error ?? 'no data'}</p>
+    }
+
+    return (
+        <Card className="mb-6 border-border bg-card/50">
+            <CardHeader>
+                <CardTitle className="flex items-center justify-between text-base">
+                    <span>GeoGamers — état du contenu</span>
+                    <span
+                        className={cn(
+                            'flex items-center gap-1 rounded px-2 py-0.5 text-xs font-normal',
+                            health.enabled
+                                ? 'bg-success/15 text-success'
+                                : 'bg-muted text-muted-foreground',
+                        )}
+                    >
+                        {health.enabled ? 'Activé' : 'Désactivé'}
+                    </span>
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+                {health.starved ? (
+                    <div className="flex items-start gap-2 rounded-lg bg-warning/10 px-3 py-2 text-sm text-warning">
+                        <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                        <span>
+                            Contenu insuffisant : {health.eligibleGames} jeux éligibles (min{' '}
+                            {health.minRequired}). Le défi du jour peut être ignoré — ajoute des
+                            captures avec pin de consensus.
+                        </span>
+                    </div>
+                ) : (
+                    <div className="flex items-center gap-2 rounded-lg bg-success/10 px-3 py-2 text-sm text-success">
+                        <CheckCircle2 className="size-4 shrink-0" />
+                        <span>
+                            Contenu suffisant : {health.eligibleGames} jeux éligibles (min{' '}
+                            {health.minRequired}).
+                        </span>
+                    </div>
+                )}
+
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                    <Stat label="Jeux éligibles" value={health.eligibleGames} />
+                    <Stat label="Captures éligibles" value={health.eligibleScreenshots} />
+                    <Stat label="Jeux en cooldown" value={health.gamesOnCooldown} />
+                    <Stat label="Joueurs (saison)" value={health.season.players} />
+                </div>
+
+                <div className="text-xs text-muted-foreground">
+                    Défi du jour :{' '}
+                    {health.todayChallengeExists ? 'créé' : 'pas encore'} · Défi courant :{' '}
+                    {health.currentChallengeDate ?? '—'} · Cooldown : {health.cooldownDays} j ·
+                    Saison : {health.season.month}
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/packages/frontend/src/components/layout/nav-items.ts
+++ b/packages/frontend/src/components/layout/nav-items.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react'
-import { Home, Play, Trophy, MapPin, User } from 'lucide-react'
+import { Home, Play, Trophy, MapPin, Crosshair, User } from 'lucide-react'
 
 /**
  * A destination link in the app's navigation. `path` is unlocalized — callers
@@ -45,6 +45,13 @@ export const PRIMARY_NAV: NavLinkItem[] = [
     icon: MapPin,
     path: '/geo',
     badgeKey: 'common.alpha',
+  },
+  {
+    key: 'geogamers',
+    labelKey: 'common.geogamers',
+    icon: Crosshair,
+    path: '/geogamers',
+    badgeKey: 'common.new',
   },
 ]
 

--- a/packages/frontend/src/components/leaderboard/GeoGamersSeasonPanel.tsx
+++ b/packages/frontend/src/components/leaderboard/GeoGamersSeasonPanel.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Trophy, Medal, Award, Loader2, Sparkles, Users } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { geoGamersApi } from '@/lib/api/geogamers'
+import { cn } from '@/lib/utils'
+import type { GeoGamersSeasonStanding } from '@the-box/types'
+
+function rankIcon(rank: number) {
+    switch (rank) {
+        case 1:
+            return <Trophy className="size-5 text-medal-gold" />
+        case 2:
+            return <Medal className="size-5 text-medal-silver" />
+        case 3:
+            return <Award className="size-5 text-medal-bronze" />
+        default:
+            return <span className="font-bold text-muted-foreground">{rank}</span>
+    }
+}
+
+export function GeoGamersSeasonPanel() {
+    const { t } = useTranslation()
+    const [standings, setStandings] = useState<GeoGamersSeasonStanding[]>([])
+    const [players, setPlayers] = useState(0)
+    const [month, setMonth] = useState('')
+    const [loading, setLoading] = useState(true)
+    const [failed, setFailed] = useState(false)
+
+    useEffect(() => {
+        let alive = true
+        geoGamersApi
+            .getSeason()
+            .then((res) => {
+                if (!alive) return
+                setStandings(res.standings)
+                setPlayers(res.players)
+                setMonth(res.month)
+            })
+            .catch(() => alive && setFailed(true))
+            .finally(() => alive && setLoading(false))
+        return () => {
+            alive = false
+        }
+    }, [])
+
+    if (loading) {
+        return (
+            <div className="flex justify-center py-12">
+                <Loader2 className="size-8 animate-spin text-primary" />
+            </div>
+        )
+    }
+
+    if (failed) {
+        return (
+            <p className="py-12 text-center text-muted-foreground">
+                {t('leaderboard.geogamers.unavailable')}
+            </p>
+        )
+    }
+
+    return (
+        <Card className="border-border bg-card/50">
+            <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                    <span>{t('leaderboard.geogamers.title', { month })}</span>
+                    <span className="flex items-center gap-1 text-sm font-normal text-muted-foreground">
+                        <Users className="size-4" />
+                        {t('leaderboard.geogamers.players', { count: players })}
+                    </span>
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                {standings.length === 0 ? (
+                    <p className="py-8 text-center text-muted-foreground">
+                        {t('leaderboard.geogamers.empty')}
+                    </p>
+                ) : (
+                    <div className="space-y-1">
+                        {standings.map((s) => (
+                            <div
+                                key={s.userId}
+                                className={cn(
+                                    'flex items-center gap-3 rounded-lg px-3 py-2',
+                                    s.rank <= 3 ? 'bg-primary/10' : 'bg-transparent',
+                                )}
+                            >
+                                <div className="flex w-8 shrink-0 justify-center">
+                                    {rankIcon(s.rank)}
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-center gap-2">
+                                        <span className="truncate font-medium">{s.username}</span>
+                                        {s.jokerUsed && (
+                                            <Sparkles className="size-3.5 shrink-0 text-neon-pink" />
+                                        )}
+                                        {s.provisional && (
+                                            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                                                {t('leaderboard.geogamers.provisional')}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <span className="text-xs text-muted-foreground">
+                                        {t('leaderboard.geogamers.daysPlayed', {
+                                            count: s.daysPlayed,
+                                        })}
+                                        {s.droppedDays > 0 &&
+                                            ` · ${t('leaderboard.geogamers.dropped')}`}
+                                    </span>
+                                </div>
+                                <span className="shrink-0 text-lg font-bold text-neon-purple">
+                                    {s.seasonScore}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}

--- a/packages/frontend/src/lib/api/geogamers.ts
+++ b/packages/frontend/src/lib/api/geogamers.ts
@@ -25,6 +25,12 @@ interface ApiEnvelope<T> {
     error?: { code: string; message?: string }
 }
 
+export interface GeoGamersSeasonResponse {
+    month: string
+    players: number
+    standings: GeoGamersSeasonStanding[]
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
     const res = await fetch(path, {
         credentials: 'include',
@@ -91,8 +97,8 @@ export const geoGamersApi = {
         })
     },
 
-    getSeason(): Promise<GeoGamersSeasonStanding[]> {
-        return request<GeoGamersSeasonStanding[]>('/api/geogamers/season')
+    getSeason(): Promise<GeoGamersSeasonResponse> {
+        return request<GeoGamersSeasonResponse>('/api/geogamers/season')
     },
 
     getSeasonMe(): Promise<GeoGamersSeasonMe | null> {

--- a/packages/frontend/src/lib/api/geogamers.ts
+++ b/packages/frontend/src/lib/api/geogamers.ts
@@ -1,0 +1,101 @@
+import type {
+    GeoGamersClaimResult,
+    GeoGamersGuessGameResult,
+    GeoGamersGuessLocationResult,
+    GeoGamersRunView,
+    GeoGamersSeasonMe,
+    GeoGamersSeasonStanding,
+    GeoPoint,
+} from '@the-box/types'
+
+export class GeoGamersApiError extends Error {
+    constructor(
+        public code: string,
+        message: string,
+        public status?: number,
+    ) {
+        super(message)
+        this.name = 'GeoGamersApiError'
+    }
+}
+
+interface ApiEnvelope<T> {
+    success: boolean
+    data: T
+    error?: { code: string; message?: string }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(path, {
+        credentials: 'include',
+        ...init,
+        headers: {
+            'Content-Type': 'application/json',
+            ...(init?.headers ?? {}),
+        },
+    })
+    const json = (await res.json()) as ApiEnvelope<T>
+    if (!res.ok || !json.success) {
+        throw new GeoGamersApiError(
+            json.error?.code ?? 'GEOGAMERS_REQUEST_FAILED',
+            json.error?.message ?? `Request to ${path} failed`,
+            res.status,
+        )
+    }
+    return json.data
+}
+
+export const geoGamersApi = {
+    startRun(): Promise<GeoGamersRunView> {
+        return request<GeoGamersRunView>('/api/geogamers/run', { method: 'POST' })
+    },
+
+    getRun(runToken: string): Promise<GeoGamersRunView> {
+        return request<GeoGamersRunView>(`/api/geogamers/run/${runToken}`)
+    },
+
+    guessGame(input: {
+        runToken: string
+        guess: string
+        timeSpentMsDelta?: number
+    }): Promise<GeoGamersGuessGameResult> {
+        return request<GeoGamersGuessGameResult>('/api/geogamers/run/guess-game', {
+            method: 'POST',
+            body: JSON.stringify(input),
+        })
+    },
+
+    guessLocation(input: {
+        runToken: string
+        geoMapId: number
+        guess: GeoPoint
+        timeSpentMsDelta?: number
+    }): Promise<GeoGamersGuessLocationResult> {
+        return request<GeoGamersGuessLocationResult>('/api/geogamers/run/guess-location', {
+            method: 'POST',
+            body: JSON.stringify(input),
+        })
+    },
+
+    useJoker(runToken: string): Promise<GeoGamersRunView> {
+        return request<GeoGamersRunView>('/api/geogamers/run/joker', {
+            method: 'POST',
+            body: JSON.stringify({ runToken }),
+        })
+    },
+
+    claimRun(runToken: string): Promise<GeoGamersClaimResult> {
+        return request<GeoGamersClaimResult>('/api/geogamers/run/claim', {
+            method: 'POST',
+            body: JSON.stringify({ runToken }),
+        })
+    },
+
+    getSeason(): Promise<GeoGamersSeasonStanding[]> {
+        return request<GeoGamersSeasonStanding[]>('/api/geogamers/season')
+    },
+
+    getSeasonMe(): Promise<GeoGamersSeasonMe | null> {
+        return request<GeoGamersSeasonMe | null>('/api/geogamers/season/me')
+    },
+}

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -10,6 +10,7 @@ import { GameList } from '@/components/admin/GameList'
 import { UserList } from '@/components/admin/UserList'
 import { EmailSettings } from '@/components/admin/EmailSettings'
 import { GrowthStats } from '@/components/admin/GrowthStats'
+import { GeoGamersHealthCard } from '@/components/admin/GeoGamersHealthCard'
 import { JobQueuePanel } from '@/components/admin/JobQueuePanel'
 import { GeoReviewPanel } from '@/components/admin/GeoReviewPanel'
 import { EmailLogPanel } from '@/components/admin/EmailLogPanel'
@@ -179,7 +180,12 @@ export default function AdminPage() {
               {activeTab === 'email' && <EmailSettings />}
               {activeTab === 'emailLog' && <EmailLogPanel />}
               {activeTab === 'growth' && <GrowthStats />}
-              {activeTab === 'geo' && <GeoReviewPanel />}
+              {activeTab === 'geo' && (
+                <>
+                  <GeoGamersHealthCard />
+                  <GeoReviewPanel />
+                </>
+              )}
             </m.div>
           </AnimatePresence>
         </div>

--- a/packages/frontend/src/pages/GeoGamersPartyPage.tsx
+++ b/packages/frontend/src/pages/GeoGamersPartyPage.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2, Users, Crown, Copy, Check } from 'lucide-react'
+import { useGeoGamersPartyStore } from '@/stores/geoGamersPartyStore'
+import { useAuth } from '@/hooks/useAuth'
+import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+export default function GeoGamersPartyPage() {
+    const { t } = useTranslation()
+    const { user } = useAuth()
+    const {
+        view,
+        code,
+        error,
+        lastGuessCorrect,
+        pendingPin,
+        selectedMapId,
+        connect,
+        create,
+        join,
+        start,
+        guessGame,
+        setPendingPin,
+        submitLocation,
+        advance,
+        leave,
+    } = useGeoGamersPartyStore()
+
+    const [joinCode, setJoinCode] = useState('')
+    const [rounds, setRounds] = useState(5)
+    const [guessText, setGuessText] = useState('')
+    const [copied, setCopied] = useState(false)
+
+    useEffect(() => {
+        connect()
+    }, [connect])
+
+    const myId = user?.id
+    const isHost = !!view && !!myId && view.hostId === myId
+    const selectedMap = useMemo(
+        () => view?.round?.maps?.find((m) => m.id === selectedMapId) ?? view?.round?.maps?.[0] ?? null,
+        [view?.round?.maps, selectedMapId],
+    )
+
+    // ---------- No party yet: create / join ----------
+    if (!view) {
+        return (
+            <div className="mx-auto max-w-md px-4 py-10">
+                <h1 className="mb-6 flex items-center gap-2 text-2xl font-bold">
+                    <Users className="h-6 w-6 text-neon-purple" /> {t('geogamersParty.title')}
+                </h1>
+                {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
+
+                <div className="mb-6 rounded-xl border border-border bg-card p-4">
+                    <h2 className="mb-3 font-semibold">{t('geogamersParty.create')}</h2>
+                    <label className="mb-2 block text-sm text-muted-foreground">
+                        {t('geogamersParty.rounds')}
+                    </label>
+                    <div className="mb-4 flex gap-2">
+                        {[3, 5, 10].map((r) => (
+                            <Button
+                                key={r}
+                                variant={rounds === r ? 'default' : 'outline'}
+                                size="sm"
+                                onClick={() => setRounds(r)}
+                            >
+                                {r}
+                            </Button>
+                        ))}
+                    </div>
+                    <Button className="w-full" onClick={() => create({ rounds, timerSeconds: 45 })}>
+                        {t('geogamersParty.createCta')}
+                    </Button>
+                </div>
+
+                <div className="rounded-xl border border-border bg-card p-4">
+                    <h2 className="mb-3 font-semibold">{t('geogamersParty.join')}</h2>
+                    <div className="flex gap-2">
+                        <Input
+                            value={joinCode}
+                            onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+                            placeholder={t('geogamersParty.codePlaceholder')}
+                            maxLength={6}
+                            className="flex-1 uppercase"
+                        />
+                        <Button disabled={joinCode.length < 4} onClick={() => join(joinCode)}>
+                            {t('geogamersParty.joinCta')}
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    // ---------- Scoreboard (shared) ----------
+    const scoreboard = (
+        <div className="mt-4 space-y-1">
+            {view.scoreboard.map((s, i) => (
+                <div
+                    key={s.playerId}
+                    className="flex items-center justify-between rounded-lg bg-muted/40 px-3 py-1.5 text-sm"
+                >
+                    <span className="flex items-center gap-2">
+                        <span className="w-5 text-muted-foreground">{i + 1}</span>
+                        {s.name}
+                        {view.hostId === s.playerId && <Crown className="h-3.5 w-3.5 text-medal-gold" />}
+                    </span>
+                    <span className="font-semibold text-neon-purple">{s.total}</span>
+                </div>
+            ))}
+        </div>
+    )
+
+    return (
+        <div className="mx-auto max-w-3xl px-4 py-6">
+            <header className="mb-4 flex items-center justify-between">
+                <h1 className="flex items-center gap-2 text-xl font-bold">
+                    <Users className="h-5 w-5 text-neon-purple" /> {t('geogamersParty.title')}
+                </h1>
+                <Button variant="ghost" size="sm" onClick={leave}>
+                    {t('geogamersParty.leave')}
+                </Button>
+            </header>
+
+            {error && <p className="mb-3 text-sm text-destructive">{error}</p>}
+
+            {/* ---------- Lobby ---------- */}
+            {view.status === 'lobby' && (
+                <section>
+                    <div className="mb-4 flex items-center gap-2 rounded-lg bg-primary/15 px-4 py-3">
+                        <span className="text-sm text-muted-foreground">
+                            {t('geogamersParty.inviteCode')}
+                        </span>
+                        <span className="font-mono text-lg font-bold tracking-widest text-neon-purple">
+                            {code}
+                        </span>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            onClick={() => {
+                                if (code) void navigator.clipboard?.writeText(code)
+                                setCopied(true)
+                                setTimeout(() => setCopied(false), 1500)
+                            }}
+                        >
+                            {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                        </Button>
+                    </div>
+
+                    <div className="space-y-1">
+                        {view.players.map((p) => (
+                            <div
+                                key={p.id}
+                                className={cn(
+                                    'flex items-center gap-2 rounded-lg px-3 py-2',
+                                    p.connected ? 'bg-muted/40' : 'bg-muted/20 opacity-50',
+                                )}
+                            >
+                                {p.isHost && <Crown className="h-4 w-4 text-medal-gold" />}
+                                {p.name}
+                            </div>
+                        ))}
+                    </div>
+
+                    <p className="mt-3 text-xs text-muted-foreground">
+                        {t('geogamersParty.playerCount', { count: view.players.length, max: 4 })}
+                    </p>
+
+                    {isHost ? (
+                        <Button className="mt-4 w-full" onClick={start}>
+                            {t('geogamersParty.start')}
+                        </Button>
+                    ) : (
+                        <p className="mt-4 text-center text-sm text-muted-foreground">
+                            {t('geogamersParty.waitingHost')}
+                        </p>
+                    )}
+                </section>
+            )}
+
+            {/* ---------- In round ---------- */}
+            {view.status === 'in_round' && view.round && (
+                <section>
+                    <p className="mb-2 text-sm text-muted-foreground">
+                        {t('geogamersParty.round', {
+                            n: view.round.index + 1,
+                            total: view.totalRounds,
+                        })}
+                    </p>
+
+                    {view.you?.done ? (
+                        <div className="rounded-xl border border-border bg-card p-6 text-center">
+                            <Loader2 className="mx-auto mb-2 h-6 w-6 animate-spin text-neon-purple" />
+                            <p className="text-sm text-muted-foreground">
+                                {t('geogamersParty.waitingOthers')}
+                            </p>
+                            {scoreboard}
+                        </div>
+                    ) : !view.you?.resolvedPhase1 ? (
+                        // identify phase
+                        <div>
+                            <div className="mb-4 overflow-hidden rounded-xl border border-border bg-card">
+                                <img
+                                    src={view.round.screenshotUrl}
+                                    alt=""
+                                    className="max-h-[50vh] w-full object-contain"
+                                />
+                            </div>
+                            {lastGuessCorrect === false && (
+                                <p className="mb-2 text-sm text-warning">
+                                    {t('geogamersParty.wrongGuess', {
+                                        left: 3 - (view.you?.attemptsUsed ?? 0),
+                                    })}
+                                </p>
+                            )}
+                            <form
+                                className="flex gap-2"
+                                onSubmit={(e) => {
+                                    e.preventDefault()
+                                    if (guessText.trim()) {
+                                        guessGame(guessText.trim())
+                                        setGuessText('')
+                                    }
+                                }}
+                            >
+                                <Input
+                                    autoFocus
+                                    value={guessText}
+                                    onChange={(e) => setGuessText(e.target.value)}
+                                    placeholder={t('geogamers.identify.placeholder')}
+                                    className="flex-1"
+                                />
+                                <Button type="submit" disabled={!guessText.trim()}>
+                                    {t('geogamers.identify.submit')}
+                                </Button>
+                            </form>
+                        </div>
+                    ) : selectedMap ? (
+                        // locate phase
+                        <div>
+                            <div className="mb-3 rounded-lg bg-primary/15 px-4 py-2 text-center text-sm">
+                                <span className="text-muted-foreground">
+                                    {t('geogamers.locate.banner')}{' '}
+                                </span>
+                                <span className="font-semibold text-neon-purple">
+                                    {view.round.gameName}
+                                </span>
+                            </div>
+                            <GeoMapCanvas
+                                imageUrl={selectedMap.imageUrl}
+                                widthPx={selectedMap.widthPx}
+                                heightPx={selectedMap.heightPx}
+                                tiles={selectedMap.tiles}
+                                pin={pendingPin}
+                                onPin={setPendingPin}
+                            />
+                            <Button
+                                className="mt-4 w-full"
+                                disabled={!pendingPin}
+                                onClick={submitLocation}
+                            >
+                                {t('geogamers.locate.confirm')}
+                            </Button>
+                        </div>
+                    ) : null}
+                </section>
+            )}
+
+            {/* ---------- Reveal / Finished ---------- */}
+            {(view.status === 'reveal' || view.status === 'finished') && (
+                <section>
+                    {view.reveal && view.status === 'reveal' && (
+                        <div className="mb-3 rounded-lg bg-primary/15 px-4 py-2 text-center">
+                            <span className="text-sm text-muted-foreground">
+                                {t('geogamersParty.answer')}{' '}
+                            </span>
+                            <span className="font-semibold text-neon-purple">
+                                {view.reveal.gameName}
+                            </span>
+                        </div>
+                    )}
+
+                    {view.status === 'finished' && (
+                        <h2 className="mb-3 text-center text-lg font-bold text-neon-purple">
+                            {t('geogamersParty.finished')}
+                        </h2>
+                    )}
+
+                    {scoreboard}
+
+                    {view.status === 'reveal' && isHost && (
+                        <Button className="mt-4 w-full" onClick={advance}>
+                            {view.currentRound + 1 >= view.totalRounds
+                                ? t('geogamersParty.seeResults')
+                                : t('geogamersParty.nextRound')}
+                        </Button>
+                    )}
+                    {view.status === 'reveal' && !isHost && (
+                        <p className="mt-4 text-center text-sm text-muted-foreground">
+                            {t('geogamersParty.waitingHost')}
+                        </p>
+                    )}
+                    {view.status === 'finished' && (
+                        <Button className="mt-4 w-full" variant="outline" onClick={leave}>
+                            {t('geogamersParty.leave')}
+                        </Button>
+                    )}
+                </section>
+            )}
+        </div>
+    )
+}

--- a/packages/frontend/src/pages/GeoGamersPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoGamersPlayPage.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import { Loader2, MapPin, Sparkles, Trophy } from 'lucide-react'
+import { useGeoGamersStore } from '@/stores/geoGamersStore'
+import { useAuth } from '@/hooks/useAuth'
+import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
+import { MapPicker } from '@/components/geo/MapPicker'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import type { GeoMap, GeoMapOption } from '@the-box/types'
+
+// GeoMapOption is a structural subset of GeoMap; MapPicker wants GeoMap[] but
+// only reads id/region/imageUrl/size, so widen safely for the picker.
+function asGeoMaps(options: GeoMapOption[]): GeoMap[] {
+    return options as unknown as GeoMap[]
+}
+
+export default function GeoGamersPlayPage() {
+    const { t } = useTranslation()
+    const { isAuthenticated, user } = useAuth()
+    const isRealAccount = isAuthenticated && !user?.isAnonymous
+
+    const {
+        phase,
+        run,
+        errorMessage,
+        guessText,
+        lastCorrect,
+        lastProximity,
+        selectedMapId,
+        pendingPin,
+        result,
+        claimed,
+        start,
+        setGuessText,
+        submitGameGuess,
+        selectMap,
+        setPendingPin,
+        submitLocation,
+        useJoker: applyJoker,
+        reset,
+    } = useGeoGamersStore()
+
+    const startedRef = useRef(false)
+    useEffect(() => {
+        if (!startedRef.current) {
+            startedRef.current = true
+            void start()
+        }
+    }, [start])
+
+    const selectedMap = useMemo(
+        () => run?.maps?.find((m) => m.id === selectedMapId) ?? run?.maps?.[0] ?? null,
+        [run?.maps, selectedMapId],
+    )
+
+    const mapPickerNeeded = (run?.maps?.length ?? 0) > 1
+
+    if (phase === 'loading' || phase === 'idle') {
+        return (
+            <div className="flex min-h-[60vh] items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-neon-purple" />
+            </div>
+        )
+    }
+
+    if (phase === 'error') {
+        return (
+            <div className="mx-auto max-w-md py-16 text-center">
+                <p className="mb-4 text-destructive">{errorMessage ?? t('geogamers.error')}</p>
+                <Button onClick={() => void start()}>{t('geogamers.retry')}</Button>
+            </div>
+        )
+    }
+
+    return (
+        <div className="mx-auto max-w-3xl px-4 py-6">
+            <header className="mb-4 flex items-center justify-between">
+                <h1 className="flex items-center gap-2 text-2xl font-bold">
+                    <MapPin className="h-6 w-6 text-neon-purple" />
+                    GeoGamers
+                </h1>
+                <Link
+                    to="../leaderboard"
+                    className="flex items-center gap-1 text-sm text-neon-purple hover:text-primary"
+                >
+                    <Trophy className="h-4 w-4" /> {t('geogamers.season.link')}
+                </Link>
+            </header>
+
+            {/* ---------------- IDENTIFY ---------------- */}
+            {phase === 'identify' && run && (
+                <section>
+                    <div className="mb-4 overflow-hidden rounded-xl border border-border bg-card">
+                        <img
+                            src={run.screenshotUrl}
+                            alt={t('geogamers.identify.screenshotAlt')}
+                            className="max-h-[55vh] w-full object-contain"
+                        />
+                    </div>
+
+                    <p className="mb-2 text-sm text-muted-foreground">
+                        {t('geogamers.identify.prompt')}
+                    </p>
+
+                    {/* attempt dots */}
+                    <div className="mb-3 flex items-center gap-2">
+                        {[100, 66, 33].map((pts, i) => (
+                            <span
+                                key={pts}
+                                className={cn(
+                                    'flex h-7 items-center justify-center rounded-full px-2 text-xs font-semibold',
+                                    i < run.attemptsUsed
+                                        ? 'bg-muted text-muted-foreground line-through'
+                                        : 'bg-primary/20 text-neon-purple',
+                                )}
+                            >
+                                {pts}
+                            </span>
+                        ))}
+                        <span className="text-xs text-muted-foreground">
+                            {t('geogamers.identify.attemptsLeft', {
+                                count: run.attemptsMax - run.attemptsUsed,
+                            })}
+                        </span>
+                    </div>
+
+                    {lastCorrect === false && (
+                        <p className="mb-2 text-sm text-warning">
+                            {lastProximity === 'very_close'
+                                ? t('geogamers.identify.proximity.very_close')
+                                : lastProximity === 'close'
+                                  ? t('geogamers.identify.proximity.close')
+                                  : t('geogamers.identify.proximity.far')}
+                        </p>
+                    )}
+
+                    <form
+                        className="flex gap-2"
+                        onSubmit={(e) => {
+                            e.preventDefault()
+                            void submitGameGuess()
+                        }}
+                    >
+                        <Input
+                            autoFocus
+                            value={guessText}
+                            onChange={(e) => setGuessText(e.target.value)}
+                            placeholder={t('geogamers.identify.placeholder')}
+                            className="flex-1"
+                        />
+                        <Button type="submit" disabled={!guessText.trim()}>
+                            {t('geogamers.identify.submit')}
+                        </Button>
+                    </form>
+
+                    {/* joker */}
+                    <div className="mt-4">
+                        {run.jokerAvailable ? (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => void applyJoker()}
+                                className="gap-1 border-neon-pink/50 text-neon-pink"
+                            >
+                                <Sparkles className="h-4 w-4" /> {t('geogamers.joker.cta')}
+                            </Button>
+                        ) : !isRealAccount ? (
+                            <p className="text-xs text-muted-foreground">
+                                {t('geogamers.joker.guestHint')}
+                            </p>
+                        ) : null}
+                    </div>
+                </section>
+            )}
+
+            {/* ---------------- LOCATE ---------------- */}
+            {phase === 'locate' && run && selectedMap && (
+                <section>
+                    <div className="mb-3 rounded-lg bg-primary/15 px-4 py-2 text-center">
+                        <span className="text-sm text-muted-foreground">
+                            {t('geogamers.locate.banner')}{' '}
+                        </span>
+                        <span className="font-semibold text-neon-purple">{run.game?.name}</span>
+                    </div>
+
+                    {mapPickerNeeded && (
+                        <div className="mb-3">
+                            <MapPicker
+                                open={false}
+                                onOpenChange={() => {}}
+                                maps={asGeoMaps(run.maps ?? [])}
+                                selectedMapId={selectedMapId}
+                                onSelect={(id) => selectMap(id ?? run.maps![0]!.id)}
+                            />
+                        </div>
+                    )}
+
+                    <GeoMapCanvas
+                        imageUrl={selectedMap.imageUrl}
+                        widthPx={selectedMap.widthPx}
+                        heightPx={selectedMap.heightPx}
+                        tiles={selectedMap.tiles}
+                        pin={pendingPin}
+                        onPin={setPendingPin}
+                    />
+
+                    <Button
+                        className="mt-4 w-full"
+                        disabled={!pendingPin}
+                        onClick={() => void submitLocation()}
+                    >
+                        {t('geogamers.locate.confirm')}
+                    </Button>
+                </section>
+            )}
+
+            {/* ---------------- RESULT ---------------- */}
+            {phase === 'result' && run && result && selectedMap && (
+                <section>
+                    <div className="mb-4">
+                        <GeoMapCanvas
+                            imageUrl={selectedMap.imageUrl}
+                            widthPx={selectedMap.widthPx}
+                            heightPx={selectedMap.heightPx}
+                            tiles={selectedMap.tiles}
+                            pin={result.guess}
+                            canonical={result.canonical}
+                            showGuessLine
+                            disabled
+                        />
+                    </div>
+
+                    <div className="rounded-xl border border-border bg-card p-4 text-center">
+                        <p className="text-sm text-muted-foreground">{run.game?.name}</p>
+                        <p className="my-2 text-3xl font-bold text-neon-purple">
+                            {result.totalPoints}
+                            <span className="text-lg text-muted-foreground"> / 200</span>
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                            {t('geogamers.result.breakdown', {
+                                game: result.gamePoints,
+                                location: result.locationPoints,
+                            })}
+                        </p>
+
+                        {isRealAccount && result.rank != null && (
+                            <p className="mt-3 text-sm text-neon-purple">
+                                {t('geogamers.result.rank', { rank: result.rank })}
+                            </p>
+                        )}
+
+                        {!isRealAccount && result.ghostRank != null && (
+                            <div className="mt-4 rounded-lg bg-primary/15 p-3">
+                                <p className="mb-2 text-sm text-neon-purple">
+                                    {t('geogamers.result.ghostRank', { rank: result.ghostRank })}
+                                </p>
+                                {claimed ? (
+                                    <p className="text-sm text-success">
+                                        {t('geogamers.result.claimed')}
+                                    </p>
+                                ) : (
+                                    <Button asChild size="sm">
+                                        <Link to="../register">{t('geogamers.result.claimCta')}</Link>
+                                    </Button>
+                                )}
+                            </div>
+                        )}
+
+                        <p className="mt-4 text-xs text-muted-foreground">
+                            {isRealAccount
+                                ? t('geogamers.result.comeBack')
+                                : t('geogamers.result.unranked')}
+                        </p>
+                    </div>
+
+                    <Button variant="ghost" className="mt-4 w-full" onClick={reset}>
+                        {t('geogamers.result.done')}
+                    </Button>
+                </section>
+            )}
+        </div>
+    )
+}

--- a/packages/frontend/src/pages/GeoGamersPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoGamersPlayPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import { Loader2, MapPin, Sparkles, Trophy } from 'lucide-react'
+import { Loader2, MapPin, Sparkles, Trophy, Users } from 'lucide-react'
 import { useGeoGamersStore } from '@/stores/geoGamersStore'
 import { useAuth } from '@/hooks/useAuth'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
@@ -82,12 +82,20 @@ export default function GeoGamersPlayPage() {
                     <MapPin className="h-6 w-6 text-neon-purple" />
                     GeoGamers
                 </h1>
-                <Link
-                    to="../leaderboard"
-                    className="flex items-center gap-1 text-sm text-neon-purple hover:text-primary"
-                >
-                    <Trophy className="h-4 w-4" /> {t('geogamers.season.link')}
-                </Link>
+                <div className="flex items-center gap-3">
+                    <Link
+                        to="party"
+                        className="flex items-center gap-1 text-sm text-neon-purple hover:text-primary"
+                    >
+                        <Users className="h-4 w-4" /> {t('geogamersParty.title')}
+                    </Link>
+                    <Link
+                        to="../leaderboard"
+                        className="flex items-center gap-1 text-sm text-neon-purple hover:text-primary"
+                    >
+                        <Trophy className="h-4 w-4" /> {t('geogamers.season.link')}
+                    </Link>
+                </div>
             </header>
 
             {/* ---------------- IDENTIFY ---------------- */}

--- a/packages/frontend/src/pages/LeaderboardPage.tsx
+++ b/packages/frontend/src/pages/LeaderboardPage.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from 'react-i18next'
 import { format } from 'date-fns'
 import { fr, enUS } from 'date-fns/locale'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Trophy, Crown, Calendar, CalendarDays } from 'lucide-react'
+import { Trophy, Crown, Calendar, CalendarDays, Crosshair } from 'lucide-react'
+import { GeoGamersSeasonPanel } from '@/components/leaderboard/GeoGamersSeasonPanel'
 import { PageHero } from '@/components/layout/PageHero'
 import {
   DailyLeaderboardPanel,
@@ -259,7 +260,7 @@ export default function LeaderboardPage() {
     <PageHero icon={Trophy} iconStyle="simple" title={t('leaderboard.title')}>
       <div className="max-w-4xl mx-auto">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid w-full grid-cols-3 mb-6 h-auto sm:h-10 p-1 gap-1">
+          <TabsList className="grid w-full grid-cols-4 mb-6 h-auto sm:h-10 p-1 gap-1">
             <TabsTrigger
               value="daily"
               className="flex-col sm:flex-row gap-1 sm:gap-0 px-1.5 sm:px-3 py-2 sm:py-1.5 text-[11px] sm:text-sm h-auto"
@@ -280,6 +281,13 @@ export default function LeaderboardPage() {
             >
               <Crown className="size-4 sm:mr-2 shrink-0" />
               <span className="truncate max-w-full">{t('leaderboard.achievementPoints')}</span>
+            </TabsTrigger>
+            <TabsTrigger
+              value="geogamers"
+              className="flex-col sm:flex-row gap-1 sm:gap-0 px-1.5 sm:px-3 py-2 sm:py-1.5 text-[11px] sm:text-sm h-auto"
+            >
+              <Crosshair className="size-4 sm:mr-2 shrink-0" />
+              <span className="truncate max-w-full">{t('leaderboard.geogamers.tab')}</span>
             </TabsTrigger>
           </TabsList>
 
@@ -321,6 +329,11 @@ export default function LeaderboardPage() {
               entries={achievementLeaderboard}
               loading={achievementLoading}
             />
+          </TabsContent>
+
+          {/* GeoGamers Season */}
+          <TabsContent value="geogamers">
+            <GeoGamersSeasonPanel />
           </TabsContent>
         </Tabs>
 

--- a/packages/frontend/src/stores/geoGamersPartyStore.ts
+++ b/packages/frontend/src/stores/geoGamersPartyStore.ts
@@ -1,0 +1,127 @@
+import { create } from 'zustand'
+import { io, type Socket } from 'socket.io-client'
+import type { GeoGamersPartyView, GeoPoint } from '@the-box/types'
+
+const SOCKET_URL = import.meta.env.VITE_API_URL || undefined
+
+let socket: Socket | null = null
+
+function getSocket(): Socket {
+    if (socket) return socket
+    const path = SOCKET_URL ? `${SOCKET_URL}/geogamers-party` : '/geogamers-party'
+    socket = io(path, {
+        autoConnect: false,
+        path: '/socket.io',
+        withCredentials: true,
+        transports: ['websocket', 'polling'],
+        reconnection: true,
+        reconnectionAttempts: Infinity,
+    })
+    return socket
+}
+
+interface PartyState {
+    connected: boolean
+    view: GeoGamersPartyView | null
+    code: string | null
+    error: string | null
+    // per-round local phase feedback
+    lastGuessCorrect: boolean | null
+    pendingPin: GeoPoint | null
+    selectedMapId: number | null
+
+    connect: () => void
+    create: (opts: { rounds: number; timerSeconds: number; name?: string }) => void
+    join: (code: string, name?: string) => void
+    start: () => void
+    guessGame: (guess: string) => void
+    setPendingPin: (p: GeoPoint | null) => void
+    selectMap: (id: number) => void
+    submitLocation: () => void
+    advance: () => void
+    leave: () => void
+}
+
+export const useGeoGamersPartyStore = create<PartyState>()((set, get) => ({
+    connected: false,
+    view: null,
+    code: null,
+    error: null,
+    lastGuessCorrect: null,
+    pendingPin: null,
+    selectedMapId: null,
+
+    connect() {
+        const s = getSocket()
+        if ((s as unknown as { _wired?: boolean })._wired) {
+            if (!s.connected) s.connect()
+            return
+        }
+        s.on('connect', () => set({ connected: true }))
+        s.on('disconnect', () => set({ connected: false }))
+        s.on('party:created', (e: { code: string }) => set({ code: e.code }))
+        s.on('party:state', (view: GeoGamersPartyView) => {
+            set((prev) => ({
+                view,
+                code: view.code,
+                // reset per-round local state when the round index advances
+                pendingPin: prev.view?.round?.index !== view.round?.index ? null : prev.pendingPin,
+                lastGuessCorrect:
+                    prev.view?.round?.index !== view.round?.index ? null : prev.lastGuessCorrect,
+                selectedMapId: view.round?.maps?.[0]?.id ?? prev.selectedMapId,
+            }))
+        })
+        s.on('party:guess_result', (e: { correct: boolean }) =>
+            set({ lastGuessCorrect: e.correct }),
+        )
+        s.on('party:error', (e: { code: string; message: string }) => set({ error: e.message }))
+        ;(s as unknown as { _wired?: boolean })._wired = true
+        s.connect()
+    },
+
+    create(opts) {
+        get().connect()
+        getSocket().emit('party:create', opts)
+    },
+
+    join(code, name) {
+        get().connect()
+        getSocket().emit('party:join', { code: code.toUpperCase(), name })
+    },
+
+    start() {
+        const code = get().code
+        if (code) getSocket().emit('party:start', { code })
+    },
+
+    guessGame(guess) {
+        const code = get().code
+        if (code) getSocket().emit('party:guess_game', { code, guess })
+    },
+
+    setPendingPin(p) {
+        set({ pendingPin: p })
+    },
+
+    selectMap(id) {
+        set({ selectedMapId: id })
+    },
+
+    submitLocation() {
+        const { code, selectedMapId, pendingPin } = get()
+        if (code && selectedMapId && pendingPin) {
+            getSocket().emit('party:guess_location', { code, geoMapId: selectedMapId, guess: pendingPin })
+        }
+    },
+
+    advance() {
+        const code = get().code
+        if (code) getSocket().emit('party:advance', { code })
+    },
+
+    leave() {
+        const code = get().code
+        if (code) getSocket().emit('party:leave', { code })
+        set({ view: null, code: null, pendingPin: null, lastGuessCorrect: null })
+    },
+}))

--- a/packages/frontend/src/stores/geoGamersStore.ts
+++ b/packages/frontend/src/stores/geoGamersStore.ts
@@ -1,0 +1,216 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type {
+    GeoGamersGuessLocationResult,
+    GeoGamersRunView,
+    GeoPoint,
+} from '@the-box/types'
+import { geoGamersApi, GeoGamersApiError } from '../lib/api/geogamers'
+import { getApiErrorMessage } from '../lib/api-errors'
+
+// UI phase, distinct from the server-side run phase: it also models the
+// loading / result / error states the page renders.
+type Phase =
+    | 'idle'
+    | 'loading'
+    | 'identify'
+    | 'locate'
+    | 'result'
+    | 'error'
+
+interface GeoGamersState {
+    phase: Phase
+    errorMessage: string | null
+    run: GeoGamersRunView | null
+
+    // identify
+    guessText: string
+    lastCorrect: boolean | null
+    lastProximity: 'far' | 'close' | 'very_close' | null
+
+    // locate
+    selectedMapId: number | null
+    pendingPin: GeoPoint | null
+
+    // result
+    result: GeoGamersGuessLocationResult | null
+
+    // guest run token persisted so a reload resumes the same run and the
+    // one-run-per-device soft cap holds; cleared on a fresh ranked start.
+    guestRunToken: string | null
+
+    // claim (guest -> account)
+    claiming: boolean
+    claimed: boolean
+
+    // actions
+    start: () => Promise<void>
+    setGuessText: (v: string) => void
+    submitGameGuess: () => Promise<void>
+    selectMap: (id: number) => void
+    setPendingPin: (p: GeoPoint | null) => void
+    submitLocation: () => Promise<void>
+    useJoker: () => Promise<void>
+    claimAfterSignup: () => Promise<boolean>
+    reset: () => void
+}
+
+function deriveUiPhase(run: GeoGamersRunView): Phase {
+    if (run.phase === 'identify') return 'identify'
+    if (run.phase === 'locate') return 'locate'
+    return 'result'
+}
+
+export const useGeoGamersStore = create<GeoGamersState>()(
+    persist(
+        (set, get) => ({
+            phase: 'idle',
+            errorMessage: null,
+            run: null,
+            guessText: '',
+            lastCorrect: null,
+            lastProximity: null,
+            selectedMapId: null,
+            pendingPin: null,
+            result: null,
+            guestRunToken: null,
+            claiming: false,
+            claimed: false,
+
+            async start() {
+                set({ phase: 'loading', errorMessage: null, result: null })
+                try {
+                    // Resume a persisted guest run when possible; otherwise start fresh.
+                    const token = get().guestRunToken
+                    let run: GeoGamersRunView
+                    if (token) {
+                        try {
+                            run = await geoGamersApi.getRun(token)
+                        } catch {
+                            run = await geoGamersApi.startRun()
+                        }
+                    } else {
+                        run = await geoGamersApi.startRun()
+                    }
+                    set({
+                        run,
+                        guestRunToken: run.runToken,
+                        phase: deriveUiPhase(run),
+                        selectedMapId: run.maps?.[0]?.id ?? null,
+                    })
+                } catch (err) {
+                    set({ phase: 'error', errorMessage: getApiErrorMessage(err) })
+                }
+            },
+
+            setGuessText(v) {
+                set({ guessText: v })
+            },
+
+            async submitGameGuess() {
+                const { run, guessText } = get()
+                if (!run || !guessText.trim()) return
+                try {
+                    const res = await geoGamersApi.guessGame({
+                        runToken: run.runToken,
+                        guess: guessText.trim(),
+                    })
+                    set({
+                        run: res.run,
+                        lastCorrect: res.correct,
+                        lastProximity: res.proximity ?? null,
+                        guessText: res.correct ? '' : '',
+                        phase: deriveUiPhase(res.run),
+                        selectedMapId: res.run.maps?.[0]?.id ?? get().selectedMapId,
+                    })
+                } catch (err) {
+                    set({ errorMessage: getApiErrorMessage(err) })
+                }
+            },
+
+            selectMap(id) {
+                set({ selectedMapId: id })
+            },
+
+            setPendingPin(p) {
+                set({ pendingPin: p })
+            },
+
+            async submitLocation() {
+                const { run, selectedMapId, pendingPin } = get()
+                if (!run || !selectedMapId || !pendingPin) return
+                try {
+                    const result = await geoGamersApi.guessLocation({
+                        runToken: run.runToken,
+                        geoMapId: selectedMapId,
+                        guess: pendingPin,
+                    })
+                    // Refresh the run view so phase flips to done.
+                    const refreshed = await geoGamersApi.getRun(run.runToken)
+                    set({ result, run: refreshed, phase: 'result' })
+                } catch (err) {
+                    set({ errorMessage: getApiErrorMessage(err) })
+                }
+            },
+
+            async useJoker() {
+                const { run } = get()
+                if (!run) return
+                try {
+                    const refreshed = await geoGamersApi.useJoker(run.runToken)
+                    set({
+                        run: refreshed,
+                        phase: deriveUiPhase(refreshed),
+                        guessText: '',
+                        lastProximity: null,
+                        lastCorrect: null,
+                    })
+                } catch (err) {
+                    set({ errorMessage: getApiErrorMessage(err) })
+                }
+            },
+
+            // Called after a successful signup while a completed guest run is in
+            // memory. Silent on failure — an expired/ineligible claim is expected.
+            async claimAfterSignup() {
+                const { run } = get()
+                if (!run) return false
+                set({ claiming: true })
+                try {
+                    await geoGamersApi.claimRun(run.runToken)
+                    set({ claiming: false, claimed: true })
+                    return true
+                } catch (err) {
+                    if (err instanceof GeoGamersApiError) {
+                        set({ claiming: false })
+                        return false
+                    }
+                    set({ claiming: false })
+                    return false
+                }
+            },
+
+            reset() {
+                set({
+                    phase: 'idle',
+                    errorMessage: null,
+                    run: null,
+                    guessText: '',
+                    lastCorrect: null,
+                    lastProximity: null,
+                    selectedMapId: null,
+                    pendingPin: null,
+                    result: null,
+                    claiming: false,
+                    claimed: false,
+                })
+            },
+        }),
+        {
+            name: 'geogamers-run',
+            // Persist ONLY the guest run token (the soft one-run-per-device
+            // handle). Run state itself is always re-fetched from the server.
+            partialize: (s) => ({ guestRunToken: s.guestRunToken }),
+        },
+    ),
+)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1878,3 +1878,96 @@ export interface GeoGamersSeasonUpdatedEvent {
   month: string // YYYY-MM
   topN: GeoGamersSeasonStanding[]
 }
+
+// ---------------- GeoGamers Party (1–4 player lobby) ----------------
+//
+// A casual, unranked variant: 1–4 players in a private lobby play the SAME
+// server-seeded round sequence, each on their own screen, with a synchronized
+// reveal between rounds. Drawn from the retired/free-play pool (never today's
+// ranked screenshot), so it never touches the season and can't be used to
+// scout the daily. State is ephemeral (Redis, ~2h TTL).
+
+export type GeoGamersPartyStatus = 'lobby' | 'in_round' | 'reveal' | 'finished'
+
+export interface GeoGamersPartyPlayer {
+  id: string // user id or guest session id
+  name: string
+  isHost: boolean
+  connected: boolean
+}
+
+export interface GeoGamersPartyConfig {
+  rounds: number // 3 | 5 | 10
+  timerSeconds: number // per-phase budget
+}
+
+// Per-player result within one round. `done` is set on completion OR timeout.
+export interface GeoGamersPartyRoundResult {
+  playerId: string
+  attemptsUsed: number
+  gamePoints: number | null
+  solvedGame: boolean
+  locationPoints: number | null
+  totalPoints: number | null
+  done: boolean
+}
+
+// One round. Answer fields (canonical, gameId, mapId) are server-only until the
+// round is revealed — the spectator-safe view omits them while in progress.
+export interface GeoGamersPartyRound {
+  index: number
+  geoScreenshotMetaId: number
+  gameId: number
+  gameName: string
+  geoMapId: number
+  canonical: GeoPoint
+  results: Record<string, GeoGamersPartyRoundResult>
+  revealed: boolean
+}
+
+export interface GeoGamersParty {
+  code: string
+  status: GeoGamersPartyStatus
+  config: GeoGamersPartyConfig
+  hostId: string
+  players: GeoGamersPartyPlayer[]
+  currentRound: number // index into rounds; -1 in lobby
+  rounds: GeoGamersPartyRound[]
+  createdAtMs: number
+}
+
+// Spectator-safe projection sent to clients. While a round is in progress the
+// answer (game identity, canonical pin) is withheld; per-player progress shows
+// only phase/points, never the guess text.
+export interface GeoGamersPartyView {
+  code: string
+  status: GeoGamersPartyStatus
+  config: GeoGamersPartyConfig
+  hostId: string
+  players: GeoGamersPartyPlayer[]
+  currentRound: number
+  totalRounds: number
+  // The active round's playable payload (screenshot only) — present when
+  // status === 'in_round'. Answer withheld.
+  round?: {
+    index: number
+    screenshotUrl: string
+    // Revealed maps for the locate phase, once THIS player has solved/exhausted.
+    maps?: GeoMapOption[]
+    gameName?: string // only after this player resolves phase 1
+  }
+  // Scoreboard (cumulative totals) — always safe to show.
+  scoreboard: Array<{ playerId: string; name: string; total: number }>
+  // Full reveal payload — present only when status === 'reveal' or 'finished'.
+  reveal?: {
+    index: number
+    gameName: string
+    canonical: GeoPoint
+    pins: Array<{ playerId: string; name: string; guess: GeoPoint | null; points: number }>
+  }
+}
+
+export interface GeoGamersPartyCreatedEvent {
+  code: string
+}
+

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1755,3 +1755,126 @@ export interface RankChangedEvent {
 // but `id:` / `event:` / `data:` are emitted directly (not wrapped) so
 // `EventSource.addEventListener('session.completed', …)` works out of the box.
 export type SseEventName = PublicEventType | 'heartbeat' | 'connected'
+
+// ============================================
+// GeoGamers Mode (guess-the-game + geolocate)
+// ============================================
+//
+// Additive daily mode that fuses classic (identify the game from a
+// screenshot) with geo (pin the spot on its map). Reuses `GeoPoint` /
+// `GeoMapOption` / `GeoMapKind` from the Geo section above. The game
+// identity is withheld from every payload until phase 1 resolves — see the
+// anti-leak notes on `GeoGamersRunView`.
+
+// A run walks through two phases then terminates:
+//   identify -> the player names the hidden game (up to 3 attempts)
+//   locate   -> the game+map are revealed; the player drops a pin
+//   done     -> both phases scored; result revealed
+export type GeoGamersRunPhase = 'identify' | 'locate' | 'done'
+
+export interface GeoGamersChallenge {
+  id: number
+  challengeDate: string // YYYY-MM-DD (UTC)
+  // geo_screenshot_meta id is NEVER exposed pre-solve; clients hold an
+  // opaque runToken and fetch the image through a proxy route.
+}
+
+// One phase-1 attempt. `normalized` is the fuzzy-matched form, retained for
+// audit / payout-time anomaly screening (first-attempt-correct rates).
+export interface GeoGamersGameAttempt {
+  guess: string
+  normalized: string
+  correct: boolean
+  at: string // ISO timestamp
+}
+
+// What the client sees. Fields below the divider are populated ONLY once
+// phase === 'locate' (game solved or all 3 attempts spent). Constructed from
+// an explicit whitelist server-side — never by spreading the run row — so a
+// pre-solve view can carry no game/map identity.
+export interface GeoGamersRunView {
+  runToken: string
+  challengeDate: string
+  phase: GeoGamersRunPhase
+  screenshotUrl: string // opaque proxy URL, carries no game slug
+  attemptsUsed: number // 0..3
+  attemptsMax: number // 3
+  timeLimitSeconds: number // per-phase active-time budget
+  timeSpentMs: number
+  jokerAvailable: boolean // account-only, once/season, phase 'identify' + 0 attempts
+  // --- revealed at phase 'locate' onward ---
+  game?: { id: number; name: string }
+  maps?: GeoMapOption[]
+  gamePoints?: number // 100 / 66 / 33 / 0, locked at reveal
+}
+
+export interface GeoGamersGuessGameResult {
+  correct: boolean
+  attemptsUsed: number
+  attemptsRemaining: number
+  gamePoints?: number // present once phase 1 resolves
+  // Near-miss feedback on the player's OWN guess (never metadata), same UX
+  // discipline as classic mode's proximity hinting.
+  proximity?: 'far' | 'close' | 'very_close'
+  run: GeoGamersRunView // refreshed view (includes game+maps on resolve)
+}
+
+export interface GeoGamersGuessLocationResult {
+  guess: GeoPoint
+  canonical: GeoPoint
+  distance: number // normalized [0..1]
+  locationPoints: number // 0..100
+  gamePoints: number
+  totalPoints: number // 0..200
+  scoreVersion: number
+  ghostRank?: number // anonymous only: "you'd be #N today"
+  rank?: number // authenticated: live daily rank
+}
+
+// Guests play unranked; signing up in the same browser session claims that
+// one day's score into the season. See the anonymous-play decision on the
+// tracking issue.
+export interface GeoGamersClaimResult {
+  claimed: boolean
+  challengeDate: string
+  totalPoints: number
+}
+
+// Season = calendar month. `seasonScore` drops each player's 3 worst days,
+// but ONLY once `daysPlayed >= 10` (until then `provisional` is true and the
+// raw total stands).
+export interface GeoGamersSeasonStanding {
+  userId: string
+  username: string
+  daysPlayed: number
+  jokerUsed: boolean
+  rawTotal: number
+  seasonScore: number
+  droppedDays: number // 0 or 3
+  provisional: boolean // daysPlayed < 10
+  rank: number
+}
+
+export interface GeoGamersSeasonMe extends GeoGamersSeasonStanding {
+  dailyBreakdown: Array<{
+    date: string
+    gamePoints: number
+    locationPoints: number
+    total: number
+    dropped: boolean
+    jokerUsed: boolean
+  }>
+}
+
+// Realtime payloads (see docs/realtime.md). Season updates are throttled
+// server-side like the classic leaderboard broadcasts.
+export interface GeoGamersRunCompletedEvent {
+  userId: string
+  challengeDate: string
+  totalPoints: number
+}
+
+export interface GeoGamersSeasonUpdatedEvent {
+  month: string // YYYY-MM
+  topN: GeoGamersSeasonStanding[]
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1907,6 +1907,7 @@ export interface GeoGamersPartyRoundResult {
   attemptsUsed: number
   gamePoints: number | null
   solvedGame: boolean
+  guess: GeoPoint | null // pin coordinates, for the reveal
   locationPoints: number | null
   totalPoints: number | null
   done: boolean

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1957,6 +1957,9 @@ export interface GeoGamersPartyView {
     maps?: GeoMapOption[]
     gameName?: string // only after this player resolves phase 1
   }
+  // The requesting player's OWN round state (safe — it's their own data). Lets
+  // the client distinguish identify / locate / waiting-for-others.
+  you?: { attemptsUsed: number; resolvedPhase1: boolean; done: boolean }
   // Scoreboard (cumulative totals) — always safe to show.
   scoreboard: Array<{ playerId: string; name: string; total: number }>
   // Full reveal payload — present only when status === 'reveal' or 'finished'.


### PR DESCRIPTION
Draft PR — **Phases 0–4** of GeoGamers mode (tracking issue #325). Ships dark behind `GEOGAMERS_ENABLED`.

## Phase 0 — types & schema
Shared types (anti-leak run view) + migration: `geogamers_challenge` / `geogamers_run` (no hint columns; guest + claim + joker-override columns) / `geogamers_joker` (once-per-season PK) / `geogamers_season`.

## Phase 1 — backend core
Pure scoring, orchestration (identify → locate → done, anti-leak, fuzzy guessing, wrong-map flooring, live/ghost rank, joker guard, guest claim-on-signup), repositories, daily scheduler (content-gate + cooldown + idempotent), `/api/geogamers` routes + opaque image proxy. **22 unit tests.**

## Phase 2 — frontend
API client, Zustand phase-machine store, `GeoGamersPlayPage`, design-token styling, fr/en i18n, nav entry.

## Phase 3 — season & competition + ecosystem
Season ranking (drop-3-worst behind a reusable `SeasonRanking` port) · standings API + leaderboard season tab · month-close payout worker · recognition-only achievements · daily web-push fan-out · key-authenticated public-API season endpoint (OpenAPI-documented) · admin content-health panel · `geogamers:season:updated` realtime.

## Phase 4 — party mode (1–4 players)
- **Pure state machine** (`geogamers-party.service`): lobby (join/reconnect/4-cap), start (server-seeded rounds), two-phase per-player play, timeout, all-done detection, reveal, advance/finish, scoreboard. **19 unit tests.**
- **Redis store** (2h TTL, NX invite codes) + content selector drawn from the eligible pool (excludes every daily screenshot, so party can't scout the daily).
- **Socket.io `/geogamers-party`** namespace: spectator-safe per-player views (answer withheld until phase-1 resolve / reveal), auto-close on all-done, host migration, guests allowed. Party image proxy.
- **Frontend** `GeoGamersPartyPage` + socket store: create/join, lobby with invite code, in-round identify→locate, waiting state, reveal + live scoreboard.

## Verification
- Full `npm run build` + lint clean; **41 geogamers unit tests** (scoring, orchestration, party state machine) + full existing suite green (fail 0 on every commit).
- Exercised against **real Postgres 16**: schema constraints, all repositories, challenge worker, drop-3-worst season query, achievement idempotency + migration round-trips, push subscriber enumeration.
- Caught & fixed a suite-hang (a route importing the services barrel pulled `queues.ts`'s eager `QueueEvents` → Redis handle → hung `node --test`); the public route now constructs its season service locally.

## Not runtime-verified here
Party mode's **live multiplayer path** (Redis + Socket.io + multiple clients) can't run in this sandbox — the pure state machine it drives is unit-tested; end-to-end multiplayer verification is deferred to a real environment / Playwright.

## Deferred (tracked on #325)
Public-API SSE / outbound webhooks, admin anomaly-review, more cross-mode achievements, immersive panoramas (Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hs4DiPYRtQCyjswKUV3tWZ