### PR TITLE
fix(geogamers): return JSON for unmatched API routes to stop parse crash

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -312,6 +312,17 @@ app.get('/share/daily', (req, res, next) => {
   }
 })
 
+// Unmatched API routes must return JSON, not the SPA shell. Otherwise a request
+// to a route that isn't mounted (e.g. `/api/geogamers/*` when the feature flag
+// is off) would fall through to the HTML fallback below, and clients calling
+// `res.json()` on it crash with "Unexpected token '<', "<!doctype "...".
+app.use('/api', (_req, res) => {
+  res.status(404).json({
+    success: false,
+    error: { code: 'NOT_FOUND', message: 'API endpoint not found' },
+  })
+})
+
 // SPA fallback - serve index.html for all other routes (must be after API routes and static files)
 app.use((_req, res) => {
   res.sendFile(path.join(frontendPath, 'index.html'))

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2652,6 +2652,7 @@
   },
   "apiErrors": {
     "default": "Something went wrong. Please try again.",
+    "GEOGAMERS_UNAVAILABLE": "GeoGamers isn't available right now.",
     "NETWORK_ERROR": "Network error. Please check your connection.",
     "VALIDATION_ERROR": "The information you entered is invalid.",
     "UNAUTHORIZED": "Please sign in to continue.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2652,6 +2652,7 @@
   },
   "apiErrors": {
     "default": "Une erreur est survenue. Veuillez réessayer.",
+    "GEOGAMERS_UNAVAILABLE": "GeoGamers n'est pas disponible pour le moment.",
     "NETWORK_ERROR": "Erreur réseau. Vérifiez votre connexion.",
     "VALIDATION_ERROR": "Les informations saisies sont invalides.",
     "UNAUTHORIZED": "Veuillez vous connecter pour continuer.",

--- a/packages/frontend/src/lib/api/geogamers.ts
+++ b/packages/frontend/src/lib/api/geogamers.ts
@@ -40,11 +40,28 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
             ...(init?.headers ?? {}),
         },
     })
-    const json = (await res.json()) as ApiEnvelope<T>
-    if (!res.ok || !json.success) {
+
+    // Guard the parse: when the GeoGamers API is disabled the request 404s to
+    // the SPA fallback and the body is HTML (`<!doctype …>`), not JSON. Blindly
+    // calling res.json() there throws "Unexpected token '<'" and surfaces that
+    // raw parser error to the player. Treat any unparseable body as a failure.
+    let json: ApiEnvelope<T> | undefined
+    try {
+        json = (await res.json()) as ApiEnvelope<T>
+    } catch {
+        json = undefined
+    }
+
+    if (!res.ok || !json || !json.success) {
+        // A 404 (feature disabled / route not mounted) or a non-JSON body both
+        // mean GeoGamers isn't available on this deployment — map them to a
+        // single friendly, localized code rather than leaking internals.
+        const unavailable = res.status === 404 || !json
         throw new GeoGamersApiError(
-            json.error?.code ?? 'GEOGAMERS_REQUEST_FAILED',
-            json.error?.message ?? `Request to ${path} failed`,
+            unavailable
+                ? 'GEOGAMERS_UNAVAILABLE'
+                : (json?.error?.code ?? 'GEOGAMERS_REQUEST_FAILED'),
+            json?.error?.message ?? `Request to ${path} failed`,
             res.status,
         )
     }


### PR DESCRIPTION
## Problem

The app crashed with `Unexpected token '<', "<!doctype "... is not valid JSON` (see screenshot below), rendering the GeoGamers page as a full-page error with a **Réessayer** button.

**Root cause:** the Express SPA fallback serves `index.html` for *any* unmatched route — including unmatched `/api/*` paths. When `GEOGAMERS_ENABLED` is not `'true'`, `/api/geogamers/*` routes are never mounted, so a request like `POST /api/geogamers/run` falls through to the HTML shell. The frontend then calls `res.json()` on `<!doctype …>` and throws the raw parser error straight into the UI.

## Fix

- **backend (`packages/backend/src/index.ts`)** — add a JSON `404` handler scoped to `/api` *before* the SPA fallback, so any unmatched API path returns `{ success: false, error: { code: 'NOT_FOUND' } }` instead of HTML. This closes the entire class of "Unexpected token '<'" errors for every API client, not just GeoGamers.
- **frontend (`packages/frontend/src/lib/api/geogamers.ts`)** — harden the request helper: guard the `res.json()` parse and map a `404` / non-JSON body to a single friendly `GEOGAMERS_UNAVAILABLE` code rather than leaking a JSON-parse error. The store's stale-guest-token retry path (`getRun` → `startRun`) still works since that error is caught and retried.
- **i18n** — add `apiErrors.GEOGAMERS_UNAVAILABLE` (fr + en) so the message renders localized.

## Notes

- No type or schema changes; changes are additive and low-risk.
- Local `npm run build` / `npm test` in this environment fail on pre-existing, unrelated issues (TypeScript 6.0.2 `baseUrl` deprecation and a missing `tsx` dev dependency) — both reproduce on a clean checkout and are handled by CI's pinned toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VDhgPNmPwHZ5mEyi7jMM7

---
_Generated by [Claude Code](https://claude.ai/code/session_016VDhgPNmPwHZ5mEyi7jMM7)_