### PR TITLE
feat(geo): vision proposer gate + accuracy study (#331 phase 5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,10 @@ GEO_AGENT_API_ENABLED=false
 GEO_AGENT_MAX_INGESTS_PER_DAY=20
 # Per-key hourly cap on agent pin proposals (phase 4), tracked in Redis.
 GEO_AGENT_MAX_PINS_PER_HOUR=60
+# Gate for LLM-vision pin proposals (phase 5). Off until the offline accuracy
+# study (npm run eval:geo-vision) clears the enable bar; while false,
+# source=agent_vision proposals are rejected with VISION_DISABLED.
+GEO_AGENT_VISION_ENABLED=false
 
 # ============================================
 # PRODUCTION DEPLOYMENT NOTES

--- a/docs/geo-agent-api.md
+++ b/docs/geo-agent-api.md
@@ -206,6 +206,18 @@ weight further. `visionPass` (0–2) lets one key submit multiple independent
 confident** — a wrong structured pin at weight 0.6 poisons the centroid; prefer
 precision over recall.
 
+**Vision gate (phase 5).** `source: "agent_vision"` is rejected with
+`403 VISION_DISABLED` until `GEO_AGENT_VISION_ENABLED=true`. The flag is only
+flipped after the offline study `npm run eval:geo-vision` clears the enable bar
+(≥40% of predictions within the map's consensus radius, median normalized error
+< 0.1, on ≥50 known-truth metas). `agent_structured` is unaffected. See
+`packages/backend/scripts/geo-vision-eval.ts`.
+
+**Per-key auto-pause (phase 5).** A key whose 7-day proposals are >60% rejected
+by consensus (≥10 submissions) is paused with `403 KEY_PAUSED` — the same bar as
+the human contributor shadow-ban, applied at the key level so a miscalibrated
+proposer can't keep flooding the review queue.
+
 ```json
 { "success": true, "data": { "pinId": 90142, "received": true, "pinCount": 7, "budget": { "used": 3, "limit": 60, "remaining": 57 } } }
 ```
@@ -225,6 +237,8 @@ proposal (same key + candidate + `visionPass`) is an idempotent no-op:
 | `BUDGET_EXHAUSTED` | 429 | Write budget hit; `Retry-After` = seconds to window reset |
 | `CANDIDATE_NOT_FOUND` | 404 | No such capture candidate (propose) |
 | `ALREADY_PROMOTED` | 409 | Candidate already has a canonical pin (propose) |
+| `VISION_DISABLED` | 403 | `agent_vision` proposals disabled pending the accuracy study |
+| `KEY_PAUSED` | 403 | Key auto-paused: >60% of its recent proposals were rejected |
 | `VALIDATION_ERROR` | 400 | Bad `gameId` / `limit` / `sources` / pin body |
 | `INTERNAL_ERROR` | 500 | Server error |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,27 @@
         "nup": "bin/nup.mjs"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
+      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@axe-core/playwright": {
       "version": "4.11.2",
       "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
@@ -13670,6 +13691,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -17976,6 +18010,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -19599,6 +19639,7 @@
       "name": "@the-box/backend",
       "version": "2.140.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.110.0",
         "@better-auth/passkey": "~1.4.10",
         "@resvg/resvg-js": "^2.6.2",
         "@the-box/types": "*",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,9 +23,11 @@
     "e2e:seed": "tsx scripts/e2e-seed.ts",
     "stripe:check": "tsx scripts/stripe-check.ts",
     "vapid:generate": "tsx scripts/generate-vapid.ts",
+    "eval:geo-vision": "tsx scripts/geo-vision-eval.ts",
     "test": "node --import tsx --test 'src/**/*.test.ts'"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.110.0",
     "@better-auth/passkey": "~1.4.10",
     "@resvg/resvg-js": "^2.6.2",
     "@the-box/types": "*",

--- a/packages/backend/scripts/geo-vision-eval.ts
+++ b/packages/backend/scripts/geo-vision-eval.ts
@@ -1,0 +1,205 @@
+/**
+ * Geo vision-localization accuracy study (issue #331, phase 5).
+ *
+ * Before agent_vision pins are allowed to vote (even downweighted), we have to
+ * know whether the model can actually localize a screenshot on a game map. This
+ * offline harness samples promoted metas (known ground truth), asks a vision
+ * model to place each screenshot on its map, and scores the predictions against
+ * the enable bar (`domain/services/geo-vision-eval.service.ts`).
+ *
+ * It does NOT flip any flag — it prints the numbers a human signs off on before
+ * setting GEO_AGENT_VISION_ENABLED=true. Exits non-zero if the bar isn't met so
+ * a pipeline can gate on it.
+ *
+ * Usage (from packages/backend):
+ *   ANTHROPIC_API_KEY=... npm run eval:geo-vision            # 50 samples
+ *   ANTHROPIC_API_KEY=... npm run eval:geo-vision -- 30      # N samples
+ *   GEO_VISION_EVAL_MODEL=<model-id> ... npm run eval:geo-vision
+ *
+ * Requires DB access (samples ground truth) and an Anthropic API key. The model
+ * is configurable via GEO_VISION_EVAL_MODEL; it must be vision-capable.
+ */
+import Anthropic from '@anthropic-ai/sdk'
+import type { GeoPoint } from '@the-box/types'
+import { db } from '../src/infrastructure/database/connection.js'
+import {
+  parseVisionPoint,
+  summarizeVisionEval,
+  VISION_ENABLE_MAX_MEDIAN_DISTANCE,
+  VISION_ENABLE_MIN_WITHIN_RADIUS,
+  type VisionEvalSample,
+} from '../src/domain/services/geo-vision-eval.service.js'
+
+// Configurable so an operator can point the study at whichever vision-capable
+// model they intend to run in production. Kept out of source as a literal.
+const MODEL = process.env['GEO_VISION_EVAL_MODEL'] || 'claude-sonnet-5'
+
+const PROMPT =
+  'You are given two images: first the FULL MAP of a video game, then a SCREENSHOT ' +
+  'captured somewhere in that game world. Estimate where on the map the screenshot ' +
+  'was taken. Reply with ONLY a JSON object {"x": <0..1>, "y": <0..1>} where x is the ' +
+  'horizontal fraction from the left (0) to right (1) edge of the map image and y the ' +
+  'vertical fraction from the top (0) to bottom (1). No prose, no code fences.'
+
+type MediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
+
+interface GroundTruthRow {
+  canonical_x: number
+  canonical_y: number
+  screenshot_url: string
+  map_url: string
+  radius: number
+}
+
+async function fetchImage(url: string): Promise<{ data: string; mediaType: MediaType } | null> {
+  try {
+    const res = await fetch(url)
+    if (!res.ok) return null
+    const buf = Buffer.from(await res.arrayBuffer())
+    const ct = (res.headers.get('content-type') || '').toLowerCase()
+    const mediaType: MediaType = ct.includes('png')
+      ? 'image/png'
+      : ct.includes('webp')
+        ? 'image/webp'
+        : ct.includes('gif')
+          ? 'image/gif'
+          : 'image/jpeg'
+    return { data: buf.toString('base64'), mediaType }
+  } catch {
+    return null
+  }
+}
+
+async function localize(
+  client: Anthropic,
+  map: { data: string; mediaType: MediaType },
+  shot: { data: string; mediaType: MediaType },
+): Promise<GeoPoint | null> {
+  const resp = await client.messages.create({
+    model: MODEL,
+    max_tokens: 200,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: PROMPT },
+          { type: 'image', source: { type: 'base64', media_type: map.mediaType, data: map.data } },
+          { type: 'image', source: { type: 'base64', media_type: shot.mediaType, data: shot.data } },
+        ],
+      },
+    ],
+  })
+  const text = resp.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n')
+  return parseVisionPoint(text)
+}
+
+async function main(): Promise<void> {
+  const sampleSize = Math.max(1, Number(process.argv[2]) || 50)
+  if (!process.env['ANTHROPIC_API_KEY']) {
+    console.error('ANTHROPIC_API_KEY is not set — cannot run the vision study.')
+    process.exitCode = 2
+    return
+  }
+
+  const result = await db.raw<{ rows: GroundTruthRow[] }>(
+    `
+    SELECT
+      m.canonical_x,
+      m.canonical_y,
+      c.image_url AS screenshot_url,
+      map.image_url AS map_url,
+      COALESCE(map.consensus_radius, 0.03) AS radius
+    FROM geo_screenshot_meta m
+    JOIN geo_screenshot_candidate c ON c.id = m.geo_screenshot_candidate_id
+    JOIN geo_map map ON map.id = m.geo_map_id
+    WHERE c.is_active = true
+      AND map.image_url IS NOT NULL
+      AND c.image_url IS NOT NULL
+    ORDER BY RANDOM()
+    LIMIT ?
+    `,
+    [sampleSize],
+  )
+  const rows = (result as unknown as { rows: GroundTruthRow[] }).rows
+
+  if (rows.length === 0) {
+    console.error('No promoted metas with a flat map image found — nothing to evaluate.')
+    process.exitCode = 1
+    return
+  }
+
+  console.log(`Model: ${MODEL} · sampling ${rows.length} promoted metas\n`)
+
+  const client = new Anthropic()
+  const samples: VisionEvalSample[] = []
+  let failures = 0
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!
+    process.stdout.write(`[${i + 1}/${rows.length}] `)
+    const [mapImg, shotImg] = await Promise.all([
+      fetchImage(row.map_url),
+      fetchImage(row.screenshot_url),
+    ])
+    if (!mapImg || !shotImg) {
+      failures++
+      console.log('image fetch failed')
+      continue
+    }
+    let predicted: GeoPoint | null = null
+    try {
+      predicted = await localize(client, mapImg, shotImg)
+    } catch (err) {
+      console.log(`vision error: ${String(err)}`)
+    }
+    if (!predicted) {
+      failures++
+      console.log('no usable localization')
+      continue
+    }
+    samples.push({
+      predicted,
+      truth: { x: Number(row.canonical_x), y: Number(row.canonical_y) },
+      radius: Number(row.radius),
+    })
+    console.log(`ok (${predicted.x.toFixed(2)}, ${predicted.y.toFixed(2)})`)
+  }
+
+  const summary = summarizeVisionEval(samples)
+  const attempts = samples.length + failures
+  const usableRate = attempts > 0 ? samples.length / attempts : 0
+
+  // The gate is conservative: the geometric bar must pass on the usable
+  // predictions AND the model must actually produce a usable answer most of
+  // the time (a model that fails to localize half the screenshots is not
+  // trustworthy even if its hits are good).
+  const verdict = summary.pass && usableRate >= 0.8
+
+  console.log('\n──────── vision localization study ────────')
+  console.log(`samples (usable):        ${summary.count}`)
+  console.log(`fetch/parse failures:    ${failures}`)
+  console.log(`usable rate:             ${(usableRate * 100).toFixed(1)}%  (need ≥ 80%)`)
+  console.log(
+    `within consensus radius: ${(summary.withinRadiusPct * 100).toFixed(1)}%  (need ≥ ${(VISION_ENABLE_MIN_WITHIN_RADIUS * 100).toFixed(0)}%)`,
+  )
+  console.log(
+    `median normalized dist:  ${summary.medianNormalizedDistance.toFixed(3)}  (need < ${VISION_ENABLE_MAX_MEDIAN_DISTANCE})`,
+  )
+  console.log(`within 0.1 normalized:   ${(summary.within01Pct * 100).toFixed(1)}%`)
+  console.log(`\nVERDICT: ${verdict ? 'PASS ✅ — vision is good enough to enable as a downweighted voter' : 'FAIL ❌ — keep GEO_AGENT_VISION_ENABLED=false (structured-only)'}`)
+  console.log('Publish these numbers in the PR that enables GEO_AGENT_VISION_ENABLED.\n')
+
+  process.exitCode = verdict ? 0 : 1
+}
+
+main()
+  .catch((err) => {
+    console.error(err)
+    process.exitCode = 1
+  })
+  .finally(() => {
+    void db.destroy()
+  })

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -65,6 +65,11 @@ export const env = {
   // Agent pins are downweighted and can never promote on their own, but the
   // budget still bounds how fast one key can flood the review queue.
   GEO_AGENT_MAX_PINS_PER_HOUR: process.env['GEO_AGENT_MAX_PINS_PER_HOUR'] || '60',
+  // Gate for LLM-vision pin proposals (phase 5). Off until the offline accuracy
+  // study (`npm run eval:geo-vision`) clears the enable bar — until then
+  // `source=agent_vision` proposals are rejected with VISION_DISABLED, so
+  // unmeasured vision pins never enter consensus even as downweighted voters.
+  GEO_AGENT_VISION_ENABLED: process.env['GEO_AGENT_VISION_ENABLED'] || 'false',
 
   // RAWG API (for fetching game screenshots)
   RAWG_API_KEY: process.env['RAWG_API_KEY'] || '',

--- a/packages/backend/src/domain/services/geo-agent-guard.service.test.ts
+++ b/packages/backend/src/domain/services/geo-agent-guard.service.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  shouldPauseAgentKey,
+  AGENT_KEY_PAUSE_MIN_SUBMISSIONS,
+  AGENT_KEY_PAUSE_REJECTION_RATIO,
+} from './geo-agent-guard.service.js'
+
+describe('shouldPauseAgentKey', () => {
+  it('never pauses below the min-submissions floor, even at 100% rejection', () => {
+    assert.equal(
+      shouldPauseAgentKey({ submitted: AGENT_KEY_PAUSE_MIN_SUBMISSIONS - 1, rejected: 9 }),
+      false,
+    )
+    assert.equal(shouldPauseAgentKey({ submitted: 0, rejected: 0 }), false)
+  })
+
+  it('pauses when the ratio exceeds the bar at/above the floor', () => {
+    // 10 submitted, 7 rejected → 0.7 > 0.6 → pause.
+    assert.equal(shouldPauseAgentKey({ submitted: 10, rejected: 7 }), true)
+  })
+
+  it('does not pause exactly at the bar (strictly greater required)', () => {
+    // 10 submitted, 6 rejected → 0.6, not > 0.6.
+    assert.equal(shouldPauseAgentKey({ submitted: 10, rejected: 6 }), false)
+  })
+
+  it('allows a well-behaved key with a low rejection ratio', () => {
+    assert.equal(shouldPauseAgentKey({ submitted: 50, rejected: 5 }), false)
+  })
+
+  it('exposes the same bar as the human shadow-ban', () => {
+    assert.equal(AGENT_KEY_PAUSE_REJECTION_RATIO, 0.6)
+    assert.equal(AGENT_KEY_PAUSE_MIN_SUBMISSIONS, 10)
+  })
+})

