### PR TITLE
feat(geo-agent): content creation & curation surface (issue #331)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,15 @@ GEO_AGENT_MAX_PINS_PER_HOUR=60
 # study (npm run eval:geo-vision) clears the enable bar; while false,
 # source=agent_vision proposals are rejected with VISION_DISABLED.
 GEO_AGENT_VISION_ENABLED=false
+# Content-creation & curation surface (phase 5): enroll games, top up
+# captures, select/reject candidate maps. Second, independent kill switch —
+# while false these endpoints return 503 AGENT_CURATE_DISABLED even for a key
+# holding geo-agent:curate.
+GEO_AGENT_CURATE_ENABLED=false
+# Per-key daily caps for the curate endpoints, each tracked separately in Redis.
+GEO_AGENT_MAX_ENROLLS_PER_DAY=5
+GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY=10
+GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY=30
 # Backfill discovery worker (phase 6). When true, a recurring job drives
 # ingestion at curated+resolved games closest to eligibility. Off by default.
 GEO_BACKFILL_ENABLED=false

--- a/docs/geo-agent-api.md
+++ b/docs/geo-agent-api.md
@@ -1,14 +1,18 @@
 # Geo Agent API — content sourcing (issue #331)
 
-Key-authenticated, read-only HTTP surface that lets an AI agent (Claude Code /
-an MCP client) safely *drive* geo content sourcing against prod. This is the
-phase-2 deliverable of the [agent-assisted geo sourcing plan](../tasks/prd-geo-agent-sourcing.html):
-it proves the auth / audit / rate-limit surface with **zero write risk** before
-ingest (phase 3) and pin proposals (phase 4) land.
+Key-authenticated HTTP surface that lets an AI agent (Claude Code / an MCP
+client) safely *drive* geo content sourcing against prod. It started as a
+read-only proof of the auth / audit / rate-limit surface (phase 2) and grew a
+write surface in three stages: ingest triggers (phase 3), downweighted pin
+proposals (phase 4), and — this phase (5) — **content creation & curation**:
+enrolling new games, topping up screenshot candidates, and picking/rejecting
+candidate maps. See the [agent-assisted geo sourcing plan](../tasks/prd-geo-agent-sourcing.html).
 
-> Design principle: the agent *proposes*, consensus + admins *dispose*. This
-> read surface exposes only diagnostics and catalog data — no writes, no user
-> PII, no raw SQL. See `docs/geo-mode.md` for the consensus gate it feeds.
+> Design principle: the agent *proposes*, consensus + admins *dispose*. Even
+> the curate endpoints only reach content the admin UI already lets an
+> operator create — no raw SQL, no user PII, and every write is scoped,
+> budgeted, and audited. See `docs/geo-mode.md` for the consensus gate the
+> pin-proposal surface feeds.
 
 Base URL: `https://the-box.battistella.ovh/api/agent/v1/geo` (prod) ·
 `http://localhost:3000/api/agent/v1/geo` (dev).
@@ -40,12 +44,22 @@ via `DELETE /api/admin/agent-keys/:id` (any admin, instant).
 
 | Scope | Grants | Phase |
 |-------|--------|-------|
-| `geo-agent:read` | `/health`, `/games-needing-content`, `/games/:id/candidates` | 2 |
+| `geo-agent:read` | `/health`, `/games-needing-content`, `/games`, `/games/:id/candidates`, `/games/:id/maps` | 2, 5 |
 | `geo-agent:ingest` | `POST /games/:id/ingest` — trigger the ingestion pipeline | 3 |
 | `geo-agent:propose` | `POST /candidates/:id/pins` — propose a downweighted consensus pin | 4 |
+| `geo-agent:curate` | `POST /games`, `POST /games/:id/captures`, `POST /games/:id/maps/:mapId/select`, `POST /games/:id/maps/:mapId/reject` — content creation & curation | 5 |
 
-A freshly minted key defaults to `geo-agent:read`. Ingest/propose are granted
-per key as later phases ship.
+A freshly minted key defaults to `geo-agent:read`. Ingest/propose/curate are
+granted per key as later phases ship.
+
+## Curate kill switch (phase 5)
+
+The four `geo-agent:curate` write endpoints sit behind a **second**,
+independent kill switch: `GEO_AGENT_CURATE_ENABLED` (default `false`). While
+off they return `503 AGENT_CURATE_DISABLED` even for a key that holds the
+scope — an operator can run read/ingest/propose in production while curation
+stays dark, and can flip curation off alone without touching the rest of the
+surface.
 
 ## Rate limit & budgets
 
@@ -54,7 +68,11 @@ Fixed-window, **60 requests / minute per key** (in-memory). On exhaustion:
 
 Write endpoints additionally carry a **per-key budget** in Redis (survives
 deploys). Ingest: `GEO_AGENT_MAX_INGESTS_PER_DAY` (default 20) per UTC day. Pin
-proposals: `GEO_AGENT_MAX_PINS_PER_HOUR` (default 60) per UTC hour. On
+proposals: `GEO_AGENT_MAX_PINS_PER_HOUR` (default 60) per UTC hour. Curate
+(phase 5), each its own daily counter: enroll —
+`GEO_AGENT_MAX_ENROLLS_PER_DAY` (default 5); capture import —
+`GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY` (default 10); map select/reject —
+`GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY` (default 30, shared by both actions). On
 exhaustion: `429 BUDGET_EXHAUSTED` with `Retry-After` (seconds to the window
 reset). Budgets fail **closed** — if Redis is unreachable the call is rejected,
 never silently unlimited.
@@ -112,6 +130,138 @@ consensus recompute.
 `topPinCount` counts raw submissions (an upper bound — promotion needs 5
 *accepted* pins). `pinsToNextThreshold` is pins until the next consensus
 recompute (`[5, 10, 20, 50]`; `0` past the top threshold).
+
+### `GET /games?limit=`
+
+The whole geo-curated catalog (issue #331, phase 5) — every game with
+`geo_curated = true`, not just the "one pin away" work queue. `limit` 1–500
+(default 200).
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "gameId": 512,
+      "gameName": "Hollow Knight",
+      "captureCount": 22,
+      "mapCount": 1,
+      "canonicalPinCount": 3,
+      "eligible": true,
+      "starved": false
+    }
+  ]
+}
+```
+
+`eligible` mirrors the GeoGamers eligibility gate (an active map + at least
+one canonical pin). `starved` flags a game whose active capture count hasn't
+reached the ingest pipeline's per-game target (30) — where
+`POST /games/:id/captures` would help.
+
+### `POST /games`
+
+Scope: `geo-agent:curate`. Enroll a game into the geo pipeline. Pass either
+`gameId` (an existing game row) or `rawgId` (looked up by `rawg_id`, or
+created from RAWG if no game has that id yet). Reuses the **same** switch the
+admin "Games" tab flips (`games.geo_curated = true` +
+`geo_metadata_status = 'pending'`) rather than duplicating the RAWG import /
+metadata-resolve / map-ingest pipeline — that one write is all it takes for
+the existing resolver + ingest tick to pick the game up on their next pass.
+Idempotent: enrolling an already-curated game just re-arms metadata
+resolution.
+
+```json
+{ "rawgId": 3498 }
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "gameId": 512,
+    "name": "Hollow Knight",
+    "created": false,
+    "curated": true,
+    "budget": { "used": 1, "limit": 5, "remaining": 4 }
+  }
+}
+```
+
+`404 GAME_NOT_FOUND` if `gameId` doesn't exist. `400 RAWG_LOOKUP_FAILED` if
+`rawgId` doesn't resolve via RAWG (or `RAWG_API_KEY` isn't configured).
+Audited as `geo-agent.enroll_game`.
+
+### `POST /games/:gameId/captures`
+
+Scope: `geo-agent:curate`. Top up an enrolled game's screenshot candidates.
+Reuses the existing RAWG importer (the same function the ingest tick calls) —
+pass `targetCount` to pull more from RAWG, or `imageUrls` to insert an
+explicit list of manual/gameplay captures instead (RAWG's promotional shots
+are often combat beauty-shots, not geolocatable stills). Requires the game to
+already have an enabled map (`409 NO_ACTIVE_MAP` otherwise).
+
+```json
+{ "targetCount": 20 }
+```
+
+```json
+{ "imageUrls": ["https://example.com/gameplay-1.jpg", "https://example.com/gameplay-2.jpg"] }
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "gameId": 512,
+    "mapId": 77,
+    "fetched": 20,
+    "inserted": 14,
+    "skipped": 6,
+    "budget": { "used": 1, "limit": 10, "remaining": 9 }
+  }
+}
+```
+
+`skipped` counts URLs/RAWG screenshots that already exist as a candidate
+(dedup on `(source, external_id)`). `409 NO_RAWG_ID` if the game has no
+`rawgId` and `imageUrls` wasn't provided. Audited as
+`geo-agent.import_captures`.
+
+### `GET /games/:gameId/maps`
+
+Every candidate map fetched for a game, active or not — so an agent can
+inspect what the ingestion pipeline found and pick the canonical one. Mirrors
+the admin geo-fetch curation panel.
+
+```json
+{
+  "success": true,
+  "data": {
+    "maps": [
+      { "id": 77, "gameId": 512, "source": "fandom", "imageUrl": "https://…", "isSelected": true },
+      { "id": 81, "gameId": 512, "source": "wand", "imageUrl": "https://…", "isSelected": false }
+    ]
+  }
+}
+```
+
+### `POST /games/:gameId/maps/:mapId/select`
+
+Scope: `geo-agent:curate`. Promote a candidate map to canonical for a game —
+the fix for a wrong-game map (e.g. Uncharted 2 with a Lost Legacy map, or
+Ocarina of Time with the 1986 original's map) once `GET /games/:id/maps`
+shows the correct one. Enables the map first if it isn't already enabled, then
+selects it; `selectedBy` is recorded as `apikey:<id>`. `404 MAP_NOT_FOUND` if
+`mapId` doesn't belong to `gameId`. Audited as `geo-agent.select_map`.
+
+### `POST /games/:gameId/maps/:mapId/reject`
+
+Scope: `geo-agent:curate`. Disable a wrong-game or prop map. Reuses the same
+`disableForGame` the admin panel uses — it **refuses to leave a game with zero
+enabled maps** (`409 LAST_ENABLED`): select a replacement canonical map first
+if this is the last enabled one. `404 NOT_FOUND` if `mapId` doesn't exist.
+Audited as `geo-agent.reject_map`.
 
 ### `GET /games/:gameId/candidates?limit=`
 
@@ -231,6 +381,7 @@ proposal (same key + candidate + `visionPass`) is an idempotent no-op:
 | Code | HTTP | Meaning |
 |------|------|---------|
 | `AGENT_API_DISABLED` | 503 | `GEO_AGENT_API_ENABLED` is off |
+| `AGENT_CURATE_DISABLED` | 503 | `GEO_AGENT_CURATE_ENABLED` is off (curate endpoints only) |
 | `UNAUTHORIZED` | 401 | Missing / malformed / invalid key |
 | `INSUFFICIENT_SCOPE` | 403 | Key lacks the required geo-agent scope (or carries a non-agent scope) |
 | `RATE_LIMITED` | 429 | Per-minute limit hit; see `Retry-After` |
@@ -239,17 +390,25 @@ proposal (same key + candidate + `visionPass`) is an idempotent no-op:
 | `ALREADY_PROMOTED` | 409 | Candidate already has a canonical pin (propose) |
 | `VISION_DISABLED` | 403 | `agent_vision` proposals disabled pending the accuracy study |
 | `KEY_PAUSED` | 403 | Key auto-paused: >60% of its recent proposals were rejected |
-| `VALIDATION_ERROR` | 400 | Bad `gameId` / `limit` / `sources` / pin body |
+| `GAME_NOT_FOUND` | 404 | No such game (`gameId` on enroll) |
+| `RAWG_LOOKUP_FAILED` | 400 | `rawgId` didn't resolve via RAWG, or `RAWG_API_KEY` isn't set |
+| `NO_ACTIVE_MAP` | 409 | Game has no enabled map to attach captures to |
+| `NO_RAWG_ID` | 409 | Game has no `rawgId` and `imageUrls` wasn't provided |
+| `MAP_NOT_FOUND` | 404 | No such map for the game (select) |
+| `NOT_FOUND` / `LAST_ENABLED` | 404 / 409 | Map reject target missing / would leave zero enabled maps |
+| `VALIDATION_ERROR` | 400 | Bad `gameId` / `limit` / `sources` / pin / enroll / capture body |
 | `INTERNAL_ERROR` | 500 | Server error |
 
 ## Audit
 
 Admin key mints/revokes are written to `admin_audit_log`
 (`agent_key.mint` / `agent_key.revoke`) with the acting admin, label, scopes.
-Write endpoints (phases 3–4) will additionally audit each agent action keyed by
-`apikey:<id>`.
+Every write endpoint audits its action keyed by `apikey:<id>`:
+`geo-agent.ingest`, `geo-agent.propose_pin`, `geo-agent.enroll_game`,
+`geo-agent.import_captures`, `geo-agent.select_map`, `geo-agent.reject_map`.
 
 ## MCP wrapper
 
-`@the-box/geo-agent-mcp` (in `packages/geo-agent-mcp/`) exposes these three
-reads as MCP tools for Claude Code. See its README for the `mcpServers` config.
+`@the-box/geo-agent-mcp` (in `packages/geo-agent-mcp/`) exposes every one of
+these endpoints as an MCP tool for Claude Code. See its README for the tool
+table and `mcpServers` config.

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -77,6 +77,19 @@ export const env = {
   // `source=agent_vision` proposals are rejected with VISION_DISABLED, so
   // unmeasured vision pins never enter consensus even as downweighted voters.
   GEO_AGENT_VISION_ENABLED: process.env['GEO_AGENT_VISION_ENABLED'] || 'false',
+  // Content-creation & curation surface (issue #331, phase 5) — the write-heavy
+  // endpoints that enroll new games, top up captures, and manage candidate
+  // maps (geo-agent:curate scope). Gated separately from GEO_AGENT_API_ENABLED
+  // so read/ingest/propose can stay on while curation stays dark until an
+  // operator explicitly opts in.
+  GEO_AGENT_CURATE_ENABLED: process.env['GEO_AGENT_CURATE_ENABLED'] || 'false',
+  // Per-key daily budget for game enrollment — the most expensive/impactful
+  // curate action (creates a game row and kicks off the full ingest pipeline).
+  GEO_AGENT_MAX_ENROLLS_PER_DAY: process.env['GEO_AGENT_MAX_ENROLLS_PER_DAY'] || '5',
+  // Per-key daily budget for capture top-ups (RAWG import or manual URLs).
+  GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY: process.env['GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY'] || '10',
+  // Per-key daily budget for map curation actions (select canonical / reject).
+  GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY: process.env['GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY'] || '30',
 
   // RAWG API (for fetching game screenshots)
   RAWG_API_KEY: process.env['RAWG_API_KEY'] || '',

--- a/packages/backend/src/domain/services/geo-metadata.service.test.ts
+++ b/packages/backend/src/domain/services/geo-metadata.service.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { pickBestMapTitle, scoreMapTitle } from './geo-metadata.service.js'
+
+describe('scoreMapTitle', () => {
+  it('scores a title mentioning the full game name highly', () => {
+    const score = scoreMapTitle('Elden Ring', 'Elden Ring', 'elden-ring')
+    assert.ok(score > 50)
+  })
+
+  it('scores a title mentioning distinguishing slug tokens', () => {
+    const score = scoreMapTitle(
+      'Ocarina of Time World Map',
+      'The Legend of Zelda: Ocarina of Time',
+      'the-legend-of-zelda-ocarina-of-time',
+    )
+    assert.ok(score > 0)
+  })
+
+  it('rejects a title with zero game-specific evidence (-Infinity gate)', () => {
+    // Regression: a franchise-wide wiki (one subdomain covering every
+    // installment) must never let an unrelated title win just because it's
+    // "the least bad" of a bad batch.
+    const score = scoreMapTitle('Western Ghats', 'Uncharted 2: Among Thieves', 'uncharted-2-among-thieves')
+    assert.equal(score, Number.NEGATIVE_INFINITY)
+  })
+
+  it('rejects a generic title that shares no distinguishing token with the game', () => {
+    // Regression: "Overworld" alone carries no evidence it's Ocarina of Time
+    // rather than the 1986 original hosted on the same legendofzelda wiki.
+    const score = scoreMapTitle(
+      'Overworld',
+      'The Legend of Zelda: Ocarina of Time',
+      'the-legend-of-zelda-ocarina-of-time',
+    )
+    assert.equal(score, Number.NEGATIVE_INFINITY)
+  })
+})
+
+describe('pickBestMapTitle', () => {
+  it('picks the canonical map for Uncharted 2, never a Lost Legacy page', () => {
+    // Uncharted 2: Among Thieves must never bind to Lost Legacy content even
+    // when both live under the same franchise-wide Fandom subdomain.
+    const titles = ['Western Ghats', 'Shambhala', 'Nepal']
+    const best = pickBestMapTitle(titles, 'Uncharted 2: Among Thieves', 'uncharted-2-among-thieves')
+    assert.equal(best, null)
+  })
+
+  it('picks the Uncharted 2 map when a genuine candidate is present', () => {
+    const titles = ['Western Ghats', 'Uncharted 2: Among Thieves World Map', 'Shambhala']
+    const best = pickBestMapTitle(titles, 'Uncharted 2: Among Thieves', 'uncharted-2-among-thieves')
+    assert.equal(best, 'Uncharted 2: Among Thieves World Map')
+  })
+
+  it('picks the Ocarina of Time map, never the 1986 original', () => {
+    // Ocarina of Time must never bind to the 1986 The Legend of Zelda dungeon
+    // map even though both live under legendofzelda.fandom.com.
+    const titles = ['Overworld', 'Dungeon 1', 'Ocarina of Time World Map']
+    const best = pickBestMapTitle(
+      titles,
+      'The Legend of Zelda: Ocarina of Time',
+      'the-legend-of-zelda-ocarina-of-time',
+    )
+    assert.equal(best, 'Ocarina of Time World Map')
+  })
+
+  it('returns null when every title on the wiki fails the specificity gate', () => {
+    const titles = ['Overworld', 'Dungeon 1', 'Dungeon 2']
+    const best = pickBestMapTitle(
+      titles,
+      'The Legend of Zelda: Ocarina of Time',
+      'the-legend-of-zelda-ocarina-of-time',
+    )
+    assert.equal(best, null)
+  })
+})

--- a/packages/backend/src/domain/services/geo-metadata.service.ts
+++ b/packages/backend/src/domain/services/geo-metadata.service.ts
@@ -7,6 +7,13 @@
 // pages in this namespace via `?action=query&list=allpages&apnamespace=2900`.
 export const FANDOM_MAP_NAMESPACE = 2900
 
+// Combined cap across every capture provider (Steam + RAWG) for one game's
+// active candidate pool. Once a game has this many active candidates the
+// ingest tick stops enqueuing more; the agent curate surface uses the same
+// number to flag a game "starved" and as `geo_import_captures`'s default
+// target count.
+export const CAPTURE_TARGET_CANDIDATES = 30
+
 /**
  * Derive Fandom subdomain candidates from a game slug. Most Fandom wikis
  * follow `<slug>.fandom.com`, but slugs use kebab-case while wikis are
@@ -32,9 +39,28 @@ export function wikiSubdomainCandidates(slug: string): string[] {
 }
 
 /**
+ * True iff a `Map:` page title carries at least one piece of evidence that
+ * it's actually about THIS game — the full game name, or one of its
+ * distinguishing slug tokens. This is a hard gate, not a scoring bonus: on a
+ * franchise-wide Fandom wiki (one subdomain hosting every entry — e.g.
+ * `unchartedgame.fandom.com` covers Uncharted 2 AND The Lost Legacy,
+ * `legendofzelda.fandom.com` covers Ocarina of Time AND the 1986 original) a
+ * title with zero specific signal must never be treated as a candidate, no
+ * matter how well it scores on generic "world/overworld/main" keywords.
+ */
+function hasSpecificGameSignal(t: string, name: string, slugTokens: readonly string[]): boolean {
+  if (name && t.includes(name)) return true
+  return slugTokens.some((tok) => t.includes(tok))
+}
+
+/**
  * Score a `Map:` page title against the curated game's name + slug to pick
  * the most likely "main" map when a wiki publishes several. Higher is
- * better. The scoring rewards titles that:
+ * better. Returns `Number.NEGATIVE_INFINITY` for a title with no specific
+ * signal for this game at all (see `hasSpecificGameSignal`) — callers must
+ * treat that as "not a match", never pick it as a fallback.
+ *
+ * For titles that pass the gate, the scoring rewards titles that:
  *   - mention the full game name (strongest signal of the canonical map),
  *   - mention slug tokens (game-specific sub-maps still beat generic ones),
  *   - mention top-level keywords (`world`, `overworld`, `atlas`, `main`,
@@ -61,6 +87,8 @@ export function scoreMapTitle(
     .split(/[^a-z0-9]+/)
     .filter((tok) => tok.length >= 3)
 
+  if (!hasSpecificGameSignal(t, name, slugTokens)) return Number.NEGATIVE_INFINITY
+
   let score = 0
   if (name && t.includes(name)) score += 50
   // Extra boost when the title *equals* the game name (e.g. "Elden Ring"
@@ -82,6 +110,25 @@ export function scoreMapTitle(
   if (tokens.length <= 1) score -= 15
   if (t === 'map' || t === 'maps') score -= 30
   return score
+}
+
+/**
+ * Pick the best-matching `Map:` page title for a game out of every title
+ * returned by one Fandom subdomain's namespace listing, or `null` if none of
+ * them carry any game-specific evidence (`scoreMapTitle` gate). Extracted as
+ * a pure function so the franchise-disambiguation fix (issue #331) has a
+ * regression test that doesn't need to mock the MediaWiki API.
+ */
+export function pickBestMapTitle(
+  titles: readonly string[],
+  gameName: string,
+  slug: string,
+): string | null {
+  const ranked = titles
+    .map((title) => ({ title, score: scoreMapTitle(title, gameName, slug) }))
+    .filter((r) => Number.isFinite(r.score))
+    .sort((a, b) => b.score - a.score)
+  return ranked[0]?.title ?? null
 }
 
 /**

--- a/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-ingest-tick-logic.ts
@@ -4,14 +4,14 @@ import { queueLogger } from '../../logger/logger.js'
 import { geoQueue } from '../queues.js'
 import { geoMapRepository } from '../../repositories/index.js'
 import { findRegistryEntryBySlug } from './geo-registry-import-logic.js'
+// Combined per-game capture-provider cap. Shared with the agent curate
+// surface (geo_list_games "starved" flag, geo_import_captures default
+// target) via the domain service so neither side drifts.
+import { CAPTURE_TARGET_CANDIDATES } from '../../../domain/services/geo-metadata.service.js'
 
 const log = queueLogger.child({ worker: 'geo-ingest-tick' })
 
 const DEFAULT_BATCH = 25
-// Combined cap across every capture provider (Steam + RAWG). Once a game
-// has this many active candidates we stop enqueuing more — admins can
-// reject duds and the next tick will top up.
-const CAPTURE_TARGET_CANDIDATES = 30
 
 interface TickRow {
   id: number

--- a/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
+++ b/packages/backend/src/infrastructure/queue/workers/geo-metadata-resolve-logic.ts
@@ -7,7 +7,7 @@ import {
   extractVersionTokens,
   isMapEligibleByGenre,
   normalizeGameTitle,
-  scoreMapTitle,
+  pickBestMapTitle,
   versionTokensMatch,
   wikiSubdomainCandidates,
 } from '../../../domain/services/geo-metadata.service.js'
@@ -264,20 +264,16 @@ async function resolveFandomInteractiveMap(
     const pages = body.query?.allpages ?? []
     if (!pages.length) continue
 
-    const ranked = pages
-      .map((p) => stripMapPrefix(p.title))
-      .filter((t): t is string => Boolean(t))
-      .map((title) => ({ title, score: scoreMapTitle(title, gameName, slug) }))
-      .sort((a, b) => b.score - a.score)
-
-    const best = ranked[0]
+    const titles = pages.map((p) => stripMapPrefix(p.title)).filter((t): t is string => Boolean(t))
+    const best = pickBestMapTitle(titles, gameName, slug)
     if (best) {
-      log.info(
-        { sub, choice: best, candidates: ranked.length },
-        'fandom map discovered',
-      )
-      return { subdomain: sub, mapName: best.title }
+      log.info({ sub, choice: best, candidates: titles.length }, 'fandom map discovered')
+      return { subdomain: sub, mapName: best }
     }
+    // Every title on this subdomain failed the game-specific-evidence gate
+    // (e.g. a franchise-wide wiki whose only pages belong to other
+    // installments) — try the next subdomain candidate rather than falling
+    // back to an unrelated page.
   }
   return null
 }

--- a/packages/backend/src/infrastructure/redis/agent-budget.test.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.test.ts
@@ -1,7 +1,10 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  captureImportBudgetKey,
+  enrollBudgetKey,
   ingestBudgetKey,
+  mapActionBudgetKey,
   pinBudgetKey,
   secondsToNextUtcHour,
   secondsToUtcMidnight,
@@ -59,5 +62,38 @@ describe('pinBudgetKey', () => {
     const before = pinBudgetKey(1, new Date('2026-07-10T15:59:59.000Z'))
     const after = pinBudgetKey(1, new Date('2026-07-10T16:00:01.000Z'))
     assert.notEqual(before, after)
+  })
+})
+
+describe('enrollBudgetKey', () => {
+  it('scopes the key by api key id and UTC day', () => {
+    assert.equal(
+      enrollBudgetKey(42, new Date('2026-07-10T15:30:00.000Z')),
+      'geo-agent:budget:enroll:42:2026-07-10',
+    )
+  })
+
+  it('rolls to a new key at the UTC day boundary', () => {
+    const before = enrollBudgetKey(1, new Date('2026-07-10T23:59:59.000Z'))
+    const after = enrollBudgetKey(1, new Date('2026-07-11T00:00:01.000Z'))
+    assert.notEqual(before, after)
+  })
+})
+
+describe('captureImportBudgetKey', () => {
+  it('scopes the key by api key id and UTC day', () => {
+    assert.equal(
+      captureImportBudgetKey(42, new Date('2026-07-10T15:30:00.000Z')),
+      'geo-agent:budget:capture-import:42:2026-07-10',
+    )
+  })
+})
+
+describe('mapActionBudgetKey', () => {
+  it('scopes the key by api key id and UTC day', () => {
+    assert.equal(
+      mapActionBudgetKey(42, new Date('2026-07-10T15:30:00.000Z')),
+      'geo-agent:budget:map-action:42:2026-07-10',
+    )
   })
 })

--- a/packages/backend/src/infrastructure/redis/agent-budget.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.ts
@@ -42,6 +42,21 @@ export function pinBudgetKey(apiKeyId: number, now: Date): string {
   return `geo-agent:budget:pins:${apiKeyId}:${now.toISOString().slice(0, 13)}`
 }
 
+/** Redis key for a key's daily enroll budget (phase 5, curate scope). Pure. */
+export function enrollBudgetKey(apiKeyId: number, now: Date): string {
+  return `geo-agent:budget:enroll:${apiKeyId}:${now.toISOString().slice(0, 10)}`
+}
+
+/** Redis key for a key's daily capture-import budget (phase 5). Pure. */
+export function captureImportBudgetKey(apiKeyId: number, now: Date): string {
+  return `geo-agent:budget:capture-import:${apiKeyId}:${now.toISOString().slice(0, 10)}`
+}
+
+/** Redis key for a key's daily map-curation-action budget (phase 5). Pure. */
+export function mapActionBudgetKey(apiKeyId: number, now: Date): string {
+  return `geo-agent:budget:map-action:${apiKeyId}:${now.toISOString().slice(0, 10)}`
+}
+
 /**
  * Atomically consume one unit of a windowed budget keyed in Redis. Returns
  * `ok: false` (without consuming) once `limit` is reached; the counter expires
@@ -84,4 +99,35 @@ export async function consumeIngestBudget(apiKeyId: number, limit: number): Prom
 export async function consumePinBudget(apiKeyId: number, limit: number): Promise<BudgetResult> {
   const now = new Date()
   return consumeWindowBudget(pinBudgetKey(apiKeyId, now), limit, secondsToNextUtcHour(now), 'pin')
+}
+
+/** Consume one unit of a key's DAILY game-enrollment budget (phase 5). */
+export async function consumeEnrollBudget(apiKeyId: number, limit: number): Promise<BudgetResult> {
+  const now = new Date()
+  return consumeWindowBudget(enrollBudgetKey(apiKeyId, now), limit, secondsToUtcMidnight(now), 'enroll')
+}
+
+/** Consume one unit of a key's DAILY capture-import budget (phase 5). */
+export async function consumeCaptureImportBudget(
+  apiKeyId: number,
+  limit: number,
+): Promise<BudgetResult> {
+  const now = new Date()
+  return consumeWindowBudget(
+    captureImportBudgetKey(apiKeyId, now),
+    limit,
+    secondsToUtcMidnight(now),
+    'capture-import',
+  )
+}
+
+/** Consume one unit of a key's DAILY map-curation-action budget (phase 5). */
+export async function consumeMapActionBudget(apiKeyId: number, limit: number): Promise<BudgetResult> {
+  const now = new Date()
+  return consumeWindowBudget(
+    mapActionBudgetKey(apiKeyId, now),
+    limit,
+    secondsToUtcMidnight(now),
+    'map-action',
+  )
 }

--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -1,8 +1,10 @@
 import type { Knex } from 'knex'
 import { db } from '../database/connection.js'
 import { repoLogger } from '../logger/logger.js'
+import { CAPTURE_TARGET_CANDIDATES } from '../../domain/services/geo-metadata.service.js'
 import type {
   GeoCandidateGameSummary,
+  GeoCatalogGame,
   GeoScreenshotCandidate,
   GeoScreenshotMeta,
 } from '@the-box/types'
@@ -209,6 +211,61 @@ export const geoScreenshotRepository = {
         .update({ status: 'promoted' })
 
       return mapMeta(rows[0]!)
+    })
+  },
+
+  /**
+   * Whole-pool catalog for the agent content-creation surface (issue #331,
+   * phase 5) — every geo-curated game with capture/map/canonical-pin counts
+   * and two derived flags: `eligible` mirrors the GeoGamers eligibility gate
+   * (an active map + at least one canonical pin); `starved` flags a game
+   * whose active capture count hasn't reached the ingest pipeline's per-game
+   * target, i.e. where `geo_import_captures` would help. Restricted to
+   * `geo_curated = true` — an agent shouldn't see the entire games table,
+   * only the geo-mode pool it can act on.
+   */
+  async listGeoCatalog(limit = 200): Promise<GeoCatalogGame[]> {
+    const rows = await db('games as g')
+      .where('g.geo_curated', true)
+      .leftJoin('geo_screenshot_candidate as gsc', function () {
+        this.on('gsc.game_id', '=', 'g.id').andOn('gsc.is_active', '=', db.raw('true'))
+      })
+      .leftJoin('geo_map as gm', function () {
+        this.on('gm.game_id', '=', 'g.id').andOn('gm.is_active', '=', db.raw('true'))
+      })
+      .leftJoin('geo_screenshot_meta as gsm', 'gsm.geo_screenshot_candidate_id', 'gsc.id')
+      .groupBy('g.id', 'g.name')
+      .orderBy('g.name', 'asc')
+      .limit(limit)
+      .select<
+        Array<{
+          id: number
+          name: string | null
+          capture_count: string
+          map_count: string
+          canonical_pin_count: string
+        }>
+      >(
+        'g.id',
+        'g.name',
+        db.raw('COUNT(DISTINCT gsc.id) as capture_count'),
+        db.raw('COUNT(DISTINCT gm.id) as map_count'),
+        db.raw('COUNT(DISTINCT gsm.id) as canonical_pin_count'),
+      )
+
+    return rows.map((r) => {
+      const captureCount = Number(r.capture_count ?? 0)
+      const mapCount = Number(r.map_count ?? 0)
+      const canonicalPinCount = Number(r.canonical_pin_count ?? 0)
+      return {
+        gameId: r.id,
+        gameName: r.name,
+        captureCount,
+        mapCount,
+        canonicalPinCount,
+        eligible: mapCount > 0 && canonicalPinCount > 0,
+        starved: captureCount < CAPTURE_TARGET_CANDIDATES,
+      }
     })
   },
 

--- a/packages/backend/src/presentation/middleware/agent-api.middleware.test.ts
+++ b/packages/backend/src/presentation/middleware/agent-api.middleware.test.ts
@@ -5,6 +5,7 @@ import type { ApiKeyScope } from '@the-box/types'
 import { env } from '../../config/env.js'
 import {
   requireAgentApiEnabled,
+  requireAgentCurateEnabled,
   requireScope,
 } from './agent-api.middleware.js'
 
@@ -123,5 +124,51 @@ describe('requireAgentApiEnabled', () => {
     assert.equal(nexted, false)
     assert.equal(state.status, 503)
     assert.equal(errorCode(state.body), 'AGENT_API_DISABLED')
+  })
+})
+
+describe('requireAgentCurateEnabled', () => {
+  const original = env.GEO_AGENT_CURATE_ENABLED
+  beforeEach(() => {
+    env.GEO_AGENT_CURATE_ENABLED = original
+  })
+  afterEach(() => {
+    env.GEO_AGENT_CURATE_ENABLED = original
+  })
+
+  it('passes through when enabled', () => {
+    env.GEO_AGENT_CURATE_ENABLED = 'true'
+    const { res, state } = mockRes()
+    let nexted = false
+    requireAgentCurateEnabled({} as Request, res, () => {
+      nexted = true
+    })
+    assert.equal(nexted, true)
+    assert.equal(state.status, 200)
+  })
+
+  it('returns 503 AGENT_CURATE_DISABLED when off (default)', () => {
+    env.GEO_AGENT_CURATE_ENABLED = 'false'
+    const { res, state } = mockRes()
+    let nexted = false
+    requireAgentCurateEnabled({} as Request, res, () => {
+      nexted = true
+    })
+    assert.equal(nexted, false)
+    assert.equal(state.status, 503)
+    assert.equal(errorCode(state.body), 'AGENT_CURATE_DISABLED')
+  })
+
+  it('is independent of GEO_AGENT_API_ENABLED', () => {
+    env.GEO_AGENT_CURATE_ENABLED = 'true'
+    env.GEO_AGENT_API_ENABLED = 'false'
+    const { res, state } = mockRes()
+    let nexted = false
+    requireAgentCurateEnabled({} as Request, res, () => {
+      nexted = true
+    })
+    assert.equal(nexted, true)
+    assert.equal(state.status, 200)
+    env.GEO_AGENT_API_ENABLED = 'true'
   })
 })

--- a/packages/backend/src/presentation/middleware/agent-api.middleware.ts
+++ b/packages/backend/src/presentation/middleware/agent-api.middleware.ts
@@ -28,6 +28,26 @@ export function requireAgentApiEnabled(_req: Request, res: Response, next: NextF
 }
 
 /**
+ * Second kill switch for the write-heavy content-creation & curation routes
+ * (issue #331, phase 5: enroll/import-captures/map-select/map-reject).
+ * Independent of GEO_AGENT_API_ENABLED so an operator can run read/ingest/
+ * propose in production while curation stays dark, and can flip it off alone
+ * without touching the rest of the surface. Checked after the main kill
+ * switch and key auth, before the scope check, so a disabled-curate 503
+ * never leaks which keys hold the curate scope.
+ */
+export function requireAgentCurateEnabled(_req: Request, res: Response, next: NextFunction): void {
+  if (env.GEO_AGENT_CURATE_ENABLED !== 'true') {
+    res.status(503).json({
+      success: false,
+      error: { code: 'AGENT_CURATE_DISABLED', message: 'The agent curate surface is disabled' },
+    })
+    return
+  }
+  next()
+}
+
+/**
  * Require a specific scope on the authenticated key. Also rejects any key that
  * carries a non-geo-agent scope reaching this surface — a streamer key can
  * never call the agent API even if it somehow held a geo-agent scope, and the

--- a/packages/backend/src/presentation/routes/agent-geo.routes.ts
+++ b/packages/backend/src/presentation/routes/agent-geo.routes.ts
@@ -1,10 +1,11 @@
-import { Router } from 'express'
+import { Router, type Request, type Response } from 'express'
 import { z } from 'zod'
 import type { GeoGameNeedingContent } from '@the-box/types'
 import { requireApiKey } from '../middleware/public-api.middleware.js'
 import {
   agentApiRateLimit,
   requireAgentApiEnabled,
+  requireAgentCurateEnabled,
   requireScope,
 } from '../middleware/agent-api.middleware.js'
 import { validateBody, validateParams, validateQuery } from '../middleware/validation.middleware.js'
@@ -14,33 +15,50 @@ import {
   geoPinRepository,
 } from '../../infrastructure/repositories/index.js'
 import { geoSourceConfigRepository } from '../../infrastructure/repositories/geo-source-config.repository.js'
+import { geoIngestFailureRepository } from '../../infrastructure/repositories/geo-ingest-failure.repository.js'
 import { adminAuditRepository } from '../../infrastructure/repositories/admin-audit.repository.js'
+import { gameRepository } from '../../infrastructure/repositories/game.repository.js'
 import { pinsToNextConsensusThreshold } from '../../domain/services/geo-consensus.service.js'
 import { shouldPauseAgentKey } from '../../domain/services/geo-agent-guard.service.js'
+import { CAPTURE_TARGET_CANDIDATES } from '../../domain/services/geo-metadata.service.js'
 import { getGeoGamersHealthSnapshot } from '../../infrastructure/geogamers-health.js'
 import {
   enqueueSingleTierImport,
   RUNNABLE_TIERS,
   type RunnableTier,
 } from '../../infrastructure/queue/workers/geo-ingest-tick-logic.js'
+import { importRawgScreenshots } from '../../infrastructure/queue/workers/geo-rawg-import-logic.js'
 import { geoQueue } from '../../infrastructure/queue/queues.js'
-import { consumeIngestBudget, consumePinBudget } from '../../infrastructure/redis/agent-budget.js'
+import { db } from '../../infrastructure/database/connection.js'
+import {
+  consumeCaptureImportBudget,
+  consumeEnrollBudget,
+  consumeIngestBudget,
+  consumeMapActionBudget,
+  consumePinBudget,
+} from '../../infrastructure/redis/agent-budget.js'
 import { env } from '../../config/env.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
 
 const log = routeLogger.child({ router: 'agent-geo' })
 
-// Agent content-sourcing surface (issue #331, phase 2 — read-only).
+// Agent content-sourcing surface (issue #331). Started read-only (phase 2),
+// then grew a write surface in stages: ingest triggers (phase 3), downweighted
+// pin proposals (phase 4), and content creation & curation (phase 5 — enroll
+// games, top up captures, select/reject candidate maps).
 //
 // Mounted at /api/agent/v1/geo. Key-authenticated with admin-minted geo-agent
 // keys, NOT session-authed and NOT the streamer public API. Every route sits
-// behind: kill switch → key auth → per-key rate limit → scope check. This
-// phase exposes only reads — it proves the auth/audit/rate-limit surface with
-// zero write risk before ingest (phase 3) and pin proposals (phase 4) land.
+// behind: kill switch → key auth → per-key rate limit → scope check. Curate
+// routes (phase 5) sit behind a SECOND independent kill switch
+// (requireAgentCurateEnabled) so an operator can run read/ingest/propose in
+// production while curation stays dark.
 //
-// A key never elevates access: these endpoints return catalog/diagnostic data,
-// never user identities or PII (candidate payloads carry pin counts, not pin
-// owners).
+// A key never elevates access beyond what the admin UI already lets an
+// operator do: curate writes only reach geo_curated flip, screenshot-candidate
+// insert, and map select/disable — the same primitives the admin Games and
+// geo-fetch panels use. No user identities or PII cross this surface
+// (candidate payloads carry pin counts, not pin owners).
 
 const router = Router()
 
@@ -92,6 +110,153 @@ router.get(
   },
 )
 
+// GET /games — the whole geo-curated catalog (issue #331, phase 5), not just
+// the "one pin away" work queue. Read-only: lets an agent see what's already
+// enrolled before deciding whether to enroll/top-up/curate a game.
+router.get(
+  '/games',
+  requireScope('geo-agent:read'),
+  validateQuery(limitQuery),
+  async (req, res, next) => {
+    try {
+      const { limit } = req.query as unknown as z.infer<typeof limitQuery>
+      const data = await geoScreenshotRepository.listGeoCatalog(limit ?? 200)
+      res.json({ success: true, data })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// POST /games — enroll a game into the geo pipeline (issue #331, phase 5).
+// Reuses the SAME curation switch the admin "Games" tab flips
+// (`games.geo_curated = true` + `geo_metadata_status = 'pending'`) rather
+// than duplicating the RAWG import / metadata-resolve / map-ingest pipeline —
+// that one write is all it takes for the existing resolver + ingest tick to
+// pick the game up on their next pass and fetch its map + captures. By
+// `gameId` the game must already exist (created via the RAWG screenshot
+// importer or another mode); by `rawgId` a new minimal game row is created
+// first if none exists yet with that rawg_id. Idempotent: enrolling an
+// already-curated game just re-arms metadata resolution. Bounded by a
+// per-key daily budget — enrollment is the most expensive curate action.
+const enrollBodySchema = z
+  .object({
+    gameId: z.coerce.number().int().positive().optional(),
+    rawgId: z.coerce.number().int().positive().optional(),
+  })
+  .refine((d) => d.gameId !== undefined || d.rawgId !== undefined, {
+    message: 'gameId or rawgId is required',
+  })
+
+interface RawgGameDetail {
+  id: number
+  slug: string
+  name: string
+  released: string | null
+  background_image: string | null
+  metacritic: number | null
+  developers?: Array<{ name: string }>
+  publishers?: Array<{ name: string }>
+  genres?: Array<{ name: string }>
+  platforms?: Array<{ platform: { name: string } }>
+}
+
+async function fetchRawgGameDetail(rawgId: number): Promise<RawgGameDetail | null> {
+  if (!env.RAWG_API_KEY) return null
+  const res = await fetch(`https://api.rawg.io/api/games/${rawgId}?key=${env.RAWG_API_KEY}`, {
+    headers: { 'User-Agent': 'the-box-geo-agent-enroll/1.0' },
+  })
+  if (!res.ok) return null
+  return (await res.json()) as RawgGameDetail
+}
+
+router.post(
+  '/games',
+  requireScope('geo-agent:curate'),
+  requireAgentCurateEnabled,
+  validateBody(enrollBodySchema),
+  async (req, res, next) => {
+    try {
+      const { gameId: bodyGameId, rawgId } = req.body as z.infer<typeof enrollBodySchema>
+      const keyId = req.apiKey!.id
+
+      const maxPerDay = Number(env.GEO_AGENT_MAX_ENROLLS_PER_DAY) || 5
+      const budget = await consumeEnrollBudget(keyId, maxPerDay)
+      if (!budget.ok) {
+        res.setHeader('Retry-After', String(budget.resetSeconds))
+        res.status(429).json({
+          success: false,
+          error: {
+            code: 'BUDGET_EXHAUSTED',
+            message: `Daily enroll budget of ${budget.limit} reached; resets at UTC midnight`,
+          },
+        })
+        return
+      }
+
+      let game = bodyGameId
+        ? await gameRepository.findById(bodyGameId)
+        : await gameRepository.findByRawgId(rawgId!)
+      let created = false
+
+      if (!game && bodyGameId) {
+        res.status(404).json({ success: false, error: { code: 'GAME_NOT_FOUND' } })
+        return
+      }
+
+      if (!game && rawgId) {
+        const detail = await fetchRawgGameDetail(rawgId)
+        if (!detail) {
+          res.status(400).json({
+            success: false,
+            error: { code: 'RAWG_LOOKUP_FAILED', message: 'could not resolve rawgId via RAWG' },
+          })
+          return
+        }
+        game = await gameRepository.create({
+          name: detail.name,
+          slug: detail.slug,
+          releaseYear: detail.released ? parseInt(detail.released.slice(0, 4), 10) : undefined,
+          developer: detail.developers?.[0]?.name,
+          publisher: detail.publishers?.[0]?.name,
+          genres: detail.genres?.map((g) => g.name),
+          platforms: detail.platforms?.map((p) => p.platform.name),
+          coverImageUrl: detail.background_image ?? undefined,
+          metacritic: detail.metacritic ?? undefined,
+          rawgId: detail.id,
+        })
+        created = true
+      }
+
+      const update: Record<string, unknown> = { geo_curated: true, geo_metadata_status: 'pending' }
+      await db('games').where({ id: game!.id }).update(update)
+      await geoIngestFailureRepository.clear(game!.id, 'metadata')
+
+      await adminAuditRepository.record({
+        adminId: `apikey:${keyId}`,
+        action: 'geo-agent.enroll_game',
+        targetKind: 'game',
+        targetId: String(game!.id),
+        after: { gameId: game!.id, rawgId: rawgId ?? game!.rawgId ?? null, created },
+        ip: req.ip ?? null,
+      })
+
+      res.json({
+        success: true,
+        data: {
+          gameId: game!.id,
+          name: game!.name,
+          created,
+          curated: true,
+          budget: { used: budget.used, limit: budget.limit, remaining: budget.remaining },
+        },
+      })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
 // GET /games/:gameId/candidates — unpinned/collecting captures for a game plus
 // its active maps (image url + dimensions), so a proposer has everything it
 // needs to localize a screenshot. Promoted captures are omitted (they already
@@ -114,6 +279,252 @@ router.get(
       // rows; filter out promoted here.
       const actionable = candidates.filter((c) => c.status !== 'promoted')
       res.json({ success: true, data: { maps, candidates: actionable } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// POST /games/:gameId/captures — top up an enrolled game's candidates
+// (issue #331, phase 5). Reuses the existing RAWG importer (the same
+// function the ingest tick calls) rather than duplicating its dedup/tombstone
+// logic; also accepts an explicit `imageUrls` list for manual/gameplay
+// captures (problem #4 in the issue — RAWG's promo shots are often not
+// geolocatable). Requires the game to already have an enabled map to attach
+// captures to. Bounded by a per-key daily budget.
+const importCapturesBodySchema = z
+  .object({
+    targetCount: z.coerce.number().int().positive().max(CAPTURE_TARGET_CANDIDATES).optional(),
+    imageUrls: z.array(z.string().url()).max(50).optional(),
+  })
+  .refine((d) => d.imageUrls === undefined || d.imageUrls.length > 0, {
+    message: 'imageUrls must be non-empty when provided',
+  })
+
+router.post(
+  '/games/:gameId/captures',
+  requireScope('geo-agent:curate'),
+  requireAgentCurateEnabled,
+  validateParams(gameIdParams),
+  validateBody(importCapturesBodySchema),
+  async (req, res, next) => {
+    try {
+      const { gameId } = req.params as unknown as z.infer<typeof gameIdParams>
+      const { targetCount, imageUrls } = req.body as z.infer<typeof importCapturesBodySchema>
+      const keyId = req.apiKey!.id
+
+      const maxPerDay = Number(env.GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY) || 10
+      const budget = await consumeCaptureImportBudget(keyId, maxPerDay)
+      if (!budget.ok) {
+        res.setHeader('Retry-After', String(budget.resetSeconds))
+        res.status(429).json({
+          success: false,
+          error: {
+            code: 'BUDGET_EXHAUSTED',
+            message: `Daily capture-import budget of ${budget.limit} reached; resets at UTC midnight`,
+          },
+        })
+        return
+      }
+
+      const map =
+        (await geoMapRepository.findCaptureDefaultByGameId(gameId)) ??
+        (await geoMapRepository.findFirstEnabledByGameId(gameId))
+      if (!map) {
+        res.status(409).json({
+          success: false,
+          error: { code: 'NO_ACTIVE_MAP', message: 'game has no enabled map to attach captures to' },
+        })
+        return
+      }
+
+      let result: { fetched: number; inserted: number; skipped: number }
+      if (imageUrls && imageUrls.length > 0) {
+        // createCandidate's (source, external_id) unique constraint already
+        // dedupes at the DB level; check first so the response can report an
+        // honest inserted/skipped split instead of always reporting insert.
+        let inserted = 0
+        let skipped = 0
+        for (const imageUrl of imageUrls) {
+          const externalId = `manual:${gameId}:${imageUrl}`
+          const existing = await db('geo_screenshot_candidate')
+            .where({ source: 'manual', external_id: externalId })
+            .first<{ id: number }>()
+          if (existing) {
+            skipped++
+            continue
+          }
+          await geoScreenshotRepository.createCandidate({
+            gameId,
+            geoMapId: map.id,
+            imageUrl,
+            source: 'manual',
+            externalId,
+          })
+          inserted++
+        }
+        result = { fetched: imageUrls.length, inserted, skipped }
+      } else {
+        const game = await gameRepository.findById(gameId)
+        if (!game?.rawgId) {
+          res.status(409).json({
+            success: false,
+            error: {
+              code: 'NO_RAWG_ID',
+              message: 'game has no rawgId to import from; pass imageUrls instead',
+            },
+          })
+          return
+        }
+        result = await importRawgScreenshots({
+          gameId,
+          geoMapId: map.id,
+          rawgId: game.rawgId,
+          maxItems: targetCount ?? CAPTURE_TARGET_CANDIDATES,
+        })
+      }
+
+      await adminAuditRepository.record({
+        adminId: `apikey:${keyId}`,
+        action: 'geo-agent.import_captures',
+        targetKind: 'game',
+        targetId: String(gameId),
+        after: { ...result, mapId: map.id, manual: !!imageUrls },
+        ip: req.ip ?? null,
+      })
+
+      res.json({
+        success: true,
+        data: { gameId, mapId: map.id, ...result, budget: { used: budget.used, limit: budget.limit, remaining: budget.remaining } },
+      })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// GET /games/:gameId/maps — every candidate map fetched for a game, active or
+// not (issue #331, phase 5), so an agent can pick the canonical one and
+// reject wrong-game/prop maps. Mirrors the admin geo-fetch curation panel.
+router.get(
+  '/games/:gameId/maps',
+  requireScope('geo-agent:read'),
+  validateParams(gameIdParams),
+  async (req, res, next) => {
+    try {
+      const { gameId } = req.params as unknown as z.infer<typeof gameIdParams>
+      const maps = await geoMapRepository.listCandidatesByGameId(gameId)
+      res.json({ success: true, data: { maps } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+const mapIdParams = z.object({
+  gameId: z.coerce.number().int().positive(),
+  mapId: z.coerce.number().int().positive(),
+})
+
+async function consumeMapActionOrReject(
+  req: Request,
+  res: Response,
+): Promise<{ ok: true; budget: { used: number; limit: number; remaining: number } } | { ok: false }> {
+  const keyId = req.apiKey!.id
+  const maxPerDay = Number(env.GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY) || 30
+  const budget = await consumeMapActionBudget(keyId, maxPerDay)
+  if (!budget.ok) {
+    res.setHeader('Retry-After', String(budget.resetSeconds))
+    res.status(429).json({
+      success: false,
+      error: {
+        code: 'BUDGET_EXHAUSTED',
+        message: `Daily map-action budget of ${budget.limit} reached; resets at UTC midnight`,
+      },
+    })
+    return { ok: false }
+  }
+  return { ok: true, budget: { used: budget.used, limit: budget.limit, remaining: budget.remaining } }
+}
+
+// POST /games/:gameId/maps/:mapId/select — promote a candidate map to
+// canonical (issue #331, phase 5). This is the operator fix for wrong-game
+// maps today: an agent can inspect `geo_list_maps` and pick the correct one.
+// Mirrors the admin geo-fetch `/maps/:mapId/select` handler exactly (enable
+// then select), attributing `selectedBy` to the agent key.
+router.post(
+  '/games/:gameId/maps/:mapId/select',
+  requireScope('geo-agent:curate'),
+  requireAgentCurateEnabled,
+  validateParams(mapIdParams),
+  async (req, res, next) => {
+    try {
+      const { gameId, mapId } = req.params as unknown as z.infer<typeof mapIdParams>
+      const budgetResult = await consumeMapActionOrReject(req, res)
+      if (!budgetResult.ok) return
+
+      const target = await geoMapRepository.findById(mapId)
+      if (!target || target.gameId !== gameId) {
+        res.status(404).json({ success: false, error: { code: 'MAP_NOT_FOUND' } })
+        return
+      }
+      if (!target.isSelected) {
+        await geoMapRepository.enableForGame(gameId, mapId)
+      }
+      const updated = await geoMapRepository.selectMap(gameId, mapId, `apikey:${req.apiKey!.id}`)
+      if (!updated) {
+        res.status(409).json({ success: false, error: { code: 'SELECT_FAILED' } })
+        return
+      }
+
+      await adminAuditRepository.record({
+        adminId: `apikey:${req.apiKey!.id}`,
+        action: 'geo-agent.select_map',
+        targetKind: 'geo_map',
+        targetId: String(mapId),
+        after: { gameId, mapId },
+        ip: req.ip ?? null,
+      })
+
+      res.json({ success: true, data: { map: updated, budget: budgetResult.budget } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// POST /games/:gameId/maps/:mapId/reject — disable a wrong-game/prop map
+// (issue #331, phase 5). Reuses `disableForGame`, which refuses to leave a
+// game with zero enabled maps — an agent must select a replacement canonical
+// map (or a good map already exists) before rejecting the last bad one.
+router.post(
+  '/games/:gameId/maps/:mapId/reject',
+  requireScope('geo-agent:curate'),
+  requireAgentCurateEnabled,
+  validateParams(mapIdParams),
+  async (req, res, next) => {
+    try {
+      const { gameId, mapId } = req.params as unknown as z.infer<typeof mapIdParams>
+      const budgetResult = await consumeMapActionOrReject(req, res)
+      if (!budgetResult.ok) return
+
+      const result = await geoMapRepository.disableForGame(gameId, mapId)
+      if (!result.ok) {
+        const status = result.reason === 'NOT_FOUND' ? 404 : 409
+        res.status(status).json({ success: false, error: { code: result.reason } })
+        return
+      }
+
+      await adminAuditRepository.record({
+        adminId: `apikey:${req.apiKey!.id}`,
+        action: 'geo-agent.reject_map',
+        targetKind: 'geo_map',
+        targetId: String(mapId),
+        after: { gameId, mapId },
+        ip: req.ip ?? null,
+      })
+
+      res.json({ success: true, data: { map: result.map, budget: budgetResult.budget } })
     } catch (err) {
       next(err)
     }

--- a/packages/geo-agent-mcp/README.md
+++ b/packages/geo-agent-mcp/README.md
@@ -16,9 +16,15 @@ the key can't, and the key is read-only in this phase.
 |------|---------|------|-------|
 | `geo_health` | `GET /health` | — | `geo-agent:read` |
 | `geo_games_needing_content` | `GET /games-needing-content` | `limit?` | `geo-agent:read` |
+| `geo_list_games` | `GET /games` | `limit?` | `geo-agent:read` |
 | `geo_list_candidates` | `GET /games/:gameId/candidates` | `gameId`, `limit?` | `geo-agent:read` |
+| `geo_list_maps` | `GET /games/:gameId/maps` | `gameId` | `geo-agent:read` |
 | `geo_ingest_game` | `POST /games/:gameId/ingest` | `gameId`, `sources?` | `geo-agent:ingest` |
 | `geo_propose_pin` | `POST /candidates/:id/pins` | `candidateId`, `x`, `y`, `source`, `rationale`, … | `geo-agent:propose` |
+| `geo_enroll_game` | `POST /games` | `gameId?`, `rawgId?` | `geo-agent:curate` |
+| `geo_import_captures` | `POST /games/:gameId/captures` | `gameId`, `targetCount?`, `imageUrls?` | `geo-agent:curate` |
+| `geo_set_canonical_map` | `POST /games/:gameId/maps/:mapId/select` | `gameId`, `mapId` | `geo-agent:curate` |
+| `geo_reject_map` | `POST /games/:gameId/maps/:mapId/reject` | `gameId`, `mapId` | `geo-agent:curate` |
 
 ## Setup
 
@@ -64,3 +70,10 @@ Add to your MCP config (e.g. `.mcp.json` or the Claude Code settings):
   `geo_propose_pin` needs `geo-agent:propose` (per-key hourly budget). Proposed
   pins are downweighted and can never promote ground truth on their own — they
   join consensus as one flagged, human-reviewed voter.
+- `geo_enroll_game`, `geo_import_captures`, `geo_set_canonical_map`, and
+  `geo_reject_map` need `geo-agent:curate` (each has its own per-key daily
+  budget) and are additionally gated by `GEO_AGENT_CURATE_ENABLED` on the
+  backend — while off they return `AGENT_CURATE_DISABLED` even for a key that
+  holds the scope. This is the content-creation surface: it enrolls new games,
+  tops up screenshot candidates, and lets an operator pick the canonical map
+  for a game or reject a wrong-game/prop map.

--- a/packages/geo-agent-mcp/src/server.test.ts
+++ b/packages/geo-agent-mcp/src/server.test.ts
@@ -72,6 +72,75 @@ describe('resolveToolPath', () => {
   it('errors on an unknown tool', () => {
     assert.ok('error' in resolveToolPath('nope', {}))
   })
+
+  it('maps geo_list_games with a validated limit', () => {
+    assert.deepEqual(resolveToolPath('geo_list_games', {}), { path: '/api/agent/v1/geo/games' })
+    assert.deepEqual(resolveToolPath('geo_list_games', { limit: 50 }), {
+      path: '/api/agent/v1/geo/games?limit=50',
+    })
+  })
+
+  it('maps geo_enroll_game to a POST with gameId or rawgId', () => {
+    assert.deepEqual(resolveToolPath('geo_enroll_game', { gameId: 5 }), {
+      path: '/api/agent/v1/geo/games',
+      method: 'POST',
+      body: { gameId: 5 },
+    })
+    assert.deepEqual(resolveToolPath('geo_enroll_game', { rawgId: 3498 }), {
+      path: '/api/agent/v1/geo/games',
+      method: 'POST',
+      body: { rawgId: 3498 },
+    })
+  })
+
+  it('rejects geo_enroll_game without gameId or rawgId', () => {
+    assert.ok('error' in resolveToolPath('geo_enroll_game', {}))
+  })
+
+  it('maps geo_import_captures to a POST, supporting targetCount and imageUrls', () => {
+    assert.deepEqual(resolveToolPath('geo_import_captures', { gameId: 7, targetCount: 10 }), {
+      path: '/api/agent/v1/geo/games/7/captures',
+      method: 'POST',
+      body: { targetCount: 10 },
+    })
+    assert.deepEqual(
+      resolveToolPath('geo_import_captures', { gameId: 7, imageUrls: ['https://x/1.jpg'] }),
+      {
+        path: '/api/agent/v1/geo/games/7/captures',
+        method: 'POST',
+        body: { imageUrls: ['https://x/1.jpg'] },
+      },
+    )
+  })
+
+  it('rejects geo_import_captures without a gameId', () => {
+    assert.ok('error' in resolveToolPath('geo_import_captures', { targetCount: 5 }))
+  })
+
+  it('maps geo_list_maps to the game maps path', () => {
+    assert.deepEqual(resolveToolPath('geo_list_maps', { gameId: 42 }), {
+      path: '/api/agent/v1/geo/games/42/maps',
+    })
+    assert.ok('error' in resolveToolPath('geo_list_maps', {}))
+  })
+
+  it('maps geo_set_canonical_map to a POST select path', () => {
+    assert.deepEqual(resolveToolPath('geo_set_canonical_map', { gameId: 42, mapId: 9 }), {
+      path: '/api/agent/v1/geo/games/42/maps/9/select',
+      method: 'POST',
+      body: {},
+    })
+    assert.ok('error' in resolveToolPath('geo_set_canonical_map', { gameId: 42 }))
+  })
+
+  it('maps geo_reject_map to a POST reject path', () => {
+    assert.deepEqual(resolveToolPath('geo_reject_map', { gameId: 42, mapId: 9 }), {
+      path: '/api/agent/v1/geo/games/42/maps/9/reject',
+      method: 'POST',
+      body: {},
+    })
+    assert.ok('error' in resolveToolPath('geo_reject_map', { mapId: 9 }))
+  })
 })
 
 describe('handleRpc', () => {

--- a/packages/geo-agent-mcp/src/server.ts
+++ b/packages/geo-agent-mcp/src/server.ts
@@ -74,6 +74,91 @@ export const TOOLS: ToolDef[] = [
     },
   },
   {
+    name: 'geo_list_games',
+    description:
+      'The whole geo-curated catalog, not just the "one pin away" work queue: every enrolled game with capture/map/canonical-pin counts and eligible/starved flags.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'Max games (1-500, default 200)' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'geo_enroll_game',
+    description:
+      'Enroll a game into the geo pipeline (needs a geo-agent:curate key). Pass either gameId (an existing game) or rawgId (looked up, or created if no game has that rawg_id yet). Flips geo_curated on so the existing metadata resolver + ingest pipeline picks it up. Subject to a per-key daily budget.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'number', description: 'Existing internal game id' },
+        rawgId: { type: 'number', description: 'RAWG game id (looked up or created)' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'geo_import_captures',
+    description:
+      'Top up an enrolled game\'s screenshot candidates (needs a geo-agent:curate key). Either pulls more from RAWG (targetCount) or inserts an explicit imageUrls list for manual/gameplay captures. Requires the game to already have an enabled map. Subject to a per-key daily budget.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'number', description: 'Game id (required)' },
+        targetCount: { type: 'number', description: 'Max RAWG screenshots to fetch (ignored if imageUrls is set)' },
+        imageUrls: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Explicit capture image URLs (manual/gameplay stills) instead of pulling from RAWG',
+        },
+      },
+      required: ['gameId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'geo_list_maps',
+    description:
+      "Every candidate map fetched for a game, active or not, so an agent can pick the canonical one and reject wrong-game/prop maps.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'number', description: 'Game id (required)' },
+      },
+      required: ['gameId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'geo_set_canonical_map',
+    description:
+      'Promote a candidate map to canonical for a game (needs a geo-agent:curate key). Use this to fix a wrong-game map once geo_list_maps shows the correct one. Subject to a per-key daily budget.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'number', description: 'Game id (required)' },
+        mapId: { type: 'number', description: 'geo_map id to select (required)' },
+      },
+      required: ['gameId', 'mapId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'geo_reject_map',
+    description:
+      'Disable a wrong-game or prop map (needs a geo-agent:curate key). Refuses to leave a game with zero enabled maps — select a replacement canonical map first if this is the last one. Subject to a per-key daily budget.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'number', description: 'Game id (required)' },
+        mapId: { type: 'number', description: 'geo_map id to reject (required)' },
+      },
+      required: ['gameId', 'mapId'],
+      additionalProperties: false,
+    },
+  },
+  {
     name: 'geo_propose_pin',
     description:
       "Propose a location pin for a capture (needs a geo-agent:propose key). The pin is DOWNWEIGHTED and can never promote ground truth on its own — it joins consensus as one flagged voter, reviewed by humans. `rationale` is required. Propose only when confident; a wrong pin poisons the centroid.",
@@ -139,6 +224,59 @@ export function resolveToolPath(
         body['sources'] = a['sources']
       }
       return { path: `/api/agent/v1/geo/games/${gameId}/ingest`, method: 'POST', body }
+    }
+    case 'geo_list_games':
+      return { path: `/api/agent/v1/geo/games${qs}` }
+    case 'geo_enroll_game': {
+      const body: Record<string, unknown> = {}
+      if (a['gameId'] !== undefined) {
+        const gameId = asPositiveInt(a['gameId'])
+        if (gameId === null) return { error: 'gameId must be a positive integer' }
+        body['gameId'] = gameId
+      }
+      if (a['rawgId'] !== undefined) {
+        const rawgId = asPositiveInt(a['rawgId'])
+        if (rawgId === null) return { error: 'rawgId must be a positive integer' }
+        body['rawgId'] = rawgId
+      }
+      if (body['gameId'] === undefined && body['rawgId'] === undefined) {
+        return { error: 'gameId or rawgId is required' }
+      }
+      return { path: '/api/agent/v1/geo/games', method: 'POST', body }
+    }
+    case 'geo_import_captures': {
+      const gameId = asPositiveInt(a['gameId'])
+      if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
+      const body: Record<string, unknown> = {}
+      if (a['targetCount'] !== undefined) {
+        const targetCount = asPositiveInt(a['targetCount'])
+        if (targetCount === null) return { error: 'targetCount must be a positive integer' }
+        body['targetCount'] = targetCount
+      }
+      if (a['imageUrls'] !== undefined) {
+        if (!Array.isArray(a['imageUrls'])) return { error: 'imageUrls must be an array' }
+        body['imageUrls'] = a['imageUrls']
+      }
+      return { path: `/api/agent/v1/geo/games/${gameId}/captures`, method: 'POST', body }
+    }
+    case 'geo_list_maps': {
+      const gameId = asPositiveInt(a['gameId'])
+      if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
+      return { path: `/api/agent/v1/geo/games/${gameId}/maps` }
+    }
+    case 'geo_set_canonical_map': {
+      const gameId = asPositiveInt(a['gameId'])
+      const mapId = asPositiveInt(a['mapId'])
+      if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
+      if (mapId === null) return { error: 'mapId is required and must be a positive integer' }
+      return { path: `/api/agent/v1/geo/games/${gameId}/maps/${mapId}/select`, method: 'POST', body: {} }
+    }
+    case 'geo_reject_map': {
+      const gameId = asPositiveInt(a['gameId'])
+      const mapId = asPositiveInt(a['mapId'])
+      if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
+      if (mapId === null) return { error: 'mapId is required and must be a positive integer' }
+      return { path: `/api/agent/v1/geo/games/${gameId}/maps/${mapId}/reject`, method: 'POST', body: {} }
     }
     case 'geo_propose_pin': {
       const candidateId = asPositiveInt(a['candidateId'])

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1238,6 +1238,22 @@ export interface GeoGameNeedingContent {
   bestCandidateId: number | null
 }
 
+// Catalog row for the agent content-creation surface (issue #331, phase 5) —
+// the whole geo-curated pool, not just the "one pin away" work queue.
+// `eligible` mirrors the GeoGamers eligibility gate (an active map + at least
+// one canonical/promoted pin); `starved` flags a game whose active capture
+// count hasn't reached the ingest pipeline's per-game target yet, so an agent
+// knows where `geo_import_captures` would actually help.
+export interface GeoCatalogGame {
+  gameId: number
+  gameName: string | null
+  captureCount: number
+  mapCount: number
+  canonicalPinCount: number
+  eligible: boolean
+  starved: boolean
+}
+
 // Content-readiness snapshot for the GeoGamers daily scheduler. Returned by
 // GET /api/admin/geogamers/health and, for content-sourcing agents, by
 // GET /api/agent/v1/geo/health. `starved` is the gate the daily worker itself
@@ -1650,13 +1666,15 @@ export type ApiKeyScope =
   | 'geo-agent:read' // health, games-needing-content, candidate listing
   | 'geo-agent:ingest' // trigger the existing geo ingestion pipeline (phase 3)
   | 'geo-agent:propose' // submit downweighted, flagged consensus pins (phase 4)
+  | 'geo-agent:curate' // enroll games, top up captures, manage candidate maps (phase 5)
 
-// The three geo-agent scopes, in privilege order. A read-only key carries only
-// the first; ingest/propose are granted per key as later phases ship.
+// The four geo-agent scopes, in privilege order. A read-only key carries only
+// the first; ingest/propose/curate are granted per key as later phases ship.
 export const GEO_AGENT_SCOPES = [
   'geo-agent:read',
   'geo-agent:ingest',
   'geo-agent:propose',
+  'geo-agent:curate',
 ] as const satisfies readonly ApiKeyScope[]
 
 export function isGeoAgentScope(scope: ApiKeyScope): boolean {


### PR DESCRIPTION
## Summary

Adds the "content creation & curation" side of the geo-agent API + MCP (issue #331) so an agent can grow the geo pool, not just read it or propose pins against existing content.

- New `geo-agent:curate` scope + `GEO_AGENT_CURATE_ENABLED` kill switch (independent of `GEO_AGENT_API_ENABLED`), so curation ships dark until an operator opts in.
- New endpoints under `/api/agent/v1/geo`, each scoped, per-key daily-budgeted (Redis), and audited to `admin_audit_log`, mirroring the existing ingest/propose routes:
  - `GET /games` — whole geo-curated catalog with capture/map/canonical-pin counts + `eligible`/`starved` flags
  - `POST /games` — enroll a game by `gameId` or `rawgId`, reusing the *same* `geo_curated` switch the admin Games tab flips (no duplicated RAWG-import/resolve/ingest logic)
  - `POST /games/:gameId/captures` — top up screenshot candidates via the existing RAWG importer, or an explicit `imageUrls` list for manual/gameplay stills
  - `GET /games/:gameId/maps` — every candidate map fetched for a game, active or not
  - `POST /games/:gameId/maps/:mapId/select` — promote a candidate map to canonical
  - `POST /games/:gameId/maps/:mapId/reject` — disable a wrong-game/prop map (reuses `disableForGame`, which refuses to leave zero enabled maps)
- **Fixes the reported wrong-game map matcher bug**: `scoreMapTitle` now requires a title to carry at least one piece of game-specific evidence (full name or a distinguishing slug token) before it's considered at all — previously a title with zero evidence could still win on a franchise-wide Fandom wiki purely from generic "world/overworld/main" keyword bonuses. Regression tests cover both reported cases: Uncharted 2 vs. a Lost Legacy map, and Ocarina of Time vs. the 1986 original's map.
- Matching MCP tools added to `@the-box/geo-agent-mcp`: `geo_list_games`, `geo_enroll_game`, `geo_import_captures`, `geo_list_maps`, `geo_set_canonical_map`, `geo_reject_map`.
- `docs/geo-agent-api.md` and the MCP README updated with the new endpoints/tools, scope, and error codes.

## Test plan

- [x] `npm run build` (types, backend, frontend, geo-agent-mcp) — clean
- [x] `npm run lint` — clean (one pre-existing unrelated warning in frontend e2e)
- [x] `npm test` — all workspaces pass, including new backend unit tests (middleware kill switch, Redis budget keys, `scoreMapTitle`/`pickBestMapTitle` regression cases) and new MCP `resolveToolPath` tests for the 6 new tools
- [x] Everything stays behind `GEO_AGENT_CURATE_ENABLED=false` by default — no behavior change for existing read/ingest/propose routes


---
_Generated by [Claude Code](https://claude.ai/code/session_01B2xWb8VBVFR9DwCjCnVZnx)_