### PR TITLE
feat(geo): backfill discovery worker (#331 phase 6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,10 @@ GEO_AGENT_MAX_PINS_PER_HOUR=60
 # study (npm run eval:geo-vision) clears the enable bar; while false,
 # source=agent_vision proposals are rejected with VISION_DISABLED.
 GEO_AGENT_VISION_ENABLED=false
+# Backfill discovery worker (phase 6). When true, a recurring job drives
+# ingestion at curated+resolved games closest to eligibility. Off by default.
+GEO_BACKFILL_ENABLED=false
+GEO_BACKFILL_BATCH=10
 
 # ============================================
 # PRODUCTION DEPLOYMENT NOTES

--- a/docs/geo-mode.md
+++ b/docs/geo-mode.md
@@ -128,6 +128,10 @@ graph LR
 
 Le worker `geo-ingest-tick-logic.ts` parcourt les jeux résolus, repère ceux qui n'ont pas atteint le quota de candidatures et enqueue le travail correspondant pour chaque tier éligible. Le résolveur de métadonnées (`geo-metadata-resolve-logic.ts`) renseigne au préalable `wiki_subdomain`, `wikidata_qid`, `steam_app_id`, etc.
 
+### Backfill discovery (issue #331, phase 6)
+
+Le tick d'ingestion normal complète **tous** les jeux résolus (y compris ceux déjà éligibles) vers le quota de candidatures. Le worker de **backfill** (`geo-backfill-logic.ts`, `backfill-tick`) inverse cette logique : il classe les jeux curés+résolus **non encore éligibles** par distance à l'éligibilité (`geo-backfill.service.ts` : carte active ? captures qui collectent des pins ? nombre de pins max ?) et relance l'ingestion pour les `GEO_BACKFILL_BATCH` (défaut 10) jeux les plus proches d'un premier pin canonique — l'effort de sourcing va donc là où il fait bouger le compteur de jeux éligibles. Sans LLM in-process : il réutilise la même requête classée + le même chemin d'ingestion qu'un agent externe piloterait à la main. Récurrent toutes les 30 min, **désactivé par défaut** (`GEO_BACKFILL_ENABLED`).
+
 ### État du pipeline
 
 Tables associées :

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -65,6 +65,13 @@ export const env = {
   // Agent pins are downweighted and can never promote on their own, but the
   // budget still bounds how fast one key can flood the review queue.
   GEO_AGENT_MAX_PINS_PER_HOUR: process.env['GEO_AGENT_MAX_PINS_PER_HOUR'] || '60',
+  // Backfill discovery worker (issue #331, phase 6). Off by default. When on, a
+  // recurring job ranks curated+resolved games that are NOT yet eligible by
+  // distance-to-eligibility and drives ingestion at the ones closest to a
+  // canonical pin — the in-app, steady-state complement to the external agent.
+  GEO_BACKFILL_ENABLED: process.env['GEO_BACKFILL_ENABLED'] || 'false',
+  // How many top-ranked sub-threshold games each backfill tick drives.
+  GEO_BACKFILL_BATCH: process.env['GEO_BACKFILL_BATCH'] || '10',
   // Gate for LLM-vision pin proposals (phase 5). Off until the offline accuracy
   // study (`npm run eval:geo-vision`) clears the enable bar — until then
   // `source=agent_vision` proposals are rejected with VISION_DISABLED, so

--- a/packages/backend/src/domain/services/geo-backfill.service.test.ts
+++ b/packages/backend/src/domain/services/geo-backfill.service.test.ts
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  backfillPriority,
+  rankBackfillTargets,
+  type BackfillCandidate,
+} from './geo-backfill.service.js'
+
+describe('backfillPriority', () => {
+  it('ranks "has map + collecting pins" above "has map, no captures" above "no map"', () => {
+    const collecting = backfillPriority({
+      gameId: 1,
+      hasActiveMap: true,
+      candidateCount: 2,
+      topPinCount: 0,
+    })
+    const mapOnly = backfillPriority({
+      gameId: 2,
+      hasActiveMap: true,
+      candidateCount: 0,
+      topPinCount: 0,
+    })
+    const noMap = backfillPriority({
+      gameId: 3,
+      hasActiveMap: false,
+      candidateCount: 0,
+      topPinCount: 0,
+    })
+    assert.ok(collecting > mapOnly)
+    assert.ok(mapOnly > noMap)
+  })
+
+  it('a game one pin away outranks any game that only has a map, regardless of pin count', () => {
+    // Even the max-pin bump can't lift a mapOnly game into the collecting band.
+    const collectingLowPins = backfillPriority({
+      gameId: 1,
+      hasActiveMap: true,
+      candidateCount: 1,
+      topPinCount: 0,
+    })
+    const mapOnly = backfillPriority({
+      gameId: 2,
+      hasActiveMap: true,
+      candidateCount: 0,
+      topPinCount: 999,
+    })
+    assert.ok(collectingLowPins > mapOnly)
+  })
+
+  it('within the collecting band, more pins ranks higher', () => {
+    const near = backfillPriority({
+      gameId: 1,
+      hasActiveMap: true,
+      candidateCount: 3,
+      topPinCount: 9,
+    })
+    const far = backfillPriority({
+      gameId: 2,
+      hasActiveMap: true,
+      candidateCount: 3,
+      topPinCount: 2,
+    })
+    assert.ok(near > far)
+  })
+})
+
+describe('rankBackfillTargets', () => {
+  const candidates: BackfillCandidate[] = [
+    { gameId: 10, hasActiveMap: false, candidateCount: 0, topPinCount: 0 }, // no map
+    { gameId: 11, hasActiveMap: true, candidateCount: 0, topPinCount: 0 }, // map only
+    { gameId: 12, hasActiveMap: true, candidateCount: 4, topPinCount: 4 }, // collecting, 4 pins
+    { gameId: 13, hasActiveMap: true, candidateCount: 4, topPinCount: 9 }, // collecting, 9 pins
+  ]
+
+  it('orders by descending priority and caps at batchSize', () => {
+    const top2 = rankBackfillTargets(candidates, 2)
+    assert.deepEqual(
+      top2.map((t) => t.gameId),
+      [13, 12],
+    )
+  })
+
+  it('returns the full ordered list when batchSize exceeds the count', () => {
+    const all = rankBackfillTargets(candidates, 100)
+    assert.deepEqual(
+      all.map((t) => t.gameId),
+      [13, 12, 11, 10],
+    )
+  })
+
+  it('returns nothing for batchSize 0', () => {
+    assert.deepEqual(rankBackfillTargets(candidates, 0), [])
+  })
+
+  it('breaks priority ties by game id', () => {
+    const tied: BackfillCandidate[] = [
+      { gameId: 30, hasActiveMap: true, candidateCount: 0, topPinCount: 0 },
+      { gameId: 20, hasActiveMap: true, candidateCount: 0, topPinCount: 0 },
+    ]
+    assert.deepEqual(
+      rankBackfillTargets(tied, 5).map((t) => t.gameId),
+      [20, 30],
+    )
+  })
+})

--- a/packages/backend/src/domain/services/geo-backfill.service.ts
+++ b/packages/backend/src/domain/services/geo-backfill.service.ts
@@ -1,0 +1,57 @@
+// Backfill discovery ranking (issue #331, phase 6).
+//
+// The regular ingest tick tops up EVERY curated+resolved game (including
+// already-eligible ones) toward the candidate cap. Backfill instead points
+// sourcing effort at games that are NOT yet eligible, ranked by how close they
+// are to earning a first canonical pin — so ingestion moves the eligible-count
+// needle instead of re-enriching games that already count.
+//
+// Pure so the ranking is unit-tested without a DB; the repo supplies the
+// signals and the worker drives ingestion for the top-ranked games.
+
+export interface BackfillCandidate {
+  gameId: number
+  // Does the game have at least one active map? (Captures anchor to a map, so
+  // no map ⇒ nothing can be pinned yet.)
+  hasActiveMap: boolean
+  // Active, not-yet-promoted captures collecting pins.
+  candidateCount: number
+  // Highest raw pin count among those captures — pin momentum toward the
+  // consensus promote threshold.
+  topPinCount: number
+}
+
+/**
+ * Priority score — higher means closer to eligibility, so it's driven first.
+ * Bucketed so a game that's "one pin away" always outranks one that still needs
+ * a map, regardless of raw counts:
+ *   3000+ : has a map AND captures collecting pins  → rank by pin momentum
+ *   2000  : has a map but no captures yet            → needs capture ingestion
+ *   1000  : curated+resolved but no active map       → needs map ingestion
+ */
+export function backfillPriority(c: BackfillCandidate): number {
+  if (c.hasActiveMap && c.candidateCount > 0) {
+    return 3000 + Math.min(Math.max(c.topPinCount, 0), 999)
+  }
+  if (c.hasActiveMap) return 2000
+  return 1000
+}
+
+export interface BackfillTarget {
+  gameId: number
+  priority: number
+}
+
+/**
+ * Rank candidates by descending priority (ties broken by game id for a stable
+ * order) and return the top `batchSize`.
+ */
+export function rankBackfillTargets(
+  candidates: BackfillCandidate[],
+  batchSize: number,
+): BackfillTarget[] {
+  return candidates
+    .map((c) => ({ gameId: c.gameId, priority: backfillPriority(c) }))
+    .sort((a, b) => b.priority - a.priority || a.gameId - b.gameId)
+    .slice(0, Math.max(0, batchSize))
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -759,7 +759,8 @@ async function start(): Promise<void> {
         if (
           job.name === 'schedule-daily-challenge' ||
           job.name === 'resolve-metadata' ||
-          job.name === 'ingest-tick'
+          job.name === 'ingest-tick' ||
+          job.name === 'backfill-tick'
         ) {
           await geoQueue.removeRepeatableByKey(job.key)
         }
@@ -788,6 +789,27 @@ async function start(): Promise<void> {
         }
       )
       logger.info('scheduled recurring ingest-tick geo job (every 15 min)')
+
+      // Backfill discovery every 30 min (issue #331, phase 6). Off by default —
+      // the stale-sweep above still removes it if it was previously registered
+      // and the flag was since turned off. Unlike ingest-tick (which tops up
+      // every resolved game), this concentrates on sub-threshold games ranked
+      // by distance-to-eligibility so effort moves the eligible-count needle.
+      if (env.GEO_BACKFILL_ENABLED === 'true') {
+        const backfillBatch = Number(env.GEO_BACKFILL_BATCH) || 10
+        await geoQueue.add(
+          'backfill-tick',
+          { kind: 'backfill-tick', batchSize: backfillBatch },
+          {
+            repeat: { every: 30 * 60 * 1000 },
+            jobId: 'geo-backfill-tick-recurring',
+          }
+        )
+        logger.info(
+          { batchSize: backfillBatch },
+          'scheduled recurring backfill-tick geo job (every 30 min)',
+        )
+      }
     } catch (error) {
       logger.warn({ error: String(error) }, 'failed to register recurring geo jobs')
     }

--- a/packages/backend/src/infrastructure/queue/queues.ts
+++ b/packages/backend/src/infrastructure/queue/queues.ts
@@ -85,6 +85,9 @@ export type GeoJobData =
     }
   | { kind: 'resolve-metadata'; batchSize?: number; gameId?: number }
   | { kind: 'ingest-tick'; batchSize?: number; gameId?: number }
