### PR TITLE
chore: sync @the-box/marketing-video to 2.145.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19776,7 +19776,7 @@
     },
     "packages/marketing-video": {
       "name": "@the-box/marketing-video",
-      "version": "2.144.0",
+      "version": "2.145.0",
       "dependencies": {
         "@remotion/cli": "^4.0.0",
         "@remotion/transitions": "^4.0.0",

--- a/packages/marketing-video/package.json
+++ b/packages/marketing-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-box/marketing-video",
-  "version": "2.144.0",
+  "version": "2.145.0",
   "private": true,
   "description": "Remotion compositions for The Box marketing videos",
   "scripts": {


### PR DESCRIPTION
The root and every other workspace were already bumped to `2.145.0` on `main` (via `887eb9c`, merged independently). This brings the last lagging workspace, `@the-box/marketing-video`, from `2.144.0` up to `2.145.0` so all six `package.json` files are in lockstep, plus the matching `package-lock.json` update.

Rebased onto the updated `main`, so the diff is now just those two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb19HWGrMJ4ssRjbfVfTnV