### PR TITLE
feat(geo): agent-assisted content sourcing — plan + phases 1–4 (#331)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,10 +136,12 @@ VAPID_SUBJECT=mailto:no-reply@the-box.battistella.ovh
 # ============================================
 # GEO AGENT API (issue #331)
 # ============================================
-# Key-authenticated, read-only agent content-sourcing surface at
-# /api/agent/v1/geo. Off by default: while false the whole surface returns
-# 503 AGENT_API_DISABLED. Keys are admin-minted (Admin -> Geo -> Cles agent).
+# Key-authenticated agent content-sourcing surface at /api/agent/v1/geo. Off by
+# default: while false the whole surface returns 503 AGENT_API_DISABLED. Keys
+# are admin-minted (Admin -> Geo -> Cles agent).
 GEO_AGENT_API_ENABLED=false
+# Per-key daily cap on agent-triggered ingestion (phase 3), tracked in Redis.
+GEO_AGENT_MAX_INGESTS_PER_DAY=20
 
 # ============================================
 # PRODUCTION DEPLOYMENT NOTES

--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,14 @@ VAPID_PRIVATE_KEY=
 VAPID_SUBJECT=mailto:no-reply@the-box.battistella.ovh
 
 # ============================================
+# GEO AGENT API (issue #331)
+# ============================================
+# Key-authenticated, read-only agent content-sourcing surface at
+# /api/agent/v1/geo. Off by default: while false the whole surface returns
+# 503 AGENT_API_DISABLED. Keys are admin-minted (Admin -> Geo -> Cles agent).
+GEO_AGENT_API_ENABLED=false
+
+# ============================================
 # PRODUCTION DEPLOYMENT NOTES
 # ============================================
 # 1. Generate strong BETTER_AUTH_SECRET: openssl rand -base64 32

--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,8 @@ VAPID_SUBJECT=mailto:no-reply@the-box.battistella.ovh
 GEO_AGENT_API_ENABLED=false
 # Per-key daily cap on agent-triggered ingestion (phase 3), tracked in Redis.
 GEO_AGENT_MAX_INGESTS_PER_DAY=20
+# Per-key hourly cap on agent pin proposals (phase 4), tracked in Redis.
+GEO_AGENT_MAX_PINS_PER_HOUR=60
 
 # ============================================
 # PRODUCTION DEPLOYMENT NOTES

--- a/docs/geo-agent-api.md
+++ b/docs/geo-agent-api.md
@@ -1,0 +1,155 @@
+# Geo Agent API — content sourcing (issue #331)
+
+Key-authenticated, read-only HTTP surface that lets an AI agent (Claude Code /
+an MCP client) safely *drive* geo content sourcing against prod. This is the
+phase-2 deliverable of the [agent-assisted geo sourcing plan](../tasks/prd-geo-agent-sourcing.html):
+it proves the auth / audit / rate-limit surface with **zero write risk** before
+ingest (phase 3) and pin proposals (phase 4) land.
+
+> Design principle: the agent *proposes*, consensus + admins *dispose*. This
+> read surface exposes only diagnostics and catalog data — no writes, no user
+> PII, no raw SQL. See `docs/geo-mode.md` for the consensus gate it feeds.
+
+Base URL: `https://the-box.battistella.ovh/api/agent/v1/geo` (prod) ·
+`http://localhost:3000/api/agent/v1/geo` (dev).
+
+All responses use the envelope `{ success: boolean, data?, error? }`.
+
+## Kill switch
+
+The whole surface is gated by `GEO_AGENT_API_ENABLED` (default `false`). While
+off, every route returns `503 AGENT_API_DISABLED` — flip the env and redeploy
+to disable instantly, alongside per-key revocation.
+
+## Authentication
+
+Bearer API keys, minted by an **admin only** (Admin → Géo → *Clés agent Géo*,
+or `POST /api/admin/agent-keys`). Keys carry only `geo-agent:*` scopes and are
+mutually exclusive with the streamer-kit scopes — a streamer key is rejected
+here with `INSUFFICIENT_SCOPE`, and a geo-agent key is rejected on the public
+streamer API.
+
+```http
+Authorization: Bearer tb_pk_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Keys are stored as SHA-256 hashes; the plaintext is shown once at mint. Revoke
+via `DELETE /api/admin/agent-keys/:id` (any admin, instant).
+
+### Scopes
+
+| Scope | Grants | Phase |
+|-------|--------|-------|
+| `geo-agent:read` | `/health`, `/games-needing-content`, `/games/:id/candidates` | 2 |
+| `geo-agent:ingest` | trigger the existing ingestion pipeline | 3 |
+| `geo-agent:propose` | submit downweighted, flagged consensus pins | 4 |
+
+A freshly minted key defaults to `geo-agent:read`. Ingest/propose are granted
+per key as later phases ship.
+
+## Rate limit
+
+Fixed-window, **60 requests / minute per key** (in-memory). On exhaustion:
+`429 RATE_LIMITED` with `Retry-After`. Write budgets (daily ingests, hourly pin
+proposals) arrive as Redis counters with phases 3–4.
+
+## Endpoints
+
+### `GET /health`
+
+Content-readiness snapshot — the same eligibility the GeoGamers daily worker
+gates on. Shared with `GET /api/admin/geogamers/health`.
+
+```json
+{
+  "success": true,
+  "data": {
+    "enabled": false,
+    "minRequired": 10,
+    "cooldownDays": 14,
+    "eligibleGames": 9,
+    "eligibleScreenshots": 41,
+    "gamesOnCooldown": 2,
+    "starved": true,
+    "todayChallengeExists": false,
+    "currentChallengeDate": null,
+    "season": { "month": "2026-07", "players": 0 }
+  }
+}
+```
+
+`starved` (`eligibleGames < minRequired`) is the signal an agent acts on.
+
+### `GET /games-needing-content?limit=`
+
+The "one pin away" work queue: games with an active map and captures collecting
+pins but no canonical pin yet. Promoting one such capture grows the eligible
+pool by one. `limit` 1–100 (default 25). Sorted by proximity to the next
+consensus recompute.
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "gameId": 512,
+      "gameName": "Hollow Knight",
+      "candidateCount": 6,
+      "topPinCount": 4,
+      "pinsToNextThreshold": 1,
+      "bestCandidateId": 8842
+    }
+  ]
+}
+```
+
+`topPinCount` counts raw submissions (an upper bound — promotion needs 5
+*accepted* pins). `pinsToNextThreshold` is pins until the next consensus
+recompute (`[5, 10, 20, 50]`; `0` past the top threshold).
+
+### `GET /games/:gameId/candidates?limit=`
+
+Unpinned/collecting captures for a game plus its active maps (image URL +
+dimensions), so a proposer has what it needs to localize a screenshot. Promoted
+captures are omitted (they already have ground truth). `limit` 1–100
+(default 50).
+
+```json
+{
+  "success": true,
+  "data": {
+    "maps": [
+      { "id": 77, "gameId": 512, "imageUrl": "https://…", "widthPx": 4096, "heightPx": 4096, "consensusRadius": 0.03 }
+    ],
+    "candidates": [
+      { "id": 8842, "gameId": 512, "geoMapId": 77, "imageUrl": "https://…", "status": "collecting", "pinCount": 4 }
+    ]
+  }
+}
+```
+
+Candidate payloads carry pin **counts**, never pin owners — no user identity or
+PII crosses this surface.
+
+## Error codes
+
+| Code | HTTP | Meaning |
+|------|------|---------|
+| `AGENT_API_DISABLED` | 503 | `GEO_AGENT_API_ENABLED` is off |
+| `UNAUTHORIZED` | 401 | Missing / malformed / invalid key |
+| `INSUFFICIENT_SCOPE` | 403 | Key lacks the required geo-agent scope (or carries a non-agent scope) |
+| `RATE_LIMITED` | 429 | Per-minute limit hit; see `Retry-After` |
+| `VALIDATION_ERROR` | 400 | Bad `gameId` / `limit` |
+| `INTERNAL_ERROR` | 500 | Server error |
+
+## Audit
+
+Admin key mints/revokes are written to `admin_audit_log`
+(`agent_key.mint` / `agent_key.revoke`) with the acting admin, label, scopes.
+Write endpoints (phases 3–4) will additionally audit each agent action keyed by
+`apikey:<id>`.
+
+## MCP wrapper
+
+`@the-box/geo-agent-mcp` (in `packages/geo-agent-mcp/`) exposes these three
+reads as MCP tools for Claude Code. See its README for the `mcpServers` config.

--- a/docs/geo-agent-api.md
+++ b/docs/geo-agent-api.md
@@ -41,17 +41,22 @@ via `DELETE /api/admin/agent-keys/:id` (any admin, instant).
 | Scope | Grants | Phase |
 |-------|--------|-------|
 | `geo-agent:read` | `/health`, `/games-needing-content`, `/games/:id/candidates` | 2 |
-| `geo-agent:ingest` | trigger the existing ingestion pipeline | 3 |
+| `geo-agent:ingest` | `POST /games/:id/ingest` — trigger the ingestion pipeline | 3 |
 | `geo-agent:propose` | submit downweighted, flagged consensus pins | 4 |
 
 A freshly minted key defaults to `geo-agent:read`. Ingest/propose are granted
 per key as later phases ship.
 
-## Rate limit
+## Rate limit & budgets
 
 Fixed-window, **60 requests / minute per key** (in-memory). On exhaustion:
-`429 RATE_LIMITED` with `Retry-After`. Write budgets (daily ingests, hourly pin
-proposals) arrive as Redis counters with phases 3–4.
+`429 RATE_LIMITED` with `Retry-After`.
+
+Write endpoints additionally carry a **per-key daily budget** in Redis (survives
+deploys). Ingest: `GEO_AGENT_MAX_INGESTS_PER_DAY` (default 20) `POST /ingest`
+calls per UTC day. On exhaustion: `429 BUDGET_EXHAUSTED` with `Retry-After`
+(seconds to UTC midnight). Budgets fail **closed** — if Redis is unreachable the
+call is rejected, never silently unlimited.
 
 ## Endpoints
 
@@ -131,6 +136,45 @@ captures are omitted (they already have ground truth). `limit` 1–100
 Candidate payloads carry pin **counts**, never pin owners — no user identity or
 PII crosses this surface.
 
+### `POST /games/:gameId/ingest`
+
+Scope: `geo-agent:ingest`. Triggers the existing map-ingestion pipeline for a
+game — a pure enqueue that reuses the same workers, tombstones/circuit-breakers,
+dedup, and license/attribution capture as the admin "Run now" button. The agent
+**proposes sourcing work; it cannot alter ground truth.**
+
+```json
+{ "sources": ["fandom", "wand"] }
+```
+
+`sources` is optional (omit for all tiers) and restricted to the allowlist
+`registry | fandom | strategywiki | fextralife | wand | wikidata` — anything
+else is a `VALIDATION_ERROR`. A tier whose `geo_source_config` row is disabled
+is skipped (`SOURCE_DISABLED`); tiers without a config row are always runnable.
+
+```json
+{
+  "success": true,
+  "data": {
+    "gameId": 512,
+    "results": [
+      { "source": "fandom", "enqueued": true, "jobId": "manual-fandom-512" },
+      { "source": "wand", "enqueued": false, "reason": "SOURCE_DISABLED" }
+    ],
+    "budget": { "used": 3, "limit": 20, "remaining": 17 }
+  }
+}
+```
+
+Per-source `reason` values mirror the admin path (`GAME_NOT_FOUND`,
+`NOT_CURATED`, `METADATA_UNRESOLVED`, `NO_REGISTRY_ENTRY`,
+`MISSING_FANDOM_METADATA`, `MISSING_WIKIDATA_QID`, `SOURCE_DISABLED`). A
+non-enqueued source is not an error — the call still returns `200` with the
+per-source breakdown. Poll `/games/:id/candidates` to see resulting captures.
+
+Every ingest is written to `admin_audit_log` as `geo-agent.ingest`, keyed
+`apikey:<id>`.
+
 ## Error codes
 
 | Code | HTTP | Meaning |
@@ -139,7 +183,8 @@ PII crosses this surface.
 | `UNAUTHORIZED` | 401 | Missing / malformed / invalid key |
 | `INSUFFICIENT_SCOPE` | 403 | Key lacks the required geo-agent scope (or carries a non-agent scope) |
 | `RATE_LIMITED` | 429 | Per-minute limit hit; see `Retry-After` |
-| `VALIDATION_ERROR` | 400 | Bad `gameId` / `limit` |
+| `BUDGET_EXHAUSTED` | 429 | Daily write budget hit; `Retry-After` = seconds to UTC midnight |
+| `VALIDATION_ERROR` | 400 | Bad `gameId` / `limit` / `sources` |
 | `INTERNAL_ERROR` | 500 | Server error |
 
 ## Audit

--- a/docs/geo-agent-api.md
+++ b/docs/geo-agent-api.md
@@ -42,7 +42,7 @@ via `DELETE /api/admin/agent-keys/:id` (any admin, instant).
 |-------|--------|-------|
 | `geo-agent:read` | `/health`, `/games-needing-content`, `/games/:id/candidates` | 2 |
 | `geo-agent:ingest` | `POST /games/:id/ingest` — trigger the ingestion pipeline | 3 |
-| `geo-agent:propose` | submit downweighted, flagged consensus pins | 4 |
+| `geo-agent:propose` | `POST /candidates/:id/pins` — propose a downweighted consensus pin | 4 |
 
 A freshly minted key defaults to `geo-agent:read`. Ingest/propose are granted
 per key as later phases ship.
@@ -52,11 +52,12 @@ per key as later phases ship.
 Fixed-window, **60 requests / minute per key** (in-memory). On exhaustion:
 `429 RATE_LIMITED` with `Retry-After`.
 
-Write endpoints additionally carry a **per-key daily budget** in Redis (survives
-deploys). Ingest: `GEO_AGENT_MAX_INGESTS_PER_DAY` (default 20) `POST /ingest`
-calls per UTC day. On exhaustion: `429 BUDGET_EXHAUSTED` with `Retry-After`
-(seconds to UTC midnight). Budgets fail **closed** — if Redis is unreachable the
-call is rejected, never silently unlimited.
+Write endpoints additionally carry a **per-key budget** in Redis (survives
+deploys). Ingest: `GEO_AGENT_MAX_INGESTS_PER_DAY` (default 20) per UTC day. Pin
+proposals: `GEO_AGENT_MAX_PINS_PER_HOUR` (default 60) per UTC hour. On
+exhaustion: `429 BUDGET_EXHAUSTED` with `Retry-After` (seconds to the window
+reset). Budgets fail **closed** — if Redis is unreachable the call is rejected,
+never silently unlimited.
 
 ## Endpoints
 
@@ -175,6 +176,44 @@ per-source breakdown. Poll `/games/:id/candidates` to see resulting captures.
 Every ingest is written to `admin_audit_log` as `geo-agent.ingest`, keyed
 `apikey:<id>`.
 
+### `POST /candidates/:id/pins`
+
+Scope: `geo-agent:propose`. Propose a location pin for a capture. **This is the
+one write that touches consensus — and it is safe by construction.** The pin is
+persisted flagged (`source = agent_structured | agent_vision`), **downweighted**
+in the centroid (×0.6 / ×0.25 vs a human pin), and — critically — **excluded
+from the promote count**: a candidate promotes only on ≥5 accepted *human* pins
+(or an admin override), so no number of agent pins can create ground truth. Pins
+land in the same review queue as crowd pins and are shown to moderators with
+their rationale.
+
+```json
+{
+  "x": 0.42,
+  "y": 0.31,
+  "source": "agent_structured",
+  "rationale": "MapGenie 'Site of Grace: First Step' marker matches the capture's stairway",
+  "confidence": 1,
+  "model": "optional-model-id",
+  "visionPass": 0
+}
+```
+
+`x`/`y` are normalized to `[0,1]`. `rationale` is **required** (≤500 chars) — it
+is the review artifact. `confidence` (1 sure … 3 guess) optionally scales the
+weight further. `visionPass` (0–2) lets one key submit multiple independent
+`agent_vision` passes per candidate as separate voters. **Propose only when
+confident** — a wrong structured pin at weight 0.6 poisons the centroid; prefer
+precision over recall.
+
+```json
+{ "success": true, "data": { "pinId": 90142, "received": true, "pinCount": 7, "budget": { "used": 3, "limit": 60, "remaining": 57 } } }
+```
+
+`409 ALREADY_PROMOTED` if the candidate already has a canonical pin. A duplicate
+proposal (same key + candidate + `visionPass`) is an idempotent no-op:
+`{ "received": true, "duplicate": true }`. Audited as `geo-agent.propose_pin`.
+
 ## Error codes
 
 | Code | HTTP | Meaning |
@@ -183,8 +222,10 @@ Every ingest is written to `admin_audit_log` as `geo-agent.ingest`, keyed
 | `UNAUTHORIZED` | 401 | Missing / malformed / invalid key |
 | `INSUFFICIENT_SCOPE` | 403 | Key lacks the required geo-agent scope (or carries a non-agent scope) |
 | `RATE_LIMITED` | 429 | Per-minute limit hit; see `Retry-After` |
-| `BUDGET_EXHAUSTED` | 429 | Daily write budget hit; `Retry-After` = seconds to UTC midnight |
-| `VALIDATION_ERROR` | 400 | Bad `gameId` / `limit` / `sources` |
+| `BUDGET_EXHAUSTED` | 429 | Write budget hit; `Retry-After` = seconds to window reset |
+| `CANDIDATE_NOT_FOUND` | 404 | No such capture candidate (propose) |
+| `ALREADY_PROMOTED` | 409 | Candidate already has a canonical pin (propose) |
+| `VALIDATION_ERROR` | 400 | Bad `gameId` / `limit` / `sources` / pin body |
 | `INTERNAL_ERROR` | 500 | Server error |
 
 ## Audit

--- a/docs/geo-mode.md
+++ b/docs/geo-mode.md
@@ -153,6 +153,14 @@ Chaque source a un disjoncteur Redis. En cas de pannes répétées (rate-limit, 
 | POST | `/api/geo/free-play/random` | Tirer une capture aléatoire pour free play |
 | POST | `/api/geo/free-play/guess` | Soumettre un pin et recevoir le score |
 
+## Diagnostic « à un pin de l'éligibilité »
+
+> **Détail technique.** Route `GET /api/admin/geo/games-needing-content` (réservé admin) et carte admin `GeoNeedingContentCard` dans l'onglet Géo.
+
+La carte de santé GeoGamers (`GET /api/admin/geogamers/health`) donne le **nombre** de jeux éligibles ; ce diagnostic complémentaire dit **quels** jeux en sont le plus proches. Il liste les jeux qui ont une carte active et des captures en cours de collecte de pins (`pending`/`collecting`, actives) mais **aucune position canonique** (`geo_screenshot_meta`) — c.-à-d. les jeux où promouvoir une capture ferait passer le compteur de jeux éligibles à `+1` (si le jeu n'a jamais servi de défi).
+
+Par jeu on renvoie : `candidateCount`, la meilleure capture (`bestCandidateId`, plus grand `pin_count`), `topPinCount`, et `pinsToNextThreshold` — le nombre de pins avant le prochain recalcul de consensus (`GEO_CONSENSUS_THRESHOLDS = [5, 10, 20, 50]`, `0` une fois le dernier seuil dépassé). Tri par `topPinCount` décroissant : les jeux les plus proches d'une promotion remontent en tête. Le compte est celui des **soumissions brutes** (pas des pins acceptés), donc c'est une borne supérieure indicative. Chaque ligne renvoie vers la file de revue filtrée sur le jeu (`?sub=queue&qGameId=…`), où l'override admin existant promeut une capture.
+
 ## API admin (`/api/admin/geo-fetch`)
 
 | Méthode | Endpoint | Description |

--- a/docs/geo-mode.md
+++ b/docs/geo-mode.md
@@ -75,6 +75,8 @@ Quand une capture n'a pas (encore) de position canonique, on demande aux joueurs
 
 L'algorithme calcule le centroïde des pins et leur écart-type sur chaque axe. Les pins trop éloignés sont rejetés. La promotion canonique nécessite assez de pins **et** un cluster suffisamment serré (`confidence > 0.5`).
 
+> **Consensus v3 (issue #331).** Les pins peuvent porter une provenance (`source`) : `human`, `agent_structured` (×0,6) ou `agent_vision` (×0,25). Les pins d'agent sont **sous-pondérés** dans le centroïde et — surtout — **exclus du compteur de promotion** : la promotion exige `GEO_CONSENSUS_MIN_PINS_TO_PROMOTE` pins **humains** acceptés (ou un override admin). Un pin machine peut donc affiner la position mais **jamais** créer une vérité terrain à lui seul. Voir `docs/geo-agent-api.md`.
+
 ### Récompense
 
 Le joueur qui pose **le tout premier pin** sur une capture reçoit un bonus (`hint_year`) — petite récompense pour encourager la découverte sans dépasser les bonus de précision attribués ensuite.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7992,6 +7992,10 @@
       "resolved": "packages/frontend",
       "link": true
     },
+    "node_modules/@the-box/geo-agent-mcp": {
+      "resolved": "packages/geo-agent-mcp",
+      "link": true
+    },
     "node_modules/@the-box/marketing-video": {
       "resolved": "packages/marketing-video",
       "link": true
@@ -19713,6 +19717,20 @@
         "typescript-eslint": "^8.52.0",
         "vite": "^7.3.1",
         "vite-plugin-pwa": "^1.3.0"
+      }
+    },
+    "packages/geo-agent-mcp": {
+      "name": "@the-box/geo-agent-mcp",
+      "version": "2.139.0",
+      "bin": {
+        "the-box-geo-agent-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.2",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/marketing-video": {

--- a/packages/backend/migrations/20260710_geo_agent_pins.ts
+++ b/packages/backend/migrations/20260710_geo_agent_pins.ts
@@ -1,0 +1,87 @@
+import type { Knex } from 'knex'
+
+// Pin provenance for agent-proposed pins (issue #331, phase 4).
+//
+// Until now every geo_pin_submission was authored by a logged-in user
+// (user_id NOT NULL, unique per (user, candidate)). The automated pin proposer
+// submits pins that have NO user — they belong to a geo-agent API key, are
+// flagged by `source`, and are DOWNWEIGHTED in consensus. Critically, agent
+// pins can never promote a candidate on their own: the consensus service (v3)
+// counts only accepted HUMAN pins toward the promote gate, so this schema
+// change is safe by construction — it can add votes, never ground truth.
+//
+// Changes:
+//   - user_id becomes nullable (agent pins have no user).
+//   - source: 'human' | 'agent_structured' | 'agent_vision' (default 'human'
+//     backfills every existing row correctly).
+//   - agent_key_id: FK to the minting api_keys row (SET NULL on revoke so the
+//     pin's history survives; the pin stays flagged via `source`).
+//   - agent_rationale / agent_model: the review artifact for a machine pin.
+//   - vision_pass: lets one key submit multiple independent vision passes per
+//     candidate (each a separate downweighted voter) without tripping the
+//     unique index.
+//   - CHECK: exactly one owner kind — a human pin has a user and no key; an
+//     agent pin has a key and no user.
+
+export async function up(knex: Knex): Promise<void> {
+  const hasSource = await knex.schema.hasColumn('geo_pin_submission', 'source')
+  if (hasSource) return
+
+  await knex.schema.alterTable('geo_pin_submission', (t) => {
+    t.string('source', 20).notNullable().defaultTo('human')
+    t.integer('agent_key_id').nullable().references('id').inTable('api_keys').onDelete('SET NULL')
+    t.string('agent_rationale', 500).nullable()
+    t.string('agent_model', 100).nullable()
+    t.smallint('vision_pass').notNullable().defaultTo(0)
+  })
+
+  // Drop NOT NULL via raw SQL so we don't disturb the existing FK on user_id.
+  await knex.raw('ALTER TABLE geo_pin_submission ALTER COLUMN user_id DROP NOT NULL')
+
+  await knex.raw(`
+    ALTER TABLE geo_pin_submission
+    ADD CONSTRAINT geo_pin_owner_check CHECK (
+      (user_id IS NOT NULL AND agent_key_id IS NULL AND source = 'human') OR
+      (user_id IS NULL AND agent_key_id IS NOT NULL AND source <> 'human')
+    )
+  `)
+
+  // One pin per (agent key, candidate, vision pass). Partial so it doesn't
+  // constrain the human rows (which keep their (user_id, candidate) unique).
+  await knex.raw(`
+    CREATE UNIQUE INDEX geo_pin_agent_uniq
+    ON geo_pin_submission (agent_key_id, geo_screenshot_candidate_id, vision_pass)
+    WHERE agent_key_id IS NOT NULL
+  `)
+
+  // Cheap lookup/filtering of machine pins in the review queue.
+  await knex.raw(`
+    CREATE INDEX geo_pin_source_idx ON geo_pin_submission (source)
+    WHERE source <> 'human'
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasSource = await knex.schema.hasColumn('geo_pin_submission', 'source')
+  if (!hasSource) return
+
+  await knex.raw('DROP INDEX IF EXISTS geo_pin_source_idx')
+  await knex.raw('DROP INDEX IF EXISTS geo_pin_agent_uniq')
+  await knex.raw('ALTER TABLE geo_pin_submission DROP CONSTRAINT IF EXISTS geo_pin_owner_check')
+
+  // Down is DATA-DESTRUCTIVE by design: agent pins have no user_id, so they
+  // must be deleted before user_id can go back to NOT NULL. Ground truth
+  // (geo_screenshot_meta) is untouched — it was only ever promoted by human
+  // consensus or an admin, never by agent pins.
+  await knex('geo_pin_submission').whereNotNull('agent_key_id').del()
+
+  await knex.raw('ALTER TABLE geo_pin_submission ALTER COLUMN user_id SET NOT NULL')
+
+  await knex.schema.alterTable('geo_pin_submission', (t) => {
+    t.dropColumn('vision_pass')
+    t.dropColumn('agent_model')
+    t.dropColumn('agent_rationale')
+    t.dropColumn('agent_key_id')
+    t.dropColumn('source')
+  })
+}

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -56,6 +56,11 @@ export const env = {
   // redeploying (the second kill switch, alongside per-key revocation). Keys
   // for it are admin-minted; scopes are enforced per route.
   GEO_AGENT_API_ENABLED: process.env['GEO_AGENT_API_ENABLED'] || 'false',
+  // Per-key daily budget for agent-triggered ingestion (phase 3). A hard
+  // ceiling on how many times one key can kick the ingestion pipeline per UTC
+  // day, tracked in Redis so it survives deploys. Independent of the 60/min
+  // rate limit — this bounds cost/abuse over a day, not burst rate.
+  GEO_AGENT_MAX_INGESTS_PER_DAY: process.env['GEO_AGENT_MAX_INGESTS_PER_DAY'] || '20',
 
   // RAWG API (for fetching game screenshots)
   RAWG_API_KEY: process.env['RAWG_API_KEY'] || '',

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -50,6 +50,13 @@ export const env = {
   GEOGAMERS_MIN_ELIGIBLE_GAMES: process.env['GEOGAMERS_MIN_ELIGIBLE_GAMES'] || '10',
   GEOGAMERS_GAME_COOLDOWN_DAYS: process.env['GEOGAMERS_GAME_COOLDOWN_DAYS'] || '14',
 
+  // Agent content-sourcing surface (issue #331, /api/agent/v1/geo). Off by
+  // default: the read-only routes return 503 AGENT_API_DISABLED until turned
+  // on, so the whole surface can be killed instantly by flipping this and
+  // redeploying (the second kill switch, alongside per-key revocation). Keys
+  // for it are admin-minted; scopes are enforced per route.
+  GEO_AGENT_API_ENABLED: process.env['GEO_AGENT_API_ENABLED'] || 'false',
+
   // RAWG API (for fetching game screenshots)
   RAWG_API_KEY: process.env['RAWG_API_KEY'] || '',
 

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -61,6 +61,10 @@ export const env = {
   // day, tracked in Redis so it survives deploys. Independent of the 60/min
   // rate limit — this bounds cost/abuse over a day, not burst rate.
   GEO_AGENT_MAX_INGESTS_PER_DAY: process.env['GEO_AGENT_MAX_INGESTS_PER_DAY'] || '20',
+  // Per-key hourly budget for agent pin proposals (phase 4), tracked in Redis.
+  // Agent pins are downweighted and can never promote on their own, but the
+  // budget still bounds how fast one key can flood the review queue.
+  GEO_AGENT_MAX_PINS_PER_HOUR: process.env['GEO_AGENT_MAX_PINS_PER_HOUR'] || '60',
 
   // RAWG API (for fetching game screenshots)
   RAWG_API_KEY: process.env['RAWG_API_KEY'] || '',

--- a/packages/backend/src/domain/services/geo-consensus.service.test.ts
+++ b/packages/backend/src/domain/services/geo-consensus.service.test.ts
@@ -1,16 +1,22 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import type { GeoPinConfidence } from '@the-box/types'
+import type { GeoPinSource } from '@the-box/types'
 import {
   evaluateConsensus,
   grantsForAcceptedPin,
   pinsToNextConsensusThreshold,
   GEO_CONSENSUS_CONFIDENCE_WEIGHTS,
   GEO_CONSENSUS_MIN_PINS_TO_PROMOTE,
+  GEO_CONSENSUS_SOURCE_WEIGHTS,
   GEO_CONSENSUS_THRESHOLDS,
   GEO_CONSENSUS_VERSION,
   type GeoPinLike,
 } from './geo-consensus.service.js'
+
+function agentPin(id: number, x: number, y: number, source: GeoPinSource): GeoPinLike {
+  return { id, pin: { x, y }, source }
+}
 
 const RADIUS = 0.05
 
@@ -300,5 +306,92 @@ describe('pinsToNextConsensusThreshold', () => {
     const top = GEO_CONSENSUS_THRESHOLDS[GEO_CONSENSUS_THRESHOLDS.length - 1]!
     assert.equal(pinsToNextConsensusThreshold(top), 0)
     assert.equal(pinsToNextConsensusThreshold(top + 25), 0)
+  })
+})
+
+describe('consensus v3 — agent pins never promote (the #331 invariant)', () => {
+  it('is version 3', () => {
+    assert.equal(GEO_CONSENSUS_VERSION, 3)
+  })
+
+  it('a tight cluster of 8 agent pins does NOT promote (0 human accepted)', () => {
+    // Enough pins, tight enough cluster to clear confidence — but all machine.
+    // Promotion must stay false regardless.
+    const pins = Array.from({ length: 8 }, (_, i) =>
+      agentPin(i + 1, 0.5 + (i % 2) * 0.0005, 0.5, 'agent_structured'),
+    )
+    const out = evaluateConsensus(pins, RADIUS)
+    assert.ok(out.acceptedCount >= GEO_CONSENSUS_MIN_PINS_TO_PROMOTE)
+    assert.equal(out.humanAcceptedCount, 0)
+    assert.equal(out.promote, false)
+  })
+
+  it('even 1000 colluding agent pins cannot promote', () => {
+    const pins = Array.from({ length: 1000 }, (_, i) =>
+      agentPin(i + 1, 0.5, 0.5, 'agent_vision'),
+    )
+    const out = evaluateConsensus(pins, RADIUS)
+    assert.equal(out.promote, false)
+  })
+
+  it('promotes on 5 accepted HUMAN pins even with agent pins mixed in', () => {
+    const humans: GeoPinLike[] = [
+      pin(1, 0.5, 0.5),
+      pin(2, 0.5005, 0.5005),
+      pin(3, 0.499, 0.5),
+      pin(4, 0.5, 0.499),
+      pin(5, 0.5005, 0.499),
+    ]
+    const agents = [
+      agentPin(6, 0.5002, 0.5002, 'agent_structured'),
+      agentPin(7, 0.4998, 0.5001, 'agent_vision'),
+    ]
+    const out = evaluateConsensus([...humans, ...agents], RADIUS)
+    assert.equal(out.humanAcceptedCount, 5)
+    assert.equal(out.promote, true)
+  })
+
+  it('4 human + many agent pins still does NOT promote (short one human)', () => {
+    const humans: GeoPinLike[] = [
+      pin(1, 0.5, 0.5),
+      pin(2, 0.5005, 0.5005),
+      pin(3, 0.499, 0.5),
+      pin(4, 0.5, 0.499),
+    ]
+    const agents = Array.from({ length: 20 }, (_, i) =>
+      agentPin(100 + i, 0.5, 0.5, 'agent_structured'),
+    )
+    const out = evaluateConsensus([...humans, ...agents], RADIUS)
+    // At most 4 human pins are accepted (a tight agent cluster may even reject
+    // a slightly-off human via the σ gate) — either way, below the gate.
+    assert.ok(out.humanAcceptedCount < GEO_CONSENSUS_MIN_PINS_TO_PROMOTE)
+    assert.equal(out.promote, false)
+  })
+
+  it('exposes the source weight table (human 1.0 / structured 0.6 / vision 0.25)', () => {
+    assert.equal(GEO_CONSENSUS_SOURCE_WEIGHTS.human, 1.0)
+    assert.equal(GEO_CONSENSUS_SOURCE_WEIGHTS.agent_structured, 0.6)
+    assert.equal(GEO_CONSENSUS_SOURCE_WEIGHTS.agent_vision, 0.25)
+  })
+
+  it('an agent pin pulls the centroid less than a human pin at the same spot', () => {
+    // 4 humans clustered at 0.5 + one outlier at 0.7. When the outlier is a
+    // (downweighted) vision agent pin it shifts the mean less than when it is
+    // a full-weight human pin.
+    const cluster: GeoPinLike[] = [
+      pin(1, 0.5, 0.5),
+      pin(2, 0.501, 0.5),
+      pin(3, 0.499, 0.5),
+      pin(4, 0.5, 0.501),
+    ]
+    const humanOutlier = evaluateConsensus([...cluster, pin(5, 0.7, 0.5)], RADIUS)
+    const agentOutlier = evaluateConsensus(
+      [...cluster, agentPin(5, 0.7, 0.5, 'agent_vision')],
+      RADIUS,
+    )
+    assert.ok(
+      agentOutlier.centroid.x < humanOutlier.centroid.x,
+      `agent outlier should pull less: human ${humanOutlier.centroid.x}, agent ${agentOutlier.centroid.x}`,
+    )
   })
 })

--- a/packages/backend/src/domain/services/geo-consensus.service.test.ts
+++ b/packages/backend/src/domain/services/geo-consensus.service.test.ts
@@ -4,8 +4,10 @@ import type { GeoPinConfidence } from '@the-box/types'
 import {
   evaluateConsensus,
   grantsForAcceptedPin,
+  pinsToNextConsensusThreshold,
   GEO_CONSENSUS_CONFIDENCE_WEIGHTS,
   GEO_CONSENSUS_MIN_PINS_TO_PROMOTE,
+  GEO_CONSENSUS_THRESHOLDS,
   GEO_CONSENSUS_VERSION,
   type GeoPinLike,
 } from './geo-consensus.service.js'
@@ -275,5 +277,28 @@ describe('grantsForAcceptedPin', () => {
     // behavior on a fresh user.
     const keys = out.map((g) => g.itemKey)
     assert.ok(!keys.includes('streak_freeze'))
+  })
+})
+
+describe('pinsToNextConsensusThreshold', () => {
+  it('targets the first threshold (5) below it', () => {
+    // "One pin away": a candidate with 4 pins needs 1 more to hit the first
+    // recompute at 5, the same count that can promote.
+    assert.equal(pinsToNextConsensusThreshold(4), 1)
+    assert.equal(pinsToNextConsensusThreshold(0), GEO_CONSENSUS_THRESHOLDS[0])
+  })
+
+  it('returns the gap to the NEXT threshold, not the current one', () => {
+    // Exactly on a threshold → the recompute for that count already fired, so
+    // the meaningful next target is the following threshold.
+    assert.equal(pinsToNextConsensusThreshold(5), 5) // → 10
+    assert.equal(pinsToNextConsensusThreshold(7), 3) // → 10
+    assert.equal(pinsToNextConsensusThreshold(10), 10) // → 20
+  })
+
+  it('returns 0 once past the top threshold (no further recompute)', () => {
+    const top = GEO_CONSENSUS_THRESHOLDS[GEO_CONSENSUS_THRESHOLDS.length - 1]!
+    assert.equal(pinsToNextConsensusThreshold(top), 0)
+    assert.equal(pinsToNextConsensusThreshold(top + 25), 0)
   })
 })

--- a/packages/backend/src/domain/services/geo-consensus.service.ts
+++ b/packages/backend/src/domain/services/geo-consensus.service.ts
@@ -33,6 +33,19 @@ function weightFor(confidence: GeoPinConfidence | undefined): number {
   return GEO_CONSENSUS_CONFIDENCE_WEIGHTS[confidence]
 }
 
+/**
+ * How many more pins a candidate needs before the consensus worker's next
+ * recompute could promote it. Recompute only fires at GEO_CONSENSUS_THRESHOLDS
+ * ([5, 10, 20, 50]); once a candidate is past the top threshold, further pins
+ * won't trigger a new recompute, so this returns 0. A negative or zero input
+ * targets the first threshold. Powers the admin "one pin away" diagnostic; note
+ * it counts raw submissions, not accepted pins, so it's an upper-bound signal.
+ */
+export function pinsToNextConsensusThreshold(pinCount: number): number {
+  const next = GEO_CONSENSUS_THRESHOLDS.find((t) => t > pinCount)
+  return next === undefined ? 0 : next - pinCount
+}
+
 export interface GeoPinLike {
   id: number
   pin: GeoPoint

--- a/packages/backend/src/domain/services/geo-consensus.service.ts
+++ b/packages/backend/src/domain/services/geo-consensus.service.ts
@@ -1,10 +1,11 @@
 import type { DomainLogger } from '../ports/logger.js'
-import type { GeoPinConfidence, GeoPoint, GeoPinStatus } from '@the-box/types'
+import type { GeoPinConfidence, GeoPinSource, GeoPoint, GeoPinStatus } from '@the-box/types'
 
 // Pin count thresholds at which the consensus worker should recompute.
 export const GEO_CONSENSUS_THRESHOLDS = [5, 10, 20, 50] as const
 
-// Minimum pins required before we can promote a candidate to canonical.
+// Minimum accepted HUMAN pins required before we can promote a candidate to
+// canonical. Agent pins never count toward this — see GEO_CONSENSUS_VERSION 3.
 export const GEO_CONSENSUS_MIN_PINS_TO_PROMOTE = 5
 
 // Pins farther than this many standard deviations from the centroid are
@@ -12,9 +13,31 @@ export const GEO_CONSENSUS_MIN_PINS_TO_PROMOTE = 5
 export const GEO_CONSENSUS_SIGMA_MULTIPLIER = 2
 
 // Current consensus algorithm version; bumped alongside formula changes so a
-// retroactive re-run can distinguish old vs new decisions. v2 introduces
-// confidence-weighted centroid + variance.
-export const GEO_CONSENSUS_VERSION = 2
+// retroactive re-run can distinguish old vs new decisions. v2 introduced
+// confidence-weighted centroid + variance. v3 (issue #331) adds source-weighted
+// contributions AND makes the promote gate count only accepted HUMAN pins, so
+// machine-proposed pins can sharpen the centroid but can never promote ground
+// truth on their own.
+export const GEO_CONSENSUS_VERSION = 3
+
+// Multiplicative weight by pin provenance, composed with the confidence weight.
+// Human pins count fully; scraped structured-coordinate pins are downweighted;
+// experimental vision pins count least. Missing source is treated as 'human'
+// (legacy rows / the crowd path), preserving pre-v3 behaviour on human data.
+export const GEO_CONSENSUS_SOURCE_WEIGHTS: Record<GeoPinSource, number> = {
+  human: 1.0,
+  agent_structured: 0.6,
+  agent_vision: 0.25,
+}
+
+function sourceWeight(source: GeoPinSource | undefined): number {
+  if (source == null) return 1.0
+  return GEO_CONSENSUS_SOURCE_WEIGHTS[source]
+}
+
+function isHuman(source: GeoPinSource | undefined): boolean {
+  return source == null || source === 'human'
+}
 
 // Self-reported confidence buckets translate to multiplicative weights on
 // the pin's contribution to centroid + variance. "Sure" pins count
@@ -28,9 +51,19 @@ export const GEO_CONSENSUS_CONFIDENCE_WEIGHTS: Record<GeoPinConfidence, number> 
   3: 0.33,
 }
 
-function weightFor(confidence: GeoPinConfidence | undefined): number {
+function confidenceWeight(confidence: GeoPinConfidence | undefined): number {
   if (confidence == null) return 1.0
   return GEO_CONSENSUS_CONFIDENCE_WEIGHTS[confidence]
+}
+
+// Effective contribution weight = confidence weight × source weight. A pin's
+// pull on the centroid/variance scales with both how sure the author claimed to
+// be and how much we trust that class of author.
+function weightFor(
+  confidence: GeoPinConfidence | undefined,
+  source: GeoPinSource | undefined,
+): number {
+  return confidenceWeight(confidence) * sourceWeight(source)
 }
 
 /**
@@ -50,6 +83,9 @@ export interface GeoPinLike {
   id: number
   pin: GeoPoint
   confidence?: GeoPinConfidence
+  // Provenance; defaults to 'human' when omitted. Agent sources are
+  // downweighted and excluded from the promote count.
+  source?: GeoPinSource
 }
 
 export interface GeoConsensusDecision {
@@ -63,6 +99,9 @@ export interface GeoConsensusResult {
   sigmaX: number
   sigmaY: number
   acceptedCount: number
+  // Accepted pins whose source is human. This — not acceptedCount — gates
+  // promotion, so agent pins can never carry a candidate over the line.
+  humanAcceptedCount: number
   rejectedCount: number
   decisions: GeoConsensusDecision[]
   promote: boolean
@@ -73,13 +112,14 @@ export interface GeoConsensusResult {
 /**
  * Compute weighted mean/σ on each axis and mark pins outside σ-multiplier
  * * σ OR outside the map's consensus radius as rejected. Promotion to
- * canonical requires ≥ min-pins AND a tight enough cluster (confidence
- * > 0.5).
+ * canonical requires ≥ min-pins accepted HUMAN pins AND a tight enough
+ * cluster (confidence > 0.5) — agent pins never count toward that gate.
  *
- * Each pin contributes proportionally to its self-reported confidence:
- * "sure" (1.0), "approx" (0.66), "guess" (0.33). Pins without a
- * recorded confidence count fully — preserving v1 behaviour for the
- * historical dataset and for contributors who skip the chip.
+ * Each pin contributes proportionally to its self-reported confidence
+ * ("sure" 1.0, "approx" 0.66, "guess" 0.33) times its source weight
+ * (human 1.0, agent_structured 0.6, agent_vision 0.25). Pins without a
+ * recorded confidence/source count as sure/human — preserving pre-v3
+ * behaviour for the historical dataset and the crowd path.
  *
  * Cluster confidence is a bounded, interpretable signal: 1 when all
  * pins sit on top of each other, 0 when the spread equals the map's
@@ -96,6 +136,7 @@ export function evaluateConsensus(
       sigmaX: 0,
       sigmaY: 0,
       acceptedCount: 0,
+      humanAcceptedCount: 0,
       rejectedCount: 0,
       decisions: [],
       promote: false,
@@ -104,14 +145,13 @@ export function evaluateConsensus(
     }
   }
 
-  // Weighted centroid. Total weight is also the divisor for variance,
-  // so a "guess"-only cluster has the same shape as the equivalent
-  // "sure" cluster — the weights only matter when confidences are mixed.
+  // Weighted centroid. Weight = confidence × source, so agent pins pull the
+  // centroid less than human pins (and low-confidence pins less than sure ones).
   let sumW = 0
   let sumWX = 0
   let sumWY = 0
-  for (const { pin, confidence } of pins) {
-    const w = weightFor(confidence)
+  for (const { pin, confidence, source } of pins) {
+    const w = weightFor(confidence, source)
     sumW += w
     sumWX += w * pin.x
     sumWY += w * pin.y
@@ -125,8 +165,8 @@ export function evaluateConsensus(
 
   let sqX = 0
   let sqY = 0
-  for (const { pin, confidence } of pins) {
-    const w = weightFor(confidence)
+  for (const { pin, confidence, source } of pins) {
+    const w = weightFor(confidence, source)
     const dx = pin.x - meanX
     const dy = pin.y - meanY
     sqX += w * dx * dx
@@ -140,9 +180,10 @@ export function evaluateConsensus(
 
   const decisions: GeoConsensusDecision[] = []
   let accepted = 0
+  let humanAccepted = 0
   let rejected = 0
 
-  for (const { id, pin } of pins) {
+  for (const { id, pin, source } of pins) {
     const dx = pin.x - meanX
     const dy = pin.y - meanY
     const distance = Math.sqrt(dx * dx + dy * dy)
@@ -153,21 +194,29 @@ export function evaluateConsensus(
     const outsideRadius = distance > mapConsensusRadius
 
     const status: GeoPinStatus = outsideSigma || outsideRadius ? 'rejected' : 'accepted'
-    if (status === 'accepted') accepted++
-    else rejected++
+    if (status === 'accepted') {
+      accepted++
+      if (isHuman(source)) humanAccepted++
+    } else {
+      rejected++
+    }
 
     decisions.push({ pinId: id, status, distanceFromCentroid: distance })
   }
 
   const spread = Math.max(sigmaX, sigmaY)
   const confidence = Math.max(0, 1 - spread / Math.max(mapConsensusRadius, 1e-6))
-  const promote = accepted >= GEO_CONSENSUS_MIN_PINS_TO_PROMOTE && confidence >= 0.5
+  // Promote gate counts HUMAN accepted pins only. This is the #331 invariant:
+  // however many agent pins pile up, a candidate can never promote without the
+  // crowd (or an admin override) — machine writes sharpen, never decide.
+  const promote = humanAccepted >= GEO_CONSENSUS_MIN_PINS_TO_PROMOTE && confidence >= 0.5
 
   return {
     centroid: { x: meanX, y: meanY },
     sigmaX,
     sigmaY,
     acceptedCount: accepted,
+    humanAcceptedCount: humanAccepted,
     rejectedCount: rejected,
     decisions,
     promote,

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -31,6 +31,8 @@ import billingWebhookRoutes from './presentation/routes/billing-webhook.routes.j
 import koeRoutes from './presentation/routes/koe.routes.js'
 import publicV1Routes from './presentation/routes/public.routes.js'
 import streamerKeysRoutes from './presentation/routes/streamer-keys.routes.js'
+import agentGeoRoutes from './presentation/routes/agent-geo.routes.js'
+import adminAgentKeysRoutes from './presentation/routes/admin-agent-keys.routes.js'
 import { testRedisConnection, tryAcquireBootLock } from './infrastructure/queue/connection.js'
 import {
   importQueue,
@@ -232,6 +234,7 @@ app.get('/healthz', async (_req, res) => {
 app.use('/api/game', gameRoutes)
 app.use('/api/leaderboard', leaderboardRoutes)
 app.use('/api/admin/geo-fetch', geoFetchRoutes)
+app.use('/api/admin/agent-keys', adminAgentKeysRoutes)
 app.use('/api/admin', adminRoutes)
 app.use('/api/user', userRoutes)
 app.use('/api/achievements', achievementRoutes)
@@ -259,6 +262,11 @@ app.use('/api/public/v1', publicV1Routes)
 // settings page. Owners flip the public-profile toggle, claim a slug,
 // and manage their keys here.
 app.use('/api/streamer-keys', streamerKeysRoutes)
+// Agent content-sourcing surface (issue #331). Key-authenticated with
+// admin-minted geo-agent keys. Always mounted; the whole surface is gated
+// per-request by GEO_AGENT_API_ENABLED (returns 503 AGENT_API_DISABLED when
+// off) so it can be killed by env flip + redeploy without a code change.
+app.use('/api/agent/v1/geo', agentGeoRoutes)
 
 // Serve frontend static files (after API routes)
 const frontendPath = path.resolve(__dirname, '..', '..', '..', 'packages', 'frontend', 'dist')

--- a/packages/backend/src/infrastructure/geogamers-health.ts
+++ b/packages/backend/src/infrastructure/geogamers-health.ts
@@ -1,0 +1,51 @@
+import type { GeoGamersHealthSnapshot } from '@the-box/types'
+import { env } from '../config/env.js'
+import { geoGamersChallengeRepository } from './repositories/geogamers-challenge.repository.js'
+import { geoGamersSeasonRepository } from './repositories/geogamers-season.repository.js'
+
+/**
+ * Content-readiness snapshot for the GeoGamers daily scheduler — the same
+ * eligibility the daily worker gates on, so an operator (or a content-sourcing
+ * agent) can see "starved" before a day silently skips.
+ *
+ * Extracted here so the admin health route and the agent read surface
+ * (`/api/agent/v1/geo/health`) share ONE query rather than drifting. Kept out of
+ * the queue import graph (repos only, no BullMQ) so the agent route and its
+ * tests never open a Redis connection.
+ *
+ * "Eligible" = a game with ≥1 promoted meta on an active map, never used as a
+ * GeoGamers challenge, not on cooldown — see
+ * `geoGamersChallengeRepository.listEligibleMetas`.
+ */
+export async function getGeoGamersHealthSnapshot(): Promise<GeoGamersHealthSnapshot> {
+  const enabled = env.GEOGAMERS_ENABLED === 'true'
+  const minRequired = Number(env.GEOGAMERS_MIN_ELIGIBLE_GAMES) || 10
+  const cooldownDays = Number(env.GEOGAMERS_GAME_COOLDOWN_DAYS) || 14
+
+  const today = new Date().toISOString().slice(0, 10)
+  const [todayChallenge, current, cooldownGameIds] = await Promise.all([
+    geoGamersChallengeRepository.findByDate(today),
+    geoGamersChallengeRepository.findCurrent(),
+    geoGamersChallengeRepository.gameIdsUsedSince(cooldownDays),
+  ])
+
+  const eligible = await geoGamersChallengeRepository.listEligibleMetas({ cooldownGameIds })
+  const eligibleGames = new Set(eligible.map((e) => e.gameId)).size
+  const eligibleScreenshots = eligible.length
+
+  const month = geoGamersSeasonRepository.currentSeasonMonth()
+  const seasonPlayers = await geoGamersSeasonRepository.playerCount(month)
+
+  return {
+    enabled,
+    minRequired,
+    cooldownDays,
+    eligibleGames,
+    eligibleScreenshots,
+    gamesOnCooldown: cooldownGameIds.length,
+    starved: eligibleGames < minRequired,
+    todayChallengeExists: !!todayChallenge,
+    currentChallengeDate: current?.challengeDate ?? null,
+    season: { month, players: seasonPlayers },
+  }
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo-consensus-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-consensus-logic.ts
@@ -117,11 +117,14 @@ export async function evaluateConsensusForCandidate(
     }
   }
 
+  // Agent pins have no user_id — skip them here so they earn no rewards and
+  // can't be shadow-banned. They still feed the consensus math below (as
+  // downweighted voters) but never the promote count (see consensus v3).
   const pinOwners = new Map<number, string>()
-  for (const p of pending) pinOwners.set(p.id, p.userId)
+  for (const p of pending) if (p.userId) pinOwners.set(p.id, p.userId)
 
   const result = geoConsensusService.evaluate(
-    pending.map((p) => ({ id: p.id, pin: p.pin, confidence: p.confidence })),
+    pending.map((p) => ({ id: p.id, pin: p.pin, confidence: p.confidence, source: p.source })),
     map.consensusRadius,
   )
 

--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -347,6 +347,17 @@ export type RunnableTier =
   | 'wand'
   | 'wikidata'
 
+// Runtime list of the single-tier map imports an operator (or an agent, #331
+// phase 3) can trigger. Kept in sync with RunnableTier via `satisfies`.
+export const RUNNABLE_TIERS = [
+  'registry',
+  'fandom',
+  'strategywiki',
+  'fextralife',
+  'wand',
+  'wikidata',
+] as const satisfies readonly RunnableTier[]
+
 export type SingleTierFailure =
   | 'GAME_NOT_FOUND'
   | 'NOT_CURATED'

--- a/packages/backend/src/infrastructure/redis/agent-budget.test.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { ingestBudgetKey, secondsToUtcMidnight } from './agent-budget.js'
+
+describe('secondsToUtcMidnight', () => {
+  it('counts seconds to the next UTC midnight', () => {
+    // 23:00:00Z → 1h = 3600s.
+    assert.equal(secondsToUtcMidnight(new Date('2026-07-10T23:00:00.000Z')), 3600)
+    // 00:00:00Z → a full day, never 0 (the key would already have rolled).
+    assert.equal(secondsToUtcMidnight(new Date('2026-07-10T00:00:00.000Z')), 86400)
+  })
+
+  it('never returns less than 1 (rounds up sub-second remainders)', () => {
+    const out = secondsToUtcMidnight(new Date('2026-07-10T23:59:59.500Z'))
+    assert.ok(out >= 1)
+  })
+})
+
+describe('ingestBudgetKey', () => {
+  it('scopes the key by api key id and UTC day', () => {
+    assert.equal(
+      ingestBudgetKey(42, new Date('2026-07-10T15:30:00.000Z')),
+      'geo-agent:budget:ingest:42:2026-07-10',
+    )
+  })
+
+  it('rolls to a new key at the UTC day boundary', () => {
+    const before = ingestBudgetKey(1, new Date('2026-07-10T23:59:59.000Z'))
+    const after = ingestBudgetKey(1, new Date('2026-07-11T00:00:01.000Z'))
+    assert.notEqual(before, after)
+  })
+})

--- a/packages/backend/src/infrastructure/redis/agent-budget.test.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { ingestBudgetKey, secondsToUtcMidnight } from './agent-budget.js'
+import {
+  ingestBudgetKey,
+  pinBudgetKey,
+  secondsToNextUtcHour,
+  secondsToUtcMidnight,
+} from './agent-budget.js'
 
 describe('secondsToUtcMidnight', () => {
   it('counts seconds to the next UTC midnight', () => {
@@ -27,6 +32,32 @@ describe('ingestBudgetKey', () => {
   it('rolls to a new key at the UTC day boundary', () => {
     const before = ingestBudgetKey(1, new Date('2026-07-10T23:59:59.000Z'))
     const after = ingestBudgetKey(1, new Date('2026-07-11T00:00:01.000Z'))
+    assert.notEqual(before, after)
+  })
+})
+
+describe('secondsToNextUtcHour', () => {
+  it('counts seconds to the top of the next UTC hour', () => {
+    assert.equal(secondsToNextUtcHour(new Date('2026-07-10T15:00:00.000Z')), 3600)
+    assert.equal(secondsToNextUtcHour(new Date('2026-07-10T15:59:00.000Z')), 60)
+  })
+
+  it('never returns less than 1', () => {
+    assert.ok(secondsToNextUtcHour(new Date('2026-07-10T15:59:59.500Z')) >= 1)
+  })
+})
+
+describe('pinBudgetKey', () => {
+  it('scopes the key by api key id and UTC hour', () => {
+    assert.equal(
+      pinBudgetKey(7, new Date('2026-07-10T15:30:00.000Z')),
+      'geo-agent:budget:pins:7:2026-07-10T15',
+    )
+  })
+
+  it('rolls to a new key at the hour boundary', () => {
+    const before = pinBudgetKey(1, new Date('2026-07-10T15:59:59.000Z'))
+    const after = pinBudgetKey(1, new Date('2026-07-10T16:00:01.000Z'))
     assert.notEqual(before, after)
   })
 })

--- a/packages/backend/src/infrastructure/redis/agent-budget.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.ts
@@ -24,28 +24,41 @@ export function secondsToUtcMidnight(now: Date): number {
   return Math.max(1, Math.ceil((midnight.getTime() - now.getTime()) / 1000))
 }
 
+/** Seconds from `now` until the top of the next UTC hour. Pure. */
+export function secondsToNextUtcHour(now: Date): number {
+  const nextHour = new Date(now)
+  nextHour.setUTCMinutes(60, 0, 0)
+  return Math.max(1, Math.ceil((nextHour.getTime() - now.getTime()) / 1000))
+}
+
 /** Redis key for a key's ingest budget on a given UTC day. Pure. */
 export function ingestBudgetKey(apiKeyId: number, now: Date): string {
   return `geo-agent:budget:ingest:${apiKeyId}:${now.toISOString().slice(0, 10)}`
 }
 
+/** Redis key for a key's pin budget in a given UTC hour. Pure. */
+export function pinBudgetKey(apiKeyId: number, now: Date): string {
+  // slice(0, 13) → "YYYY-MM-DDTHH" (hour granularity).
+  return `geo-agent:budget:pins:${apiKeyId}:${now.toISOString().slice(0, 13)}`
+}
+
 /**
- * Atomically consume one unit of a key's daily ingest budget. Returns
- * `ok: false` (without consuming) once `limit` is reached. The counter expires
- * at the next UTC midnight so a fresh budget rolls over automatically.
- *
- * On any Redis error the call FAILS CLOSED (`ok: false`): a budget we can't
- * verify must not silently become unlimited.
+ * Atomically consume one unit of a windowed budget keyed in Redis. Returns
+ * `ok: false` (without consuming) once `limit` is reached; the counter expires
+ * at the end of the window so it rolls over automatically. FAILS CLOSED on any
+ * Redis error — a budget we can't verify must not silently become unlimited.
  */
-export async function consumeIngestBudget(apiKeyId: number, limit: number): Promise<BudgetResult> {
-  const now = new Date()
-  const key = ingestBudgetKey(apiKeyId, now)
-  const resetSeconds = secondsToUtcMidnight(now)
+async function consumeWindowBudget(
+  key: string,
+  limit: number,
+  resetSeconds: number,
+  label: string,
+): Promise<BudgetResult> {
   try {
     const redis = getRedis()
     const used = await redis.incr(key)
     if (used === 1) {
-      // First hit today — bound the key's lifetime to the current UTC day.
+      // First hit in this window — bound the key's lifetime to the window.
       await redis.expire(key, resetSeconds + 60)
     }
     if (used > limit) {
@@ -56,7 +69,19 @@ export async function consumeIngestBudget(apiKeyId: number, limit: number): Prom
     }
     return { ok: true, used, limit, remaining: Math.max(0, limit - used), resetSeconds }
   } catch (err) {
-    log.error({ err: String(err), apiKeyId }, 'ingest budget check failed — failing closed')
+    log.error({ err: String(err), key, label }, `${label} budget check failed — failing closed`)
     return { ok: false, used: limit, limit, remaining: 0, resetSeconds }
   }
+}
+
+/** Consume one unit of a key's DAILY ingest budget (phase 3). */
+export async function consumeIngestBudget(apiKeyId: number, limit: number): Promise<BudgetResult> {
+  const now = new Date()
+  return consumeWindowBudget(ingestBudgetKey(apiKeyId, now), limit, secondsToUtcMidnight(now), 'ingest')
+}
+
+/** Consume one unit of a key's HOURLY pin-proposal budget (phase 4). */
+export async function consumePinBudget(apiKeyId: number, limit: number): Promise<BudgetResult> {
+  const now = new Date()
+  return consumeWindowBudget(pinBudgetKey(apiKeyId, now), limit, secondsToNextUtcHour(now), 'pin')
 }

--- a/packages/backend/src/infrastructure/redis/agent-budget.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.ts
@@ -1,0 +1,62 @@
+import { getRedis } from './redis.client.js'
+import { logger } from '../logger/logger.js'
+
+const log = logger.child({ module: 'agent-budget' })
+
+// Per-key daily budget counter for the agent API (issue #331, phase 3). Backed
+// by Redis (INCR + EXPIRE keyed by UTC day) so it survives deploys — an
+// in-memory counter would reset on every redeploy and let a looping agent
+// multiply its quota. Distinct from the 60/min rate limit: this bounds total
+// ingests per day, that bounds burst rate.
+
+export interface BudgetResult {
+  ok: boolean
+  used: number
+  limit: number
+  remaining: number
+  resetSeconds: number
+}
+
+/** Seconds from `now` until the next UTC midnight. Pure — unit-testable. */
+export function secondsToUtcMidnight(now: Date): number {
+  const midnight = new Date(now)
+  midnight.setUTCHours(24, 0, 0, 0)
+  return Math.max(1, Math.ceil((midnight.getTime() - now.getTime()) / 1000))
+}
+
+/** Redis key for a key's ingest budget on a given UTC day. Pure. */
+export function ingestBudgetKey(apiKeyId: number, now: Date): string {
+  return `geo-agent:budget:ingest:${apiKeyId}:${now.toISOString().slice(0, 10)}`
+}
+
+/**
+ * Atomically consume one unit of a key's daily ingest budget. Returns
+ * `ok: false` (without consuming) once `limit` is reached. The counter expires
+ * at the next UTC midnight so a fresh budget rolls over automatically.
+ *
+ * On any Redis error the call FAILS CLOSED (`ok: false`): a budget we can't
+ * verify must not silently become unlimited.
+ */
+export async function consumeIngestBudget(apiKeyId: number, limit: number): Promise<BudgetResult> {
+  const now = new Date()
+  const key = ingestBudgetKey(apiKeyId, now)
+  const resetSeconds = secondsToUtcMidnight(now)
+  try {
+    const redis = getRedis()
+    const used = await redis.incr(key)
+    if (used === 1) {
+      // First hit today — bound the key's lifetime to the current UTC day.
+      await redis.expire(key, resetSeconds + 60)
+    }
+    if (used > limit) {
+      // Over budget: undo this increment so rejected calls don't inflate the
+      // counter (and thus don't push the reset further via repeated hits).
+      await redis.decr(key)
+      return { ok: false, used: limit, limit, remaining: 0, resetSeconds }
+    }
+    return { ok: true, used, limit, remaining: Math.max(0, limit - used), resetSeconds }
+  } catch (err) {
+    log.error({ err: String(err), apiKeyId }, 'ingest budget check failed — failing closed')
+    return { ok: false, used: limit, limit, remaining: 0, resetSeconds }
+  }
+}

--- a/packages/backend/src/infrastructure/repositories/api-key.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/api-key.repository.ts
@@ -1,6 +1,11 @@
 import crypto from 'node:crypto'
 import { db } from '../database/connection.js'
-import type { ApiKeyMode, ApiKeyScope, ApiKeySummary } from '@the-box/types'
+import { GEO_AGENT_SCOPES, type ApiKeyMode, type ApiKeyScope, type ApiKeySummary } from '@the-box/types'
+
+// Postgres text[] literal of the geo-agent scopes, e.g. `{geo-agent:read,…}`.
+// Used with the array-overlap operator (`&&`) to find/act on agent keys
+// regardless of which admin minted them.
+const GEO_AGENT_SCOPES_PG_ARRAY = `{${GEO_AGENT_SCOPES.join(',')}}`
 
 // Single source of truth for the plaintext format. Keys look like
 //   tb_pk_live_<43-char-base64url>
@@ -107,6 +112,32 @@ export const apiKeyRepository = {
       .andWhere('user_id', userId)
       .first<ApiKeyRow>()
     return row ?? null
+  },
+
+  /**
+   * All keys carrying any geo-agent:* scope, regardless of the minting admin —
+   * the governance view for the admin agent-key panel. One query via the
+   * Postgres array-overlap operator covers all three scopes.
+   */
+  async listGeoAgentKeys(): Promise<ApiKeyRow[]> {
+    return await db('api_keys')
+      .whereRaw('scopes && ?::text[]', [GEO_AGENT_SCOPES_PG_ARRAY])
+      .orderBy('created_at', 'desc')
+      .select<ApiKeyRow[]>('*')
+  },
+
+  /**
+   * Revoke an agent key by id alone (no owner scoping), so any admin can
+   * revoke any agent key. Guarded to keys that actually carry a geo-agent
+   * scope so this admin path can never soft-delete a streamer's personal key.
+   */
+  async revokeGeoAgentKey(id: number): Promise<boolean> {
+    const updated = await db('api_keys')
+      .where('id', id)
+      .andWhere('is_active', true)
+      .andWhereRaw('scopes && ?::text[]', [GEO_AGENT_SCOPES_PG_ARRAY])
+      .update({ is_active: false, revoked_at: db.fn.now() })
+    return updated > 0
   },
 
   /**

--- a/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
@@ -2,6 +2,7 @@ import { db } from '../database/connection.js'
 import { repoLogger } from '../logger/logger.js'
 import type {
   GeoPinConfidence,
+  GeoPinSource,
   GeoPinStatus,
   GeoPinSubmission,
   GeoPoint,
@@ -11,13 +12,19 @@ const log = repoLogger.child({ repository: 'geo-pin' })
 
 export interface GeoPinSubmissionRow {
   id: number
-  user_id: string
+  // Null for agent-proposed pins (see the 20260710_geo_agent_pins migration).
+  user_id: string | null
   geo_screenshot_candidate_id: number
   x: number
   y: number
   status: GeoPinStatus
   confidence: number | null
   is_anonymous: boolean
+  source: GeoPinSource
+  agent_key_id: number | null
+  agent_rationale: string | null
+  agent_model: string | null
+  vision_pass: number
   distance_from_centroid: number | null
   reviewed_at: Date | null
   created_at: Date
@@ -38,6 +45,10 @@ function mapPin(row: GeoPinSubmissionRow): GeoPinSubmission {
     status: row.status,
     confidence,
     isAnonymous: row.is_anonymous === true,
+    source: row.source ?? 'human',
+    agentRationale: row.agent_rationale ?? undefined,
+    agentModel: row.agent_model ?? undefined,
+    visionPass: row.vision_pass ?? undefined,
     distanceFromCentroid: row.distance_from_centroid ?? undefined,
     reviewedAt: row.reviewed_at?.toISOString(),
     createdAt: row.created_at.toISOString(),
@@ -77,6 +88,56 @@ export const geoPinRepository = {
       .returning<GeoPinSubmissionRow[]>('*')
 
     return row ? mapPin(row) : null
+  },
+
+  /**
+   * Submit an AGENT-proposed pin (issue #331). No user — owned by a geo-agent
+   * API key, flagged by `source`, and downweighted in consensus. The unique
+   * partial index (agent_key_id, candidate, vision_pass) means a duplicate
+   * proposal is a benign no-op (returns null) rather than an error, mirroring
+   * the human path's ON CONFLICT DO NOTHING.
+   */
+  async submitAgent(data: {
+    agentKeyId: number
+    geoScreenshotCandidateId: number
+    pin: GeoPoint
+    source: Exclude<GeoPinSource, 'human'>
+    rationale: string
+    model?: string
+    confidence?: GeoPinConfidence
+    visionPass?: number
+  }): Promise<GeoPinSubmission | null> {
+    log.info(
+      {
+        agentKeyId: data.agentKeyId,
+        candidateId: data.geoScreenshotCandidateId,
+        source: data.source,
+      },
+      'submit agent pin',
+    )
+    try {
+      const [row] = await db('geo_pin_submission')
+        .insert({
+          user_id: null,
+          agent_key_id: data.agentKeyId,
+          geo_screenshot_candidate_id: data.geoScreenshotCandidateId,
+          x: data.pin.x,
+          y: data.pin.y,
+          confidence: data.confidence ?? null,
+          is_anonymous: false,
+          source: data.source,
+          agent_rationale: data.rationale,
+          agent_model: data.model ?? null,
+          vision_pass: data.visionPass ?? 0,
+        })
+        .returning<GeoPinSubmissionRow[]>('*')
+      return row ? mapPin(row) : null
+    } catch (err) {
+      // 23505 = unique_violation on the partial agent index → duplicate
+      // proposal for this (key, candidate, pass). Treat as a benign no-op.
+      if ((err as { code?: string }).code === '23505') return null
+      throw err
+    }
   },
 
   async listByCandidate(candidateId: number): Promise<GeoPinSubmission[]> {

--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -397,6 +397,86 @@ export const geoScreenshotRepository = {
     return summaries
   },
 
+  /**
+   * The "one pin away" diagnostic. Games that have an active map and captures
+   * still collecting pins (pending/collecting, active) but NO canonical pin yet
+   * — i.e. promoting one of their candidates would grow the GeoGamers-eligible
+   * pool by one (assuming the game has never been a challenge). Games that
+   * already have a promoted meta are excluded: their content exists, so they
+   * don't need pinning effort.
+   *
+   * Per game we surface the candidate count and the single best candidate (most
+   * pins, ties broken by id), so the admin card can deep-link straight to the
+   * capture closest to promotion. Ordered by top pin count desc so the games
+   * nearest the next consensus recompute float to the top.
+   */
+  async listGamesNeedingContent(limit = 25): Promise<
+    Array<{
+      gameId: number
+      gameName: string | null
+      candidateCount: number
+      topPinCount: number
+      bestCandidateId: number | null
+    }>
+  > {
+    const result = await db.raw<{
+      rows: Array<{
+        game_id: number
+        game_name: string | null
+        candidate_count: string
+        top_pin_count: string
+        best_candidate_id: number | null
+      }>
+    }>(
+      `
+      SELECT
+        g.id AS game_id,
+        g.name AS game_name,
+        stats.candidate_count,
+        stats.top_pin_count,
+        best.id AS best_candidate_id
+      FROM games g
+      JOIN LATERAL (
+        SELECT
+          COUNT(*) AS candidate_count,
+          COALESCE(MAX(c.pin_count), 0) AS top_pin_count
+        FROM geo_screenshot_candidate c
+        WHERE c.game_id = g.id
+          AND c.is_active = true
+          AND c.status IN ('pending', 'collecting')
+      ) stats ON stats.candidate_count > 0
+      LEFT JOIN LATERAL (
+        SELECT c.id
+        FROM geo_screenshot_candidate c
+        WHERE c.game_id = g.id
+          AND c.is_active = true
+          AND c.status IN ('pending', 'collecting')
+        ORDER BY c.pin_count DESC, c.id ASC
+        LIMIT 1
+      ) best ON true
+      WHERE EXISTS (
+        SELECT 1 FROM geo_map m WHERE m.game_id = g.id AND m.is_active = true
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM geo_screenshot_meta sm
+        JOIN geo_screenshot_candidate cc ON cc.id = sm.geo_screenshot_candidate_id
+        WHERE cc.game_id = g.id AND cc.is_active = true
+      )
+      ORDER BY stats.top_pin_count DESC, stats.candidate_count DESC, g.id ASC
+      LIMIT ?
+      `,
+      [limit],
+    )
+    return result.rows.map((r) => ({
+      gameId: r.game_id,
+      gameName: r.game_name,
+      candidateCount: Number(r.candidate_count ?? 0),
+      topPinCount: Number(r.top_pin_count ?? 0),
+      bestCandidateId: r.best_candidate_id ?? null,
+    }))
+  },
+
   async listCandidatesForReview(args: {
     status?: GeoScreenshotCandidateRow['status']
     gameId?: number

--- a/packages/backend/src/presentation/middleware/agent-api.middleware.test.ts
+++ b/packages/backend/src/presentation/middleware/agent-api.middleware.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import type { Request, Response } from 'express'
+import type { ApiKeyScope } from '@the-box/types'
+import { env } from '../../config/env.js'
+import {
+  requireAgentApiEnabled,
+  requireScope,
+} from './agent-api.middleware.js'
+
+// Minimal Express res double: captures the status + json body and whether the
+// handler chain continued (next called).
+function mockRes() {
+  const state: { status: number; body: unknown } = { status: 200, body: undefined }
+  const res = {
+    status(code: number) {
+      state.status = code
+      return res
+    },
+    json(payload: unknown) {
+      state.body = payload
+      return res
+    },
+  } as unknown as Response
+  return { res, state }
+}
+
+function reqWithScopes(scopes: ApiKeyScope[] | undefined): Request {
+  return { apiKey: scopes ? { id: 1, scopes } : undefined } as unknown as Request
+}
+
+function errorCode(body: unknown): string | undefined {
+  return (body as { error?: { code?: string } } | undefined)?.error?.code
+}
+
+describe('requireScope', () => {
+  it('passes a read-only agent key requesting geo-agent:read', () => {
+    const { res, state } = mockRes()
+    let nexted = false
+    requireScope('geo-agent:read')(reqWithScopes(['geo-agent:read']), res, () => {
+      nexted = true
+    })
+    assert.equal(nexted, true)
+    assert.equal(state.status, 200)
+  })
+
+  it('rejects when the key lacks the requested scope (read key, ingest route)', () => {
+    const { res, state } = mockRes()
+    let nexted = false
+    requireScope('geo-agent:ingest')(reqWithScopes(['geo-agent:read']), res, () => {
+      nexted = true
+    })
+    assert.equal(nexted, false)
+    assert.equal(state.status, 403)
+    assert.equal(errorCode(state.body), 'INSUFFICIENT_SCOPE')
+  })
+
+  it('rejects a streamer key even though it authenticated', () => {
+    // A key carrying only streamer scopes can never reach the agent surface.
+    const { res, state } = mockRes()
+    let nexted = false
+    requireScope('geo-agent:read')(reqWithScopes(['read:public', 'webhooks:self']), res, () => {
+      nexted = true
+    })
+    assert.equal(nexted, false)
+    assert.equal(state.status, 403)
+  })
+
+  it('rejects a mixed key (mutual exclusion): every scope must be geo-agent', () => {
+    // Defense in depth against a key that somehow carries both families —
+    // holding geo-agent:read is not enough if a streamer scope rides along.
+    const { res, state } = mockRes()
+    let nexted = false
+    requireScope('geo-agent:read')(
+      reqWithScopes(['geo-agent:read', 'read:public']),
+      res,
+      () => {
+        nexted = true
+      },
+    )
+    assert.equal(nexted, false)
+    assert.equal(state.status, 403)
+  })
+
+  it('rejects when no key is attached', () => {
+    const { res, state } = mockRes()
+    let nexted = false
+    requireScope('geo-agent:read')(reqWithScopes(undefined), res, () => {
+      nexted = true
+    })
+    assert.equal(nexted, false)
+    assert.equal(state.status, 403)
+  })
+})
+
+describe('requireAgentApiEnabled', () => {
+  const original = env.GEO_AGENT_API_ENABLED
+  beforeEach(() => {
+    env.GEO_AGENT_API_ENABLED = original
+  })
+  afterEach(() => {
+    env.GEO_AGENT_API_ENABLED = original
+  })
+
+  it('passes through when enabled', () => {
+    env.GEO_AGENT_API_ENABLED = 'true'
+    const { res, state } = mockRes()
+    let nexted = false
+    requireAgentApiEnabled({} as Request, res, () => {
+      nexted = true
+    })
+    assert.equal(nexted, true)
+    assert.equal(state.status, 200)
+  })
+
+  it('returns 503 AGENT_API_DISABLED when off (default)', () => {
+    env.GEO_AGENT_API_ENABLED = 'false'
+    const { res, state } = mockRes()
+    let nexted = false
+    requireAgentApiEnabled({} as Request, res, () => {
+      nexted = true
+    })
+    assert.equal(nexted, false)
+    assert.equal(state.status, 503)
+    assert.equal(errorCode(state.body), 'AGENT_API_DISABLED')
+  })
+})

--- a/packages/backend/src/presentation/middleware/agent-api.middleware.ts
+++ b/packages/backend/src/presentation/middleware/agent-api.middleware.ts
@@ -1,0 +1,61 @@
+import type { Request, Response, NextFunction } from 'express'
+import type { ApiKeyScope } from '@the-box/types'
+import { isGeoAgentScope } from '@the-box/types'
+import { env } from '../../config/env.js'
+import { createRateLimiter } from './rate-limit.middleware.js'
+
+// Middleware for the agent content-sourcing surface (/api/agent/v1/geo,
+// issue #331). Composes on top of the shared `requireApiKey` from
+// public-api.middleware: that attaches `req.apiKey`; the guards here add the
+// kill switch, scope enforcement, and a per-key rate limit.
+
+/**
+ * Kill switch. Every agent route sits behind this so the entire surface can be
+ * disabled instantly by flipping GEO_AGENT_API_ENABLED and redeploying —
+ * complementing per-key revocation. Returns a clean, machine-readable 503
+ * rather than a bare 404 so an integrator polling the surface can tell "turned
+ * off" from "wrong URL".
+ */
+export function requireAgentApiEnabled(_req: Request, res: Response, next: NextFunction): void {
+  if (env.GEO_AGENT_API_ENABLED !== 'true') {
+    res.status(503).json({
+      success: false,
+      error: { code: 'AGENT_API_DISABLED', message: 'The agent API is disabled' },
+    })
+    return
+  }
+  next()
+}
+
+/**
+ * Require a specific scope on the authenticated key. Also rejects any key that
+ * carries a non-geo-agent scope reaching this surface — a streamer key can
+ * never call the agent API even if it somehow held a geo-agent scope, and the
+ * mint-time mutual-exclusion guarantee is re-checked here as defense in depth.
+ * Must run after `requireApiKey` (needs `req.apiKey`).
+ */
+export function requireScope(scope: ApiKeyScope) {
+  return function (req: Request, res: Response, next: NextFunction): void {
+    const scopes = req.apiKey?.scopes
+    const authorized =
+      Array.isArray(scopes) && scopes.includes(scope) && scopes.every(isGeoAgentScope)
+    if (!authorized) {
+      res.status(403).json({
+        success: false,
+        error: { code: 'INSUFFICIENT_SCOPE', message: `Requires scope ${scope}` },
+      })
+      return
+    }
+    next()
+  }
+}
+
+// Per-key fixed-window rate limit. 60/min is generous for an exploratory agent
+// loop (health poll + candidate reads); the write budgets that actually bound
+// ingestion and pin proposals land with phases 3–4 as Redis counters. Keyed by
+// key id so two agents don't share a bucket; falls back to IP pre-auth.
+export const agentApiRateLimit = createRateLimiter({
+  windowMs: 60_000,
+  max: 60,
+  key: (req) => (req.apiKey ? `agent-key:${req.apiKey.id}` : `agent-ip:${req.ip ?? 'unknown'}`),
+})

--- a/packages/backend/src/presentation/routes/admin-agent-keys.routes.ts
+++ b/packages/backend/src/presentation/routes/admin-agent-keys.routes.ts
@@ -1,0 +1,117 @@
+import { Router } from 'express'
+import { z } from 'zod'
+import { GEO_AGENT_SCOPES, type ApiKeyCreated, type ApiKeySummary } from '@the-box/types'
+import { adminMiddleware } from '../middleware/auth.middleware.js'
+import { validateBody, validateParams } from '../middleware/validation.middleware.js'
+import { recordAdminGeoAudit } from '../middleware/admin-audit.js'
+import { apiKeyRepository } from '../../infrastructure/repositories/api-key.repository.js'
+import { logger } from '../../infrastructure/logger/logger.js'
+
+// Admin-only management of geo-agent API keys (issue #331, phase 2). Distinct
+// from the streamer self-service key surface (streamer-keys.routes.ts): those
+// keys are user-minted and reach a streamer's own public data; these are minted
+// by an admin, carry ONLY geo-agent:* scopes, and reach the agent content-
+// sourcing surface (/api/agent/v1/geo). The two scope families are mutually
+// exclusive on a single key — enforced here at mint time and re-checked by
+// requireScope on every agent route.
+//
+// Mounted at /api/admin/agent-keys behind adminMiddleware. Every mint/revoke is
+// written to admin_audit_log.
+
+const router = Router()
+router.use(adminMiddleware)
+
+const log = logger.child({ router: 'admin-agent-keys' })
+
+// A mint may request any non-empty subset of the geo-agent scopes. Default to
+// read-only: ingest/propose are granted deliberately per key as phases 3–4
+// ship, so a freshly minted key can never write until an admin opts it in.
+const scopeEnum = z.enum(GEO_AGENT_SCOPES)
+const createSchema = z.object({
+  label: z.string().trim().min(1).max(64),
+  mode: z.enum(['live', 'test']).default('live'),
+  scopes: z.array(scopeEnum).nonempty().max(GEO_AGENT_SCOPES.length).optional(),
+})
+
+// Cap active agent keys so a mistake or a compromised admin session can't mint
+// an unbounded fleet. Generous for the "one exploration key + one steady-state
+// key + spare" shape.
+const MAX_ACTIVE_AGENT_KEYS = 10
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const keys = await apiKeyRepository.listGeoAgentKeys()
+    const data: ApiKeySummary[] = keys.map(apiKeyRepository.mapRow)
+    res.json({ success: true, data })
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.post('/', validateBody(createSchema), async (req, res, next) => {
+  try {
+    const adminId = req.userId!
+    const body = req.body as z.infer<typeof createSchema>
+
+    const active = await apiKeyRepository.listGeoAgentKeys()
+    if (active.filter((k) => k.is_active).length >= MAX_ACTIVE_AGENT_KEYS) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'TOO_MANY_KEYS',
+          message: 'Revoke an existing agent key before minting a new one',
+        },
+      })
+      return
+    }
+
+    // De-dupe requested scopes; default to read-only. Zod already guarantees
+    // every entry is a geo-agent scope, so mutual exclusion with streamer
+    // scopes holds by construction.
+    const scopes = body.scopes ? [...new Set(body.scopes)] : ['geo-agent:read' as const]
+
+    const { row, plaintext } = await apiKeyRepository.create({
+      userId: adminId,
+      label: body.label,
+      mode: body.mode,
+      scopes,
+    })
+
+    await recordAdminGeoAudit(req, {
+      action: 'agent_key.mint',
+      target: { kind: 'api_key', id: row.id },
+      after: { label: row.label, mode: row.mode, scopes: row.scopes },
+    })
+    log.info({ adminId, keyId: row.id, scopes: row.scopes }, 'geo-agent key minted')
+
+    const payload: ApiKeyCreated = { ...apiKeyRepository.mapRow(row), plaintext }
+    res.status(201).json({ success: true, data: payload })
+  } catch (err) {
+    next(err)
+  }
+})
+
+const idParams = z.object({ id: z.coerce.number().int().positive() })
+
+router.delete('/:id', validateParams(idParams), async (req, res, next) => {
+  try {
+    const { id } = req.params as unknown as z.infer<typeof idParams>
+    const ok = await apiKeyRepository.revokeGeoAgentKey(id)
+    if (!ok) {
+      // Either no such geo-agent key, or it was already revoked. A uniform
+      // 404 keeps this admin path from probing non-agent key ids.
+      res.status(404).json({ success: false, error: { code: 'KEY_NOT_FOUND' } })
+      return
+    }
+    await recordAdminGeoAudit(req, {
+      action: 'agent_key.revoke',
+      target: { kind: 'api_key', id },
+    })
+    log.info({ adminId: req.userId, keyId: id }, 'geo-agent key revoked')
+    res.json({ success: true, data: { ok: true } })
+  } catch (err) {
+    next(err)
+  }
+})
+
+export default router

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -1953,7 +1953,7 @@ router.post('/geo/candidates/:id/override', async (req, res, next) => {
         return
       }
       const consensus = evaluateConsensus(
-        pins.map((p) => ({ id: p.id, pin: p.pin, confidence: p.confidence })),
+        pins.map((p) => ({ id: p.id, pin: p.pin, confidence: p.confidence, source: p.source })),
         map.consensusRadius,
       )
       canonicalX = consensus.centroid.x

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -47,7 +47,10 @@ import {
   emailLogRepository,
 } from '../../infrastructure/repositories/index.js'
 import { GEO_CONSENSUS_VERSION } from '../../domain/services/index.js'
-import { evaluateConsensus } from '../../domain/services/geo-consensus.service.js'
+import {
+  evaluateConsensus,
+  pinsToNextConsensusThreshold,
+} from '../../domain/services/geo-consensus.service.js'
 import { isMapEligibleByGenre } from '../../domain/services/geo-metadata.service.js'
 import { geoQueue, type GeoJobData } from '../../infrastructure/queue/queues.js'
 import { findRegistryEntryBySlug } from '../../infrastructure/queue/workers/geo-registry-import-logic.js'
@@ -1802,6 +1805,27 @@ router.get('/geo/candidates/by-game', async (req, res, next) => {
       limit,
     })
     res.json({ success: true, data: summaries })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// GET /api/admin/geo/games-needing-content — the "one pin away" diagnostic.
+// Games with an active map and captures collecting pins but no canonical pin
+// yet: promoting one of their candidates makes the game eligible for GeoGamers.
+// Sorted so the games closest to the next consensus recompute come first, which
+// is where pinning effort moves the eligible-count needle. Complements the
+// GeoGamers health card (which shows the aggregate count but not *which* games).
+router.get('/geo/games-needing-content', async (req, res, next) => {
+  try {
+    const rawLimit = Number(req.query.limit)
+    const limit = Number.isFinite(rawLimit) ? Math.min(100, Math.max(1, Math.trunc(rawLimit))) : 25
+    const rows = await geoScreenshotRepository.listGamesNeedingContent(limit)
+    const data = rows.map((r) => ({
+      ...r,
+      pinsToNextThreshold: pinsToNextConsensusThreshold(r.topPinCount),
+    }))
+    res.json({ success: true, data })
   } catch (err) {
     next(err)
   }

--- a/packages/backend/src/presentation/routes/admin.routes.ts
+++ b/packages/backend/src/presentation/routes/admin.routes.ts
@@ -3,9 +3,8 @@ import { z } from 'zod'
 import { adminService, jobService } from '../../domain/services/index.js'
 import { billingService } from '../../domain/services/index.js'
 import { userRepository } from '../../infrastructure/repositories/user.repository.js'
-import { geoGamersChallengeRepository } from '../../infrastructure/repositories/geogamers-challenge.repository.js'
-import { geoGamersSeasonRepository } from '../../infrastructure/repositories/geogamers-season.repository.js'
 import { createGeoGamersChallenge } from '../../infrastructure/queue/workers/geogamers-challenge-logic.js'
+import { getGeoGamersHealthSnapshot } from '../../infrastructure/geogamers-health.js'
 import { adminMiddleware } from '../middleware/auth.middleware.js'
 import { recordAdminGeoAudit } from '../middleware/admin-audit.js'
 import {
@@ -3628,39 +3627,10 @@ router.post('/scraping/reset', async (req, res, next) => {
 // challenge and the current season's player count.
 router.get('/geogamers/health', async (_req, res, next) => {
   try {
-    const enabled = env.GEOGAMERS_ENABLED === 'true'
-    const minRequired = Number(env.GEOGAMERS_MIN_ELIGIBLE_GAMES) || 10
-    const cooldownDays = Number(env.GEOGAMERS_GAME_COOLDOWN_DAYS) || 14
-
-    const today = new Date().toISOString().slice(0, 10)
-    const [todayChallenge, current, cooldownGameIds] = await Promise.all([
-      geoGamersChallengeRepository.findByDate(today),
-      geoGamersChallengeRepository.findCurrent(),
-      geoGamersChallengeRepository.gameIdsUsedSince(cooldownDays),
-    ])
-
-    const eligible = await geoGamersChallengeRepository.listEligibleMetas({ cooldownGameIds })
-    const eligibleGames = new Set(eligible.map((e) => e.gameId)).size
-    const eligibleScreenshots = eligible.length
-
-    const month = geoGamersSeasonRepository.currentSeasonMonth()
-    const seasonPlayers = await geoGamersSeasonRepository.playerCount(month)
-
-    res.json({
-      success: true,
-      data: {
-        enabled,
-        minRequired,
-        cooldownDays,
-        eligibleGames,
-        eligibleScreenshots,
-        gamesOnCooldown: cooldownGameIds.length,
-        starved: eligibleGames < minRequired,
-        todayChallengeExists: !!todayChallenge,
-        currentChallengeDate: current?.challengeDate ?? null,
-        season: { month, players: seasonPlayers },
-      },
-    })
+    // Shared with the agent read surface (/api/agent/v1/geo/health) so the
+    // eligibility query lives in one place.
+    const data = await getGeoGamersHealthSnapshot()
+    res.json({ success: true, data })
   } catch (err) {
     next(err)
   }

--- a/packages/backend/src/presentation/routes/agent-geo.routes.ts
+++ b/packages/backend/src/presentation/routes/agent-geo.routes.ts
@@ -11,6 +11,7 @@ import { validateBody, validateParams, validateQuery } from '../middleware/valid
 import {
   geoScreenshotRepository,
   geoMapRepository,
+  geoPinRepository,
 } from '../../infrastructure/repositories/index.js'
 import { geoSourceConfigRepository } from '../../infrastructure/repositories/geo-source-config.repository.js'
 import { adminAuditRepository } from '../../infrastructure/repositories/admin-audit.repository.js'
@@ -21,8 +22,12 @@ import {
   RUNNABLE_TIERS,
   type RunnableTier,
 } from '../../infrastructure/queue/workers/geo-ingest-tick-logic.js'
-import { consumeIngestBudget } from '../../infrastructure/redis/agent-budget.js'
+import { geoQueue } from '../../infrastructure/queue/queues.js'
+import { consumeIngestBudget, consumePinBudget } from '../../infrastructure/redis/agent-budget.js'
 import { env } from '../../config/env.js'
+import { routeLogger } from '../../infrastructure/logger/logger.js'
+
+const log = routeLogger.child({ router: 'agent-geo' })
 
 // Agent content-sourcing surface (issue #331, phase 2 — read-only).
 //
@@ -196,6 +201,123 @@ router.post(
           results,
           budget: { used: budget.used, limit: budget.limit, remaining: budget.remaining },
         },
+      })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// POST /candidates/:id/pins — propose a downweighted, flagged pin (phase 4).
+// The write path that lets a machine participate in consensus WITHOUT being
+// able to promote ground truth: agent pins feed the same consensus queue as
+// crowd pins but are excluded from the human-gated promote count (consensus
+// v3) and downweighted in the centroid. `rationale` is required — it is the
+// artifact a human reviewer reads. Bounded by a per-key hourly budget.
+const pinBodySchema = z.object({
+  x: z.number().min(0).max(1),
+  y: z.number().min(0).max(1),
+  source: z.enum(['agent_structured', 'agent_vision']),
+  rationale: z.string().trim().min(1).max(500),
+  confidence: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  model: z.string().trim().max(100).optional(),
+  // Only meaningful for agent_vision: multiple independent passes vote against
+  // each other. 0-2 → up to 3 passes per candidate per key.
+  visionPass: z.number().int().min(0).max(2).optional(),
+})
+
+router.post(
+  '/candidates/:id/pins',
+  requireScope('geo-agent:propose'),
+  validateParams(z.object({ id: z.coerce.number().int().positive() })),
+  validateBody(pinBodySchema),
+  async (req, res, next) => {
+    try {
+      const { id: candidateId } = req.params as unknown as { id: number }
+      const body = req.body as z.infer<typeof pinBodySchema>
+      const keyId = req.apiKey!.id
+
+      const candidate = await geoScreenshotRepository.findCandidateById(candidateId)
+      if (!candidate) {
+        res.status(404).json({ success: false, error: { code: 'CANDIDATE_NOT_FOUND' } })
+        return
+      }
+      // Never let a machine pin touch a candidate that already has ground
+      // truth — proposals only make sense while a candidate is collecting.
+      const existingMeta = await geoScreenshotRepository.findMetaByCandidateId(candidateId)
+      if (existingMeta) {
+        res.status(409).json({
+          success: false,
+          error: { code: 'ALREADY_PROMOTED', message: 'candidate already has a canonical pin' },
+        })
+        return
+      }
+
+      const maxPerHour = Number(env.GEO_AGENT_MAX_PINS_PER_HOUR) || 60
+      const budget = await consumePinBudget(keyId, maxPerHour)
+      if (!budget.ok) {
+        res.setHeader('Retry-After', String(budget.resetSeconds))
+        res.status(429).json({
+          success: false,
+          error: {
+            code: 'BUDGET_EXHAUSTED',
+            message: `Hourly pin budget of ${budget.limit} reached`,
+          },
+        })
+        return
+      }
+
+      const submission = await geoPinRepository.submitAgent({
+        agentKeyId: keyId,
+        geoScreenshotCandidateId: candidateId,
+        pin: { x: body.x, y: body.y },
+        source: body.source,
+        rationale: body.rationale,
+        model: body.model,
+        confidence: body.confidence,
+        visionPass: body.visionPass,
+      })
+
+      const budgetInfo = { used: budget.used, limit: budget.limit, remaining: budget.remaining }
+
+      // Duplicate proposal (same key+candidate+pass) — idempotent no-op.
+      if (!submission) {
+        res.json({ success: true, data: { received: true, duplicate: true, budget: budgetInfo } })
+        return
+      }
+
+      const newPinCount = await geoScreenshotRepository.incrementPinCount(candidateId)
+      // Enqueue consensus evaluation on the same threshold-gated path as the
+      // crowd. Agent pins can trigger a recompute but never a promotion.
+      try {
+        await geoQueue.add('evaluate-consensus', {
+          kind: 'evaluate-consensus',
+          geoScreenshotCandidateId: candidateId,
+          pinCountAtEnqueue: newPinCount,
+        })
+      } catch (e) {
+        log.warn({ err: String(e), candidateId }, 'failed to enqueue geo consensus job')
+      }
+
+      await adminAuditRepository.record({
+        adminId: `apikey:${keyId}`,
+        action: 'geo-agent.propose_pin',
+        targetKind: 'geo_screenshot_candidate',
+        targetId: String(candidateId),
+        after: {
+          x: body.x,
+          y: body.y,
+          source: body.source,
+          rationale: body.rationale,
+          model: body.model ?? null,
+          visionPass: body.visionPass ?? 0,
+        },
+        ip: req.ip ?? null,
+      })
+
+      res.json({
+        success: true,
+        data: { pinId: submission.id, received: true, pinCount: newPinCount, budget: budgetInfo },
       })
     } catch (err) {
       next(err)

--- a/packages/backend/src/presentation/routes/agent-geo.routes.ts
+++ b/packages/backend/src/presentation/routes/agent-geo.routes.ts
@@ -1,0 +1,108 @@
+import { Router } from 'express'
+import { z } from 'zod'
+import type { GeoGameNeedingContent } from '@the-box/types'
+import { requireApiKey } from '../middleware/public-api.middleware.js'
+import {
+  agentApiRateLimit,
+  requireAgentApiEnabled,
+  requireScope,
+} from '../middleware/agent-api.middleware.js'
+import { validateParams, validateQuery } from '../middleware/validation.middleware.js'
+import {
+  geoScreenshotRepository,
+  geoMapRepository,
+} from '../../infrastructure/repositories/index.js'
+import { pinsToNextConsensusThreshold } from '../../domain/services/geo-consensus.service.js'
+import { getGeoGamersHealthSnapshot } from '../../infrastructure/geogamers-health.js'
+
+// Agent content-sourcing surface (issue #331, phase 2 — read-only).
+//
+// Mounted at /api/agent/v1/geo. Key-authenticated with admin-minted geo-agent
+// keys, NOT session-authed and NOT the streamer public API. Every route sits
+// behind: kill switch → key auth → per-key rate limit → scope check. This
+// phase exposes only reads — it proves the auth/audit/rate-limit surface with
+// zero write risk before ingest (phase 3) and pin proposals (phase 4) land.
+//
+// A key never elevates access: these endpoints return catalog/diagnostic data,
+// never user identities or PII (candidate payloads carry pin counts, not pin
+// owners).
+
+const router = Router()
+
+// Order matters: enable-gate first (cheapest reject), then authenticate, then
+// rate-limit per key. Scope is checked per route since later phases add
+// endpoints with stronger scopes on the same router.
+router.use(requireAgentApiEnabled)
+router.use(requireApiKey())
+router.use(agentApiRateLimit)
+
+const limitQuery = z.object({
+  limit: z.coerce.number().int().positive().max(100).optional(),
+})
+
+const gameIdParams = z.object({
+  gameId: z.coerce.number().int().positive(),
+})
+
+// GET /health — content-readiness snapshot (shares the admin query). Tells an
+// agent whether the eligible-game pool is starved and by how much.
+router.get('/health', requireScope('geo-agent:read'), async (_req, res, next) => {
+  try {
+    const data = await getGeoGamersHealthSnapshot()
+    res.json({ success: true, data })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// GET /games-needing-content — the "one pin away" list: games with an active
+// map and captures collecting pins but no canonical pin yet. This is the
+// agent's work queue — where a proposed pin would grow the eligible pool.
+router.get(
+  '/games-needing-content',
+  requireScope('geo-agent:read'),
+  validateQuery(limitQuery),
+  async (req, res, next) => {
+    try {
+      const { limit } = req.query as unknown as z.infer<typeof limitQuery>
+      const rows = await geoScreenshotRepository.listGamesNeedingContent(limit ?? 25)
+      const data: GeoGameNeedingContent[] = rows.map((r) => ({
+        ...r,
+        pinsToNextThreshold: pinsToNextConsensusThreshold(r.topPinCount),
+      }))
+      res.json({ success: true, data })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// GET /games/:gameId/candidates — unpinned/collecting captures for a game plus
+// its active maps (image url + dimensions), so a proposer has everything it
+// needs to localize a screenshot. Promoted captures are omitted (they already
+// have ground truth); rejected ones are already excluded by the repo.
+router.get(
+  '/games/:gameId/candidates',
+  requireScope('geo-agent:read'),
+  validateParams(gameIdParams),
+  validateQuery(limitQuery),
+  async (req, res, next) => {
+    try {
+      const { gameId } = req.params as unknown as z.infer<typeof gameIdParams>
+      const { limit } = req.query as unknown as z.infer<typeof limitQuery>
+      const [maps, candidates] = await Promise.all([
+        geoMapRepository.listEnabledByGameId(gameId),
+        geoScreenshotRepository.listCandidatesForReview({ gameId, limit: limit ?? 50 }),
+      ])
+      // Only captures still awaiting a canonical pin are actionable for the
+      // agent. `listCandidatesForReview` already drops rejected (is_active=false)
+      // rows; filter out promoted here.
+      const actionable = candidates.filter((c) => c.status !== 'promoted')
+      res.json({ success: true, data: { maps, candidates: actionable } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+export default router

--- a/packages/backend/src/presentation/routes/agent-geo.routes.ts
+++ b/packages/backend/src/presentation/routes/agent-geo.routes.ts
@@ -7,13 +7,22 @@ import {
   requireAgentApiEnabled,
   requireScope,
 } from '../middleware/agent-api.middleware.js'
-import { validateParams, validateQuery } from '../middleware/validation.middleware.js'
+import { validateBody, validateParams, validateQuery } from '../middleware/validation.middleware.js'
 import {
   geoScreenshotRepository,
   geoMapRepository,
 } from '../../infrastructure/repositories/index.js'
+import { geoSourceConfigRepository } from '../../infrastructure/repositories/geo-source-config.repository.js'
+import { adminAuditRepository } from '../../infrastructure/repositories/admin-audit.repository.js'
 import { pinsToNextConsensusThreshold } from '../../domain/services/geo-consensus.service.js'
 import { getGeoGamersHealthSnapshot } from '../../infrastructure/geogamers-health.js'
+import {
+  enqueueSingleTierImport,
+  RUNNABLE_TIERS,
+  type RunnableTier,
+} from '../../infrastructure/queue/workers/geo-ingest-tick-logic.js'
+import { consumeIngestBudget } from '../../infrastructure/redis/agent-budget.js'
+import { env } from '../../config/env.js'
 
 // Agent content-sourcing surface (issue #331, phase 2 — read-only).
 //
@@ -99,6 +108,95 @@ router.get(
       // rows; filter out promoted here.
       const actionable = candidates.filter((c) => c.status !== 'promoted')
       res.json({ success: true, data: { maps, candidates: actionable } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// POST /games/:gameId/ingest — trigger the existing map-ingestion pipeline for
+// one game (phase 3). Pure enqueue: reuses `enqueueSingleTierImport`, so
+// tombstones/circuit-breakers, dedup, and license/attribution capture are
+// untouched. The agent can request specific tiers or default to all; it can
+// NEVER add a source outside the RunnableTier allowlist, and a source with a
+// disabled geo_source_config row is skipped (its kill switch is honored).
+// Bounded by a per-key Redis daily budget on top of the 60/min rate limit.
+const ingestBodySchema = z.object({
+  sources: z.array(z.enum(RUNNABLE_TIERS)).nonempty().max(RUNNABLE_TIERS.length).optional(),
+})
+
+router.post(
+  '/games/:gameId/ingest',
+  requireScope('geo-agent:ingest'),
+  validateParams(gameIdParams),
+  validateBody(ingestBodySchema),
+  async (req, res, next) => {
+    try {
+      const { gameId } = req.params as unknown as z.infer<typeof gameIdParams>
+      const { sources } = req.body as z.infer<typeof ingestBodySchema>
+      const requested: RunnableTier[] = sources ?? [...RUNNABLE_TIERS]
+
+      // Daily budget check BEFORE enqueuing. Validation errors (bad tier /
+      // gameId) are already handled by the schemas above and don't consume it.
+      const maxPerDay = Number(env.GEO_AGENT_MAX_INGESTS_PER_DAY) || 20
+      const keyId = req.apiKey!.id
+      const budget = await consumeIngestBudget(keyId, maxPerDay)
+      if (!budget.ok) {
+        res.setHeader('Retry-After', String(budget.resetSeconds))
+        res.status(429).json({
+          success: false,
+          error: {
+            code: 'BUDGET_EXHAUSTED',
+            message: `Daily ingest budget of ${budget.limit} reached; resets at UTC midnight`,
+          },
+        })
+        return
+      }
+
+      // Honor the per-source kill switch where a config row exists. Sources
+      // without a geo_source_config row (registry/fextralife/wikidata) have no
+      // switch and are always runnable — matching the admin "Run now" button.
+      const configs = await geoSourceConfigRepository.list()
+      const disabled = new Set(
+        configs.filter((c) => !c.isEnabled).map((c) => c.source as string),
+      )
+
+      const results: Array<
+        | { source: RunnableTier; enqueued: true; jobId: string }
+        | { source: RunnableTier; enqueued: false; reason: string }
+      > = []
+      for (const source of requested) {
+        if (disabled.has(source)) {
+          results.push({ source, enqueued: false, reason: 'SOURCE_DISABLED' })
+          continue
+        }
+        const outcome = await enqueueSingleTierImport(gameId, source)
+        results.push(
+          outcome.enqueued
+            ? { source, enqueued: true, jobId: outcome.jobId }
+            : { source, enqueued: false, reason: outcome.reason },
+        )
+      }
+
+      // Audit every ingest trigger keyed to the API key (writes are always
+      // logged). Best-effort — never blocks the response.
+      await adminAuditRepository.record({
+        adminId: `apikey:${keyId}`,
+        action: 'geo-agent.ingest',
+        targetKind: 'game',
+        targetId: String(gameId),
+        after: { requested, enqueued: results.filter((r) => r.enqueued).map((r) => r.source) },
+        ip: req.ip ?? null,
+      })
+
+      res.json({
+        success: true,
+        data: {
+          gameId,
+          results,
+          budget: { used: budget.used, limit: budget.limit, remaining: budget.remaining },
+        },
+      })
     } catch (err) {
       next(err)
     }

--- a/packages/frontend/e2e/geo-admin.spec.ts
+++ b/packages/frontend/e2e/geo-admin.spec.ts
@@ -40,6 +40,25 @@ test.describe('Geo Admin', () => {
         await expect(page.getByRole('tab', { name: /review queue|file de revue/i })).toBeVisible()
     })
 
+    test('renders the "one pin away" content-gap card', async ({ page }) => {
+        if (!(await geoRoutesReachable(page))) test.skip(true, 'geo router unreachable')
+
+        // The diagnostic endpoint must be reachable (any status < 500 means the
+        // route is mounted; empty content is a valid 200).
+        const res = await page.request.get(
+            '/api/admin/geo/games-needing-content?limit=10',
+            { failOnStatusCode: false },
+        )
+        expect(res.status()).toBeLessThan(500)
+
+        await page.goto('/en/admin?tab=geo')
+        // The card renders regardless of seed data: either a game list or the
+        // "no game waiting for a canonical pin" empty state.
+        await expect(
+            page.getByText(/à un pin de l.éligibilité/i),
+        ).toBeVisible({ timeout: 10_000 })
+    })
+
     test('review queue renders (possibly empty)', async ({ page }) => {
         if (!(await geoRoutesReachable(page))) test.skip(true, 'geo router unreachable')
 

--- a/packages/frontend/src/components/admin/AgentKeysCard.tsx
+++ b/packages/frontend/src/components/admin/AgentKeysCard.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useRef, useState } from 'react'
+import { Copy, KeyRound, Loader2, Trash2 } from 'lucide-react'
+import type { ApiKeyCreated, ApiKeyScope, ApiKeySummary } from '@the-box/types'
+import { fetchAdminJson } from '@/lib/api/admin'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+// Admin management of geo-agent API keys (issue #331, phase 2). Mints
+// admin-owned, geo-agent-scoped keys for the content-sourcing surface
+// (/api/agent/v1/geo) — distinct from the streamer self-service keys. The
+// plaintext is shown exactly once, at mint.
+
+const SCOPE_OPTIONS: Array<{ scope: ApiKeyScope; label: string; hint: string }> = [
+    { scope: 'geo-agent:read', label: 'read', hint: 'santé, jeux à compléter, captures' },
+    { scope: 'geo-agent:ingest', label: 'ingest', hint: 'déclencher le pipeline (phase 3)' },
+    { scope: 'geo-agent:propose', label: 'propose', hint: 'proposer des pins (phase 4)' },
+]
+
+export function AgentKeysCard() {
+    const [keys, setKeys] = useState<ApiKeySummary[] | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+    const [label, setLabel] = useState('')
+    const [scopes, setScopes] = useState<ApiKeyScope[]>(['geo-agent:read'])
+    const [mode, setMode] = useState<'live' | 'test'>('live')
+    const [minting, setMinting] = useState(false)
+    const [minted, setMinted] = useState<ApiKeyCreated | null>(null)
+    const [notice, setNotice] = useState<string | null>(null)
+    const mounted = useRef(true)
+
+    async function load() {
+        try {
+            const data = await fetchAdminJson<ApiKeySummary[]>('/api/admin/agent-keys')
+            if (mounted.current) setKeys(data)
+        } catch (e) {
+            if (mounted.current) setError(String(e))
+        } finally {
+            if (mounted.current) setLoading(false)
+        }
+    }
+
+    useEffect(() => {
+        mounted.current = true
+        void load()
+        return () => {
+            mounted.current = false
+        }
+    }, [])
+
+    function toggleScope(scope: ApiKeyScope) {
+        setScopes((prev) =>
+            prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope],
+        )
+    }
+
+    async function mint() {
+        if (!label.trim() || scopes.length === 0) return
+        setMinting(true)
+        setNotice(null)
+        setMinted(null)
+        try {
+            const created = await fetchAdminJson<ApiKeyCreated>('/api/admin/agent-keys', {
+                method: 'POST',
+                body: JSON.stringify({ label: label.trim(), mode, scopes }),
+            })
+            if (mounted.current) {
+                setMinted(created)
+                setLabel('')
+                setScopes(['geo-agent:read'])
+            }
+            await load()
+        } catch (e) {
+            if (mounted.current) setNotice(String(e))
+        } finally {
+            if (mounted.current) setMinting(false)
+        }
+    }
+
+    async function revoke(id: number) {
+        setNotice(null)
+        try {
+            await fetchAdminJson(`/api/admin/agent-keys/${id}`, { method: 'DELETE' })
+            await load()
+        } catch (e) {
+            if (mounted.current) setNotice(String(e))
+        }
+    }
+
+    return (
+        <Card className="mb-6 border-border bg-card/50">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                    <KeyRound className="size-4 text-neon-pink" />
+                    <span>Clés agent Géo (#331)</span>
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <p className="text-xs text-muted-foreground">
+                    Clés d&apos;API pour la surface de sourcing agent
+                    (<code>/api/agent/v1/geo</code>). Réservées admin, portée{' '}
+                    <code>geo-agent:*</code> uniquement. Le texte en clair n&apos;est affiché
+                    qu&apos;une seule fois. Nécessite <code>GEO_AGENT_API_ENABLED=true</code> côté
+                    backend pour être utilisable.
+                </p>
+
+                {/* Mint form */}
+                <div className="space-y-2 rounded-lg border border-border/60 p-3">
+                    <div className="flex flex-wrap items-end gap-2">
+                        <div className="flex-1 min-w-40">
+                            <label className="text-xs text-muted-foreground">Libellé</label>
+                            <Input
+                                value={label}
+                                maxLength={64}
+                                placeholder="ex. exploration-claude"
+                                onChange={(e) => setLabel(e.target.value)}
+                            />
+                        </div>
+                        <div>
+                            <label className="text-xs text-muted-foreground">Mode</label>
+                            <select
+                                className="block h-9 rounded-md border border-input bg-background px-2 text-sm"
+                                value={mode}
+                                onChange={(e) => setMode(e.target.value as 'live' | 'test')}
+                            >
+                                <option value="live">live</option>
+                                <option value="test">test</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div className="flex flex-wrap gap-3">
+                        {SCOPE_OPTIONS.map((o) => (
+                            <label
+                                key={o.scope}
+                                className="flex items-center gap-1.5 text-xs"
+                                title={o.hint}
+                            >
+                                <input
+                                    type="checkbox"
+                                    checked={scopes.includes(o.scope)}
+                                    onChange={() => toggleScope(o.scope)}
+                                />
+                                <code>{o.label}</code>
+                            </label>
+                        ))}
+                    </div>
+                    <Button
+                        size="sm"
+                        disabled={minting || !label.trim() || scopes.length === 0}
+                        onClick={() => void mint()}
+                    >
+                        {minting && <Loader2 className="mr-1 size-4 animate-spin" />}
+                        Créer la clé
+                    </Button>
+                    {notice && <p className="text-xs text-destructive">{notice}</p>}
+                </div>
+
+                {/* One-shot plaintext reveal */}
+                {minted && (
+                    <div className="space-y-1 rounded-lg bg-warning/10 p-3 text-sm">
+                        <p className="font-medium text-warning">
+                            Copie cette clé maintenant — elle ne sera plus affichée.
+                        </p>
+                        <div className="flex items-center gap-2">
+                            <code className="break-all rounded bg-background px-2 py-1 text-xs">
+                                {minted.plaintext}
+                            </code>
+                            <Button
+                                size="icon"
+                                variant="ghost"
+                                onClick={() => void navigator.clipboard?.writeText(minted.plaintext)}
+                                title="Copier"
+                            >
+                                <Copy className="size-4" />
+                            </Button>
+                        </div>
+                    </div>
+                )}
+
+                {/* Key list */}
+                {loading ? (
+                    <div className="flex justify-center py-4">
+                        <Loader2 className="size-5 animate-spin text-primary" />
+                    </div>
+                ) : error ? (
+                    <p className="text-sm text-muted-foreground">Clés : {error}</p>
+                ) : !keys || keys.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">Aucune clé agent.</p>
+                ) : (
+                    <ul className="divide-y divide-border/60">
+                        {keys.map((k) => (
+                            <li key={k.id} className="flex items-center justify-between gap-3 py-2">
+                                <div className="min-w-0">
+                                    <div className="flex items-center gap-2 text-sm font-medium">
+                                        {k.label}
+                                        {!k.isActive && (
+                                            <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                                                révoquée
+                                            </span>
+                                        )}
+                                    </div>
+                                    <div className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                                        <code>{k.keyPrefix}…</code>
+                                        <span>{k.mode}</span>
+                                        <span>{k.scopes.join(' ')}</span>
+                                    </div>
+                                </div>
+                                {k.isActive && (
+                                    <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        className="shrink-0 text-destructive"
+                                        onClick={() => void revoke(k.id)}
+                                        title="Révoquer"
+                                    >
+                                        <Trash2 className="size-4" />
+                                    </Button>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    )
+}

--- a/packages/frontend/src/components/admin/GeoNeedingContentCard.tsx
+++ b/packages/frontend/src/components/admin/GeoNeedingContentCard.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { AlertTriangle, Loader2, MapPin, Target } from 'lucide-react'
+import type { GeoGameNeedingContent } from '@the-box/types'
+import { fetchAdminJson } from '@/lib/api/admin'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+/**
+ * The "one pin away" diagnostic (issue #331, phase 1). The GeoGamers health
+ * card shows the *aggregate* eligible-game count; this card shows *which*
+ * games are closest to becoming eligible — games with captures collecting
+ * pins but no canonical pin yet — so an admin can spend pinning effort where
+ * it moves the eligible-count needle. Each row deep-links into the review
+ * queue for that game, where the existing override promotes a candidate.
+ */
+export function GeoNeedingContentCard() {
+    const [rows, setRows] = useState<GeoGameNeedingContent[] | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+    const [, setSearchParams] = useSearchParams()
+    const mounted = useRef(true)
+
+    useEffect(() => {
+        mounted.current = true
+        void (async () => {
+            try {
+                const data = await fetchAdminJson<GeoGameNeedingContent[]>(
+                    '/api/admin/geo/games-needing-content?limit=10',
+                )
+                if (mounted.current) setRows(data)
+            } catch (e) {
+                if (mounted.current) setError(String(e))
+            } finally {
+                if (mounted.current) setLoading(false)
+            }
+        })()
+        return () => {
+            mounted.current = false
+        }
+    }, [])
+
+    // Deep-link into the review queue seeded on this game. GeoReviewPanel reads
+    // the `qGameId`/`qGameName` params once to pre-select the queue tab + game
+    // filter, then strips them from the URL.
+    const openInQueue = (game: GeoGameNeedingContent) => {
+        setSearchParams(
+            (prev) => {
+                const next = new URLSearchParams(prev)
+                next.set('tab', 'geo')
+                next.set('sub', 'queue')
+                next.set('qGameId', String(game.gameId))
+                next.set('qGameName', game.gameName ?? `#${game.gameId}`)
+                return next
+            },
+            { replace: true },
+        )
+    }
+
+    if (loading) {
+        return (
+            <div className="flex justify-center py-6">
+                <Loader2 className="size-6 animate-spin text-primary" />
+            </div>
+        )
+    }
+    if (error) {
+        return (
+            <p className="py-4 text-sm text-muted-foreground">
+                Jeux à compléter : {error}
+            </p>
+        )
+    }
+
+    return (
+        <Card className="mb-6 border-border bg-card/50">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                    <Target className="size-4 text-neon-pink" />
+                    <span>À un pin de l&apos;éligibilité</span>
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+                {!rows || rows.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        Aucun jeu en attente de pin canonique : toutes les captures
+                        collectées ont déjà une position de consensus, ou aucun jeu
+                        n&apos;a encore de carte active avec des captures.
+                    </p>
+                ) : (
+                    <>
+                        <p className="text-xs text-muted-foreground">
+                            Jeux avec une carte active et des captures qui collectent des
+                            pins, mais sans position canonique. Promouvoir une capture
+                            (via la file de revue) rend le jeu éligible au mode GeoGamers.
+                        </p>
+                        <ul className="divide-y divide-border/60">
+                            {rows.map((g) => (
+                                <li
+                                    key={g.gameId}
+                                    className="flex items-center justify-between gap-3 py-2"
+                                >
+                                    <div className="min-w-0">
+                                        <div className="truncate text-sm font-medium">
+                                            {g.gameName ?? `#${g.gameId}`}
+                                        </div>
+                                        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                                            <span>
+                                                {g.candidateCount} capture
+                                                {g.candidateCount > 1 ? 's' : ''}
+                                            </span>
+                                            <span className="flex items-center gap-1">
+                                                <MapPin className="size-3" />
+                                                {g.topPinCount} pin
+                                                {g.topPinCount === 1 ? '' : 's'} (max)
+                                            </span>
+                                            {g.pinsToNextThreshold > 0 && (
+                                                <span className="flex items-center gap-1 text-warning">
+                                                    <AlertTriangle className="size-3" />
+                                                    {g.pinsToNextThreshold} pin
+                                                    {g.pinsToNextThreshold === 1 ? '' : 's'}{' '}
+                                                    avant recalcul
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        className="shrink-0"
+                                        onClick={() => openInQueue(g)}
+                                    >
+                                        Revoir
+                                    </Button>
+                                </li>
+                            ))}
+                        </ul>
+                    </>
+                )}
+            </CardContent>
+        </Card>
+    )
+}

--- a/packages/frontend/src/components/admin/GeoReviewPanel.tsx
+++ b/packages/frontend/src/components/admin/GeoReviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
@@ -33,6 +33,14 @@ export function GeoReviewPanel() {
     // segment is read once for backward compatibility (cold-start CTAs)
     // but no longer written.
     const [searchParams, setSearchParams] = useSearchParams()
+    // Deep-link seed from the "À un pin de l'éligibilité" card: `qGameId` /
+    // `qGameName` pre-select the queue tab filtered to one game. Read once for
+    // the initial state below, then stripped from the URL by the effect so the
+    // filter is dismissable and doesn't re-seed on the next render.
+    const seedGameIdRaw = searchParams.get('qGameId')
+    const seedGameId =
+        seedGameIdRaw && Number.isFinite(Number(seedGameIdRaw)) ? Number(seedGameIdRaw) : null
+    const seedGameName = searchParams.get('qGameName')
     const subFromUrl = searchParams.get('sub')
     const subInUrl: GeoSubTab | null =
         subFromUrl && (SUB_TABS as string[]).includes(subFromUrl)
@@ -76,12 +84,29 @@ export function GeoReviewPanel() {
     // other statuses are still reachable via the chip row, but the page
     // should not open on `collecting` (no decision possible) or `all` (mixes
     // already-handled rows into the queue).
-    const [statusFilter, setStatusFilter] = useState<StatusFilter>('pending')
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>(
+        seedGameId != null ? 'all' : 'pending',
+    )
     // Per-game filter for the Pins tab. Set when the operator clicks "Voir
     // les captures" on a Maps row so the candidate list narrows to that game.
     // Cleared via the badge in the Pins header. Lifted here (rather than inside
     // GeoReviewQueue) because the catalog tab and the status rail also drive it.
-    const [gameFilter, setGameFilter] = useState<GameFilter | null>(null)
+    const [gameFilter, setGameFilter] = useState<GameFilter | null>(
+        seedGameId != null
+            ? { gameId: seedGameId, gameName: seedGameName ?? `#${seedGameId}` }
+            : null,
+    )
+    // Strip the one-shot deep-link seed params after the initial state has
+    // captured them, so the game filter can be cleared and a refresh doesn't
+    // re-apply it. Runs once on mount.
+    useEffect(() => {
+        if (!searchParams.has('qGameId') && !searchParams.has('qGameName')) return
+        const params = new URLSearchParams(searchParams)
+        params.delete('qGameId')
+        params.delete('qGameName')
+        setSearchParams(params, { replace: true })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
     // Owned here (not inside GeoMapsTab) so an in-flight manual run keeps
     // polling and the live banner stays visible when the operator switches
     // between Pins / Maps / Games tabs.
@@ -106,7 +131,9 @@ export function GeoReviewPanel() {
         if (health.coverage.withMap === 0) return 'acquisition'
         return 'queue'
     })()
-    const activeTab: GeoSubTab = subInUrl ?? resolvedDefault ?? 'queue'
+    // A game-seeded deep link always wants the queue, even before the health
+    // snapshot that drives resolvedDefault has loaded.
+    const activeTab: GeoSubTab = subInUrl ?? (seedGameId != null ? 'queue' : resolvedDefault) ?? 'queue'
     // When the cold-start state-machine routes to `catalog`, pre-select the
     // Candidats filter so the CTA the moderator sees in the empty state is
     // the curation funnel (the actual first action they need to take).

--- a/packages/frontend/src/components/admin/geo-review/ReviewWorkspace.tsx
+++ b/packages/frontend/src/components/admin/geo-review/ReviewWorkspace.tsx
@@ -123,6 +123,7 @@ export function ReviewWorkspace({
                 className="flex-1 space-y-3 p-4 sm:p-6 pt-0 sm:pt-0"
                 aria-busy={saving}
             >
+                {detail && <AgentPinsNotice pins={detail.pins} />}
                 <CompareBody
                     detail={detail}
                     pin={pin}
@@ -140,6 +141,39 @@ export function ReviewWorkspace({
                 />
             )}
         </Card>
+    )
+}
+
+// Surfaces machine-proposed pins (issue #331) to the moderator: which pins came
+// from an agent, their source tier, and the required rationale. Agent pins are
+// downweighted in consensus and never promote on their own, so this is context
+// for the human decision, not an action. Renders nothing when there are none.
+function AgentPinsNotice({ pins }: { pins: GeoPinSubmission[] }) {
+    const agentPins = pins.filter((p) => p.source && p.source !== 'human')
+    if (agentPins.length === 0) return null
+    return (
+        <div className="rounded-lg border border-neon-pink/40 bg-neon-pink/5 p-3 text-xs space-y-1.5">
+            <div className="font-semibold text-neon-pink">
+                {agentPins.length} pin{agentPins.length > 1 ? 's' : ''} proposé
+                {agentPins.length > 1 ? 's' : ''} par un agent (pondération réduite, jamais
+                promu automatiquement)
+            </div>
+            <ul className="space-y-1">
+                {agentPins.map((p) => (
+                    <li key={p.id} className="text-muted-foreground">
+                        <span className="font-mono">
+                            {p.source === 'agent_vision' ? 'vision' : 'structured'}
+                            {p.agentModel ? ` · ${p.agentModel}` : ''}
+                        </span>
+                        {p.agentRationale ? ` — ${p.agentRationale}` : ''}{' '}
+                        <span className="opacity-60">
+                            ({p.pin.x.toFixed(3)}, {p.pin.y.toFixed(3)}
+                            {p.status !== 'pending' ? ` · ${p.status}` : ''})
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </div>
     )
 }
 

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -11,6 +11,7 @@ import { UserList } from '@/components/admin/UserList'
 import { EmailSettings } from '@/components/admin/EmailSettings'
 import { GrowthStats } from '@/components/admin/GrowthStats'
 import { GeoGamersHealthCard } from '@/components/admin/GeoGamersHealthCard'
+import { GeoNeedingContentCard } from '@/components/admin/GeoNeedingContentCard'
 import { JobQueuePanel } from '@/components/admin/JobQueuePanel'
 import { GeoReviewPanel } from '@/components/admin/GeoReviewPanel'
 import { EmailLogPanel } from '@/components/admin/EmailLogPanel'
@@ -183,6 +184,7 @@ export default function AdminPage() {
               {activeTab === 'geo' && (
                 <>
                   <GeoGamersHealthCard />
+                  <GeoNeedingContentCard />
                   <GeoReviewPanel />
                 </>
               )}

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -12,6 +12,7 @@ import { EmailSettings } from '@/components/admin/EmailSettings'
 import { GrowthStats } from '@/components/admin/GrowthStats'
 import { GeoGamersHealthCard } from '@/components/admin/GeoGamersHealthCard'
 import { GeoNeedingContentCard } from '@/components/admin/GeoNeedingContentCard'
+import { AgentKeysCard } from '@/components/admin/AgentKeysCard'
 import { JobQueuePanel } from '@/components/admin/JobQueuePanel'
 import { GeoReviewPanel } from '@/components/admin/GeoReviewPanel'
 import { EmailLogPanel } from '@/components/admin/EmailLogPanel'
@@ -185,6 +186,7 @@ export default function AdminPage() {
                 <>
                   <GeoGamersHealthCard />
                   <GeoNeedingContentCard />
+                  <AgentKeysCard />
                   <GeoReviewPanel />
                 </>
               )}

--- a/packages/geo-agent-mcp/README.md
+++ b/packages/geo-agent-mcp/README.md
@@ -12,11 +12,12 @@ the key can't, and the key is read-only in this phase.
 
 ## Tools
 
-| Tool | Maps to | Args |
-|------|---------|------|
-| `geo_health` | `GET /health` | — |
-| `geo_games_needing_content` | `GET /games-needing-content` | `limit?` |
-| `geo_list_candidates` | `GET /games/:gameId/candidates` | `gameId`, `limit?` |
+| Tool | Maps to | Args | Scope |
+|------|---------|------|-------|
+| `geo_health` | `GET /health` | — | `geo-agent:read` |
+| `geo_games_needing_content` | `GET /games-needing-content` | `limit?` | `geo-agent:read` |
+| `geo_list_candidates` | `GET /games/:gameId/candidates` | `gameId`, `limit?` | `geo-agent:read` |
+| `geo_ingest_game` | `POST /games/:gameId/ingest` | `gameId`, `sources?` | `geo-agent:ingest` |
 
 ## Setup
 
@@ -58,5 +59,6 @@ Add to your MCP config (e.g. `.mcp.json` or the Claude Code settings):
 
 - stdout is the JSON-RPC channel; all diagnostics go to stderr.
 - The server echoes the client's requested MCP `protocolVersion`.
-- Ingest (`geo-agent:ingest`) and pin-proposal (`geo-agent:propose`) tools land
-  in phases 3–4; this build is read-only.
+- `geo_ingest_game` needs a key with the `geo-agent:ingest` scope and is bounded
+  by a per-key daily budget. Pin-proposal (`geo-agent:propose`) tools land in
+  phase 4.

--- a/packages/geo-agent-mcp/README.md
+++ b/packages/geo-agent-mcp/README.md
@@ -18,6 +18,7 @@ the key can't, and the key is read-only in this phase.
 | `geo_games_needing_content` | `GET /games-needing-content` | `limit?` | `geo-agent:read` |
 | `geo_list_candidates` | `GET /games/:gameId/candidates` | `gameId`, `limit?` | `geo-agent:read` |
 | `geo_ingest_game` | `POST /games/:gameId/ingest` | `gameId`, `sources?` | `geo-agent:ingest` |
+| `geo_propose_pin` | `POST /candidates/:id/pins` | `candidateId`, `x`, `y`, `source`, `rationale`, … | `geo-agent:propose` |
 
 ## Setup
 
@@ -59,6 +60,7 @@ Add to your MCP config (e.g. `.mcp.json` or the Claude Code settings):
 
 - stdout is the JSON-RPC channel; all diagnostics go to stderr.
 - The server echoes the client's requested MCP `protocolVersion`.
-- `geo_ingest_game` needs a key with the `geo-agent:ingest` scope and is bounded
-  by a per-key daily budget. Pin-proposal (`geo-agent:propose`) tools land in
-  phase 4.
+- `geo_ingest_game` needs `geo-agent:ingest` (per-key daily budget);
+  `geo_propose_pin` needs `geo-agent:propose` (per-key hourly budget). Proposed
+  pins are downweighted and can never promote ground truth on their own — they
+  join consensus as one flagged, human-reviewed voter.

--- a/packages/geo-agent-mcp/README.md
+++ b/packages/geo-agent-mcp/README.md
@@ -1,0 +1,62 @@
+# @the-box/geo-agent-mcp
+
+A tiny [MCP](https://modelcontextprotocol.io) stdio server that exposes The Box's
+**geo content-sourcing** read tools (issue #331, phase 2) to an MCP-capable
+agent such as the Claude Code CLI. Zero runtime dependencies — it speaks
+newline-delimited JSON-RPC directly.
+
+It is a thin wrapper: every tool maps 1:1 to a `GET` on the key-authenticated
+agent API (`/api/agent/v1/geo`). The MCP layer holds **no logic and no
+privileges of its own** — a compromised or hallucinating agent can do nothing
+the key can't, and the key is read-only in this phase.
+
+## Tools
+
+| Tool | Maps to | Args |
+|------|---------|------|
+| `geo_health` | `GET /health` | — |
+| `geo_games_needing_content` | `GET /games-needing-content` | `limit?` |
+| `geo_list_candidates` | `GET /games/:gameId/candidates` | `gameId`, `limit?` |
+
+## Setup
+
+1. **Mint a key.** Admin → Géo → *Clés agent Géo* → create a key with the
+   `geo-agent:read` scope. Copy the plaintext (`tb_pk_live_…`) — shown once.
+2. **Enable the surface.** Set `GEO_AGENT_API_ENABLED=true` on the backend and
+   redeploy. While off, every tool returns `AGENT_API_DISABLED`.
+3. **Build:** `npm run build -w @the-box/geo-agent-mcp`.
+
+## Wire into Claude Code
+
+Add to your MCP config (e.g. `.mcp.json` or the Claude Code settings):
+
+```json
+{
+  "mcpServers": {
+    "the-box-geo": {
+      "command": "node",
+      "args": ["packages/geo-agent-mcp/dist/index.js"],
+      "env": {
+        "THE_BOX_AGENT_KEY": "tb_pk_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "THE_BOX_API_URL": "https://the-box.battistella.ovh"
+      }
+    }
+  }
+}
+```
+
+`THE_BOX_API_URL` defaults to `http://localhost:3000` for local dev.
+
+## Env
+
+| Var | Required | Default | Purpose |
+|-----|----------|---------|---------|
+| `THE_BOX_AGENT_KEY` | yes | — | geo-agent API key (bearer) |
+| `THE_BOX_API_URL` | no | `http://localhost:3000` | backend base URL |
+
+## Notes
+
+- stdout is the JSON-RPC channel; all diagnostics go to stderr.
+- The server echoes the client's requested MCP `protocolVersion`.
+- Ingest (`geo-agent:ingest`) and pin-proposal (`geo-agent:propose`) tools land
+  in phases 3–4; this build is read-only.

--- a/packages/geo-agent-mcp/package.json
+++ b/packages/geo-agent-mcp/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@the-box/geo-agent-mcp",
+  "version": "2.139.0",
+  "private": true,
+  "description": "MCP stdio server exposing The Box geo content-sourcing read tools (issue #331)",
+  "type": "module",
+  "bin": {
+    "the-box-geo-agent-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "node --import tsx --test 'src/**/*.test.ts'"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/geo-agent-mcp/src/index.ts
+++ b/packages/geo-agent-mcp/src/index.ts
@@ -10,7 +10,7 @@
 // Wire into Claude Code (see README.md) with an `mcpServers` entry pointing at
 // this file and the two env vars.
 
-import { handleRpc, type JsonRpcMessage } from './server.js'
+import { handleRpc, type ApiRequest, type JsonRpcMessage } from './server.js'
 
 const API_URL = (process.env['THE_BOX_API_URL'] ?? 'http://localhost:3000').replace(/\/+$/, '')
 const AGENT_KEY = process.env['THE_BOX_AGENT_KEY'] ?? ''
@@ -23,10 +23,17 @@ if (!AGENT_KEY) {
   log('WARNING: THE_BOX_AGENT_KEY is not set — every tool call will fail with 401.')
 }
 
-async function callApi(path: string): Promise<unknown> {
-  const res = await fetch(`${API_URL}${path}`, {
+async function callApi(reqSpec: ApiRequest): Promise<unknown> {
+  const method = reqSpec.method ?? 'GET'
+  const init: RequestInit = {
+    method,
     headers: { Authorization: `Bearer ${AGENT_KEY}`, Accept: 'application/json' },
-  })
+  }
+  if (method === 'POST') {
+    ;(init.headers as Record<string, string>)['Content-Type'] = 'application/json'
+    init.body = JSON.stringify(reqSpec.body ?? {})
+  }
+  const res = await fetch(`${API_URL}${reqSpec.path}`, init)
   const json = (await res.json().catch(() => ({}))) as {
     success?: boolean
     data?: unknown

--- a/packages/geo-agent-mcp/src/index.ts
+++ b/packages/geo-agent-mcp/src/index.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// MCP stdio entrypoint for the geo content-sourcing tools (issue #331).
+// Speaks newline-delimited JSON-RPC on stdin/stdout — the MCP stdio transport.
+// stdout is the protocol channel; all diagnostics go to stderr.
+//
+// Config via env:
+//   THE_BOX_AGENT_KEY   (required) — a geo-agent API key (tb_pk_live_… / test)
+//   THE_BOX_API_URL     (optional) — backend base URL, default http://localhost:3000
+//
+// Wire into Claude Code (see README.md) with an `mcpServers` entry pointing at
+// this file and the two env vars.
+
+import { handleRpc, type JsonRpcMessage } from './server.js'
+
+const API_URL = (process.env['THE_BOX_API_URL'] ?? 'http://localhost:3000').replace(/\/+$/, '')
+const AGENT_KEY = process.env['THE_BOX_AGENT_KEY'] ?? ''
+
+function log(msg: string): void {
+  process.stderr.write(`[geo-agent-mcp] ${msg}\n`)
+}
+
+if (!AGENT_KEY) {
+  log('WARNING: THE_BOX_AGENT_KEY is not set — every tool call will fail with 401.')
+}
+
+async function callApi(path: string): Promise<unknown> {
+  const res = await fetch(`${API_URL}${path}`, {
+    headers: { Authorization: `Bearer ${AGENT_KEY}`, Accept: 'application/json' },
+  })
+  const json = (await res.json().catch(() => ({}))) as {
+    success?: boolean
+    data?: unknown
+    error?: { code?: string }
+  }
+  if (!res.ok || !json?.success) {
+    throw new Error(json?.error?.code ?? `HTTP ${res.status}`)
+  }
+  return json.data
+}
+
+function write(obj: object): void {
+  process.stdout.write(`${JSON.stringify(obj)}\n`)
+}
+
+async function main(): Promise<void> {
+  let buffer = ''
+  process.stdin.setEncoding('utf8')
+  process.stdin.on('data', (chunk: string) => {
+    buffer += chunk
+    let nl: number
+    // Process every complete newline-delimited message; keep the remainder.
+    while ((nl = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, nl).trim()
+      buffer = buffer.slice(nl + 1)
+      if (!line) continue
+      let msg: JsonRpcMessage
+      try {
+        msg = JSON.parse(line) as JsonRpcMessage
+      } catch {
+        log(`skipping unparseable line: ${line.slice(0, 120)}`)
+        continue
+      }
+      void handleRpc(msg, { callApi })
+        .then((response) => {
+          if (response) write(response)
+        })
+        .catch((err) => log(`handler error: ${String(err)}`))
+    }
+  })
+  process.stdin.on('end', () => process.exit(0))
+  log(`ready — API ${API_URL}`)
+}
+
+void main()

--- a/packages/geo-agent-mcp/src/server.test.ts
+++ b/packages/geo-agent-mcp/src/server.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { handleRpc, resolveToolPath, TOOLS, SERVER_INFO } from './server.js'
+
+const noopApi = async () => ({})
+
+describe('resolveToolPath', () => {
+  it('maps geo_health to the health path', () => {
+    assert.deepEqual(resolveToolPath('geo_health', {}), {
+      path: '/api/agent/v1/geo/health',
+    })
+  })
+
+  it('appends a validated limit', () => {
+    assert.deepEqual(resolveToolPath('geo_games_needing_content', { limit: 5 }), {
+      path: '/api/agent/v1/geo/games-needing-content?limit=5',
+    })
+  })
+
+  it('rejects a non-positive limit', () => {
+    const out = resolveToolPath('geo_games_needing_content', { limit: -1 })
+    assert.ok('error' in out)
+  })
+
+  it('requires a positive gameId for candidates', () => {
+    assert.ok('error' in resolveToolPath('geo_list_candidates', {}))
+    assert.deepEqual(resolveToolPath('geo_list_candidates', { gameId: 42, limit: 10 }), {
+      path: '/api/agent/v1/geo/games/42/candidates?limit=10',
+    })
+  })
+
+  it('errors on an unknown tool', () => {
+    assert.ok('error' in resolveToolPath('nope', {}))
+  })
+})
+
+describe('handleRpc', () => {
+  it('echoes the client protocol version on initialize', async () => {
+    const res = (await handleRpc(
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } },
+      { callApi: noopApi },
+    )) as { result: { protocolVersion: string; serverInfo: { name: string } } }
+    assert.equal(res.result.protocolVersion, '2025-06-18')
+    assert.equal(res.result.serverInfo.name, SERVER_INFO.name)
+  })
+
+  it('lists all tools', async () => {
+    const res = (await handleRpc(
+      { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      { callApi: noopApi },
+    )) as { result: { tools: unknown[] } }
+    assert.equal(res.result.tools.length, TOOLS.length)
+  })
+
+  it('returns null for notifications (no id)', async () => {
+    const res = await handleRpc(
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      { callApi: noopApi },
+    )
+    assert.equal(res, null)
+  })
+
+  it('calls the API and wraps the result as tool text', async () => {
+    let called = ''
+    const res = (await handleRpc(
+      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'geo_health', arguments: {} } },
+      {
+        callApi: async (path) => {
+          called = path
+          return { starved: true, eligibleGames: 9 }
+        },
+      },
+    )) as { result: { content: Array<{ text: string }>; isError?: boolean } }
+    assert.equal(called, '/api/agent/v1/geo/health')
+    assert.equal(res.result.isError ?? false, false)
+    assert.match(res.result.content[0]!.text, /eligibleGames/)
+  })
+
+  it('surfaces an API error as an isError tool result, not a crash', async () => {
+    const res = (await handleRpc(
+      { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'geo_health', arguments: {} } },
+      {
+        callApi: async () => {
+          throw new Error('UNAUTHORIZED')
+        },
+      },
+    )) as { result: { content: Array<{ text: string }>; isError?: boolean } }
+    assert.equal(res.result.isError, true)
+    assert.match(res.result.content[0]!.text, /UNAUTHORIZED/)
+  })
+
+  it('returns method-not-found for an unknown method', async () => {
+    const res = (await handleRpc(
+      { jsonrpc: '2.0', id: 5, method: 'bogus/method' },
+      { callApi: noopApi },
+    )) as { error: { code: number } }
+    assert.equal(res.error.code, -32601)
+  })
+})

--- a/packages/geo-agent-mcp/src/server.test.ts
+++ b/packages/geo-agent-mcp/src/server.test.ts
@@ -29,6 +29,23 @@ describe('resolveToolPath', () => {
     })
   })
 
+  it('maps geo_ingest_game to a POST with a sources body', () => {
+    assert.deepEqual(
+      resolveToolPath('geo_ingest_game', { gameId: 7, sources: ['fandom', 'wand'] }),
+      { path: '/api/agent/v1/geo/games/7/ingest', method: 'POST', body: { sources: ['fandom', 'wand'] } },
+    )
+    // Sources omitted → POST with an empty body (server defaults to all tiers).
+    assert.deepEqual(resolveToolPath('geo_ingest_game', { gameId: 7 }), {
+      path: '/api/agent/v1/geo/games/7/ingest',
+      method: 'POST',
+      body: {},
+    })
+  })
+
+  it('rejects geo_ingest_game without a gameId', () => {
+    assert.ok('error' in resolveToolPath('geo_ingest_game', { sources: ['fandom'] }))
+  })
+
   it('errors on an unknown tool', () => {
     assert.ok('error' in resolveToolPath('nope', {}))
   })
@@ -65,8 +82,8 @@ describe('handleRpc', () => {
     const res = (await handleRpc(
       { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'geo_health', arguments: {} } },
       {
-        callApi: async (path) => {
-          called = path
+        callApi: async (req) => {
+          called = req.path
           return { starved: true, eligibleGames: 9 }
         },
       },

--- a/packages/geo-agent-mcp/src/server.test.ts
+++ b/packages/geo-agent-mcp/src/server.test.ts
@@ -46,6 +46,29 @@ describe('resolveToolPath', () => {
     assert.ok('error' in resolveToolPath('geo_ingest_game', { sources: ['fandom'] }))
   })
 
+  it('maps geo_propose_pin to a POST with the pin body', () => {
+    assert.deepEqual(
+      resolveToolPath('geo_propose_pin', {
+        candidateId: 88,
+        x: 0.4,
+        y: 0.6,
+        source: 'agent_structured',
+        rationale: 'landmark match',
+        model: 'm',
+      }),
+      {
+        path: '/api/agent/v1/geo/candidates/88/pins',
+        method: 'POST',
+        body: { x: 0.4, y: 0.6, source: 'agent_structured', rationale: 'landmark match', model: 'm' },
+      },
+    )
+  })
+
+  it('rejects geo_propose_pin missing required fields', () => {
+    assert.ok('error' in resolveToolPath('geo_propose_pin', { candidateId: 1, x: 0.5, y: 0.5, source: 'agent_vision' })) // no rationale
+    assert.ok('error' in resolveToolPath('geo_propose_pin', { candidateId: 1, x: 0.5, y: 0.5, rationale: 'x', source: 'human' })) // bad source
+  })
+
   it('errors on an unknown tool', () => {
     assert.ok('error' in resolveToolPath('nope', {}))
   })

--- a/packages/geo-agent-mcp/src/server.ts
+++ b/packages/geo-agent-mcp/src/server.ts
@@ -73,6 +73,30 @@ export const TOOLS: ToolDef[] = [
       additionalProperties: false,
     },
   },
+  {
+    name: 'geo_propose_pin',
+    description:
+      "Propose a location pin for a capture (needs a geo-agent:propose key). The pin is DOWNWEIGHTED and can never promote ground truth on its own — it joins consensus as one flagged voter, reviewed by humans. `rationale` is required. Propose only when confident; a wrong pin poisons the centroid.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        candidateId: { type: 'number', description: 'geo_screenshot_candidate id (required)' },
+        x: { type: 'number', description: 'Normalized x in [0,1] (required)' },
+        y: { type: 'number', description: 'Normalized y in [0,1] (required)' },
+        source: {
+          type: 'string',
+          enum: ['agent_structured', 'agent_vision'],
+          description: 'agent_structured (scraped coords) or agent_vision (LLM localization)',
+        },
+        rationale: { type: 'string', description: 'Why this location — the review artifact (required, <=500 chars)' },
+        confidence: { type: 'number', enum: [1, 2, 3], description: 'Optional self-reported confidence (1 sure … 3 guess)' },
+        model: { type: 'string', description: 'Optional model id for a vision pin' },
+        visionPass: { type: 'number', description: 'Optional independent vision pass index 0-2' },
+      },
+      required: ['candidateId', 'x', 'y', 'source', 'rationale'],
+      additionalProperties: false,
+    },
+  },
 ]
 
 function asPositiveInt(value: unknown): number | null {
@@ -115,6 +139,29 @@ export function resolveToolPath(
         body['sources'] = a['sources']
       }
       return { path: `/api/agent/v1/geo/games/${gameId}/ingest`, method: 'POST', body }
+    }
+    case 'geo_propose_pin': {
+      const candidateId = asPositiveInt(a['candidateId'])
+      if (candidateId === null) return { error: 'candidateId is required and must be a positive integer' }
+      if (typeof a['x'] !== 'number' || typeof a['y'] !== 'number') {
+        return { error: 'x and y are required numbers in [0,1]' }
+      }
+      if (a['source'] !== 'agent_structured' && a['source'] !== 'agent_vision') {
+        return { error: 'source must be agent_structured or agent_vision' }
+      }
+      if (typeof a['rationale'] !== 'string' || a['rationale'].trim() === '') {
+        return { error: 'rationale is required' }
+      }
+      const body: Record<string, unknown> = {
+        x: a['x'],
+        y: a['y'],
+        source: a['source'],
+        rationale: a['rationale'],
+      }
+      for (const k of ['confidence', 'model', 'visionPass'] as const) {
+        if (a[k] !== undefined) body[k] = a[k]
+      }
+      return { path: `/api/agent/v1/geo/candidates/${candidateId}/pins`, method: 'POST', body }
     }
     default:
       return { error: `unknown tool: ${name}` }

--- a/packages/geo-agent-mcp/src/server.ts
+++ b/packages/geo-agent-mcp/src/server.ts
@@ -1,0 +1,151 @@
+// Zero-dependency MCP server core for The Box geo content-sourcing tools
+// (issue #331, phase 2). Pure JSON-RPC dispatch — no stdio, no network — so it
+// is fully unit-testable. `index.ts` wires this to a newline-delimited stdio
+// transport and a real HTTP client.
+
+export const SERVER_INFO = { name: 'the-box-geo-agent', version: '2.139.0' } as const
+export const DEFAULT_PROTOCOL_VERSION = '2024-11-05'
+
+export interface ToolDef {
+  name: string
+  description: string
+  inputSchema: {
+    type: 'object'
+    properties: Record<string, unknown>
+    required?: string[]
+    additionalProperties?: boolean
+  }
+}
+
+// Maps a tool call to a GET path on /api/agent/v1/geo. Kept declarative so the
+// tool list and the routing agree by construction.
+export const TOOLS: ToolDef[] = [
+  {
+    name: 'geo_health',
+    description:
+      'GeoGamers content-readiness snapshot: eligible game count, whether the pool is starved, and the min required. No arguments.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'geo_games_needing_content',
+    description:
+      'The "one pin away" list: games with an active map and captures collecting pins but no canonical pin yet — where a proposed pin would grow the eligible pool. Sorted by proximity to promotion.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'Max games (1-100, default 25)' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'geo_list_candidates',
+    description:
+      "Unpinned/collecting captures for a game plus its active maps (image url + dimensions), so a proposer can localize a screenshot.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'number', description: 'Game id (required)' },
+        limit: { type: 'number', description: 'Max captures (1-100, default 50)' },
+      },
+      required: ['gameId'],
+      additionalProperties: false,
+    },
+  },
+]
+
+function asPositiveInt(value: unknown): number | null {
+  const n = Number(value)
+  return Number.isInteger(n) && n > 0 ? n : null
+}
+
+/** Resolve a tool call to the agent-API path, or an error message. */
+export function resolveToolPath(
+  name: string,
+  args: Record<string, unknown> | undefined,
+): { path: string } | { error: string } {
+  const a = args ?? {}
+  const limit = a['limit'] !== undefined ? asPositiveInt(a['limit']) : undefined
+  if (a['limit'] !== undefined && limit === null) return { error: 'limit must be a positive integer' }
+  const qs = limit !== undefined ? `?limit=${limit}` : ''
+
+  switch (name) {
+    case 'geo_health':
+      return { path: '/api/agent/v1/geo/health' }
+    case 'geo_games_needing_content':
+      return { path: `/api/agent/v1/geo/games-needing-content${qs}` }
+    case 'geo_list_candidates': {
+      const gameId = asPositiveInt(a['gameId'])
+      if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
+      return { path: `/api/agent/v1/geo/games/${gameId}/candidates${qs}` }
+    }
+    default:
+      return { error: `unknown tool: ${name}` }
+  }
+}
+
+export interface JsonRpcMessage {
+  jsonrpc?: string
+  id?: string | number | null
+  method?: string
+  params?: Record<string, unknown>
+}
+
+export interface RpcDeps {
+  // Perform an authenticated GET against the agent API, returning parsed JSON.
+  callApi: (path: string) => Promise<unknown>
+  protocolVersion?: string
+}
+
+function result(id: JsonRpcMessage['id'], value: unknown) {
+  return { jsonrpc: '2.0', id, result: value }
+}
+function rpcError(id: JsonRpcMessage['id'], code: number, message: string) {
+  return { jsonrpc: '2.0', id, error: { code, message } }
+}
+function toolText(text: string, isError = false) {
+  return { content: [{ type: 'text', text }], isError }
+}
+
+/**
+ * Handle a single JSON-RPC message. Returns the response object to write, or
+ * null for notifications (no id) which take no reply.
+ */
+export async function handleRpc(
+  msg: JsonRpcMessage,
+  deps: RpcDeps,
+): Promise<object | null> {
+  // Notifications carry no id and expect no response.
+  if (msg.id === undefined || msg.id === null) return null
+
+  switch (msg.method) {
+    case 'initialize':
+      return result(msg.id, {
+        protocolVersion:
+          (msg.params?.['protocolVersion'] as string | undefined) ??
+          deps.protocolVersion ??
+          DEFAULT_PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      })
+    case 'ping':
+      return result(msg.id, {})
+    case 'tools/list':
+      return result(msg.id, { tools: TOOLS })
+    case 'tools/call': {
+      const name = msg.params?.['name'] as string | undefined
+      const args = msg.params?.['arguments'] as Record<string, unknown> | undefined
+      if (!name) return rpcError(msg.id, -32602, 'missing tool name')
+      const resolved = resolveToolPath(name, args)
+      if ('error' in resolved) return result(msg.id, toolText(resolved.error, true))
+      try {
+        const data = await deps.callApi(resolved.path)
+        return result(msg.id, toolText(JSON.stringify(data, null, 2)))
+      } catch (err) {
+        return result(msg.id, toolText(`request failed: ${String(err)}`, true))
+      }
+    }
+    default:
+      return rpcError(msg.id, -32601, `method not found: ${msg.method}`)
+  }
+}

--- a/packages/geo-agent-mcp/src/server.ts
+++ b/packages/geo-agent-mcp/src/server.ts
@@ -52,6 +52,27 @@ export const TOOLS: ToolDef[] = [
       additionalProperties: false,
     },
   },
+  {
+    name: 'geo_ingest_game',
+    description:
+      'Trigger the map-ingestion pipeline for a game (needs a geo-agent:ingest key). Optionally restrict to specific tiers; defaults to all. Subject to a per-key daily budget.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'number', description: 'Game id (required)' },
+        sources: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['registry', 'fandom', 'strategywiki', 'fextralife', 'wand', 'wikidata'],
+          },
+          description: 'Optional tier allowlist; omit for all',
+        },
+      },
+      required: ['gameId'],
+      additionalProperties: false,
+    },
+  },
 ]
 
 function asPositiveInt(value: unknown): number | null {
@@ -59,11 +80,17 @@ function asPositiveInt(value: unknown): number | null {
   return Number.isInteger(n) && n > 0 ? n : null
 }
 
-/** Resolve a tool call to the agent-API path, or an error message. */
+export interface ApiRequest {
+  path: string
+  method?: 'GET' | 'POST'
+  body?: unknown
+}
+
+/** Resolve a tool call to an agent-API request, or an error message. */
 export function resolveToolPath(
   name: string,
   args: Record<string, unknown> | undefined,
-): { path: string } | { error: string } {
+): ApiRequest | { error: string } {
   const a = args ?? {}
   const limit = a['limit'] !== undefined ? asPositiveInt(a['limit']) : undefined
   if (a['limit'] !== undefined && limit === null) return { error: 'limit must be a positive integer' }
@@ -79,6 +106,16 @@ export function resolveToolPath(
       if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
       return { path: `/api/agent/v1/geo/games/${gameId}/candidates${qs}` }
     }
+    case 'geo_ingest_game': {
+      const gameId = asPositiveInt(a['gameId'])
+      if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
+      const body: Record<string, unknown> = {}
+      if (a['sources'] !== undefined) {
+        if (!Array.isArray(a['sources'])) return { error: 'sources must be an array' }
+        body['sources'] = a['sources']
+      }
+      return { path: `/api/agent/v1/geo/games/${gameId}/ingest`, method: 'POST', body }
+    }
     default:
       return { error: `unknown tool: ${name}` }
   }
@@ -92,8 +129,9 @@ export interface JsonRpcMessage {
 }
 
 export interface RpcDeps {
-  // Perform an authenticated GET against the agent API, returning parsed JSON.
-  callApi: (path: string) => Promise<unknown>
+  // Perform an authenticated request against the agent API, returning parsed
+  // JSON. Defaults to GET; the ingest tool issues a POST with a JSON body.
+  callApi: (req: ApiRequest) => Promise<unknown>
   protocolVersion?: string
 }
 
@@ -139,7 +177,7 @@ export async function handleRpc(
       const resolved = resolveToolPath(name, args)
       if ('error' in resolved) return result(msg.id, toolText(resolved.error, true))
       try {
-        const data = await deps.callApi(resolved.path)
+        const data = await deps.callApi(resolved)
         return result(msg.id, toolText(JSON.stringify(data, null, 2)))
       } catch (err) {
         return result(msg.id, toolText(`request failed: ${String(err)}`, true))

--- a/packages/geo-agent-mcp/tsconfig.json
+++ b/packages/geo-agent-mcp/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1238,6 +1238,24 @@ export interface GeoGameNeedingContent {
   bestCandidateId: number | null
 }
 
+// Content-readiness snapshot for the GeoGamers daily scheduler. Returned by
+// GET /api/admin/geogamers/health and, for content-sourcing agents, by
+// GET /api/agent/v1/geo/health. `starved` is the gate the daily worker itself
+// checks: fewer than `minRequired` distinct eligible games means a day can
+// silently skip.
+export interface GeoGamersHealthSnapshot {
+  enabled: boolean
+  minRequired: number
+  cooldownDays: number
+  eligibleGames: number
+  eligibleScreenshots: number
+  gamesOnCooldown: number
+  starved: boolean
+  todayChallengeExists: boolean
+  currentChallengeDate: string | null
+  season: { month: string; players: number }
+}
+
 export interface GeoChallenge {
   id: number
   challengeDate: string
@@ -1605,10 +1623,33 @@ export interface PushSubscriptionSummary {
 // Public API / Streamer Kit (M1)
 // ============================================
 
-// One of four scopes a key can carry. M1 only branches on read:public vs the
-// owner-only scopes; the latter three are stored against the key for forward
-// compatibility with M2 (SSE + webhooks) so we don't need a second migration.
-export type ApiKeyScope = 'read:public' | 'read:self' | 'stream:self' | 'webhooks:self'
+// Scopes a key can carry. The streamer-kit scopes (`read:public` … `webhooks:self`)
+// gate the public streamer API; the `geo-agent:*` scopes gate the separate
+// agent content-sourcing surface (`/api/agent/v1/geo`, issue #331). The two
+// families are mutually exclusive on a single key — a geo-agent key is minted by
+// an admin and can only reach the agent surface, never a streamer's data, and a
+// streamer key is rejected on the agent surface. Enforced at mint time and by
+// `requireScope` per route.
+export type ApiKeyScope =
+  | 'read:public'
+  | 'read:self'
+  | 'stream:self'
+  | 'webhooks:self'
+  | 'geo-agent:read' // health, games-needing-content, candidate listing
+  | 'geo-agent:ingest' // trigger the existing geo ingestion pipeline (phase 3)
+  | 'geo-agent:propose' // submit downweighted, flagged consensus pins (phase 4)
+
+// The three geo-agent scopes, in privilege order. A read-only key carries only
+// the first; ingest/propose are granted per key as later phases ship.
+export const GEO_AGENT_SCOPES = [
+  'geo-agent:read',
+  'geo-agent:ingest',
+  'geo-agent:propose',
+] as const satisfies readonly ApiKeyScope[]
+
+export function isGeoAgentScope(scope: ApiKeyScope): boolean {
+  return scope.startsWith('geo-agent:')
+}
 
 export type ApiKeyMode = 'live' | 'test'
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1222,6 +1222,22 @@ export interface GeoCandidateGameSummary {
   oldestPendingAt: string | null
 }
 
+// Diagnostic surfaced by the admin "content readiness" card: games that have
+// an active map and captures collecting pins but no canonical (promoted) pin
+// yet — the "one pin away" list that gates GeoGamers eligibility. Promoting one
+// candidate for such a game (that has never been a challenge) grows the eligible
+// pool by one. `topPinCount` is the raw submission count on the best candidate;
+// `pinsToNextThreshold` is how many more pins until the next consensus recompute
+// could promote it (0 once past the top threshold).
+export interface GeoGameNeedingContent {
+  gameId: number
+  gameName: string | null
+  candidateCount: number
+  topPinCount: number
+  pinsToNextThreshold: number
+  bestCandidateId: number | null
+}
+
 export interface GeoChallenge {
   id: number
   challengeDate: string

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1388,9 +1388,15 @@ export type GeoPinConfidence = 1 | 2 | 3
 
 export type GeoPinStatus = 'pending' | 'accepted' | 'rejected'
 
+// Provenance of a pin. `human` is a crowd/contributor pin; the `agent_*` values
+// are machine-proposed pins (issue #331) that are downweighted in consensus and
+// — critically — never counted toward the human-gated promote threshold.
+export type GeoPinSource = 'human' | 'agent_structured' | 'agent_vision'
+
 export interface GeoPinSubmission {
   id: number
-  userId: string
+  // Null for agent-proposed pins (they belong to an API key, not a user).
+  userId: string | null
   geoScreenshotCandidateId: number
   pin: GeoPoint
   status: GeoPinStatus
@@ -1400,6 +1406,12 @@ export interface GeoPinSubmission {
   // admin moderation can downweight or filter without re-deriving
   // provenance after the fact.
   isAnonymous: boolean
+  // Pin provenance. Defaults to 'human'; agent pins carry an agent source plus
+  // the fields below for review.
+  source: GeoPinSource
+  agentRationale?: string
+  agentModel?: string
+  visionPass?: number
   distanceFromCentroid?: number
   reviewedAt?: string
   createdAt: string

--- a/tasks/prd-geo-agent-sourcing.html
+++ b/tasks/prd-geo-agent-sourcing.html
@@ -1,0 +1,679 @@
+<!-- SUMMARY:
+Detailed implementation plan for issue #331 (agent-assisted geo content sourcing).
+Corrects four code-level assumptions in the original proposal, fixes a consensus
+auto-promote hole (agent pins alone could reach MIN_PINS_TO_PROMOTE), specs the
+pin-provenance migration, the /api/agent/v1/geo surface, budgets, and a 7-phase
+delivery plan with file-level tasks. Recommends dropping the promote_pin tool.
+-->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Geo Agent Sourcing — Implementation Plan (#331)</title>
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --panel: #12121a;
+    --panel-2: #17171f;
+    --border: #26263a;
+    --text: #d6d6e0;
+    --muted: #8b8b9e;
+    --primary: #a855f7;
+    --primary-dim: #7c3aed;
+    --pink: #ec4899;
+    --ok: #34d399;
+    --warn: #fbbf24;
+    --bad: #f87171;
+    --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 16px/1.65 Inter, system-ui, -apple-system, "Segoe UI", sans-serif;
+    padding: 2.5rem 1.25rem 6rem;
+  }
+  main { max-width: 72ch; margin: 0 auto; }
+  h1, h2, h3 { line-height: 1.25; color: #fff; }
+  h1 { font-size: 1.7rem; margin: 0 0 .25rem; }
+  h1 .accent {
+    background: linear-gradient(90deg, var(--primary), var(--pink));
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  h2 {
+    font-size: 1.25rem; margin: 3rem 0 .75rem;
+    padding-top: 1.5rem; border-top: 1px solid var(--border);
+  }
+  h2 .num { color: var(--primary); font-family: var(--mono); font-size: 1rem; margin-right: .5rem; }
+  h3 { font-size: 1.02rem; margin: 1.75rem 0 .5rem; }
+  p { margin: .7rem 0; }
+  a { color: var(--primary); }
+  a:focus-visible, summary:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+  code, pre {
+    font-family: var(--mono); font-size: .84em;
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px;
+  }
+  code { padding: .1em .35em; }
+  pre {
+    padding: .9rem 1rem; overflow-x: auto; line-height: 1.55;
+    margin: .9rem 0;
+  }
+  pre code { background: none; border: none; padding: 0; }
+  table {
+    width: 100%; border-collapse: collapse; margin: 1rem 0;
+    font-size: .88rem; display: block; overflow-x: auto;
+  }
+  th, td {
+    text-align: left; padding: .5rem .65rem; border: 1px solid var(--border);
+    vertical-align: top;
+  }
+  th { background: var(--panel); color: #fff; white-space: nowrap; }
+  td code { white-space: nowrap; }
+  .meta {
+    color: var(--muted); font-size: .85rem; margin-bottom: 2rem;
+    font-family: var(--mono);
+  }
+  .badge {
+    display: inline-block; font-family: var(--mono); font-size: .72rem;
+    padding: .1rem .5rem; border-radius: 999px; border: 1px solid var(--border);
+    vertical-align: middle; margin-left: .35rem;
+  }
+  .badge.ship { color: var(--ok); border-color: var(--ok); }
+  .badge.risk { color: var(--bad); border-color: var(--bad); }
+  .badge.gate { color: var(--warn); border-color: var(--warn); }
+  .callout {
+    border-left: 3px solid var(--primary); background: var(--panel);
+    padding: .75rem 1rem; border-radius: 0 6px 6px 0; margin: 1rem 0;
+  }
+  .callout.danger { border-left-color: var(--bad); }
+  .callout.ok { border-left-color: var(--ok); }
+  .callout strong:first-child { color: #fff; }
+  .tldr {
+    background: var(--panel); border: 1px solid var(--primary-dim);
+    border-radius: 8px; padding: 1rem 1.25rem; margin: 1.5rem 0;
+    box-shadow: 0 0 24px rgba(168, 85, 247, .12);
+  }
+  .tldr h2 { border: none; margin: 0 0 .5rem; padding: 0; font-size: 1.05rem; }
+  ul, ol { padding-left: 1.4rem; }
+  li { margin: .3rem 0; }
+  li::marker { color: var(--primary); }
+  .phase {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+    padding: 1rem 1.25rem; margin: 1.25rem 0;
+  }
+  .phase h3 { margin-top: 0; }
+  .files { font-family: var(--mono); font-size: .78rem; color: var(--muted); margin-top: .6rem; }
+  .files b { color: var(--text); font-weight: 500; }
+  figure { margin: 1.5rem 0; }
+  figcaption { color: var(--muted); font-size: .82rem; text-align: center; margin-top: .4rem; }
+  svg text { font-family: var(--mono); }
+  .small { font-size: .85rem; color: var(--muted); }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { transition: none !important; animation: none !important; }
+  }
+</style>
+
+<main>
+<h1>Geo Agent Sourcing — <span class="accent">Implementation Plan</span></h1>
+<p class="meta">issue #331 · rev 1 · 2026-07-10 · grounded in code as of <code>e9968db</code> (v2.139.0)</p>
+
+<div class="tldr">
+<h2>TL;DR</h2>
+<p>Issue #331's direction is right: the pin is the bottleneck, the agent proposes,
+consensus disposes. This plan grounds it in the actual code and changes five things:</p>
+<ol>
+  <li><strong>Fixes an auto-promote hole</strong> — under today's consensus rules,
+      5 tightly-clustered agent pins would satisfy <code>MIN_PINS_TO_PROMOTE</code>
+      and silently become ground truth with zero humans. Agent pins must never
+      count toward the promote gate.</li>
+  <li><strong>Corrects the structured-coordinates assumption</strong> — MapGenie/Wand
+      adapters only fetch a flat <code>og:image</code> today; no adapter extracts
+      marker coordinates. Phase 4 is real new work, and the hard part is
+      screenshot↔landmark <em>association</em>, not scraping.</li>
+  <li><strong>Drops <code>geo.promote_pin</code> from the agent surface</strong> —
+      promotion already exists as the admin override route; a promote tool (even
+      "admin-gated") violates propose/dispose for zero gain.</li>
+  <li><strong>Specs the missing provenance model</strong> — <code>geo_pin_submission</code>
+      has no <code>source</code> column and requires a non-null <code>user_id</code>;
+      agent pins need a migration, not just a flag.</li>
+  <li><strong>Separates key minting from streamer self-service</strong> — scopes exist
+      but are unenforced and not settable at mint; geo-agent keys must be
+      admin-minted only.</li>
+</ol>
+<p><strong>Ship order:</strong> Phase 1 (diagnostic endpoint + admin card) is standalone
+and unblocks manual pinning toward the 10-game GeoGamers gate today.</p>
+</div>
+
+<h2><span class="num">1</span>Reality check — issue assumptions vs. the code</h2>
+
+<p>Everything below was verified against the backend at <code>e9968db</code>.
+Each row changes the plan's shape.</p>
+
+<table>
+<thead><tr><th>#331 says / implies</th><th>What the code says</th><th>Impact on plan</th></tr></thead>
+<tbody>
+<tr>
+  <td>Machine pins are "downweighted + flagged <code>source='agent'</code>"</td>
+  <td>No provenance column exists. <code>geo_pin_submission</code> =
+      <code>user_id (NOT NULL, FK)</code>, <code>x</code>, <code>y</code>, <code>status</code>,
+      <code>confidence (1..3)</code>, <code>is_anonymous</code>,
+      <code>distance_from_centroid</code> — plus unique <code>(user_id, candidate_id)</code>
+      (<code>migrations/20260419_add_geolocation_mode.ts:121</code>)</td>
+  <td>New migration (§4). Must also decide the <em>identity</em> of an agent pin —
+      it has no user. We use nullable <code>user_id</code> + <code>agent_key_id</code>
+      with a CHECK, not a synthetic user (§3.1).</td>
+</tr>
+<tr>
+  <td>"Downweighted" voter in consensus</td>
+  <td>Weighting is <em>only</em> self-reported confidence:
+      <code>GEO_CONSENSUS_CONFIDENCE_WEIGHTS = {1: 1.0, 2: 0.66, 3: 0.33}</code>.
+      Contributor trust/tier is <b>not</b> a weight input. Promote gate:
+      <code>acceptedCount ≥ 5 &amp;&amp; confidence ≥ 0.5</code>
+      (<code>geo-consensus.service.ts:75</code>)</td>
+  <td class="callout danger" style="display:table-cell">
+      <strong>Safety hole:</strong> downweighting alone is insufficient — weight
+      affects the centroid, not the count. 5 agent pins in a tight cluster would
+      auto-promote. Fix: agent pins are excluded from the promote count entirely (§3.2).</td>
+</tr>
+<tr>
+  <td>"The pipeline already has Wand/MapGenie adapters to build on" (for structured
+      coordinates)</td>
+  <td>True for <em>maps</em> only. <code>maps-fetch-mapgenie.ts</code> /
+      <code>geo-wand-import-logic.ts</code> fetch <code>og:image</code>, probe
+      dimensions, insert a <code>geo_map</code> row. Marker crawling is an explicit
+      "phase-2 crawler" placeholder (<code>maps-fetch-mapgenie.ts:11-15</code>).
+      No adapter anywhere produces coordinates.</td>
+  <td>Phase 4 re-scoped (§6): marker crawler + coordinate-space normalization +
+      the genuinely hard problem — associating a <em>screenshot</em> with a
+      <em>landmark</em>. Honest sizing: L, not S.</td>
+</tr>
+<tr>
+  <td>"Reuse the existing API-key infra with a new <code>geo-agent</code> role/scope"</td>
+  <td>Right infra, two caveats: <code>scopes text[]</code> exists but enforcement is
+      "Reserved for M2" (one <code>hasScope</code> call at <code>public.routes.ts:527</code>);
+      and scopes are <b>not settable at mint</b> — <code>POST /api/streamer-keys</code>
+      always writes <code>DEFAULT_SCOPES</code>, and any user can mint.</td>
+  <td>Geo-agent keys are admin-minted only (new admin route + panel section),
+      never via streamer self-service. Real scope enforcement middleware ships in
+      Phase 2 (§5).</td>
+</tr>
+<tr>
+  <td>Per-tool rate limits + global daily budget</td>
+  <td>Public-API limiter is an in-memory per-process <code>Map</code>
+      (<code>public-api.middleware.ts:155</code>) — resets on deploy, wrong for
+      daily budgets. A Redis limiter already exists at
+      <code>infrastructure/redis/rate-limiter.ts</code>.</td>
+  <td>Per-minute limits reuse the in-memory pattern; <em>daily/hourly write
+      budgets</em> use Redis counters (§5.3).</td>
+</tr>
+<tr>
+  <td>Audit via <code>admin_audit</code></td>
+  <td>Exists and fits: <code>admin_audit_log.admin_id</code> is
+      <code>varchar(64)</code>, helper <code>adminAuditRepository.record()</code> is
+      best-effort/non-blocking (<code>admin-audit.repository.ts</code>).</td>
+  <td>Reuse as-is with <code>adminId = "apikey:&lt;id&gt;"</code>; add
+      <code>rationale</code> into the <code>after</code> jsonb. No new table.</td>
+</tr>
+<tr>
+  <td><code>geo.health</code> reuses <code>/api/admin/geogamers/health</code></td>
+  <td>Confirmed: route at <code>admin.routes.ts:3605</code> returns
+      <code>{eligibleGames, eligibleScreenshots, starved, minRequired, …}</code>;
+      eligibility = distinct games with ≥1 promoted meta on an active map, never
+      used as a challenge, not on cooldown
+      (<code>geogamers-challenge.repository.ts:105</code>).</td>
+  <td>Extract the aggregation into a service both routes call (§6 Phase 2), don't
+      duplicate the query.</td>
+</tr>
+</tbody>
+</table>
+
+<h2><span class="num">2</span>Target architecture</h2>
+
+<figure>
+<svg viewBox="0 0 680 400" role="img" aria-label="Trust flow: agent proposes through a scoped HTTP API into the existing consensus gate; only humans and consensus promote to canonical ground truth" style="width:100%;height:auto">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#8b8b9e"/>
+    </marker>
+  </defs>
+  <!-- Agent box -->
+  <rect x="20" y="20" width="300" height="70" rx="8" fill="#12121a" stroke="#a855f7"/>
+  <text x="170" y="48" fill="#fff" font-size="13" text-anchor="middle">Agent (Claude Code / MCP client)</text>
+  <text x="170" y="70" fill="#8b8b9e" font-size="11" text-anchor="middle">admin-minted key · geo-agent:* scopes</text>
+  <!-- API surface -->
+  <rect x="20" y="130" width="300" height="86" rx="8" fill="#12121a" stroke="#26263a"/>
+  <text x="170" y="155" fill="#fff" font-size="13" text-anchor="middle">/api/agent/v1/geo (HTTP)</text>
+  <text x="170" y="175" fill="#8b8b9e" font-size="11" text-anchor="middle">scope check · Redis budgets · audit log</text>
+  <text x="170" y="195" fill="#fbbf24" font-size="11" text-anchor="middle">kill switch: GEO_AGENT_API_ENABLED</text>
+  <!-- Ingest -->
+  <rect x="20" y="256" width="140" height="64" rx="8" fill="#12121a" stroke="#26263a"/>
+  <text x="90" y="282" fill="#fff" font-size="12" text-anchor="middle">geoQueue</text>
+  <text x="90" y="300" fill="#8b8b9e" font-size="10" text-anchor="middle">existing ingest jobs</text>
+  <!-- Pins -->
+  <rect x="180" y="256" width="140" height="64" rx="8" fill="#12121a" stroke="#26263a"/>
+  <text x="250" y="276" fill="#fff" font-size="12" text-anchor="middle">geo_pin_submission</text>
+  <text x="250" y="293" fill="#ec4899" font-size="10" text-anchor="middle">source = agent_*</text>
+  <text x="250" y="308" fill="#8b8b9e" font-size="10" text-anchor="middle">weight ×0.6 / ×0.25</text>
+  <!-- Consensus gate -->
+  <rect x="380" y="130" width="280" height="110" rx="8" fill="#17171f" stroke="#fbbf24"/>
+  <text x="520" y="155" fill="#fbbf24" font-size="13" text-anchor="middle">THE GATE (unchanged path)</text>
+  <text x="520" y="178" fill="#d6d6e0" font-size="11" text-anchor="middle">geo-consensus.service · v3</text>
+  <text x="520" y="196" fill="#d6d6e0" font-size="11" text-anchor="middle">promote needs ≥5 accepted HUMAN pins</text>
+  <text x="520" y="214" fill="#d6d6e0" font-size="11" text-anchor="middle">or admin override (Geo Review panel)</text>
+  <!-- Ground truth -->
+  <rect x="380" y="290" width="280" height="64" rx="8" fill="#12121a" stroke="#34d399"/>
+  <text x="520" y="316" fill="#34d399" font-size="13" text-anchor="middle">geo_screenshot_meta</text>
+  <text x="520" y="336" fill="#8b8b9e" font-size="11" text-anchor="middle">canonical pin → eligible game → GeoGamers</text>
+  <!-- Arrows -->
+  <line x1="170" y1="90" x2="170" y2="130" stroke="#8b8b9e" marker-end="url(#arr)"/>
+  <line x1="90" y1="216" x2="90" y2="256" stroke="#8b8b9e" marker-end="url(#arr)"/>
+  <line x1="250" y1="216" x2="250" y2="256" stroke="#8b8b9e" marker-end="url(#arr)"/>
+  <line x1="320" y1="288" x2="380" y2="200" stroke="#8b8b9e" marker-end="url(#arr)"/>
+  <line x1="520" y1="240" x2="520" y2="290" stroke="#8b8b9e" marker-end="url(#arr)"/>
+  <text x="345" y="235" fill="#8b8b9e" font-size="10">votes</text>
+  <text x="527" y="268" fill="#8b8b9e" font-size="10">promote</text>
+</svg>
+<figcaption>Agent writes land as downweighted votes or queued ingest jobs.
+Nothing the agent does crosses the gate without ≥5 accepted human pins or an
+explicit admin action in the existing Geo Review panel.</figcaption>
+</figure>
+
+<p>Two deliberate simplifications vs. the issue:</p>
+<ul>
+  <li><strong>HTTP first, MCP as a thin wrapper.</strong> The capability surface is a
+      plain key-authenticated HTTP API (testable with curl, e2e-testable with
+      Playwright's request fixture). The MCP server is a ~200-line stdio wrapper
+      that maps tools 1:1 to endpoints — it holds no logic and no privileges of
+      its own, so a compromised/hallucinating MCP layer can't do anything the key
+      can't.</li>
+  <li><strong>No <code>geo.promote_pin</code> tool.</strong> Admin promotion already
+      exists (<code>POST /api/admin/geo/candidates/:id/override</code>, session-authed,
+      audited, with a purpose-built review UI). Re-exposing it behind an API key —
+      a bearer credential that can leak — only widens the blast radius.</li>
+</ul>
+
+<h2><span class="num">3</span>Design decisions</h2>
+
+<h3>3.1 Identity of an agent pin</h3>
+<p><code>geo_pin_submission.user_id</code> is NOT NULL with an FK to
+<code>user</code>, and uniqueness is <code>(user_id, candidate_id)</code>. Options:</p>
+<table>
+<thead><tr><th>Option</th><th>Verdict</th></tr></thead>
+<tbody>
+<tr><td>Synthetic "system user" per agent key</td>
+    <td>Rejected — pollutes user-facing joins (leaderboards, contributor stats,
+        Better Auth), and <code>geo_contributor_stats</code> / shadow-ban logic would
+        need agent carve-outs everywhere.</td></tr>
+<tr><td><b>Nullable <code>user_id</code> + <code>agent_key_id</code> FK + CHECK
+        (exactly one owner)</b></td>
+    <td><b>Chosen.</b> One migration; human paths unchanged (their
+        <code>user_id</code> stays NOT NULL in practice); agent pins are trivially
+        filterable; revoking the key orphans nothing.</td></tr>
+</tbody>
+</table>
+<p class="small">Contributor stats, tier promotion, token rewards, and shadow-ban
+(<code>geo-reward.service.ts</code>) apply only to pins with a <code>user_id</code> —
+agent pins earn nothing and can't be shadow-banned (they're governed by budgets +
+kill switch instead). <code>applyConsensus</code>'s <code>pinOwners</code> map simply
+skips ownerless pins, which it already tolerates.</p>
+
+<h3>3.2 Consensus: weights sharpen, humans promote</h3>
+<p>Extend the pure service (<code>geo-consensus.service.ts</code>) — no infra change:</p>
+<pre><code>export type GeoPinSource = 'human' | 'agent_structured' | 'agent_vision'
+
+export const GEO_CONSENSUS_SOURCE_WEIGHTS: Record&lt;GeoPinSource, number&gt; = {
+  human: 1.0,
+  agent_structured: 0.6,   // scraped marker coords, provenance attached
+  agent_vision: 0.25,      // LLM localization, experimental
+}
+
+// effective weight = confidenceWeight * sourceWeight
+// GeoPinLike gains: source?: GeoPinSource   (default 'human')
+
+// Promote gate (v3):
+//   humanAcceptedCount >= GEO_CONSENSUS_MIN_PINS_TO_PROMOTE (still 5)
+//   && confidence >= 0.5
+// Agent pins: contribute to centroid + sigma + confidence, NEVER to the count.
+
+export const GEO_CONSENSUS_VERSION = 3  // bump (was 2)</code></pre>
+<div class="callout ok">
+<strong>Why this rule:</strong> it preserves the exact property the issue asks for
+("machine writes can never directly mutate ground truth") as an <em>invariant of
+the math</em>, not a policy hope. Even 1,000 colluding agent pins cannot promote a
+candidate; they can only make the eventual human-driven consensus more precise —
+or get rejected as outliers by the existing 2σ filter. A property test asserts
+<code>promote === false</code> for any all-agent pin set (§8).</div>
+<p class="small">Note <code>consensus_version</code> is already persisted on
+<code>geo_screenshot_meta</code>, so v2/v3 metas stay distinguishable. Rejected-agent-pin
+ratios per key become a health metric (§9).</p>
+
+<h3>3.3 Key scopes &amp; minting</h3>
+<pre><code>// packages/types/src/index.ts — extend the union
+export type ApiKeyScope =
+  | 'read:public' | 'read:self' | 'stream:self' | 'webhooks:self'
+  | 'geo-agent:read'      // health, needing-content, candidates
+  | 'geo-agent:ingest'    // trigger existing ingest jobs
+  | 'geo-agent:propose'   // submit downweighted pins</code></pre>
+<ul>
+  <li>Minted <b>only</b> via a new admin route (<code>POST /api/admin/agent-keys</code>,
+      <code>adminMiddleware</code>, audited) — never via <code>streamer-keys.routes.ts</code>.
+      <code>apiKeyRepository.create()</code> already accepts a <code>scopes</code>
+      override, so the repo needs no change.</li>
+  <li>Geo-agent scopes and streamer scopes are mutually exclusive on one key
+      (validated at mint). A geo-agent key on the public streamer API gets
+      <code>INSUFFICIENT_SCOPE</code>, and vice versa.</li>
+  <li>Revocation = existing soft-revoke (<code>is_active=false</code>) — instant,
+      since <code>findByHash</code> filters on <code>is_active</code>.</li>
+  <li>Progressive trust: Phase 2 keys get <code>read</code> only; <code>ingest</code>
+      and <code>propose</code> are granted per key as later phases ship.</li>
+</ul>
+
+<h3>3.4 Budgets, limits, kill switch</h3>
+<table>
+<thead><tr><th>Control</th><th>Mechanism</th><th>Default</th></tr></thead>
+<tbody>
+<tr><td>Global kill switch</td><td><code>env.GEO_AGENT_API_ENABLED</code> — checked per request; router also not mounted when false at boot</td><td><code>false</code></td></tr>
+<tr><td>Per-minute rate limit</td><td>reuse <code>createRateLimiter</code> pattern, keyed by key id</td><td>60/min</td></tr>
+<tr><td>Ingest budget</td><td>Redis counter <code>geo-agent:budget:ingest:&lt;keyId&gt;:&lt;utcDay&gt;</code> (reuse <code>infrastructure/redis/rate-limiter.ts</code>)</td><td><code>GEO_AGENT_MAX_INGESTS_PER_DAY=20</code></td></tr>
+<tr><td>Pin budget</td><td>Redis counter <code>geo-agent:budget:pins:&lt;keyId&gt;:&lt;utcHour&gt;</code></td><td><code>GEO_AGENT_MAX_PINS_PER_HOUR=60</code></td></tr>
+<tr><td>Vision passes per candidate</td><td><code>vision_pass</code> column cap (service-enforced)</td><td>3</td></tr>
+<tr><td>Per-source pause</td><td>existing <code>geo_source_config.is_enabled</code> + circuit breakers — unchanged</td><td>—</td></tr>
+</tbody>
+</table>
+<p class="small">Budgets live in Redis (not the in-memory Map) because they must
+survive deploys — a redeploy resetting the daily ingest budget would let a looping
+agent 10× its quota. 429 responses carry <code>Retry-After</code> like the public API.</p>
+
+<h2><span class="num">4</span>Schema — one migration (Phase 4)</h2>
+<pre><code>// packages/backend/migrations/2026MMDD_geo_agent_pins.ts
+alter table geo_pin_submission
+  alter column user_id drop not null,
+  add column source varchar(20) not null default 'human',
+      -- 'human' | 'agent_structured' | 'agent_vision'
+  add column agent_key_id integer null references api_keys(id),
+  add column agent_rationale varchar(500) null,
+  add column agent_model varchar(100) null,   -- e.g. model id for vision pins
+  add column vision_pass smallint not null default 0,
+  add constraint geo_pin_owner_check check (
+    (user_id is not null and agent_key_id is null and source = 'human') or
+    (user_id is null and agent_key_id is not null and source &lt;&gt; 'human')
+  );
+
+-- human uniqueness unchanged: (user_id, candidate_id)
+create unique index geo_pin_agent_uniq
+  on geo_pin_submission (agent_key_id, geo_screenshot_candidate_id, vision_pass)
+  where agent_key_id is not null;
+create index geo_pin_source_idx on geo_pin_submission (source)
+  where source &lt;&gt; 'human';</code></pre>
+<ul>
+  <li><code>geo_screenshot_meta.promoted_via</code> stays <code>consensus | admin</code> —
+      there is intentionally no <code>'agent'</code> value.</li>
+  <li>Down migration deletes agent pins, then restores NOT NULL — stated explicitly
+      in the file so a rollback is data-destructive by design, not by surprise.</li>
+  <li><code>GeoPinSubmissionRow</code> (<code>geo-pin.repository.ts:12</code>) and
+      <code>geoPinRepository.submit()</code> gain the new fields;
+      <code>listPendingByCandidate</code> starts selecting <code>source</code> so the
+      worker can feed it to <code>evaluateConsensus</code>.</li>
+</ul>
+
+<h2><span class="num">5</span>The agent API surface</h2>
+<p>New mount <code>/api/agent/v1/geo</code> (<code>agent-geo.routes.ts</code>) behind:
+<code>requireApiKey()</code> (reused) → <code>requireScope(…)</code> (new, wraps the
+existing <code>hasScope</code> helper) → budget middleware → Zod validation → audit.
+Envelope and error codes follow the public API (<code>UNAUTHORIZED</code>,
+<code>INSUFFICIENT_SCOPE</code>, <code>RATE_LIMITED</code>, <code>VALIDATION_ERROR</code> +
+new <code>BUDGET_EXHAUSTED</code>, <code>AGENT_API_DISABLED</code>).</p>
+
+<table>
+<thead><tr><th>Endpoint</th><th>Scope</th><th>Maps to (existing code)</th></tr></thead>
+<tbody>
+<tr><td><code>GET /health</code></td><td><code>geo-agent:read</code></td>
+    <td>shared service extracted from <code>admin.routes.ts:3605</code> (geogamers
+        health) + pipeline counts from <code>GET /api/admin/geo/health</code></td></tr>
+<tr><td><code>GET /games-needing-content</code></td><td><code>geo-agent:read</code></td>
+    <td>new query (§6 Phase 1) — same service the admin card uses</td></tr>
+<tr><td><code>GET /games/:gameId/candidates</code></td><td><code>geo-agent:read</code></td>
+    <td><code>geoScreenshotRepository.listCandidatesForReview</code> +
+        <code>geo-map.repository</code> (map image/dims so a proposer can localize)</td></tr>
+<tr><td><code>POST /games/:gameId/ingest</code><br>
+        <span class="small"><code>{ sources?: RunnableTier[] }</code></span></td>
+    <td><code>geo-agent:ingest</code></td>
+    <td><code>enqueueSingleTierImport(gameId, source)</code> /
+        <code>runGeoIngestTick(…, gameId)</code> from
+        <code>geo-ingest-tick-logic.ts</code> — queue-only, 202 + attempt ids</td></tr>
+<tr><td><code>POST /candidates/:id/pins</code><br>
+        <span class="small"><code>{ x, y, source, rationale, confidence?, model?, visionPass? }</code></span></td>
+    <td><code>geo-agent:propose</code></td>
+    <td><code>geoPinRepository.submit</code> → <code>incrementPinCount</code> →
+        <code>geoQueue.add('evaluate-consensus', …)</code> — the <em>identical</em>
+        path as <code>POST /api/geo/contribute/pin</code>
+        (<code>geo.routes.ts:132</code>), minus rewards/first-pin bonus</td></tr>
+</tbody>
+</table>
+<p class="small">Deliberately absent: promote/override, candidate reject/demote, map
+selection, user or PII reads, raw SQL, file access. Responses never include other
+users' identities — candidate payloads carry pin <em>counts</em>, not pin owners.</p>
+
+<h3>Every call audited</h3>
+<pre><code>adminAuditRepository.record({
+  adminId: `apikey:${req.apiKey.id}`,          // varchar(64) — fits
+  action:  'geo-agent.propose_pin',            // or .ingest / .read is NOT logged
+  targetKind: 'geo_screenshot_candidate',
+  targetId: String(candidateId),
+  after: { x, y, source, rationale, model },
+  requestId, ip,
+})</code></pre>
+<p class="small">Reads are rate-limited but not audit-logged (volume). Writes always
+are. <code>listRecent({ adminId: 'apikey:…' })</code> makes the existing admin audit
+view filterable per key with zero UI work.</p>
+
+<h2><span class="num">6</span>Phased delivery</h2>
+
+<div class="phase">
+<h3>Phase 1 — "one pin away" diagnostic <span class="badge ship">ship now · S</span></h3>
+<p>No agent, no keys — immediately unblocks manual pinning toward the 10-game gate
+(prod is at 9/10).</p>
+<ul>
+  <li><code>GET /api/admin/geo/games-needing-content</code> — games with an active map
+      and ≥1 non-promoted candidate, no eligible meta; per game:
+      <code>{ gameId, name, candidateCount, topPinCount, pinsToNextThreshold,
+      bestCandidateId }</code>, sorted by <code>topPinCount</code> desc (closest to
+      the next <code>GEO_CONSENSUS_THRESHOLDS</code> recompute first).
+      <code>pinsToNextThreshold = nextThreshold(topPinCount) − topPinCount</code>.</li>
+  <li>Admin card next to <code>GeoGamersHealthCard</code> in the Géo tab: top-10 list,
+      deep-links into <code>GeoReviewQueue</code> (admin can promote via the existing
+      override) and to <code>/geo/contribute</code>.</li>
+  <li>Also surface <code>gamesOnCooldown</code> context: a game can be "eligible-blocked"
+      purely by challenge cooldown — distinguish that from "needs pins".</li>
+</ul>
+<p class="files"><b>Files:</b> admin.routes.ts (route + query via
+geo-screenshot.repository summarize/new method) · components/admin/GeoNeedingContentCard.tsx ·
+hooks/useGeoHealth.ts (extend) · e2e/geo-admin.spec.ts · docs/geo-mode.md</p>
+</div>
+
+<div class="phase">
+<h3>Phase 2 — key scopes + read-only surface <span class="badge ship">M</span></h3>
+<ul>
+  <li>Extend <code>ApiKeyScope</code> (types package — rebuild), add
+      <code>requireScope()</code> middleware, enforce on new routes.</li>
+  <li>Admin mint/revoke: <code>POST/GET/DELETE /api/admin/agent-keys</code> + a small
+      panel section (label, scopes checkboxes, plaintext shown once — same UX as
+      streamer keys). Mutual-exclusion validation with streamer scopes.</li>
+  <li>Mount <code>/api/agent/v1/geo</code> with the three <b>read</b> endpoints;
+      <code>GEO_AGENT_API_ENABLED</code> flag (default false) in <code>env.ts</code>.</li>
+  <li>Extract shared geogamers-health service so admin + agent routes share one query.</li>
+  <li>MCP wrapper: <code>packages/geo-agent-mcp</code> — stdio server, tools
+      <code>geo_health</code> / <code>geo_games_needing_content</code> /
+      <code>geo_list_candidates</code>, key via <code>THE_BOX_AGENT_KEY</code> env.
+      README with a Claude Code <code>mcpServers</code> snippet.</li>
+</ul>
+<p class="files"><b>Files:</b> types/src/index.ts · presentation/middleware/agent-api.middleware.ts ·
+presentation/routes/agent-geo.routes.ts · admin.routes.ts · config/env.ts ·
+packages/geo-agent-mcp/* · docs/geo-agent-api.md (new)</p>
+</div>
+
+<div class="phase">
+<h3>Phase 3 — ingest trigger <span class="badge ship">S</span></h3>
+<ul>
+  <li><code>POST /games/:gameId/ingest</code> behind <code>geo-agent:ingest</code> +
+      Redis daily budget. Pure enqueue — reuses tick logic, circuit breakers,
+      <code>geo_source_config</code>, dedup, and license/attribution capture untouched.</li>
+  <li>Source allowlist = <code>RunnableTier</code> ∩ <code>geo_source_config.is_enabled</code>;
+      anything else → <code>VALIDATION_ERROR</code>. The agent cannot add sources.</li>
+  <li>Response includes <code>geo_ingest_attempt</code> correlation ids so the agent can
+      poll outcomes via the read surface (add attempts to the candidates/health reads).</li>
+</ul>
+<p class="files"><b>Files:</b> agent-geo.routes.ts · geo-ingest-tick-logic.ts (export reuse only) ·
+infrastructure/redis budget helper · MCP tool geo_ingest_game</p>
+</div>
+
+<div class="phase">
+<h3>Phase 4 — pin proposals, structured tier <span class="badge gate">L · design-gated</span></h3>
+<ul>
+  <li>Migration §4 + consensus v3 (§3.2) + repo/worker plumbing
+      (<code>submit</code>, <code>listPendingByCandidate</code> → pass <code>source</code>).</li>
+  <li><code>POST /candidates/:id/pins</code> behind <code>geo-agent:propose</code> +
+      hourly budget. <code>rationale</code> required (≤500 chars) — it is the review
+      artifact.</li>
+  <li>Geo Review UI: source filter on <code>GeoReviewQueue</code>; agent pins rendered
+      in a distinct color on the <code>GeoReviewPanel</code> map with
+      rationale/model tooltip; count badge "N agent pins" on candidate rows.</li>
+  <li><b>Structured-coordinate extraction is scoped as its own worker</b>
+      (<code>maps-fetch-mapgenie</code> phase-2 crawler slot): crawl marker JSON,
+      normalize provider coords → the map's [0,1] space (per-map affine calibration,
+      stored alongside the map row), and — the hard part — match screenshots to
+      landmarks. First target: sources where the <em>screenshot itself</em> carries
+      location context (wiki location-page images), not generic landmark lists.
+      If association confidence is low, the agent should <em>not</em> pin — precision
+      over recall; a wrong structured pin at weight 0.6 poisons a centroid.</li>
+</ul>
+<p class="files"><b>Files:</b> migrations/2026MMDD_geo_agent_pins.ts · geo-consensus.service.ts (+tests) ·
+geo-pin.repository.ts · geo-consensus-logic.ts · geo-reward.service.ts (skip ownerless) ·
+agent-geo.routes.ts · GeoReviewQueue.tsx / GeoReviewPanel.tsx · docs/geo-mode.md</p>
+</div>
+
+<div class="phase">
+<h3>Phase 5 — vision proposer <span class="badge risk">M · accuracy-gated</span></h3>
+<ul>
+  <li><b>Study before write access:</b> offline harness
+      <code>packages/backend/scripts/geo-vision-eval.ts</code> — sample K≥50 promoted
+      metas (known ground truth), run vision localization (screenshot + map image),
+      report median normalized distance, % within <code>consensus_radius</code>
+      (default 0.03), and % within 0.1. <b>Enable bar:</b> ≥40% within radius and
+      median &lt; 0.1; below that, vision pins add noise even at weight 0.25 —
+      skip the tier, keep structured-only.</li>
+  <li>If passed: <code>source='agent_vision'</code>, up to 3 independent passes per
+      candidate (<code>vision_pass</code> 0..2, different prompt seeds), each a
+      separate 0.25-weight voter so the 2σ filter can discard disagreeing passes.</li>
+  <li>Track per-key rejected-ratio; auto-pause proposals from a key whose 7-day
+      rejection ratio exceeds the human shadow-ban bar (0.6) — same philosophy,
+      budget-level enforcement.</li>
+</ul>
+<p class="files"><b>Files:</b> scripts/geo-vision-eval.ts · agent-geo.routes.ts (allow source=vision) ·
+budget/pause helper · docs/geo-agent-api.md (published accuracy numbers)</p>
+</div>
+
+<div class="phase">
+<h3>Phase 6 — backfill discovery worker <span class="badge ship">M</span></h3>
+<ul>
+  <li>New <code>GeoJobData</code> kind <code>backfill-tick</code>: rank games by
+      "distance to eligibility" (has map? has candidates? top pin count?) using the
+      Phase-1 query, then enqueue ingest for the top N <em>sub-threshold</em> games —
+      inverting today's tick, which tops up already-resolved games to 30 candidates.</li>
+  <li>Steady-state automation of what the external agent does exploratively; no LLM
+      in-process — it reuses the same ranked query + ingest path. Cron-registered
+      like other geo jobs, off by default (<code>GEO_BACKFILL_ENABLED</code>).</li>
+</ul>
+<p class="files"><b>Files:</b> queues.ts (kind) · workers/geo-backfill-logic.ts ·
+geo.worker.ts router · env.ts</p>
+</div>
+
+<h2><span class="num">7</span>Security &amp; governance checklist (from #331, made concrete)</h2>
+<table>
+<thead><tr><th>#331 item</th><th>Concrete mechanism</th><th>Phase</th></tr></thead>
+<tbody>
+<tr><td>geo-agent scope, revocable, never superuser</td>
+    <td>3 granular scopes (§3.3); admin-only mint; mutual exclusion with streamer
+        scopes; soft-revoke is instant</td><td>2</td></tr>
+<tr><td>Per-tool rate limits + global budget</td>
+    <td>60/min per key (in-memory) + Redis daily/hourly write budgets (§3.4)</td><td>2–4</td></tr>
+<tr><td>All calls in admin audit with key id + rationale</td>
+    <td><code>adminId='apikey:&lt;id&gt;'</code>, rationale in <code>after</code> jsonb;
+        writes always logged</td><td>2</td></tr>
+<tr><td>Machine pins flagged + downweighted, visible in review</td>
+    <td><code>source</code> column, ×0.6/×0.25 weights, <b>excluded from promote
+        count</b> (stronger than downweighting), review-UI filter + map color</td><td>4</td></tr>
+<tr><td>No raw SQL / fs / secrets / PII</td>
+    <td>Five endpoints total, all repo-backed; candidate payloads carry counts not
+        owners; keys hashed at rest (existing)</td><td>2</td></tr>
+<tr><td>Kill switch</td>
+    <td><code>GEO_AGENT_API_ENABLED</code> checked per request + key revocation +
+        existing <code>geo_source_config</code> per-source disable</td><td>2</td></tr>
+<tr><td>Licensing / source allowlist</td>
+    <td>Ingest restricted to <code>RunnableTier</code> ∩ enabled sources; license /
+        attribution capture unchanged on <code>geo_map</code>; agent cannot register
+        new sources</td><td>3</td></tr>
+</tbody>
+</table>
+
+<h2><span class="num">8</span>Test plan</h2>
+<ul>
+  <li><b>Unit (node test runner):</b> consensus v3 — property test: any pin set with
+      &lt;5 accepted human pins ⇒ <code>promote=false</code> regardless of agent pins;
+      weight composition (confidence × source); 2σ rejection of a deliberately wrong
+      agent pin; version bump. Budget counter math (UTC day/hour rollover). Scope
+      middleware matrix (each endpoint × each scope × disabled flag).</li>
+  <li><b>Route tests:</b> mint/revoke agent keys admin-only; streamer key rejected on
+      agent routes with <code>INSUFFICIENT_SCOPE</code>; propose-pin path increments
+      <code>pin_count</code> and enqueues <code>evaluate-consensus</code> only at
+      thresholds; no rewards/contributor mutation for agent pins.</li>
+  <li><b>E2E (Playwright):</b> Phase 1 card renders + deep-links (extend
+      <code>geo-admin.spec.ts</code>); Geo Review shows/filters agent pins;
+      admin key panel mint flow (plaintext shown once).</li>
+  <li><b>Offline:</b> vision eval harness output committed to the PR that proposes
+      enabling Phase 5 — the numbers are the review artifact.</li>
+</ul>
+
+<h2><span class="num">9</span>Metrics &amp; rollout</h2>
+<ul>
+  <li><b>North star:</b> <code>eligibleGames</code> (already on the health endpoint) —
+      the 10-game gate is the whole point.</li>
+  <li>Per key: proposals, accepted/rejected ratio, promoted-with-agent-participation
+      count (join meta → candidate → agent pins), budget exhaustions — derivable from
+      audit log + pin table; add to the admin health card in Phase 4.</li>
+  <li>Rollout: each phase ships dark behind its flag; Phase 4+ enables on one
+      hand-picked game first; revert path = kill switch + (worst case)
+      <code>DELETE FROM geo_pin_submission WHERE source &lt;&gt; 'human'</code> —
+      ground truth is untouchable by construction, so recovery never involves
+      <code>geo_screenshot_meta</code>.</li>
+</ul>
+
+<h2><span class="num">10</span>Open questions from #331 — resolved</h2>
+<table>
+<thead><tr><th>Question</th><th>Resolution</th></tr></thead>
+<tbody>
+<tr><td>Where does the agent run?</td>
+    <td>Both, sequenced: external (Claude Code + MCP key) for exploration in Phases
+        2–5; the in-app Phase-6 worker takes over steady-state backfill with no LLM
+        in-process. The HTTP surface is identical for both, so nothing is rebuilt.</td></tr>
+<tr><td>Is vision good enough even as a downweighted voter?</td>
+    <td>Empirical gate with published numbers (§ Phase 5): ≥40% within consensus
+        radius and median &lt; 0.1 on ≥50 known metas, else the tier stays off.
+        Not a judgment call.</td></tr>
+<tr><td>Ever auto-promote high-confidence structured pins?</td>
+    <td><b>No — removed from the design.</b> Promotion is human-count-gated in the
+        math (§3.2) or explicit admin action. If structured pins prove extremely
+        accurate, the cheap lever is raising their weight (sharper centroids →
+        faster human-driven promotion), never bypassing the gate.</td></tr>
+</tbody>
+</table>
+
+<p class="small" style="margin-top:3rem">Sources: <code>geo-consensus.service.ts</code>,
+<code>geo-reward.service.ts</code>, <code>geo-pin.repository.ts</code>,
+<code>geo-screenshot.repository.ts</code>, <code>geogamers-challenge.repository.ts</code>,
+<code>geo-ingest-tick-logic.ts</code>, <code>maps-fetch-mapgenie.ts</code>,
+<code>geo-wand-import-logic.ts</code>, <code>api-key.repository.ts</code>,
+<code>public-api.middleware.ts</code>, <code>admin-audit.repository.ts</code>,
+<code>admin.routes.ts</code>, migrations <code>20260419/20260503/20260504/20260508/20260518/20260522</code>,
+<code>docs/geo-mode.md</code>, <code>docs/geogamers.md</code>, <code>docs/public-api.md</code>.</p>
+</main>


### PR DESCRIPTION
## Summary

Implements #331 (agent-assisted geo content sourcing). Commits:

1. **Plan** — code-grounded implementation plan at `tasks/prd-geo-agent-sourcing.html`.
2. **Phase 1** — the "one pin away" content-gap diagnostic.
3. **Phase 2** — scoped read-only agent API + admin-minted keys + MCP wrapper.
4. **Phase 3** — agent ingest trigger with a per-key daily budget.
5. **Phase 4** — the agent **pin proposer** + **consensus v3** (the load-bearing phase).

The agent *proposes*; consensus + admins *dispose*. Everything ships dark behind `GEO_AGENT_API_ENABLED`.

## Phase 4 — machines can write, but can never create ground truth

This is the phase the whole design rests on. It lets a machine submit pins into consensus while making "agent pins can't auto-promote" a **math invariant**, not a policy hope.

**Consensus v3** (`geo-consensus.service`, property-tested):
- Pins carry a provenance `source`: `human | agent_structured | agent_vision`.
- Effective weight = confidence × source (human 1.0, structured 0.6, vision 0.25) — agent pins pull the centroid less.
- **The promote gate counts accepted _human_ pins only.** A property test asserts that even 1000 tightly-clustered agent pins never promote; promotion needs ≥5 accepted human pins (or an admin override). Version bumped 2 → 3.

**Schema** (`20260710_geo_agent_pins`): `user_id` nullable; `source`, `agent_key_id` (FK, `SET NULL` on revoke), `agent_rationale`, `agent_model`, `vision_pass`; a CHECK enforcing exactly one owner kind; partial unique + source indexes. Down is data-destructive by design (deletes agent pins) but never touches `geo_screenshot_meta`.

**Endpoint** `POST /api/agent/v1/geo/candidates/:id/pins` (scope `geo-agent:propose`):
- Writes a flagged, downweighted pin into the **same** `evaluate-consensus` queue as the crowd; `rationale` required (the review artifact).
- Per-key **hourly** Redis budget (`GEO_AGENT_MAX_PINS_PER_HOUR`, default 60), fails closed. `409` on already-promoted; duplicate proposals are idempotent no-ops. Audited as `geo-agent.propose_pin`.
- The consensus worker skips ownerless pins for rewards/shadow-ban and passes `source` through to the evaluator.

**Plus:** MCP `geo_propose_pin` tool; a review-workspace notice surfacing agent pins with their source + rationale to moderators; docs.

## Verification

Full workspace build typechecks, migration typechecks, lint 0 errors, **356 backend + 15 MCP tests pass** (incl. the consensus-v3 property tests).

## Plan corrections delivered

1. Consensus auto-promote hole — **fixed in phase 4** (human-only promote count). ✅
2. Structured-coordinates assumption corrected (adapters only fetch `og:image`).
3. `geo.promote_pin` agent tool dropped.
4. Pin-provenance migration — **shipped in phase 4**. ✅
5. Key minting separated from streamer self-service — phase 2. ✅

## Remaining

- **Phase 5** — LLM-vision proposer, gated on a measured accuracy study (≥40% within consensus radius on ≥50 known metas) before it's allowed to vote. The `agent_vision` source + `vision_pass` plumbing already exists; phase 5 is the eval harness + enabling it.
- **Phase 6** — in-app backfill discovery worker targeting sub-threshold games.
- The in-app structured-coordinate *crawler* (site-specific scraping + coordinate calibration) remains a follow-up; the `propose_pin` endpoint is the mechanism by which an external agent submits computed coordinates today (the plan's "external MCP for exploration" model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvJoyRSYB7UMaRfuMsT5Jd