### PR TITLE
fix(geo): stop wrong-game map assignment + geolocatable capture seeding

### DIFF
--- a/packages/backend/src/domain/services/geo-manual-capture.service.test.ts
+++ b/packages/backend/src/domain/services/geo-manual-capture.service.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildManualCaptureCandidates,
+  isValidCaptureUrl,
+  manualCaptureExternalId,
+} from './geo-manual-capture.service.js'
+
+describe('isValidCaptureUrl', () => {
+  it('accepts absolute http(s) image URLs (with query strings)', () => {
+    assert.equal(isValidCaptureUrl('https://cdn.example.com/shots/a.jpg'), true)
+    assert.equal(isValidCaptureUrl('http://example.com/x.PNG'), true)
+    assert.equal(
+      isValidCaptureUrl('https://static.wikia.nocookie.net/x/Yharnam.png?cb=123'),
+      true,
+    )
+  })
+
+  it('rejects non-image, non-http, and malformed URLs', () => {
+    assert.equal(isValidCaptureUrl('https://example.com/page.html'), false)
+    assert.equal(isValidCaptureUrl('ftp://example.com/a.jpg'), false)
+    assert.equal(isValidCaptureUrl('/relative/a.jpg'), false)
+    assert.equal(isValidCaptureUrl('not a url'), false)
+    assert.equal(isValidCaptureUrl(''), false)
+  })
+})
+
+describe('manualCaptureExternalId', () => {
+  it('is deterministic and trimming-stable', () => {
+    const a = manualCaptureExternalId('https://e.com/a.jpg')
+    const b = manualCaptureExternalId('  https://e.com/a.jpg  ')
+    assert.equal(a, b)
+    assert.match(a, /^manual:[0-9a-f]{32}$/)
+  })
+
+  it('differs for different URLs', () => {
+    assert.notEqual(
+      manualCaptureExternalId('https://e.com/a.jpg'),
+      manualCaptureExternalId('https://e.com/b.jpg'),
+    )
+  })
+})
+
+describe('buildManualCaptureCandidates', () => {
+  it('drops invalid URLs and collapses duplicates', () => {
+    const out = buildManualCaptureCandidates([
+      'https://e.com/a.jpg',
+      '  https://e.com/a.jpg  ', // dup after trim
+      'https://e.com/page.html', // invalid
+      'https://e.com/b.png',
+      'garbage',
+    ])
+    assert.equal(out.length, 2)
+    assert.deepEqual(
+      out.map((c) => c.imageUrl).sort(),
+      ['https://e.com/a.jpg', 'https://e.com/b.png'],
+    )
+    for (const c of out) {
+      assert.equal(c.source, 'manual')
+      assert.match(c.externalId, /^manual:[0-9a-f]{32}$/)
+    }
+  })
+
+  it('returns an empty list when nothing is valid', () => {
+    assert.deepEqual(buildManualCaptureCandidates(['x', 'https://e.com/y.html']), [])
+  })
+})