--- a/packages/backend/src/domain/services/geo-agent-guard.service.ts
+++ b/packages/backend/src/domain/services/geo-agent-guard.service.ts
@@ -1,0 +1,23 @@
+// Per-key anti-abuse for the agent propose surface (issue #331, phase 5).
+//
+// Mirrors the human contributor shadow-ban (geo-reward.service): a geo-agent
+// key whose recent proposals are mostly rejected by consensus is auto-paused,
+// so a miscalibrated proposer can't keep flooding the review queue with noise.
+// Pure so the threshold logic is unit-tested without a DB; the route pairs it
+// with `geoPinRepository.agentKeyRejectionRatio7d`.
+
+// Same bar as the human shadow-ban, deliberately: SHADOW_BAN_MIN_SUBMISSIONS /
+// SHADOW_BAN_REJECTION_RATIO in geo-reward.service. Kept as its own constants
+// so the two policies can diverge later without a surprising coupling.
+export const AGENT_KEY_PAUSE_MIN_SUBMISSIONS = 10
+export const AGENT_KEY_PAUSE_REJECTION_RATIO = 0.6
+
+/**
+ * True when a key's 7-day proposals should be paused: enough submissions to
+ * judge (≥ min) AND a rejection ratio above the bar. Below the min-submissions
+ * floor a key is always allowed — we don't punish a key on a tiny sample.
+ */
+export function shouldPauseAgentKey(counts: { submitted: number; rejected: number }): boolean {
+  if (counts.submitted < AGENT_KEY_PAUSE_MIN_SUBMISSIONS) return false
+  return counts.rejected / counts.submitted > AGENT_KEY_PAUSE_REJECTION_RATIO
+}

