### PR TITLE
feat(geo-agent): add confirm/promote-pin and manual-map-upload MCP tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,14 @@ GEO_AGENT_CURATE_ENABLED=false
 GEO_AGENT_MAX_ENROLLS_PER_DAY=5
 GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY=10
 GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY=30
+# Confirm/promote surface (phase 7): confirm & promote a capture's qualifying
+# consensus pin to canonical ground truth. Third, independent kill switch —
+# while false the endpoint returns 503 AGENT_PROMOTE_DISABLED even for a key
+# holding geo-agent:promote. Promotion only happens where the crowd already
+# earned it (consensus qualifies); the agent supplies no coordinates.
+GEO_AGENT_PROMOTE_ENABLED=false
+# Per-key daily cap on agent-confirmed promotions, tracked in Redis.
+GEO_AGENT_MAX_PROMOTES_PER_DAY=20
 # Backfill discovery worker (phase 6). When true, a recurring job drives
 # ingestion at curated+resolved games closest to eligibility. Off by default.
 GEO_BACKFILL_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,8 @@ GEO_AGENT_CURATE_ENABLED=false
 GEO_AGENT_MAX_ENROLLS_PER_DAY=5
 GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY=10
 GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY=30
+# Per-key daily cap on manual map uploads (register a map by URL + dimensions).
+GEO_AGENT_MAX_MAP_UPLOADS_PER_DAY=10
 # Confirm/promote surface (phase 7): confirm & promote a capture's qualifying
 # consensus pin to canonical ground truth. Third, independent kill switch —
 # while false the endpoint returns 503 AGENT_PROMOTE_DISABLED even for a key

--- a/docs/geo-agent-api.md
+++ b/docs/geo-agent-api.md
@@ -5,7 +5,8 @@ client) safely *drive* geo content sourcing against prod. It started as a
 read-only proof of the auth / audit / rate-limit surface (phase 2) and grew a
 write surface in stages: ingest triggers (phase 3), downweighted pin proposals
 (phase 4), **content creation & curation** (phase 5) — enrolling new games,
-topping up screenshot candidates, and picking/rejecting candidate maps — and
+topping up screenshot candidates, uploading a manual map, and picking/rejecting
+candidate maps — and
 **confirm/promote** (phase 7): letting the agent pull the trigger on a
 promotion the crowd has already earned. See the
 [agent-assisted geo sourcing plan](../tasks/prd-geo-agent-sourcing.html).
@@ -49,7 +50,7 @@ via `DELETE /api/admin/agent-keys/:id` (any admin, instant).
 | `geo-agent:read` | `/health`, `/games-needing-content`, `/games`, `/games/:id/candidates`, `/games/:id/maps` | 2, 5 |
 | `geo-agent:ingest` | `POST /games/:id/ingest` — trigger the ingestion pipeline | 3 |
 | `geo-agent:propose` | `POST /candidates/:id/pins` — propose a downweighted consensus pin | 4 |
-| `geo-agent:curate` | `POST /games`, `POST /games/:id/captures`, `POST /games/:id/maps/:mapId/select`, `POST /games/:id/maps/:mapId/reject` — content creation & curation | 5 |
+| `geo-agent:curate` | `POST /games`, `POST /games/:id/captures`, `POST /games/:id/maps`, `POST /games/:id/maps/:mapId/select`, `POST /games/:id/maps/:mapId/reject` — content creation & curation | 5 |
 | `geo-agent:promote` | `POST /candidates/:id/promote` — confirm & promote a capture's qualifying consensus pin to canonical | 7 |
 
 A freshly minted key defaults to `geo-agent:read`. Ingest/propose/curate/promote
@@ -84,7 +85,8 @@ proposals: `GEO_AGENT_MAX_PINS_PER_HOUR` (default 60) per UTC hour. Curate
 (phase 5), each its own daily counter: enroll —
 `GEO_AGENT_MAX_ENROLLS_PER_DAY` (default 5); capture import —
 `GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY` (default 10); map select/reject —
-`GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY` (default 30, shared by both actions).
+`GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY` (default 30, shared by both actions); map
+upload — `GEO_AGENT_MAX_MAP_UPLOADS_PER_DAY` (default 10).
 Promote (phase 7): `GEO_AGENT_MAX_PROMOTES_PER_DAY` (default 20) per UTC day. On
 exhaustion: `429 BUDGET_EXHAUSTED` with `Retry-After` (seconds to the window
 reset). Budgets fail **closed** — if Redis is unreachable the call is rejected,