+  // Backfill discovery (issue #331, phase 6): rank sub-threshold games by
+  // distance-to-eligibility and drive ingestion at the closest ones.
+  | { kind: 'backfill-tick'; batchSize?: number }
   // ===== Multi-source map fetch pipeline (replaces topup-screenshots) =====
   // Parent orchestrator job. Re-enqueued by each child on completion until
   // the pipeline reaches awaiting_curation, ready, or blocked.

--- a/packages/backend/src/infrastructure/queue/workers/geo-backfill-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-backfill-logic.ts
@@ -1,0 +1,41 @@
+import { queueLogger } from '../../logger/logger.js'
+import { geoScreenshotRepository } from '../../repositories/index.js'
+import { rankBackfillTargets, type BackfillTarget } from '../../../domain/services/geo-backfill.service.js'
+import { runGeoIngestTick } from './geo-ingest-tick-logic.js'
+
+const log = queueLogger.child({ worker: 'geo-backfill-tick' })
+
+const DEFAULT_BATCH = 10
+// Coarse cap on how many sub-threshold games the ranker considers per tick.
+const CANDIDATE_CAP = 500
+
+export interface BackfillTickResult {
+  scanned: number
+  enqueuedGames: number
+  targets: BackfillTarget[]
+}
+
+/**
+ * One backfill pass (issue #331, phase 6). Ranks curated+resolved games that
+ * aren't eligible yet by distance-to-eligibility and drives the existing
+ * ingest tick for the top `batchSize` — concentrating sourcing on the games
+ * closest to a first canonical pin. No LLM in-process: it reuses the same
+ * ranked query + ingest path an external agent would drive by hand.
+ */
+export async function runGeoBackfillTick(batchSize = DEFAULT_BATCH): Promise<BackfillTickResult> {
+  const candidates = await geoScreenshotRepository.listBackfillCandidates(CANDIDATE_CAP)
+  const targets = rankBackfillTargets(candidates, batchSize)
+
+  for (const target of targets) {
+    // Per-game ingest cascade — same path as the admin "Run for this game"
+    // button and the agent ingest trigger. Idempotent (deterministic jobIds +
+    // per-source tombstones), so re-driving a game across ticks is safe.
+    await runGeoIngestTick(undefined, target.gameId)
+  }
+
+  log.info(
+    { scanned: candidates.length, enqueued: targets.length, batchSize },
+    'geo-backfill-tick run',
+  )
+  return { scanned: candidates.length, enqueuedGames: targets.length, targets }
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo.worker.ts
@@ -13,6 +13,7 @@ import { importSteamScreenshots } from './geo-steam-import-logic.js'
 import { importRawgScreenshots } from './geo-rawg-import-logic.js'
 import { resolveGeoMetadataBatch } from './geo-metadata-resolve-logic.js'
 import { runGeoIngestTick } from './geo-ingest-tick-logic.js'
+import { runGeoBackfillTick } from './geo-backfill-logic.js'
 import { advancePipeline, runMapsPipeline } from './maps-pipeline-logic.js'
 import {
   shouldAdvanceAfterFailure,
@@ -126,6 +127,10 @@ export const geoWorker = new Worker<GeoJobData>(
 
     if (data.kind === 'ingest-tick') {
       return await runGeoIngestTick(data.batchSize, data.gameId)
+    }
+
+    if (data.kind === 'backfill-tick') {
+      return await runGeoBackfillTick(data.batchSize)
     }
 
     if (data.kind === 'maps:pipeline') {

--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -477,6 +477,70 @@ export const geoScreenshotRepository = {
     }))
   },
 
+  /**
+   * Candidates for the backfill discovery worker (issue #331, phase 6):
+   * curated + metadata-resolved games (so the ingest pipeline can act on them)
+   * that are NOT yet eligible — i.e. have no promoted meta on any active
+   * candidate. Returns the raw signals the ranking needs (active map? captures
+   * collecting pins? top pin count?); the pure `rankBackfillTargets` decides
+   * ordering. Coarsely pre-sorted + capped so a huge catalog doesn't fetch the
+   * whole table.
+   */
+  async listBackfillCandidates(limit = 500): Promise<
+    Array<{
+      gameId: number
+      hasActiveMap: boolean
+      candidateCount: number
+      topPinCount: number
+    }>
+  > {
+    const result = await db.raw<{
+      rows: Array<{
+        game_id: number
+        has_active_map: boolean
+        candidate_count: string
+        top_pin_count: string
+      }>
+    }>(
+      `
+      SELECT
+        g.id AS game_id,
+        EXISTS (
+          SELECT 1 FROM geo_map m WHERE m.game_id = g.id AND m.is_active = true
+        ) AS has_active_map,
+        COALESCE(stats.candidate_count, 0) AS candidate_count,
+        COALESCE(stats.top_pin_count, 0) AS top_pin_count
+      FROM games g
+      LEFT JOIN LATERAL (
+        SELECT
+          COUNT(*) AS candidate_count,
+          COALESCE(MAX(c.pin_count), 0) AS top_pin_count
+        FROM geo_screenshot_candidate c
+        WHERE c.game_id = g.id
+          AND c.is_active = true
+          AND c.status IN ('pending', 'collecting')
+      ) stats ON true
+      WHERE g.geo_curated = true
+        AND g.geo_metadata_status = 'resolved'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM geo_screenshot_meta sm
+          JOIN geo_screenshot_candidate cc ON cc.id = sm.geo_screenshot_candidate_id
+          WHERE cc.game_id = g.id AND cc.is_active = true
+        )
+      ORDER BY top_pin_count DESC, has_active_map DESC, g.id ASC
+      LIMIT ?
+      `,
+      [limit],
+    )
+    return result.rows.map((r) => ({
+      gameId: r.game_id,
+      hasActiveMap: r.has_active_map === true,
+      candidateCount: Number(r.candidate_count ?? 0),
+      topPinCount: Number(r.top_pin_count ?? 0),
+    }))
+  },
+
   async listCandidatesForReview(args: {
     status?: GeoScreenshotCandidateRow['status']
     gameId?: number


### PR DESCRIPTION
## Summary

Phase 6 of #331 — the final phase. An in-app, steady-state complement to the external agent: a recurring worker that concentrates ingestion on the games *closest to becoming eligible*, so sourcing effort moves the eligible-game count instead of re-enriching games that already count. **No LLM in-process** — it reuses the same ranked query + ingest path an external agent would drive by hand. Off by default behind `GEO_BACKFILL_ENABLED`.

## The inversion

The regular ingest tick tops up **every** curated+resolved game (including already-eligible ones) toward the candidate cap. Backfill instead:

1. Ranks curated+resolved games that are **not yet eligible** (no promoted meta on an active candidate) by **distance to eligibility**.
2. Drives the existing per-game ingest cascade for the top `GEO_BACKFILL_BATCH` (default 10).

## What's in it

- **Pure, unit-tested ranking** (`geo-backfill.service`): `backfillPriority` buckets `has map + captures collecting pins` > `map only` > `no map`, and ranks by pin momentum within the top band; `rankBackfillTargets` sorts + caps. 7 tests including the invariant that a "one pin away" game always outranks a "needs a map" one regardless of raw counts.
- **Repo** `listBackfillCandidates` supplies the signals (active map? candidate count? top pin count?) for curated+resolved-not-eligible games, coarsely pre-sorted + capped so a large catalog doesn't fetch the whole table.
- **Worker** `geo-backfill-logic.ts` (`runGeoBackfillTick`) ranks and re-drives the existing idempotent per-game ingest tick.
- **Wiring**: new `backfill-tick` `GeoJobData` kind + worker-router dispatch; recurring cron (every 30 min) registered behind `GEO_BACKFILL_ENABLED`, with the stale-repeatable sweep updated to include it.
- **Docs** (`geo-mode.md`) + `.env.example`.

## Verification

Full workspace build typechecks, lint 0 errors, **378 backend + 15 MCP tests pass**.

Restarts the designated branch from `main` after #333 merged — a **new PR**, not a continuation.

## This completes the #331 plan

All six phases are now implemented: diagnostic (1), scoped read-only API + keys + MCP (2), ingest trigger (3), pin proposer + consensus v3 (4), vision gate + accuracy study (5), backfill worker (6). The only remaining follow-up is the in-app structured-coordinate *crawler* — the plan intentionally scoped that as a separate effort (the `propose_pin` endpoint is the mechanism by which an external agent submits computed coordinates today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvJoyRSYB7UMaRfuMsT5Jd

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvJoyRSYB7UMaRfuMsT5Jd)_