--- a/packages/backend/src/domain/services/geo-vision-eval.service.test.ts
+++ b/packages/backend/src/domain/services/geo-vision-eval.service.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  euclideanDistance,
+  normalizedDistance,
+  parseVisionPoint,
+  summarizeVisionEval,
+  VISION_ENABLE_MAX_MEDIAN_DISTANCE,
+  VISION_ENABLE_MIN_WITHIN_RADIUS,
+  type VisionEvalSample,
+} from './geo-vision-eval.service.js'
+
+describe('distance helpers', () => {
+  it('euclidean is raw distance in map space', () => {
+    assert.ok(Math.abs(euclideanDistance({ x: 0, y: 0 }, { x: 0.3, y: 0.4 }) - 0.5) < 1e-9)
+  })
+  it('normalized divides by the unit-square diagonal (√2)', () => {
+    // Opposite corners → raw √2 → normalized 1.
+    assert.ok(Math.abs(normalizedDistance({ x: 0, y: 0 }, { x: 1, y: 1 }) - 1) < 1e-9)
+  })
+})
+
+describe('summarizeVisionEval', () => {
+  it('returns a non-passing zero summary for an empty set', () => {
+    const out = summarizeVisionEval([])
+    assert.equal(out.count, 0)
+    assert.equal(out.pass, false)
+  })
+
+  it('passes when ≥40% land within radius and median error < 0.1', () => {
+    // 5 spot-on predictions (distance 0) → 100% within radius, median 0.
+    const samples: VisionEvalSample[] = Array.from({ length: 5 }, () => ({
+      predicted: { x: 0.5, y: 0.5 },
+      truth: { x: 0.5, y: 0.5 },
+      radius: 0.03,
+    }))
+    const out = summarizeVisionEval(samples)
+    assert.equal(out.withinRadiusPct, 1)
+    assert.equal(out.medianNormalizedDistance, 0)
+    assert.equal(out.pass, true)
+  })
+
+  it('fails when predictions are far off (noise floor)', () => {
+    // All predictions at the opposite corner → 0% within radius, median ≈ 1.
+    const samples: VisionEvalSample[] = Array.from({ length: 10 }, () => ({
+      predicted: { x: 1, y: 1 },
+      truth: { x: 0, y: 0 },
+      radius: 0.03,
+    }))
+    const out = summarizeVisionEval(samples)
+    assert.equal(out.withinRadiusPct, 0)
+    assert.equal(out.pass, false)
+  })
+
+  it('fails when within-radius is below the 40% bar despite some hits', () => {
+    // 3 hits + 7 far misses → 30% within radius < 40% → fail even if the 3
+    // hits drag the median around.
+    const hits: VisionEvalSample[] = Array.from({ length: 3 }, () => ({
+      predicted: { x: 0.5, y: 0.5 },
+      truth: { x: 0.5, y: 0.5 },
+      radius: 0.03,
+    }))
+    const misses: VisionEvalSample[] = Array.from({ length: 7 }, () => ({
+      predicted: { x: 0.9, y: 0.9 },
+      truth: { x: 0.1, y: 0.1 },
+      radius: 0.03,
+    }))
+    const out = summarizeVisionEval([...hits, ...misses])
+    assert.ok(out.withinRadiusPct < VISION_ENABLE_MIN_WITHIN_RADIUS)
+    assert.equal(out.pass, false)
+  })
+
+  it('exposes the enable bar as constants', () => {
+    assert.equal(VISION_ENABLE_MIN_WITHIN_RADIUS, 0.4)
+    assert.equal(VISION_ENABLE_MAX_MEDIAN_DISTANCE, 0.1)
+  })
+})
+
+describe('parseVisionPoint', () => {
+  it('parses bare JSON', () => {
+    assert.deepEqual(parseVisionPoint('{"x":0.4,"y":0.6}'), { x: 0.4, y: 0.6 })
+  })
+  it('parses JSON embedded in prose / code fences', () => {
+    assert.deepEqual(
+      parseVisionPoint('Here it is:\n```json\n{ "x": 0.25, "y": 0.75 }\n```\nDone.'),
+      { x: 0.25, y: 0.75 },
+    )
+  })
+  it('rejects out-of-range or missing coords', () => {
+    assert.equal(parseVisionPoint('{"x":1.4,"y":0.2}'), null)
+    assert.equal(parseVisionPoint('{"x":0.2}'), null)
+    assert.equal(parseVisionPoint('no json here'), null)
+    assert.equal(parseVisionPoint(''), null)
+  })
+})