@@ -258,6 +260,49 @@ the admin geo-fetch curation panel.
   }
 }
 ```
+
+### `POST /games/:gameId/maps`
+
+Scope: `geo-agent:curate`. **Manual map upload** — the last-resort content path
+when the ingestion tiers found no usable map. The agent supplies a map image URL
+it hosts itself and has verified, declares its pixel dimensions and
+license/attribution, and the server records a `source = "manual"` map row.
+Mirrors the admin "Tier 3 manual map upload" exactly: **no image bytes are sent
+and nothing is processed server-side** — the agent owns hosting and the license
+claim. The map lands **disabled** by default (enable/select it afterwards with
+`.../select`); pass `"enable": true` to enable (and select) it immediately.
+
+```json
+{
+  "imageUrl": "https://cdn.example.com/eldenring-lands-between.jpg",
+  "widthPx": 4096,
+  "heightPx": 4096,
+  "license": "CC-BY-4.0",
+  "attribution": "Elden Ring Wiki",
+  "sourceUrl": "https://eldenring.wiki.fextralife.com/Map",
+  "consensusRadius": 0.03,
+  "region": "Limgrave",
+  "enable": false
+}
+```
+
+`imageUrl`/`sourceUrl` must be valid URLs (≤1000 chars); `widthPx`/`heightPx`
+are positive integers (≤32768); `license` is required (≤100 chars). Returns the
+created map and the budget.
+
+```json
+{
+  "success": true,
+  "data": {
+    "map": { "id": 91, "gameId": 512, "source": "manual", "imageUrl": "https://…", "isSelected": false },
+    "budget": { "used": 1, "limit": 10, "remaining": 9 }
+  }
+}
+```
+
+`404 GAME_NOT_FOUND` if the game doesn't exist. `409 DUPLICATE_MAP` if a map
+with the same `imageUrl` already exists for the game (the `(game_id, image_url)`
+unique constraint). Audited as `geo-agent.upload_map`.
 
 ### `POST /games/:gameId/maps/:mapId/select`
 
@@ -447,7 +492,8 @@ how far off it is. Audited as `geo-agent.promote_candidate`.
 | `CONSENSUS_NOT_READY` | 409 | Consensus doesn't yet qualify to promote (promote) |
 | `VISION_DISABLED` | 403 | `agent_vision` proposals disabled pending the accuracy study |
 | `KEY_PAUSED` | 403 | Key auto-paused: >60% of its recent proposals were rejected |
-| `GAME_NOT_FOUND` | 404 | No such game (`gameId` on enroll) |
+| `GAME_NOT_FOUND` | 404 | No such game (`gameId` on enroll / map upload) |
+| `DUPLICATE_MAP` | 409 | A map with this `imageUrl` already exists for the game (upload) |
 | `RAWG_LOOKUP_FAILED` | 400 | `rawgId` didn't resolve via RAWG, or `RAWG_API_KEY` isn't set |
 | `NO_ACTIVE_MAP` | 409 | Game has no enabled map to attach captures to |
 | `NO_RAWG_ID` | 409 | Game has no `rawgId` and `imageUrls` wasn't provided |
@@ -462,8 +508,8 @@ Admin key mints/revokes are written to `admin_audit_log`
 (`agent_key.mint` / `agent_key.revoke`) with the acting admin, label, scopes.
 Every write endpoint audits its action keyed by `apikey:<id>`:
 `geo-agent.ingest`, `geo-agent.propose_pin`, `geo-agent.enroll_game`,
-`geo-agent.import_captures`, `geo-agent.select_map`, `geo-agent.reject_map`,
-`geo-agent.promote_candidate`.
+`geo-agent.import_captures`, `geo-agent.upload_map`, `geo-agent.select_map`,
+`geo-agent.reject_map`, `geo-agent.promote_candidate`.
 
 ## MCP wrapper
 

--- a/docs/geo-agent-api.md
+++ b/docs/geo-agent-api.md
@@ -3,10 +3,12 @@
 Key-authenticated HTTP surface that lets an AI agent (Claude Code / an MCP
 client) safely *drive* geo content sourcing against prod. It started as a
 read-only proof of the auth / audit / rate-limit surface (phase 2) and grew a
-write surface in three stages: ingest triggers (phase 3), downweighted pin
-proposals (phase 4), and — this phase (5) — **content creation & curation**:
-enrolling new games, topping up screenshot candidates, and picking/rejecting
-candidate maps. See the [agent-assisted geo sourcing plan](../tasks/prd-geo-agent-sourcing.html).
+write surface in stages: ingest triggers (phase 3), downweighted pin proposals
+(phase 4), **content creation & curation** (phase 5) — enrolling new games,
+topping up screenshot candidates, and picking/rejecting candidate maps — and
+**confirm/promote** (phase 7): letting the agent pull the trigger on a
+promotion the crowd has already earned. See the
+[agent-assisted geo sourcing plan](../tasks/prd-geo-agent-sourcing.html).
 
 > Design principle: the agent *proposes*, consensus + admins *dispose*. Even
 > the curate endpoints only reach content the admin UI already lets an
@@ -48,9 +50,10 @@ via `DELETE /api/admin/agent-keys/:id` (any admin, instant).
 | `geo-agent:ingest` | `POST /games/:id/ingest` — trigger the ingestion pipeline | 3 |
 | `geo-agent:propose` | `POST /candidates/:id/pins` — propose a downweighted consensus pin | 4 |
 | `geo-agent:curate` | `POST /games`, `POST /games/:id/captures`, `POST /games/:id/maps/:mapId/select`, `POST /games/:id/maps/:mapId/reject` — content creation & curation | 5 |
+| `geo-agent:promote` | `POST /candidates/:id/promote` — confirm & promote a capture's qualifying consensus pin to canonical | 7 |
 
-A freshly minted key defaults to `geo-agent:read`. Ingest/propose/curate are
-granted per key as later phases ship.
+A freshly minted key defaults to `geo-agent:read`. Ingest/propose/curate/promote
+are granted per key as later phases ship.
 
 ## Curate kill switch (phase 5)
 
@@ -60,6 +63,15 @@ off they return `503 AGENT_CURATE_DISABLED` even for a key that holds the
 scope — an operator can run read/ingest/propose in production while curation
 stays dark, and can flip curation off alone without touching the rest of the
 surface.
+
+## Promote kill switch (phase 7)
+
+The single `geo-agent:promote` write endpoint sits behind a **third**,
+independent kill switch: `GEO_AGENT_PROMOTE_ENABLED` (default `false`). While
+off it returns `503 AGENT_PROMOTE_DISABLED` even for a key that holds the
+scope — promotion is the one agent write that creates ground truth, so it can
+stay dark while read/ingest/propose/curate run in production, and can be flipped
+off alone.
 
 ## Rate limit & budgets
 
@@ -72,7 +84,8 @@ proposals: `GEO_AGENT_MAX_PINS_PER_HOUR` (default 60) per UTC hour. Curate
 (phase 5), each its own daily counter: enroll —
 `GEO_AGENT_MAX_ENROLLS_PER_DAY` (default 5); capture import —
 `GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY` (default 10); map select/reject —
-`GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY` (default 30, shared by both actions). On
+`GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY` (default 30, shared by both actions).
+Promote (phase 7): `GEO_AGENT_MAX_PROMOTES_PER_DAY` (default 20) per UTC day. On
 exhaustion: `429 BUDGET_EXHAUSTED` with `Retry-After` (seconds to the window
 reset). Budgets fail **closed** — if Redis is unreachable the call is rejected,
 never silently unlimited.
@@ -376,18 +389,62 @@ proposer can't keep flooding the review queue.
 proposal (same key + candidate + `visionPass`) is an idempotent no-op:
 `{ "received": true, "duplicate": true }`. Audited as `geo-agent.propose_pin`.
 
+### `POST /candidates/:id/promote`
+
+Scope: `geo-agent:promote`. **Confirm and promote** a capture's consensus pin to
+canonical ground truth. This is the one agent write that *creates* ground truth,
+and it is safe by construction: the agent supplies **no coordinates** and can
+promote only where the crowd already earned it. The server re-runs consensus
+over the candidate's pins and refuses unless it **qualifies** — the same
+auto-promote gate the consensus worker uses: ≥5 accepted **human** pins
+(`GEO_CONSENSUS_MIN_PINS_TO_PROMOTE`) and a tight enough cluster
+(`confidence ≥ 0.5`). Agent pins are downweighted voters and excluded from that
+human count (consensus v3), so no pile of machine pins can manufacture a
+qualifying candidate — the agent merely pulls the trigger on a promotion the
+crowd earned but that a threshold recompute (`[5, 10, 20, 50]`) may not have
+fired for. Promotes via the consensus centroid (`promoted_via = 'consensus'`),
+attributing `promoted_by` to `apikey:<id>` — the same primitive the admin
+override uses.
+
+The request takes **no body**.
+
+```json
+{
+  "success": true,
+  "data": {
+    "meta": {
+      "id": 4521,
+      "canonicalX": 0.42,
+      "canonicalY": 0.31,
+      "confidence": 0.87,
+      "promotedVia": "consensus"
+    },
+    "budget": { "used": 1, "limit": 20, "remaining": 19 }
+  }
+}
+```
+
+`404 CANDIDATE_NOT_FOUND` if no such capture. `409 ALREADY_PROMOTED` if it
+already has a canonical pin. `409 NO_PINS` if the candidate has no pins yet.
+`409 CONSENSUS_NOT_READY` if consensus doesn't qualify — the error `data` carries
+`humanAcceptedCount`, `requiredHumanPins`, and `confidence` so an agent can see
+how far off it is. Audited as `geo-agent.promote_candidate`.
+
 ## Error codes
 
 | Code | HTTP | Meaning |
 |------|------|---------|
 | `AGENT_API_DISABLED` | 503 | `GEO_AGENT_API_ENABLED` is off |
 | `AGENT_CURATE_DISABLED` | 503 | `GEO_AGENT_CURATE_ENABLED` is off (curate endpoints only) |
+| `AGENT_PROMOTE_DISABLED` | 503 | `GEO_AGENT_PROMOTE_ENABLED` is off (promote endpoint only) |
 | `UNAUTHORIZED` | 401 | Missing / malformed / invalid key |
 | `INSUFFICIENT_SCOPE` | 403 | Key lacks the required geo-agent scope (or carries a non-agent scope) |
 | `RATE_LIMITED` | 429 | Per-minute limit hit; see `Retry-After` |
 | `BUDGET_EXHAUSTED` | 429 | Write budget hit; `Retry-After` = seconds to window reset |
-| `CANDIDATE_NOT_FOUND` | 404 | No such capture candidate (propose) |
-| `ALREADY_PROMOTED` | 409 | Candidate already has a canonical pin (propose) |
+| `CANDIDATE_NOT_FOUND` | 404 | No such capture candidate (propose / promote) |
+| `ALREADY_PROMOTED` | 409 | Candidate already has a canonical pin (propose / promote) |
+| `NO_PINS` | 409 | Candidate has no pins to compute consensus from (promote) |
+| `CONSENSUS_NOT_READY` | 409 | Consensus doesn't yet qualify to promote (promote) |
 | `VISION_DISABLED` | 403 | `agent_vision` proposals disabled pending the accuracy study |
 | `KEY_PAUSED` | 403 | Key auto-paused: >60% of its recent proposals were rejected |
 | `GAME_NOT_FOUND` | 404 | No such game (`gameId` on enroll) |
@@ -405,7 +462,8 @@ Admin key mints/revokes are written to `admin_audit_log`
 (`agent_key.mint` / `agent_key.revoke`) with the acting admin, label, scopes.
 Every write endpoint audits its action keyed by `apikey:<id>`:
 `geo-agent.ingest`, `geo-agent.propose_pin`, `geo-agent.enroll_game`,
-`geo-agent.import_captures`, `geo-agent.select_map`, `geo-agent.reject_map`.
+`geo-agent.import_captures`, `geo-agent.select_map`, `geo-agent.reject_map`,
+`geo-agent.promote_candidate`.
 
 ## MCP wrapper
 

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -90,6 +90,16 @@ export const env = {
   GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY: process.env['GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY'] || '10',
   // Per-key daily budget for map curation actions (select canonical / reject).
   GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY: process.env['GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY'] || '30',
+  // Confirm/promote surface (issue #331, phase 7) — the one write that creates
+  // ground truth, but only where the crowd already earned it: promotion is
+  // gated on qualifying consensus (≥5 accepted HUMAN pins + confidence ≥ 0.5)
+  // and the agent supplies no coordinates. Third, independent kill switch so an
+  // operator can run read/ingest/propose/curate while promote stays dark. While
+  // false the endpoint returns 503 AGENT_PROMOTE_DISABLED even for a key that
+  // holds geo-agent:promote.
+  GEO_AGENT_PROMOTE_ENABLED: process.env['GEO_AGENT_PROMOTE_ENABLED'] || 'false',
+  // Per-key daily budget for agent-confirmed promotions, tracked in Redis.
+  GEO_AGENT_MAX_PROMOTES_PER_DAY: process.env['GEO_AGENT_MAX_PROMOTES_PER_DAY'] || '20',
 
   // RAWG API (for fetching game screenshots)
   RAWG_API_KEY: process.env['RAWG_API_KEY'] || '',

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -90,6 +90,10 @@ export const env = {
   GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY: process.env['GEO_AGENT_MAX_CAPTURE_IMPORTS_PER_DAY'] || '10',
   // Per-key daily budget for map curation actions (select canonical / reject).
   GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY: process.env['GEO_AGENT_MAX_MAP_ACTIONS_PER_DAY'] || '30',
+  // Per-key daily budget for manual map uploads (register a map by URL +
+  // declared dimensions). Bounded tighter than select/reject since each upload
+  // creates a new asset row.
+  GEO_AGENT_MAX_MAP_UPLOADS_PER_DAY: process.env['GEO_AGENT_MAX_MAP_UPLOADS_PER_DAY'] || '10',
   // Confirm/promote surface (issue #331, phase 7) — the one write that creates
   // ground truth, but only where the crowd already earned it: promotion is
   // gated on qualifying consensus (≥5 accepted HUMAN pins + confidence ≥ 0.5)

--- a/packages/backend/src/infrastructure/redis/agent-budget.test.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.test.ts
@@ -6,6 +6,7 @@ import {
   ingestBudgetKey,
   mapActionBudgetKey,
   pinBudgetKey,
+  promoteBudgetKey,
   secondsToNextUtcHour,
   secondsToUtcMidnight,
 } from './agent-budget.js'
@@ -95,5 +96,20 @@ describe('mapActionBudgetKey', () => {
       mapActionBudgetKey(42, new Date('2026-07-10T15:30:00.000Z')),
       'geo-agent:budget:map-action:42:2026-07-10',
     )
+  })
+})
+
+describe('promoteBudgetKey', () => {
+  it('scopes the key by api key id and UTC day', () => {
+    assert.equal(
+      promoteBudgetKey(42, new Date('2026-07-10T15:30:00.000Z')),
+      'geo-agent:budget:promote:42:2026-07-10',
+    )
+  })
+
+  it('rolls to a new key at the UTC day boundary', () => {
+    const before = promoteBudgetKey(1, new Date('2026-07-10T23:59:59.000Z'))
+    const after = promoteBudgetKey(1, new Date('2026-07-11T00:00:01.000Z'))
+    assert.notEqual(before, after)
   })
 })

--- a/packages/backend/src/infrastructure/redis/agent-budget.test.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.test.ts
@@ -5,6 +5,7 @@ import {
   enrollBudgetKey,
   ingestBudgetKey,
   mapActionBudgetKey,
+  mapUploadBudgetKey,
   pinBudgetKey,
   promoteBudgetKey,
   secondsToNextUtcHour,
@@ -95,6 +96,15 @@ describe('mapActionBudgetKey', () => {
     assert.equal(
       mapActionBudgetKey(42, new Date('2026-07-10T15:30:00.000Z')),
       'geo-agent:budget:map-action:42:2026-07-10',
+    )
+  })
+})
+
+describe('mapUploadBudgetKey', () => {
+  it('scopes the key by api key id and UTC day', () => {
+    assert.equal(
+      mapUploadBudgetKey(42, new Date('2026-07-10T15:30:00.000Z')),
+      'geo-agent:budget:map-upload:42:2026-07-10',
     )
   })
 })

--- a/packages/backend/src/infrastructure/redis/agent-budget.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.ts
@@ -57,6 +57,11 @@ export function mapActionBudgetKey(apiKeyId: number, now: Date): string {
   return `geo-agent:budget:map-action:${apiKeyId}:${now.toISOString().slice(0, 10)}`
 }
 
+/** Redis key for a key's daily confirm/promote budget (phase 7). Pure. */
+export function promoteBudgetKey(apiKeyId: number, now: Date): string {
+  return `geo-agent:budget:promote:${apiKeyId}:${now.toISOString().slice(0, 10)}`
+}
+
 /**
  * Atomically consume one unit of a windowed budget keyed in Redis. Returns
  * `ok: false` (without consuming) once `limit` is reached; the counter expires
@@ -129,5 +134,16 @@ export async function consumeMapActionBudget(apiKeyId: number, limit: number): P
     limit,
     secondsToUtcMidnight(now),
     'map-action',
+  )
+}
+
+/** Consume one unit of a key's DAILY confirm/promote budget (phase 7). */
+export async function consumePromoteBudget(apiKeyId: number, limit: number): Promise<BudgetResult> {
+  const now = new Date()
+  return consumeWindowBudget(
+    promoteBudgetKey(apiKeyId, now),
+    limit,
+    secondsToUtcMidnight(now),
+    'promote',
   )
 }

--- a/packages/backend/src/infrastructure/redis/agent-budget.ts
+++ b/packages/backend/src/infrastructure/redis/agent-budget.ts
@@ -57,6 +57,11 @@ export function mapActionBudgetKey(apiKeyId: number, now: Date): string {
   return `geo-agent:budget:map-action:${apiKeyId}:${now.toISOString().slice(0, 10)}`
 }
 
+/** Redis key for a key's daily manual map-upload budget (phase 5). Pure. */
+export function mapUploadBudgetKey(apiKeyId: number, now: Date): string {
+  return `geo-agent:budget:map-upload:${apiKeyId}:${now.toISOString().slice(0, 10)}`
+}
+
 /** Redis key for a key's daily confirm/promote budget (phase 7). Pure. */
 export function promoteBudgetKey(apiKeyId: number, now: Date): string {
   return `geo-agent:budget:promote:${apiKeyId}:${now.toISOString().slice(0, 10)}`
@@ -134,6 +139,17 @@ export async function consumeMapActionBudget(apiKeyId: number, limit: number): P
     limit,
     secondsToUtcMidnight(now),
     'map-action',
+  )
+}
+
+/** Consume one unit of a key's DAILY manual map-upload budget (phase 5). */
+export async function consumeMapUploadBudget(apiKeyId: number, limit: number): Promise<BudgetResult> {
+  const now = new Date()
+  return consumeWindowBudget(
+    mapUploadBudgetKey(apiKeyId, now),
+    limit,
+    secondsToUtcMidnight(now),
+    'map-upload',
   )
 }
 

--- a/packages/backend/src/presentation/middleware/agent-api.middleware.ts
+++ b/packages/backend/src/presentation/middleware/agent-api.middleware.ts
@@ -48,6 +48,26 @@ export function requireAgentCurateEnabled(_req: Request, res: Response, next: Ne
 }
 
 /**
+ * Third kill switch for the confirm/promote route (issue #331, phase 7) — the
+ * one agent write that creates ground truth (only where consensus already
+ * qualifies). Independent of GEO_AGENT_API_ENABLED and GEO_AGENT_CURATE_ENABLED
+ * so an operator can run read/ingest/propose/curate in production while promote
+ * stays dark, and can flip it off alone. Checked after the main kill switch and
+ * key auth, before the scope check, so a disabled-promote 503 never leaks which
+ * keys hold the promote scope.
+ */
+export function requireAgentPromoteEnabled(_req: Request, res: Response, next: NextFunction): void {
+  if (env.GEO_AGENT_PROMOTE_ENABLED !== 'true') {
+    res.status(503).json({
+      success: false,
+      error: { code: 'AGENT_PROMOTE_DISABLED', message: 'The agent promote surface is disabled' },
+    })
+    return
+  }
+  next()
+}
+
+/**
  * Require a specific scope on the authenticated key. Also rejects any key that
  * carries a non-geo-agent scope reaching this surface — a streamer key can
  * never call the agent API even if it somehow held a geo-agent scope, and the

--- a/packages/backend/src/presentation/routes/agent-geo.routes.ts
+++ b/packages/backend/src/presentation/routes/agent-geo.routes.ts
@@ -41,6 +41,7 @@ import {
   consumeEnrollBudget,
   consumeIngestBudget,
   consumeMapActionBudget,
+  consumeMapUploadBudget,
   consumePinBudget,
   consumePromoteBudget,
 } from '../../infrastructure/redis/agent-budget.js'
@@ -422,6 +423,132 @@ router.get(
       const { gameId } = req.params as unknown as z.infer<typeof gameIdParams>
       const maps = await geoMapRepository.listCandidatesByGameId(gameId)
       res.json({ success: true, data: { maps } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// POST /games/:gameId/maps — manual map upload (issue #331, phase 5). The
+// last-resort content path when the ingestion tiers didn't produce a usable
+// map: the agent supplies a map image URL it has verified and hosts itself,
+// declares its pixel dimensions and license/attribution, and we record a
+// `source = 'manual'` geo_map row. Mirrors the admin "Tier 3 manual map upload"
+// (`POST /api/admin/geo/maps/manual`) exactly — no server-side image
+// processing, the agent is responsible for hosting the asset somewhere stable
+// and for the license claim. Lands DISABLED by default (an admin or the agent
+// enables/selects it via the existing select endpoint); pass `enable: true` to
+// enable it immediately. Bounded by its own per-key daily budget.
+const uploadMapBodySchema = z.object({
+  imageUrl: z.string().url().max(1000),
+  widthPx: z.coerce.number().int().positive().max(32_768),
+  heightPx: z.coerce.number().int().positive().max(32_768),
+  license: z.string().trim().min(1).max(100),
+  attribution: z.string().trim().max(500).optional(),
+  sourceUrl: z.string().url().max(1000).optional(),
+  consensusRadius: z.coerce.number().min(0.001).max(1).optional(),
+  region: z.string().trim().min(1).max(100).optional(),
+  // Enable (and select, via enableForGame) the map immediately instead of
+  // leaving it disabled for later curation. Defaults to false.
+  enable: z.boolean().optional(),
+})
+
+router.post(
+  '/games/:gameId/maps',
+  requireScope('geo-agent:curate'),
+  requireAgentCurateEnabled,
+  validateParams(gameIdParams),
+  validateBody(uploadMapBodySchema),
+  async (req, res, next) => {
+    try {
+      const { gameId } = req.params as unknown as z.infer<typeof gameIdParams>
+      const body = req.body as z.infer<typeof uploadMapBodySchema>
+      const keyId = req.apiKey!.id
+
+      const maxPerDay = Number(env.GEO_AGENT_MAX_MAP_UPLOADS_PER_DAY) || 10
+      const budget = await consumeMapUploadBudget(keyId, maxPerDay)
+      if (!budget.ok) {
+        res.setHeader('Retry-After', String(budget.resetSeconds))
+        res.status(429).json({
+          success: false,
+          error: {
+            code: 'BUDGET_EXHAUSTED',
+            message: `Daily map-upload budget of ${budget.limit} reached; resets at UTC midnight`,
+          },
+        })
+        return
+      }
+
+      const game = await gameRepository.findById(gameId)
+      if (!game) {
+        res.status(404).json({ success: false, error: { code: 'GAME_NOT_FOUND' } })
+        return
+      }
+
+      let map
+      try {
+        map = await geoMapRepository.create({
+          gameId,
+          source: 'manual',
+          sourceUrl: body.sourceUrl,
+          imageUrl: body.imageUrl,
+          widthPx: body.widthPx,
+          heightPx: body.heightPx,
+          license: body.license,
+          attribution: body.attribution,
+          consensusRadius: body.consensusRadius,
+          region: body.region,
+          isActive: !!body.enable,
+        })
+      } catch (err) {
+        // (game_id, image_url) is unique — a repeat upload of the same URL is a
+        // clean 409, not a 500. Any other DB error propagates.
+        if (err && typeof err === 'object' && (err as { code?: string }).code === '23505') {
+          res.status(409).json({
+            success: false,
+            error: { code: 'DUPLICATE_MAP', message: 'a map with this image URL already exists for the game' },
+          })
+          return
+        }
+        throw err
+      }
+
+      if (body.enable) {
+        await geoMapRepository.enableForGame(gameId, map.id)
+      }
+
+      // A usable map now exists — clear the map-tier ingest tombstones so a
+      // future ingest tick isn't short-circuited by a stale circuit-breaker.
+      // Mirrors the admin manual-upload path (clears the fetch tiers, not the
+      // metadata tombstone).
+      await db('geo_ingest_failure')
+        .where({ game_id: gameId })
+        .whereIn('source', [...RUNNABLE_TIERS])
+        .del()
+
+      await adminAuditRepository.record({
+        adminId: `apikey:${keyId}`,
+        action: 'geo-agent.upload_map',
+        targetKind: 'geo_map',
+        targetId: String(map.id),
+        after: {
+          gameId,
+          source: 'manual',
+          imageUrl: body.imageUrl,
+          sourceUrl: body.sourceUrl ?? null,
+          license: body.license,
+          enabled: !!body.enable,
+        },
+        ip: req.ip ?? null,
+      })
+
+      res.json({
+        success: true,
+        data: {
+          map,
+          budget: { used: budget.used, limit: budget.limit, remaining: budget.remaining },
+        },
+      })
     } catch (err) {
       next(err)
     }

--- a/packages/backend/src/presentation/routes/agent-geo.routes.ts
+++ b/packages/backend/src/presentation/routes/agent-geo.routes.ts
@@ -6,6 +6,7 @@ import {
   agentApiRateLimit,
   requireAgentApiEnabled,
   requireAgentCurateEnabled,
+  requireAgentPromoteEnabled,
   requireScope,
 } from '../middleware/agent-api.middleware.js'
 import { validateBody, validateParams, validateQuery } from '../middleware/validation.middleware.js'
@@ -18,7 +19,12 @@ import { geoSourceConfigRepository } from '../../infrastructure/repositories/geo
 import { geoIngestFailureRepository } from '../../infrastructure/repositories/geo-ingest-failure.repository.js'
 import { adminAuditRepository } from '../../infrastructure/repositories/admin-audit.repository.js'
 import { gameRepository } from '../../infrastructure/repositories/game.repository.js'
-import { pinsToNextConsensusThreshold } from '../../domain/services/geo-consensus.service.js'
+import {
+  evaluateConsensus,
+  pinsToNextConsensusThreshold,
+  GEO_CONSENSUS_MIN_PINS_TO_PROMOTE,
+  GEO_CONSENSUS_VERSION,
+} from '../../domain/services/geo-consensus.service.js'
 import { shouldPauseAgentKey } from '../../domain/services/geo-agent-guard.service.js'
 import { CAPTURE_TARGET_CANDIDATES } from '../../domain/services/geo-metadata.service.js'
 import { getGeoGamersHealthSnapshot } from '../../infrastructure/geogamers-health.js'
@@ -36,6 +42,7 @@ import {
   consumeIngestBudget,
   consumeMapActionBudget,
   consumePinBudget,
+  consumePromoteBudget,
 } from '../../infrastructure/redis/agent-budget.js'
 import { env } from '../../config/env.js'
 import { routeLogger } from '../../infrastructure/logger/logger.js'
@@ -760,6 +767,139 @@ router.post(
       res.json({
         success: true,
         data: { pinId: submission.id, received: true, pinCount: newPinCount, budget: budgetInfo },
+      })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// POST /candidates/:id/promote — confirm & promote a capture's consensus pin to
+// canonical ground truth (issue #331, phase 7). This is the ONE agent write
+// that creates ground truth, and it is safe by construction: the agent supplies
+// NO coordinates and can promote only where the crowd already earned it. The
+// route re-runs consensus over the candidate's pins and refuses unless it
+// QUALIFIES (`evaluateConsensus(...).promote === true` — ≥5 accepted HUMAN pins
+// and a tight enough cluster, exactly the auto-promote gate). Agent pins are
+// downweighted voters and excluded from the human promote count (consensus v3),
+// so no pile of machine pins can manufacture a qualifying candidate — the agent
+// merely pulls the trigger on a promotion the humans already earned but that a
+// threshold recompute may not have fired for. Mirrors the admin override's
+// consensus-centroid path (`promotedVia = 'consensus'`), attributing
+// `promotedBy` to the agent key. Gated behind a THIRD independent kill switch
+// (requireAgentPromoteEnabled) and bounded by a per-key daily budget.
+router.post(
+  '/candidates/:id/promote',
+  requireScope('geo-agent:promote'),
+  requireAgentPromoteEnabled,
+  validateParams(z.object({ id: z.coerce.number().int().positive() })),
+  async (req, res, next) => {
+    try {
+      const { id: candidateId } = req.params as unknown as { id: number }
+      const keyId = req.apiKey!.id
+
+      const maxPerDay = Number(env.GEO_AGENT_MAX_PROMOTES_PER_DAY) || 20
+      const budget = await consumePromoteBudget(keyId, maxPerDay)
+      if (!budget.ok) {
+        res.setHeader('Retry-After', String(budget.resetSeconds))
+        res.status(429).json({
+          success: false,
+          error: {
+            code: 'BUDGET_EXHAUSTED',
+            message: `Daily promote budget of ${budget.limit} reached; resets at UTC midnight`,
+          },
+        })
+        return
+      }
+
+      const candidate = await geoScreenshotRepository.findCandidateById(candidateId)
+      if (!candidate) {
+        res.status(404).json({ success: false, error: { code: 'CANDIDATE_NOT_FOUND' } })
+        return
+      }
+
+      // Never promote a candidate that already has ground truth — an admin must
+      // delete the meta first rather than have coordinates shift under players.
+      const existingMeta = await geoScreenshotRepository.findMetaByCandidateId(candidateId)
+      if (existingMeta) {
+        res.status(409).json({
+          success: false,
+          error: { code: 'ALREADY_PROMOTED', message: 'candidate already has a canonical pin' },
+        })
+        return
+      }
+
+      const pins = await geoPinRepository.listByCandidate(candidateId)
+      if (pins.length === 0) {
+        res.status(409).json({
+          success: false,
+          error: { code: 'NO_PINS', message: 'no pins to compute consensus from' },
+        })
+        return
+      }
+
+      const map = await geoMapRepository.findById(candidate.geoMapId)
+      if (!map) {
+        res.status(404).json({ success: false, error: { code: 'MAP_NOT_FOUND' } })
+        return
+      }
+
+      const consensus = evaluateConsensus(
+        pins.map((p) => ({ id: p.id, pin: p.pin, confidence: p.confidence, source: p.source })),
+        map.consensusRadius,
+      )
+
+      // The invariant: the agent can only CONFIRM a promotion the crowd earned.
+      // If consensus doesn't qualify (too few accepted human pins, or the
+      // cluster is too loose), refuse — the agent cannot force ground truth.
+      if (!consensus.promote) {
+        res.status(409).json({
+          success: false,
+          error: {
+            code: 'CONSENSUS_NOT_READY',
+            message: `consensus not ready to promote (need ≥${GEO_CONSENSUS_MIN_PINS_TO_PROMOTE} accepted human pins and a tight cluster)`,
+          },
+          data: {
+            humanAcceptedCount: consensus.humanAcceptedCount,
+            requiredHumanPins: GEO_CONSENSUS_MIN_PINS_TO_PROMOTE,
+            confidence: consensus.confidence,
+          },
+        })
+        return
+      }
+
+      const meta = await geoScreenshotRepository.promoteCandidateToMeta({
+        candidateId,
+        geoMapId: candidate.geoMapId,
+        canonicalX: consensus.centroid.x,
+        canonicalY: consensus.centroid.y,
+        confidence: consensus.confidence,
+        consensusVersion: GEO_CONSENSUS_VERSION,
+        promotedVia: 'consensus',
+        promotedBy: `apikey:${keyId}`,
+      })
+
+      await adminAuditRepository.record({
+        adminId: `apikey:${keyId}`,
+        action: 'geo-agent.promote_candidate',
+        targetKind: 'geo_screenshot_candidate',
+        targetId: String(candidateId),
+        after: {
+          metaId: meta.id,
+          canonicalX: consensus.centroid.x,
+          canonicalY: consensus.centroid.y,
+          confidence: consensus.confidence,
+          humanAcceptedCount: consensus.humanAcceptedCount,
+        },
+        ip: req.ip ?? null,
+      })
+
+      res.json({
+        success: true,
+        data: {
+          meta,
+          budget: { used: budget.used, limit: budget.limit, remaining: budget.remaining },
+        },
       })
     } catch (err) {
       next(err)

--- a/packages/frontend/src/components/admin/AgentKeysCard.tsx
+++ b/packages/frontend/src/components/admin/AgentKeysCard.tsx
@@ -15,6 +15,8 @@ const SCOPE_OPTIONS: Array<{ scope: ApiKeyScope; label: string; hint: string }> 
     { scope: 'geo-agent:read', label: 'read', hint: 'santé, jeux à compléter, captures' },
     { scope: 'geo-agent:ingest', label: 'ingest', hint: 'déclencher le pipeline (phase 3)' },
     { scope: 'geo-agent:propose', label: 'propose', hint: 'proposer des pins (phase 4)' },
+    { scope: 'geo-agent:curate', label: 'curate', hint: 'inscrire des jeux, cartes candidates (phase 5)' },
+    { scope: 'geo-agent:promote', label: 'promote', hint: 'confirmer/promouvoir un pin de consensus (phase 7)' },
 ]
 
 export function AgentKeysCard() {

--- a/packages/geo-agent-mcp/README.md
+++ b/packages/geo-agent-mcp/README.md
@@ -25,6 +25,7 @@ the key can't, and the key is read-only in this phase.
 | `geo_import_captures` | `POST /games/:gameId/captures` | `gameId`, `targetCount?`, `imageUrls?` | `geo-agent:curate` |
 | `geo_set_canonical_map` | `POST /games/:gameId/maps/:mapId/select` | `gameId`, `mapId` | `geo-agent:curate` |
 | `geo_reject_map` | `POST /games/:gameId/maps/:mapId/reject` | `gameId`, `mapId` | `geo-agent:curate` |
+| `geo_upload_map` | `POST /games/:gameId/maps` | `gameId`, `imageUrl`, `widthPx`, `heightPx`, `license`, … | `geo-agent:curate` |
 | `geo_promote_candidate` | `POST /candidates/:id/promote` | `candidateId` | `geo-agent:promote` |
 
 ## Setup
@@ -76,8 +77,13 @@ Add to your MCP config (e.g. `.mcp.json` or the Claude Code settings):
   budget) and are additionally gated by `GEO_AGENT_CURATE_ENABLED` on the
   backend — while off they return `AGENT_CURATE_DISABLED` even for a key that
   holds the scope. This is the content-creation surface: it enrolls new games,
-  tops up screenshot candidates, and lets an operator pick the canonical map
-  for a game or reject a wrong-game/prop map.
+  tops up screenshot candidates, lets an operator pick the canonical map for a
+  game or reject a wrong-game/prop map, and — via `geo_upload_map` — registers
+  a manual map image (by URL + declared dimensions + license) as the last-resort
+  content path when the ingestion tiers found no usable map. Uploaded maps are
+  recorded `source = manual` and land **disabled** by default (enable/select
+  afterwards) unless `enable: true`; nothing is processed server-side, so the
+  agent hosts the asset and owns the license claim.
 - `geo_promote_candidate` needs `geo-agent:promote` (per-key daily budget) and
   is gated by a third, independent kill switch `GEO_AGENT_PROMOTE_ENABLED` —
   while off it returns `AGENT_PROMOTE_DISABLED` even for a key that holds the

--- a/packages/geo-agent-mcp/README.md
+++ b/packages/geo-agent-mcp/README.md
@@ -25,6 +25,7 @@ the key can't, and the key is read-only in this phase.
 | `geo_import_captures` | `POST /games/:gameId/captures` | `gameId`, `targetCount?`, `imageUrls?` | `geo-agent:curate` |
 | `geo_set_canonical_map` | `POST /games/:gameId/maps/:mapId/select` | `gameId`, `mapId` | `geo-agent:curate` |
 | `geo_reject_map` | `POST /games/:gameId/maps/:mapId/reject` | `gameId`, `mapId` | `geo-agent:curate` |
+| `geo_promote_candidate` | `POST /candidates/:id/promote` | `candidateId` | `geo-agent:promote` |
 
 ## Setup
 
@@ -77,3 +78,14 @@ Add to your MCP config (e.g. `.mcp.json` or the Claude Code settings):
   holds the scope. This is the content-creation surface: it enrolls new games,
   tops up screenshot candidates, and lets an operator pick the canonical map
   for a game or reject a wrong-game/prop map.
+- `geo_promote_candidate` needs `geo-agent:promote` (per-key daily budget) and
+  is gated by a third, independent kill switch `GEO_AGENT_PROMOTE_ENABLED` —
+  while off it returns `AGENT_PROMOTE_DISABLED` even for a key that holds the
+  scope. It **confirms and promotes** a capture's consensus pin to canonical
+  ground truth, but only where the crowd already earned it: the agent supplies
+  **no coordinates**, and the server promotes only if consensus already
+  qualifies (≥5 accepted human pins + a tight cluster — the same auto-promote
+  gate). Agent pins are excluded from that human count, so this can never
+  fabricate ground truth; it just pulls the trigger on a promotion the crowd
+  earned. Returns `CONSENSUS_NOT_READY` (with the current human-pin count and
+  confidence) when consensus doesn't yet qualify.

--- a/packages/geo-agent-mcp/src/server.test.ts
+++ b/packages/geo-agent-mcp/src/server.test.ts
@@ -69,6 +69,36 @@ describe('resolveToolPath', () => {
     assert.ok('error' in resolveToolPath('geo_propose_pin', { candidateId: 1, x: 0.5, y: 0.5, rationale: 'x', source: 'human' })) // bad source
   })
 
+  it('maps geo_upload_map to a POST maps path with the map body', () => {
+    assert.deepEqual(
+      resolveToolPath('geo_upload_map', {
+        gameId: 42,
+        imageUrl: 'https://cdn.example.com/eldenring-map.jpg',
+        widthPx: 4096,
+        heightPx: 4096,
+        license: 'CC-BY-4.0',
+        enable: true,
+      }),
+      {
+        path: '/api/agent/v1/geo/games/42/maps',
+        method: 'POST',
+        body: {
+          imageUrl: 'https://cdn.example.com/eldenring-map.jpg',
+          widthPx: 4096,
+          heightPx: 4096,
+          license: 'CC-BY-4.0',
+          enable: true,
+        },
+      },
+    )
+  })
+
+  it('rejects geo_upload_map missing required fields', () => {
+    assert.ok('error' in resolveToolPath('geo_upload_map', { gameId: 1, imageUrl: 'https://x/1.png', widthPx: 10, heightPx: 10 })) // no license
+    assert.ok('error' in resolveToolPath('geo_upload_map', { gameId: 1, imageUrl: 'https://x/1.png', license: 'CC0', heightPx: 10 })) // no widthPx
+    assert.ok('error' in resolveToolPath('geo_upload_map', { imageUrl: 'https://x/1.png', widthPx: 10, heightPx: 10, license: 'CC0' })) // no gameId
+  })
+
   it('maps geo_promote_candidate to a POST promote path', () => {
     assert.deepEqual(resolveToolPath('geo_promote_candidate', { candidateId: 88 }), {
       path: '/api/agent/v1/geo/candidates/88/promote',

--- a/packages/geo-agent-mcp/src/server.test.ts
+++ b/packages/geo-agent-mcp/src/server.test.ts
@@ -69,6 +69,18 @@ describe('resolveToolPath', () => {
     assert.ok('error' in resolveToolPath('geo_propose_pin', { candidateId: 1, x: 0.5, y: 0.5, rationale: 'x', source: 'human' })) // bad source
   })
 
+  it('maps geo_promote_candidate to a POST promote path', () => {
+    assert.deepEqual(resolveToolPath('geo_promote_candidate', { candidateId: 88 }), {
+      path: '/api/agent/v1/geo/candidates/88/promote',
+      method: 'POST',
+      body: {},
+    })
+  })
+
+  it('rejects geo_promote_candidate without a candidateId', () => {
+    assert.ok('error' in resolveToolPath('geo_promote_candidate', {}))
+  })
+
   it('errors on an unknown tool', () => {
     assert.ok('error' in resolveToolPath('nope', {}))
   })

--- a/packages/geo-agent-mcp/src/server.ts
+++ b/packages/geo-agent-mcp/src/server.ts
@@ -159,6 +159,28 @@ export const TOOLS: ToolDef[] = [
     },
   },
   {
+    name: 'geo_upload_map',
+    description:
+      "Register a map image for a game (needs a geo-agent:curate key) — the last-resort content path when the ingestion tiers found no usable map. You host the image yourself and pass its URL plus its pixel dimensions and license; nothing is processed server-side. Recorded as a `manual` map, DISABLED by default (enable/select it afterwards) unless `enable: true`. Subject to a per-key daily budget.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'number', description: 'Game id (required)' },
+        imageUrl: { type: 'string', description: 'Publicly reachable map image URL you host (required)' },
+        widthPx: { type: 'number', description: 'Map image width in pixels (required)' },
+        heightPx: { type: 'number', description: 'Map image height in pixels (required)' },
+        license: { type: 'string', description: 'License of the asset, e.g. "CC-BY-4.0" (required, ≤100 chars)' },
+        attribution: { type: 'string', description: 'Optional attribution string (≤500 chars)' },
+        sourceUrl: { type: 'string', description: 'Optional source/provenance page URL' },
+        consensusRadius: { type: 'number', description: 'Optional consensus radius in [0.001,1] (default 0.03)' },
+        region: { type: 'string', description: 'Optional region/zone label for multi-map games' },
+        enable: { type: 'boolean', description: 'Enable (and select) the map immediately; default false' },
+      },
+      required: ['gameId', 'imageUrl', 'widthPx', 'heightPx', 'license'],
+      additionalProperties: false,
+    },
+  },
+  {
     name: 'geo_propose_pin',
     description:
       "Propose a location pin for a capture (needs a geo-agent:propose key). The pin is DOWNWEIGHTED and can never promote ground truth on its own — it joins consensus as one flagged voter, reviewed by humans. `rationale` is required. Propose only when confident; a wrong pin poisons the centroid.",
@@ -290,6 +312,31 @@ export function resolveToolPath(
       if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
       if (mapId === null) return { error: 'mapId is required and must be a positive integer' }
       return { path: `/api/agent/v1/geo/games/${gameId}/maps/${mapId}/reject`, method: 'POST', body: {} }
+    }
+    case 'geo_upload_map': {
+      const gameId = asPositiveInt(a['gameId'])
+      if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
+      if (typeof a['imageUrl'] !== 'string' || a['imageUrl'].trim() === '') {
+        return { error: 'imageUrl is required' }
+      }
+      const widthPx = asPositiveInt(a['widthPx'])
+      const heightPx = asPositiveInt(a['heightPx'])
+      if (widthPx === null || heightPx === null) {
+        return { error: 'widthPx and heightPx are required positive integers' }
+      }
+      if (typeof a['license'] !== 'string' || a['license'].trim() === '') {
+        return { error: 'license is required' }
+      }
+      const body: Record<string, unknown> = {
+        imageUrl: a['imageUrl'],
+        widthPx,
+        heightPx,
+        license: a['license'],
+      }
+      for (const k of ['attribution', 'sourceUrl', 'consensusRadius', 'region', 'enable'] as const) {
+        if (a[k] !== undefined) body[k] = a[k]
+      }
+      return { path: `/api/agent/v1/geo/games/${gameId}/maps`, method: 'POST', body }
     }
     case 'geo_propose_pin': {
       const candidateId = asPositiveInt(a['candidateId'])

--- a/packages/geo-agent-mcp/src/server.ts
+++ b/packages/geo-agent-mcp/src/server.ts
@@ -182,6 +182,19 @@ export const TOOLS: ToolDef[] = [
       additionalProperties: false,
     },
   },
+  {
+    name: 'geo_promote_candidate',
+    description:
+      "Confirm & promote a capture's consensus pin to canonical ground truth (needs a geo-agent:promote key). Safe by construction: you supply NO coordinates — the server re-runs consensus and promotes only if it already QUALIFIES (≥5 accepted human pins + a tight cluster). Agent pins never count toward that gate, so this can only pull the trigger on a promotion the crowd already earned. Rejected with CONSENSUS_NOT_READY otherwise.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        candidateId: { type: 'number', description: 'geo_screenshot_candidate id (required)' },
+      },
+      required: ['candidateId'],
+      additionalProperties: false,
+    },
+  },
 ]
 
 function asPositiveInt(value: unknown): number | null {
@@ -300,6 +313,11 @@ export function resolveToolPath(
         if (a[k] !== undefined) body[k] = a[k]
       }
       return { path: `/api/agent/v1/geo/candidates/${candidateId}/pins`, method: 'POST', body }
+    }
+    case 'geo_promote_candidate': {
+      const candidateId = asPositiveInt(a['candidateId'])
+      if (candidateId === null) return { error: 'candidateId is required and must be a positive integer' }
+      return { path: `/api/agent/v1/geo/candidates/${candidateId}/promote`, method: 'POST', body: {} }
     }
     default:
       return { error: `unknown tool: ${name}` }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1667,14 +1667,16 @@ export type ApiKeyScope =
   | 'geo-agent:ingest' // trigger the existing geo ingestion pipeline (phase 3)
   | 'geo-agent:propose' // submit downweighted, flagged consensus pins (phase 4)
   | 'geo-agent:curate' // enroll games, top up captures, manage candidate maps (phase 5)
+  | 'geo-agent:promote' // confirm & promote a capture's qualifying consensus pin (phase 7)
 
-// The four geo-agent scopes, in privilege order. A read-only key carries only
-// the first; ingest/propose/curate are granted per key as later phases ship.
+// The geo-agent scopes, in privilege order. A read-only key carries only the
+// first; ingest/propose/curate/promote are granted per key as later phases ship.
 export const GEO_AGENT_SCOPES = [
   'geo-agent:read',
   'geo-agent:ingest',
   'geo-agent:propose',
   'geo-agent:curate',
+  'geo-agent:promote',
 ] as const satisfies readonly ApiKeyScope[]
 
 export function isGeoAgentScope(scope: ApiKeyScope): boolean {


### PR DESCRIPTION
Adds two new capabilities to the geo-agent MCP surface (`/api/agent/v1/geo` + `@the-box/geo-agent-mcp`).

---

## 1. Confirm / promote a pin

New `geo-agent:promote` scope, `POST /candidates/:id/promote` endpoint, and `geo_promote_candidate` MCP tool — lets a trusted agent promote a capture's consensus pin to canonical ground truth.

**Safe by construction** (preserves the *agent proposes, consensus + admins dispose* invariant):
- The agent supplies **no coordinates**. The server re-runs `evaluateConsensus` and promotes **only if consensus already qualifies** (`result.promote === true` — ≥5 accepted **human** pins + a tight cluster, the same auto-promote gate).
- Agent pins are excluded from the human promote count (consensus v3), so no pile of machine pins can manufacture a qualifying candidate — the agent just pulls the trigger on a promotion the crowd already earned but that a threshold recompute may not have fired for.
- Promotes via the consensus centroid (`promoted_via = 'consensus'`, `promoted_by = apikey:<id>`) — the same primitive the admin override uses.

Controls: third independent kill switch `GEO_AGENT_PROMOTE_ENABLED` (default off), per-key daily budget `GEO_AGENT_MAX_PROMOTES_PER_DAY` (default 20, fails closed). Errors: `CANDIDATE_NOT_FOUND` / `ALREADY_PROMOTED` / `NO_PINS` / `CONSENSUS_NOT_READY` (the last carries `humanAcceptedCount` / `requiredHumanPins` / `confidence`). Audited as `geo-agent.promote_candidate`.

## 2. Manual map upload

New `POST /games/:gameId/maps` endpoint and `geo_upload_map` MCP tool (under the existing `geo-agent:curate` scope) — the last-resort content path when the ingestion tiers found no usable map.

- Mirrors the admin "Tier 3 manual map upload" primitive exactly: the agent supplies a map image **URL it hosts and has verified**, declares pixel dimensions + license/attribution, and the server records a `source = 'manual'` map row.
- **No image bytes are sent and nothing is processed server-side** — the agent owns hosting and the license claim (same as the admin path; MCP is JSON-only).
- Lands **disabled** by default (enable/select afterwards via `.../select`) unless `enable: true`.

Controls: reuses the `geo-agent:curate` scope + `GEO_AGENT_CURATE_ENABLED` kill switch; adds a dedicated per-key daily budget `GEO_AGENT_MAX_MAP_UPLOADS_PER_DAY` (default 10). A repeat of the same image URL surfaces as a clean `409 DUPLICATE_MAP` (the `(game_id, image_url)` unique constraint) instead of a 500. Errors: `GAME_NOT_FOUND` / `DUPLICATE_MAP` / `VALIDATION_ERROR`. Audited as `geo-agent.upload_map`.

---

## Changes

| Area | File |
|------|------|
| Scope | `packages/types/src/index.ts` (`geo-agent:promote`) |
| Env / kill switches / budgets | `packages/backend/src/config/env.ts`, `.env.example` |
| Kill-switch middleware | `agent-api.middleware.ts` (`requireAgentPromoteEnabled`) |
| Redis budgets | `agent-budget.ts` — `promoteBudgetKey`, `mapUploadBudgetKey` (+ tests) |
| Endpoints | `agent-geo.routes.ts` — `POST /candidates/:id/promote`, `POST /games/:gameId/maps` |
| MCP tools | `packages/geo-agent-mcp/src/server.ts` — `geo_promote_candidate`, `geo_upload_map` (+ tests) |
| Admin mint UI | `AgentKeysCard.tsx` (surfaces the previously-missing `curate` scope + new `promote`) |
| Docs | `docs/geo-agent-api.md`, `packages/geo-agent-mcp/README.md` |

## Testing

- `npm run build` — all packages typecheck ✅
- `npm test` — 396 backend + 25 types + 27 MCP tests pass, 0 failures ✅ (new budget-key and tool-mapping tests included)
- `npm run lint` — clean (one pre-existing unrelated warning) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb19HWGrMJ4ssRjbfVfTnV