--- a/packages/backend/src/domain/services/geo-manual-capture.service.test.ts
+++ b/packages/backend/src/domain/services/geo-manual-capture.service.test.ts
@@ -14,6 +14,13 @@ describe('isValidCaptureUrl', () => {
       isValidCaptureUrl('https://static.wikia.nocookie.net/x/Yharnam.png?cb=123'),
       true,
     )
+    // Fandom/Wikia CDN pattern: extension followed by /revision/latest.
+    assert.equal(
+      isValidCaptureUrl(
+        'https://static.wikia.nocookie.net/bloodborne/images/0/03/Central_Yharnam_concept_art_1.jpg/revision/latest?cb=20180727134944',
+      ),
+      true,
+    )
   })
 
   it('rejects non-image, non-http, and malformed URLs', () => {

--- a/packages/backend/src/domain/services/geo-manual-capture.service.ts
+++ b/packages/backend/src/domain/services/geo-manual-capture.service.ts
@@ -1,0 +1,67 @@
+import crypto from 'node:crypto'
+
+// Curated geolocatable-capture seeding. RAWG (the automatic capture source)
+// returns promotional / combat beauty-shots that usually can't be located on a
+// map. This service turns an operator-supplied list of KNOWN-geolocatable
+// capture URLs into `source='manual'` candidate rows — the reliable path to
+// captures a proposer can actually pin. Pure helpers (no I/O) so they stay
+// testable; the async seeder in the worker layer feeds these into the existing
+// geoScreenshotRepository.createCandidate path.
+
+export interface ManualCaptureCandidate {
+  imageUrl: string
+  source: 'manual'
+  externalId: string
+}
+
+// Accept common raster image extensions, tolerating a query string or fragment
+// after the path (CDN URLs frequently append `?cb=...`).
+const IMAGE_PATH = /\.(png|jpe?g|webp|gif|bmp)$/i
+
+/**
+ * A curated capture URL is valid iff it is an absolute http(s) URL whose path
+ * ends in a known raster image extension. Deliberately strict — a bad URL
+ * should be dropped at seed time, not surface as a broken candidate later.
+ */
+export function isValidCaptureUrl(url: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(url.trim())
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false
+  return IMAGE_PATH.test(parsed.pathname)
+}
+
+/**
+ * Deterministic dedup key for a manual capture: `manual:` + sha256 of the
+ * trimmed URL (truncated). Reused as the candidate's `external_id`, so the
+ * (source, external_id) unique index makes re-seeding idempotent.
+ */
+export function manualCaptureExternalId(url: string): string {
+  const hash = crypto.createHash('sha256').update(url.trim()).digest('hex')
+  return `manual:${hash.slice(0, 32)}`
+}
+
+/**
+ * Turn curated capture URLs into candidate inputs: drop invalid URLs, collapse
+ * duplicates (by normalized URL), and stamp a stable external id on each. The
+ * caller pairs the result with a game id + geo map id and inserts via
+ * createCandidate.
+ */
+export function buildManualCaptureCandidates(
+  urls: readonly string[],
+): ManualCaptureCandidate[] {
+  const seen = new Set<string>()
+  const out: ManualCaptureCandidate[] = []
+  for (const raw of urls) {
+    const url = raw.trim()
+    if (!isValidCaptureUrl(url)) continue
+    const externalId = manualCaptureExternalId(url)
+    if (seen.has(externalId)) continue
+    seen.add(externalId)
+    out.push({ imageUrl: url, source: 'manual', externalId })
+  }
+  return out
+}

--- a/packages/backend/src/domain/services/geo-manual-capture.service.ts
+++ b/packages/backend/src/domain/services/geo-manual-capture.service.ts
@@ -22,8 +22,10 @@ const IMAGE_PATH = /\.(png|jpe?g|webp|gif|bmp)(\/|$)/i
 
 /**
  * A curated capture URL is valid iff it is an absolute http(s) URL whose path
- * ends in a known raster image extension. Deliberately strict — a bad URL
- * should be dropped at seed time, not surface as a broken candidate later.
+ * carries a known raster image extension — either at the end (`/a.jpg`) or
+ * followed by a further segment as Fandom/Wikia CDN URLs do
+ * (`/a.jpg/revision/latest`). Deliberately strict — a bad URL should be dropped
+ * at seed time, not surface as a broken candidate later.
  */
 export function isValidCaptureUrl(url: string): boolean {
   let parsed: URL

--- a/packages/backend/src/domain/services/geo-manual-capture.service.ts
+++ b/packages/backend/src/domain/services/geo-manual-capture.service.ts
@@ -14,9 +14,11 @@ export interface ManualCaptureCandidate {
   externalId: string
 }
 
-// Accept common raster image extensions, tolerating a query string or fragment
-// after the path (CDN URLs frequently append `?cb=...`).
-const IMAGE_PATH = /\.(png|jpe?g|webp|gif|bmp)$/i
+// Accept common raster image extensions. The extension may sit at the end of
+// the path OR be followed by a further path segment — Fandom/Wikia CDN URLs
+// look like `…/Central_Yharnam.jpg/revision/latest`. Query strings/fragments
+// (`?cb=…`) live outside the pathname and don't affect the match.
+const IMAGE_PATH = /\.(png|jpe?g|webp|gif|bmp)(\/|$)/i
 
 /**
  * A curated capture URL is valid iff it is an absolute http(s) URL whose path

--- a/packages/backend/src/domain/services/geo-metadata.service.test.ts
+++ b/packages/backend/src/domain/services/geo-metadata.service.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  fandomMapTitleAcceptable,
+  fandomWikiBaseTokens,
+  isFranchiseWiki,
+} from './geo-metadata.service.js'
+
+describe('fandomWikiBaseTokens', () => {
+  it('drops platform/lang/site suffix tokens', () => {
+    assert.deepEqual(fandomWikiBaseTokens('zelda_gamepedia_en'), ['zelda'])
+    assert.deepEqual(fandomWikiBaseTokens('uncharted'), ['uncharted'])
+    assert.deepEqual(fandomWikiBaseTokens('eldenring'), ['eldenring'])
+    assert.deepEqual(fandomWikiBaseTokens('thelastofus'), ['thelastofus'])
+  })
+})
+
+describe('isFranchiseWiki', () => {
+  it('treats game-specific wikis as single-game', () => {
+    assert.equal(isFranchiseWiki('bloodborne', 'bloodborne'), false)
+    assert.equal(isFranchiseWiki('eldenring', 'elden-ring'), false)
+  })
+
+  it('detects franchise wikis where the slug carries installment tokens', () => {
+    // Observed wrong-map cases: subdomain much shorter than the slug.
+    assert.equal(
+      isFranchiseWiki('uncharted', 'uncharted-2-among-thieves'),
+      true,
+    )
+    assert.equal(
+      isFranchiseWiki('zelda_gamepedia_en', 'the-legend-of-zelda-ocarina-of-time'),
+      true,
+    )
+  })
+
+  it('is safe on empty inputs', () => {
+    assert.equal(isFranchiseWiki('', 'bloodborne'), false)
+    assert.equal(isFranchiseWiki('bloodborne', ''), false)
+  })
+})
+
+describe('fandomMapTitleAcceptable', () => {
+  it('accepts any map on a game-specific wiki (nothing to disambiguate)', () => {
+    // Bloodborne: real single-game-wiki map with only generic keywords.
+    assert.equal(
+      fandomMapTitleAcceptable('World Map', 'Bloodborne', 'bloodborne', 'bloodborne'),
+      true,
+    )
+    assert.equal(
+      fandomMapTitleAcceptable('The Lands Between', 'Elden Ring', 'eldenring', 'elden-ring'),
+      true,
+    )
+  })
+
+  it('REJECTS a sibling installment map on a franchise wiki (regression)', () => {
+    // Uncharted 2 must never bind Lost Legacy's "Western Ghats".
+    assert.equal(
+      fandomMapTitleAcceptable(
+        'Western Ghats',
+        'Uncharted 2: Among Thieves',
+        'uncharted',
+        'uncharted-2-among-thieves',
+      ),
+      false,
+    )
+    // Ocarina of Time must never bind the 1986 "Level 1" dungeon map, even
+    // though it shares the "Legend of Zelda" franchise words.
+    assert.equal(
+      fandomMapTitleAcceptable(
+        'Level 1 (First Quest) (The Legend of Zelda)',
+        'The Legend of Zelda: Ocarina of Time',
+        'zelda_gamepedia_en',
+        'the-legend-of-zelda-ocarina-of-time',
+      ),
+      false,
+    )
+  })
+
+  it('accepts a franchise-wiki map that fully names the game', () => {
+    assert.equal(
+      fandomMapTitleAcceptable(
+        'The Legend of Zelda: Ocarina of Time World Map',
+        'The Legend of Zelda: Ocarina of Time',
+        'zelda_gamepedia_en',
+        'the-legend-of-zelda-ocarina-of-time',
+      ),
+      true,
+    )
+  })
+})

--- a/packages/backend/src/domain/services/geo-metadata.service.ts
+++ b/packages/backend/src/domain/services/geo-metadata.service.ts
@@ -129,6 +129,11 @@ export function isFranchiseWiki(subdomain: string, slug: string): boolean {
   if (collapsed === base) return false
   // Slug materially longer than the wiki base → the wiki name omits the
   // installment-identifying tokens, i.e. it covers the whole franchise.
+  //
+  // Limitation: the fixed +3 margin misses franchises whose slug barely exceeds
+  // the base (e.g. `baldursgateiii` vs a `baldursgate` wiki). Those fall back to
+  // single-game handling — a conservative miss (may still accept a sibling map),
+  // never a false franchise flag. Widen deliberately if such a case surfaces.
   return collapsed.length > base.length + 3
 }
 

--- a/packages/backend/src/domain/services/geo-metadata.service.ts
+++ b/packages/backend/src/domain/services/geo-metadata.service.ts
@@ -84,6 +84,75 @@ export function scoreMapTitle(
   return score
 }
 
+// ---------------------------------------------------------------------------
+// Franchise-wiki disambiguation — prevents wrong-game map assignment.
+//
+// A Fandom subdomain is either game-specific (`bloodborne`, `eldenring` — every
+// Map: page belongs to that one game) or franchise-scoped (`uncharted`, `zelda`
+// — the Map: namespace mixes maps from many installments). On a game-specific
+// wiki a generically-titled map ("World Map") is safe to accept. On a franchise
+// wiki it is NOT: a game with no map of its own would otherwise be assigned a
+// sibling installment's map — the observed bug where "Uncharted 2: Among
+// Thieves" got Lost Legacy's "Western Ghats" and "Ocarina of Time" got the 1986
+// "Level 1" dungeon map.
+// ---------------------------------------------------------------------------
+
+// Subdomain tokens that carry no game identity (platform/lang/site suffixes).
+const WIKI_STOPWORDS = new Set([
+  'gamepedia', 'fandom', 'wiki', 'wikia', 'en', 'community', 'the',
+])
+
+/**
+ * Reduce a Fandom subdomain to its identity tokens, dropping platform/lang
+ * suffixes: `zelda_gamepedia_en` → `['zelda']`, `uncharted` → `['uncharted']`,
+ * `eldenring` → `['eldenring']`. Pure helper for franchise detection.
+ */
+export function fandomWikiBaseTokens(subdomain: string): string[] {
+  return subdomain
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((tok) => tok.length > 0 && !WIKI_STOPWORDS.has(tok))
+}
+
+/**
+ * True when the wiki spans more than one game (franchise wiki), inferred from
+ * the subdomain being materially shorter than the game's collapsed slug. On a
+ * game-specific wiki the collapsed slug equals the base (`bloodborne` ==
+ * `bloodborne`, `eldenring` == `eldenring`); on a franchise wiki the slug
+ * carries installment tokens the subdomain omits (`uncharted` vs
+ * `uncharted2amongthieves`, `zelda` vs `thelegendofzeldaocarinaoftime`).
+ */
+export function isFranchiseWiki(subdomain: string, slug: string): boolean {
+  const collapsed = slug.toLowerCase().replace(/[^a-z0-9]/g, '')
+  const base = fandomWikiBaseTokens(subdomain).join('')
+  if (!base || !collapsed) return false
+  if (collapsed === base) return false
+  // Slug materially longer than the wiki base → the wiki name omits the
+  // installment-identifying tokens, i.e. it covers the whole franchise.
+  return collapsed.length > base.length + 3
+}
+
+/**
+ * Decide whether a Map: title may be auto-assigned to a game. On a
+ * game-specific wiki there is nothing to disambiguate (always true). On a
+ * franchise wiki, only accept a title that unambiguously names THIS game — the
+ * full normalized game name must appear in the title. Deliberately strict: a
+ * false negative (no map) is recoverable via other import tiers or manual
+ * assignment, whereas a false positive feeds another game's map into the
+ * consensus pipeline.
+ */
+export function fandomMapTitleAcceptable(
+  mapTitle: string,
+  gameName: string,
+  subdomain: string,
+  slug: string,
+): boolean {
+  if (!isFranchiseWiki(subdomain, slug)) return true
+  const title = normalizeGameTitle(mapTitle.replace(/_/g, ' '))
+  const name = normalizeGameTitle(gameName)
+  return name.length > 0 && title.includes(name)
+}
+
 /**
  * Parse the Steam appid from a store URL, e.g.
  *   https://store.steampowered.com/app/1245620/ELDEN_RING/

--- a/packages/backend/src/infrastructure/queue/workers/geo-manual-capture-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-manual-capture-logic.ts
@@ -1,0 +1,46 @@
+import { queueLogger } from '../../logger/logger.js'
+import { geoScreenshotRepository } from '../../repositories/index.js'
+import { buildManualCaptureCandidates } from '../../../domain/services/geo-manual-capture.service.js'
+
+const log = queueLogger.child({ worker: 'geo-manual-capture' })
+
+export interface SeedManualCapturesInput {
+  gameId: number
+  geoMapId: number
+  urls: readonly string[]
+}
+
+export interface SeedManualCapturesResult {
+  received: number
+  valid: number
+  inserted: number
+}
+
+/**
+ * Seed curated, geolocatable capture URLs for a game as `source='manual'`
+ * candidates against the given map. Idempotent: createCandidate's
+ * (source, external_id) unique index means re-seeding the same URLs inserts
+ * nothing new. Invalid/duplicate URLs are dropped before insertion (see
+ * buildManualCaptureCandidates).
+ */
+export async function seedManualCaptures(
+  input: SeedManualCapturesInput,
+): Promise<SeedManualCapturesResult> {
+  const candidates = buildManualCaptureCandidates(input.urls)
+  let inserted = 0
+  for (const c of candidates) {
+    await geoScreenshotRepository.createCandidate({
+      gameId: input.gameId,
+      geoMapId: input.geoMapId,
+      imageUrl: c.imageUrl,
+      source: 'manual',
+      externalId: c.externalId,
+    })
+    inserted++
+  }
+  log.info(
+    { gameId: input.gameId, geoMapId: input.geoMapId, received: input.urls.length, valid: candidates.length },
+    'seeded manual geolocatable captures',
+  )
+  return { received: input.urls.length, valid: candidates.length, inserted }
+}

--- a/packages/backend/src/infrastructure/queue/workers/geo-manual-capture-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-manual-capture-logic.ts
@@ -1,5 +1,6 @@
+import { db } from '../../database/connection.js'
 import { queueLogger } from '../../logger/logger.js'
-import { geoScreenshotRepository } from '../../repositories/index.js'
+import { geoMapRepository, geoScreenshotRepository } from '../../repositories/index.js'
 import { buildManualCaptureCandidates } from '../../../domain/services/geo-manual-capture.service.js'
 
 const log = queueLogger.child({ worker: 'geo-manual-capture' })
@@ -11,24 +12,50 @@ export interface SeedManualCapturesInput {
 }
 
 export interface SeedManualCapturesResult {
-  received: number
-  valid: number
-  inserted: number
+  received: number // URLs supplied
+  valid: number // URLs that passed validation + in-batch dedup
+  inserted: number // rows actually created this run
+  skipped: number // valid candidates that already existed (idempotent re-seed)
 }
 
 /**
  * Seed curated, geolocatable capture URLs for a game as `source='manual'`
- * candidates against the given map. Idempotent: createCandidate's
- * (source, external_id) unique index means re-seeding the same URLs inserts
- * nothing new. Invalid/duplicate URLs are dropped before insertion (see
+ * candidates against the given map. Idempotent — re-seeding the same URLs is a
+ * no-op — and the returned counts distinguish new inserts from already-present
+ * rows. Invalid/duplicate URLs are dropped before insertion (see
  * buildManualCaptureCandidates).
  */
 export async function seedManualCaptures(
   input: SeedManualCapturesInput,
 ): Promise<SeedManualCapturesResult> {
   const candidates = buildManualCaptureCandidates(input.urls)
+  if (candidates.length === 0) {
+    return { received: input.urls.length, valid: 0, inserted: 0, skipped: 0 }
+  }
+
+  // The map must exist and belong to this game — never seed captures against a
+  // different game's map (the exact class of bug this feature exists to avoid).
+  const map = await geoMapRepository.findById(input.geoMapId)
+  if (!map || map.gameId !== input.gameId) {
+    throw new Error(
+      `geoMapId ${input.geoMapId} does not belong to game ${input.gameId}`,
+    )
+  }
+
+  // Pre-fetch which external ids already exist so the returned counts are
+  // accurate on an idempotent re-seed — createCandidate's onConflict-ignore
+  // returns the existing row, making insert-vs-conflict indistinguishable from
+  // its result alone.
+  const externalIds = candidates.map((c) => c.externalId)
+  const existingRows = await db('geo_screenshot_candidate')
+    .where('source', 'manual')
+    .whereIn('external_id', externalIds)
+    .select<Array<{ external_id: string }>>('external_id')
+  const existing = new Set(existingRows.map((r) => r.external_id))
+
   let inserted = 0
   for (const c of candidates) {
+    if (existing.has(c.externalId)) continue
     await geoScreenshotRepository.createCandidate({
       gameId: input.gameId,
       geoMapId: input.geoMapId,
@@ -38,9 +65,17 @@ export async function seedManualCaptures(
     })
     inserted++
   }
+  const skipped = candidates.length - inserted
   log.info(
-    { gameId: input.gameId, geoMapId: input.geoMapId, received: input.urls.length, valid: candidates.length },
+    {
+      gameId: input.gameId,
+      geoMapId: input.geoMapId,
+      received: input.urls.length,
+      valid: candidates.length,
+      inserted,
+      skipped,
+    },
     'seeded manual geolocatable captures',
   )
-  return { received: input.urls.length, valid: candidates.length, inserted }
+  return { received: input.urls.length, valid: candidates.length, inserted, skipped }
 }

--- a/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
@@ -5,6 +5,7 @@ import { geoIngestFailureRepository } from '../../repositories/index.js'
 import {
   FANDOM_MAP_NAMESPACE,
   extractVersionTokens,
+  fandomMapTitleAcceptable,
   isMapEligibleByGenre,
   normalizeGameTitle,
   scoreMapTitle,
@@ -264,9 +265,26 @@ async function resolveFandomInteractiveMap(
     const pages = body.query?.allpages ?? []
     if (!pages.length) continue
 
-    const ranked = pages
+    const titles = pages
       .map((p) => stripMapPrefix(p.title))
       .filter((t): t is string => Boolean(t))
+
+    // On a franchise wiki (uncharted, zelda, …) the Map: namespace mixes maps
+    // from many installments; only keep titles that unambiguously name THIS
+    // game so we never assign a sibling's map. Game-specific wikis pass through
+    // unchanged. Rejected titles are logged so the drop is visible.
+    const acceptable = titles.filter((title) =>
+      fandomMapTitleAcceptable(title, gameName, sub, slug),
+    )
+    const rejected = titles.length - acceptable.length
+    if (rejected > 0) {
+      log.info(
+        { sub, gameName, rejected, kept: acceptable.length },
+        'skipped franchise-wiki maps that did not name the game',
+      )
+    }
+
+    const ranked = acceptable
       .map((title) => ({ title, score: scoreMapTitle(title, gameName, slug) }))
       .sort((a, b) => b.score - a.score)
 
@@ -278,6 +296,9 @@ async function resolveFandomInteractiveMap(
       )
       return { subdomain: sub, mapName: best.title }
     }
+    // No game-specific map on this wiki — fall through to the next subdomain
+    // candidate, then return null so other tiers / manual assignment can supply
+    // a map rather than mis-assigning one here.
   }
   return null
 }

--- a/packages/geo-agent-mcp/mcp-call.sh
+++ b/packages/geo-agent-mcp/mcp-call.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bridge one MCP tool call through the geo-agent stdio server and print the
+# tool's text result. Reads the key from THE_BOX_AGENT_KEY (never stored here).
+#   usage: THE_BOX_AGENT_KEY=... ./mcp-call.sh <tool_name> '<json-args>'
+set -euo pipefail
+TOOL="${1:?tool name required}"
+ARGS='{}'
+[ $# -ge 2 ] && ARGS="$2"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export THE_BOX_API_URL="${THE_BOX_API_URL:-https://the-box.battistella.ovh}"
+
+{
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"claude-code-session","version":"1"}}}'
+  printf '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"%s","arguments":%s}}\n' "$TOOL" "$ARGS"
+  sleep 3   # keep stdin open so the async fetch resolves before EOF-exit
+} | node "$DIR/dist/index.js" 2>/dev/null \
+  | jq -r 'select(.id==2) | if .result.isError then "TOOL ERROR: \(.result.content[0].text)" else .result.content[0].text end'


### PR DESCRIPTION
## Problem
The Fandom map resolver assigned **wrong-game maps** to games on shared *franchise* wikis. Observed in production:
- **Uncharted 2: Among Thieves** (game 173) → Lost Legacy's *"Western Ghats"* (a photo of an in-game paper-map prop).
- **Zelda: Ocarina of Time** (game 200) → the 1986 *"Level 1 (First Quest)"* dungeon map.

`resolveFandomInteractiveMap` took the top-scored `Map:` page unconditionally. On a franchise wiki (`uncharted.fandom.com`, `zelda_gamepedia_en`) the `Map:` namespace mixes maps from many installments, so a game with no map of its own was handed a sibling's. `scoreMapTitle` awards generic points (`world`/`map`) with zero game match, so raising the score threshold wasn't viable — Bloodborne's correct single-game-wiki map passes the same way.

## Fix
- `isFranchiseWiki(subdomain, slug)` — true when the subdomain is materially shorter than the collapsed slug (`uncharted` vs `uncharted2amongthieves`).
- `fandomMapTitleAcceptable(...)` — on franchise wikis, only accept a `Map:` title that names the game; **game-specific wikis (bloodborne, eldenring) are unchanged**. Bias: *no map beats wrong map* (recoverable via other tiers / manual assignment).
- Resolver filters titles through the gate before ranking; logs rejected franchise maps.

## Also: geolocatable capture seeding
RAWG (the auto capture source) yields promo/combat beauty-shots that usually can't be located on a map. The schema already supports `source='manual'` captures but had no seeding path. Added `geo-manual-capture.service` (validate/dedupe/idempotent) + `seedManualCaptures` worker reusing `createCandidate`.

## Tests
13 new pure unit tests incl. the exact UC2 + OoT regressions. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)