--- a/packages/backend/src/domain/services/geo-vision-eval.service.ts
+++ b/packages/backend/src/domain/services/geo-vision-eval.service.ts
@@ -1,0 +1,107 @@
+import type { GeoPoint } from '@the-box/types'
+
+// Accuracy metrics for the LLM-vision localization study (issue #331, phase 5).
+//
+// Before agent_vision pins are allowed to vote (even at weight 0.25), the
+// offline harness `scripts/geo-vision-eval.ts` runs vision localization against
+// known-truth promoted metas and feeds the results here. The verdict gates
+// flipping GEO_AGENT_VISION_ENABLED: if the model can't localize well enough,
+// vision pins add noise rather than signal and the tier stays off.
+//
+// Pure — no I/O — so the metric math and the JSON parsing are unit-tested.
+
+// Enable bar: at least this fraction of predictions must land within the map's
+// consensus radius, AND the median normalized error must be below the cap.
+export const VISION_ENABLE_MIN_WITHIN_RADIUS = 0.4
+export const VISION_ENABLE_MAX_MEDIAN_DISTANCE = 0.1
+
+export interface VisionEvalSample {
+  predicted: GeoPoint
+  truth: GeoPoint
+  // The map's consensus_radius — raw euclidean units in the [0,1] map space,
+  // the same convention geo-consensus compares against.
+  radius: number
+}
+
+export interface VisionEvalSummary {
+  count: number
+  medianNormalizedDistance: number
+  withinRadiusPct: number
+  within01Pct: number
+  pass: boolean
+}
+
+/** Raw euclidean distance in the map's [0,1] space (matches consensus radius). */
+export function euclideanDistance(a: GeoPoint, b: GeoPoint): number {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  return Math.sqrt(dx * dx + dy * dy)
+}
+
+/**
+ * Normalized to [0,1] by the diagonal of the unit square (√2) — the same
+ * "normalized distance" geo-scoring uses, so the median/0.1 bar is comparable
+ * to the free-play scoring curve.
+ */
+export function normalizedDistance(a: GeoPoint, b: GeoPoint): number {
+  return euclideanDistance(a, b) / Math.SQRT2
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0
+  const s = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 === 0 ? (s[mid - 1]! + s[mid]!) / 2 : s[mid]!
+}
+
+export function summarizeVisionEval(samples: VisionEvalSample[]): VisionEvalSummary {
+  const count = samples.length
+  if (count === 0) {
+    return {
+      count: 0,
+      medianNormalizedDistance: 0,
+      withinRadiusPct: 0,
+      within01Pct: 0,
+      pass: false,
+    }
+  }
+  const norm = samples.map((s) => normalizedDistance(s.predicted, s.truth))
+  const withinRadius = samples.filter(
+    (s) => euclideanDistance(s.predicted, s.truth) <= s.radius,
+  ).length
+  const within01 = norm.filter((d) => d <= 0.1).length
+  const medianNormalizedDistance = median(norm)
+  const withinRadiusPct = withinRadius / count
+  const within01Pct = within01 / count
+  const pass =
+    withinRadiusPct >= VISION_ENABLE_MIN_WITHIN_RADIUS &&
+    medianNormalizedDistance < VISION_ENABLE_MAX_MEDIAN_DISTANCE
+  return { count, medianNormalizedDistance, withinRadiusPct, within01Pct, pass }
+}
+
+/**
+ * Parse a vision model's reply into a normalized point. Tolerant of prose or
+ * code fences around the JSON; returns null when no valid `{x,y}` in [0,1] is
+ * present. The harness counts a null as a miss, never a crash — one bad
+ * completion shouldn't abort a 50-sample run.
+ */
+export function parseVisionPoint(text: string): GeoPoint | null {
+  if (!text) return null
+  const candidates: string[] = []
+  const braced = text.match(/\{[^{}]*\}/)
+  if (braced) candidates.push(braced[0])
+  candidates.push(text.trim())
+  for (const c of candidates) {
+    try {
+      const obj = JSON.parse(c) as { x?: unknown; y?: unknown }
+      const x = Number(obj.x)
+      const y = Number(obj.y)
+      if (Number.isFinite(x) && Number.isFinite(y) && x >= 0 && x <= 1 && y >= 0 && y <= 1) {
+        return { x, y }
+      }
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null
+}

--- a/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-pin.repository.ts
@@ -202,6 +202,36 @@ export const geoPinRepository = {
     return Number(result?.count ?? 0)
   },
 
+  // Same shape as userRejectionRatio7d but keyed by the agent API key, for the
+  // per-key auto-pause (issue #331, phase 5). Counts this key's agent pins in
+  // the last 7 days and how many consensus rejected.
+  async agentKeyRejectionRatio7d(
+    agentKeyId: number,
+  ): Promise<{ submitted: number; rejected: number }> {
+    const sevenDaysSeconds = 7 * 24 * 60 * 60
+    const rows = await db('geo_pin_submission')
+      .where({ agent_key_id: agentKeyId })
+      .where(
+        'created_at',
+        '>=',
+        db.raw(`NOW() - make_interval(secs => ?)`, [sevenDaysSeconds]),
+      )
+      .select<Array<{ status: GeoPinStatus; count: string }>>(
+        'status',
+        db.raw('COUNT(*) as count'),
+      )
+      .groupBy('status')
+
+    let submitted = 0
+    let rejected = 0
+    for (const r of rows) {
+      const c = Number(r.count)
+      submitted += c
+      if (r.status === 'rejected') rejected += c
+    }
+    return { submitted, rejected }
+  },
+
   async userRejectionRatio7d(userId: string): Promise<{ submitted: number; rejected: number }> {
     // 7 days = 604800 seconds, expressed as a bound parameter for the same
     // reason as countByUserInWindow.

--- a/packages/backend/src/presentation/routes/agent-geo.routes.ts
+++ b/packages/backend/src/presentation/routes/agent-geo.routes.ts
@@ -16,6 +16,7 @@ import {
 import { geoSourceConfigRepository } from '../../infrastructure/repositories/geo-source-config.repository.js'
 import { adminAuditRepository } from '../../infrastructure/repositories/admin-audit.repository.js'
 import { pinsToNextConsensusThreshold } from '../../domain/services/geo-consensus.service.js'
+import { shouldPauseAgentKey } from '../../domain/services/geo-agent-guard.service.js'
 import { getGeoGamersHealthSnapshot } from '../../infrastructure/geogamers-health.js'
 import {
   enqueueSingleTierImport,
@@ -249,6 +250,36 @@ router.post(
         res.status(409).json({
           success: false,
           error: { code: 'ALREADY_PROMOTED', message: 'candidate already has a canonical pin' },
+        })
+        return
+      }
+
+      // Vision proposals are gated behind the accuracy study (phase 5). Until
+      // GEO_AGENT_VISION_ENABLED is flipped (after eval:geo-vision passes the
+      // enable bar), reject agent_vision so unmeasured vision pins can't add
+      // noise to consensus. Structured pins are unaffected.
+      if (body.source === 'agent_vision' && env.GEO_AGENT_VISION_ENABLED !== 'true') {
+        res.status(403).json({
+          success: false,
+          error: {
+            code: 'VISION_DISABLED',
+            message: 'Vision proposals are disabled pending accuracy validation',
+          },
+        })
+        return
+      }
+
+      // Per-key auto-pause: a key whose recent proposals are mostly rejected by
+      // consensus is paused (same bar as the human shadow-ban). Checked before
+      // the budget so a paused key doesn't burn its quota probing.
+      const rejectionRatio = await geoPinRepository.agentKeyRejectionRatio7d(keyId)
+      if (shouldPauseAgentKey(rejectionRatio)) {
+        res.status(403).json({
+          success: false,
+          error: {
+            code: 'KEY_PAUSED',
+            message: 'Key paused: too many recent proposals were rejected by consensus',
+          },
         })
         return
       }


### PR DESCRIPTION
## Summary

Phase 5 of #331 (agent-assisted geo content sourcing), building on the merged phases 1–4 (PR #332). It keeps LLM-vision pins **out of consensus until they're measured**, and auto-pauses any agent key the crowd keeps rejecting. Ships dark behind `GEO_AGENT_VISION_ENABLED`.

The `agent_vision` source + `vision_pass` plumbing already exists from phase 4 — phase 5 is the **gate** and the **study** that justify turning it on.

## What's in it

**Vision gate.** `POST /candidates/:id/pins` with `source: "agent_vision"` is rejected with `403 VISION_DISABLED` until `GEO_AGENT_VISION_ENABLED=true` (default false). `agent_structured` is unaffected. So unmeasured vision pins can never enter consensus, even as downweighted voters.

**Accuracy study** — `packages/backend/scripts/geo-vision-eval.ts` (`npm run eval:geo-vision`):
- Samples promoted metas (known ground truth), fetches each screenshot + its map, asks a vision model to localize, and scores against the **enable bar**: ≥40% of predictions within the map's consensus radius **and** median normalized error < 0.1, on ≥50 samples.
- Prints the metrics + a **PASS/FAIL verdict** and exits non-zero on fail. It flips no flag itself — it produces the numbers a human signs off on before enabling vision, and those numbers get published in the PR that enables it.
- Uses the official `@anthropic-ai/sdk` (added as a backend dep); model is configurable via `GEO_VISION_EVAL_MODEL` (any vision-capable model).

**Pure, unit-tested core** — the metric math (`summarizeVisionEval`), the reply parser (`parseVisionPoint`), and the pause decision (`shouldPauseAgentKey`) are all pure and tested (15 new tests), so the harness's I/O shell is the only untested part.

**Per-key auto-pause.** A key whose 7-day proposals are >60% rejected by consensus (≥10 submissions) gets `403 KEY_PAUSED` — the same bar as the human contributor shadow-ban, applied at the key level, checked before the budget so a paused key doesn't burn quota probing. Backed by a new `agentKeyRejectionRatio7d` repo query.

**Docs** — `docs/geo-agent-api.md` (new error codes + the vision gate + the study) and `.env.example`.

## Verification

Full workspace build typechecks, the eval harness typechecks against the SDK in isolation, lint 0 errors, **371 backend + 15 MCP tests pass**.

Because #332 was merged and its branch deleted, this restarts the designated branch from `main` — it's a **new PR**, not a continuation of #332.

## Note

The eval harness needs a live DB + an Anthropic API key to run, so I couldn't execute it in this environment — the pure metric/parse/pause logic is unit-tested, but the end-to-end study (and the migration from phase 4) should be exercised in staging before `GEO_AGENT_VISION_ENABLED` is flipped.

Remaining: **phase 6** (in-app backfill discovery worker) and the structured-coordinate crawler follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvJoyRSYB7UMaRfuMsT5Jd

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvJoyRSYB7UMaRfuMsT5Jd)_