### PR TITLE
feat(geogamers): admin "create today's challenge" + enablement runbook

### DIFF
--- a/docs/geogamers.md
+++ b/docs/geogamers.md
@@ -146,6 +146,26 @@ the round reveals. Screenshots stream through a party image proxy. Frontend:
 | `GEOGAMERS_MIN_ELIGIBLE_GAMES` | `10` | content gate for challenge creation |
 | `GEOGAMERS_GAME_COOLDOWN_DAYS` | `14` | per-game reuse cooldown |
 
+## Enabling in production
+
+The mode ships dark. To turn it on:
+
+1. **Check content readiness** first — Admin → Géo → the *GeoGamers — état du
+   contenu* card (`GET /api/admin/geogamers/health`). You need
+   `eligibleGames ≥ GEOGAMERS_MIN_ELIGIBLE_GAMES` (default 10) — i.e. that many
+   distinct games with a consensus/admin geo canonical pin that have never been
+   a challenge. If starved, add geo content (Geo Contribute / admin Geo-Fetch)
+   or **lower `GEOGAMERS_MIN_ELIGIBLE_GAMES`** for a smaller launch/testing.
+2. **Set `GEOGAMERS_ENABLED=true`** on the backend env and **redeploy**. This
+   mounts `/api/geogamers/*` and registers the 00:05 UTC scheduler. (The
+   frontend already handles the disabled state gracefully — a 404 maps to
+   `GEOGAMERS_UNAVAILABLE` — so a mismatched frontend never shows a raw error.)
+3. **Create today's challenge now** instead of waiting for the cron: the health
+   card's *Créer le défi du jour* button → `POST /api/admin/geogamers/create-challenge`
+   (idempotent; returns `created` / `ALREADY_EXISTS` / `INSUFFICIENT_CONTENT`).
+4. **Launch at a month boundary** if you want a clean first season — season
+   scoring is month-shaped, so mid-month is effectively a short "pré-saison".
+
 ## Status
 
 Implemented: Phase 0 (types + schema), Phase 1 (backend core — scoring,

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -5,6 +5,7 @@ import { billingService } from '../../domain/services/index.js'
 import { userRepository } from '../../infrastructure/repositories/user.repository.js'
 import { geoGamersChallengeRepository } from '../../infrastructure/repositories/geogamers-challenge.repository.js'
 import { geoGamersSeasonRepository } from '../../infrastructure/repositories/geogamers-season.repository.js'
+import { createGeoGamersChallenge } from '../../infrastructure/queue/workers/geogamers-challenge-logic.js'
 import { adminMiddleware } from '../middleware/auth.middleware.js'
 import { recordAdminGeoAudit } from '../middleware/admin-audit.js'
 import {
@@ -3636,6 +3637,25 @@ router.get('/geogamers/health', async (_req, res, next) => {
         season: { month, players: seasonPlayers },
       },
     })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// POST /api/admin/geogamers/create-challenge — create TODAY's GeoGamers
+// challenge on demand (idempotent), instead of waiting for the 00:05 UTC cron.
+// The enablement path: set GEOGAMERS_ENABLED=true, redeploy, then hit this so
+// there's a playable challenge immediately. Returns the same gate feedback the
+// worker logs (created / ALREADY_EXISTS / INSUFFICIENT_CONTENT).
+router.post('/geogamers/create-challenge', async (req, res, next) => {
+  try {
+    const result = await createGeoGamersChallenge()
+    await recordAdminGeoAudit(req, {
+      action: 'geogamers.create_challenge',
+      target: { kind: 'geogamers_challenge', id: String(result.challengeId ?? result.challengeDate) },
+      after: { created: result.created, skipped: result.skipped ?? null },
+    })
+    res.json({ success: true, data: result })
   } catch (err) {
     next(err)
   }

--- a/packages/frontend/src/components/admin/GeoGamersHealthCard.tsx
+++ b/packages/frontend/src/components/admin/GeoGamersHealthCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react'
 import { fetchAdminJson } from '@/lib/api/admin'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -33,19 +33,25 @@ export function GeoGamersHealthCard() {
     const [error, setError] = useState<string | null>(null)
     const [creating, setCreating] = useState(false)
     const [notice, setNotice] = useState<string | null>(null)
+    // Guards against setState after unmount (the fetches outlive a quick tab switch).
+    const mounted = useRef(true)
 
     async function load() {
         try {
-            setHealth(await fetchAdminJson<GeoGamersHealth>('/api/admin/geogamers/health'))
+            const d = await fetchAdminJson<GeoGamersHealth>('/api/admin/geogamers/health')
+            if (mounted.current) setHealth(d)
         } catch (e) {
-            setError(String(e))
+            if (mounted.current) setError(String(e))
         } finally {
-            setLoading(false)
+            if (mounted.current) setLoading(false)
         }
     }
 
     useEffect(() => {
         void load()
+        return () => {
+            mounted.current = false
+        }
     }, [])
 
     async function createChallenge() {
@@ -56,12 +62,12 @@ export function GeoGamersHealthCard() {
                 '/api/admin/geogamers/create-challenge',
                 { method: 'POST' },
             )
-            setNotice(res.message)
+            if (mounted.current) setNotice(res.message)
             await load()
         } catch (e) {
-            setNotice(String(e))
+            if (mounted.current) setNotice(String(e))
         } finally {
-            setCreating(false)
+            if (mounted.current) setCreating(false)
         }
     }
 

--- a/packages/frontend/src/components/admin/GeoGamersHealthCard.tsx
+++ b/packages/frontend/src/components/admin/GeoGamersHealthCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react'
 import { fetchAdminJson } from '@/lib/api/admin'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 interface GeoGamersHealth {
@@ -30,17 +31,39 @@ export function GeoGamersHealthCard() {
     const [health, setHealth] = useState<GeoGamersHealth | null>(null)
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [creating, setCreating] = useState(false)
+    const [notice, setNotice] = useState<string | null>(null)
+
+    async function load() {
+        try {
+            setHealth(await fetchAdminJson<GeoGamersHealth>('/api/admin/geogamers/health'))
+        } catch (e) {
+            setError(String(e))
+        } finally {
+            setLoading(false)
+        }
+    }
 
     useEffect(() => {
-        let cancelled = false
-        fetchAdminJson<GeoGamersHealth>('/api/admin/geogamers/health')
-            .then((d) => !cancelled && setHealth(d))
-            .catch((e) => !cancelled && setError(String(e)))
-            .finally(() => !cancelled && setLoading(false))
-        return () => {
-            cancelled = true
-        }
+        void load()
     }, [])
+
+    async function createChallenge() {
+        setCreating(true)
+        setNotice(null)
+        try {
+            const res = await fetchAdminJson<{ message: string }>(
+                '/api/admin/geogamers/create-challenge',
+                { method: 'POST' },
+            )
+            setNotice(res.message)
+            await load()
+        } catch (e) {
+            setNotice(String(e))
+        } finally {
+            setCreating(false)
+        }
+    }
 
     if (loading) {
         return (
@@ -102,6 +125,21 @@ export function GeoGamersHealthCard() {
                     {health.todayChallengeExists ? 'créé' : 'pas encore'} · Défi courant :{' '}
                     {health.currentChallengeDate ?? '—'} · Cooldown : {health.cooldownDays} j ·
                     Saison : {health.season.month}
+                </div>
+
+                {/* Manual first-challenge creation — avoids waiting for the
+                    00:05 UTC cron right after enabling the feature. */}
+                <div className="flex items-center gap-3">
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={creating || health.todayChallengeExists}
+                        onClick={() => void createChallenge()}
+                    >
+                        {creating && <Loader2 className="mr-1 size-4 animate-spin" />}
+                        {health.todayChallengeExists ? 'Défi du jour déjà créé' : 'Créer le défi du jour'}
+                    </Button>
+                    {notice && <span className="text-xs text-muted-foreground">{notice}</span>}
                 </div>
             </CardContent>
         </Card>


### PR DESCRIPTION
Follow-up to the merged GeoGamers feature (#327), to smooth **turning the mode on**.

## Why
GeoGamers ships dark behind `GEOGAMERS_ENABLED`. Even after setting the flag and redeploying, there's **no playable challenge until the 00:05 UTC cron runs** — so the mode would still show "not available" until the next midnight. This removes that friction.

## What
- **`POST /api/admin/geogamers/create-challenge`** — creates today's challenge on demand (idempotent; audit-logged). Returns the worker's gate feedback: `created` / `ALREADY_EXISTS` / `INSUFFICIENT_CONTENT`.
- **"Créer le défi du jour" button** on the admin content-health card (Admin → Géo), disabled once today's challenge exists, showing the result inline.
- **Enablement runbook** in `docs/geogamers.md`: check the health card → set `GEOGAMERS_ENABLED=true` + redeploy → create the first challenge → prefer a month boundary.

## Verification
- `npm run build` + lint clean; full unit suite green (fail 0). The new endpoint is thin glue over `createGeoGamersChallenge()`, already verified against real Postgres (gate / create / idempotency / cooldown).

## Note
The remaining enablement steps are **your infra**: `GEOGAMERS_ENABLED=true` is a backend env var + redeploy, and the content gate needs enough consensus-pinned geo games (or a lowered `GEOGAMERS_MIN_ELIGIBLE_GAMES`). The health card tells you if you're starved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hs4DiPYRtQCyjswKUV3tWZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hs4DiPYRtQCyjswKUV3tWZ)_