### PR TITLE
feat(geo-agent): map-create tool + endpoint

### DIFF
--- a/packages/backend/src/presentation/routes/agent-geo.routes.ts
+++ b/packages/backend/src/presentation/routes/agent-geo.routes.ts
@@ -531,6 +531,94 @@ router.post(
   },
 )
 
+// POST /games/:gameId/maps — create a basemap from a hosted image URL and (by
+// default) promote it to canonical (phase 5b). The agent-facing analogue of
+// the admin "manual map upload": it reaches the SAME geoMapRepository.create
+// primitive an operator uses, gated by curate scope + the curate kill switch +
+// the shared per-key map-action budget. Use when a game has no usable map, or
+// only a wrong/prop/cropped candidate the ingest tiers produced — an agent can
+// host a full-world image at a reachable URL and register it in one call.
+// `makeCanonical` (default true) enables + selects the new row so it becomes
+// the capture-default, demoting whatever crop/prop was selected before.
+const createMapBodySchema = z.object({
+  imageUrl: z.string().url().max(1000),
+  widthPx: z.number().int().positive().max(32_768),
+  heightPx: z.number().int().positive().max(32_768),
+  license: z.string().min(1).max(100),
+  attribution: z.string().max(500).optional(),
+  sourceUrl: z.string().url().max(1000).optional(),
+  consensusRadius: z.number().min(0.001).max(1).optional(),
+  region: z.string().trim().min(1).max(100).optional(),
+  makeCanonical: z.boolean().optional(),
+})
+
+router.post(
+  '/games/:gameId/maps',
+  requireScope('geo-agent:curate'),
+  requireAgentCurateEnabled,
+  validateParams(gameIdParams),
+  validateBody(createMapBodySchema),
+  async (req, res, next) => {
+    try {
+      const { gameId } = req.params as unknown as z.infer<typeof gameIdParams>
+      const body = req.body as z.infer<typeof createMapBodySchema>
+      const budgetResult = await consumeMapActionOrReject(req, res)
+      if (!budgetResult.ok) return
+
+      const game = await db('games').where({ id: gameId }).first<{ id: number }>()
+      if (!game) {
+        res.status(404).json({ success: false, error: { code: 'GAME_NOT_FOUND' } })
+        return
+      }
+
+      const makeCanonical = body.makeCanonical ?? true
+      const map = await geoMapRepository.create({
+        gameId,
+        source: 'manual',
+        sourceUrl: body.sourceUrl,
+        imageUrl: body.imageUrl,
+        widthPx: body.widthPx,
+        heightPx: body.heightPx,
+        license: body.license,
+        attribution: body.attribution,
+        consensusRadius: body.consensusRadius,
+        region: body.region,
+        isActive: makeCanonical,
+      })
+
+      let finalMap = map
+      if (makeCanonical) {
+        await geoMapRepository.enableForGame(gameId, map.id)
+        const selected = await geoMapRepository.selectMap(
+          gameId,
+          map.id,
+          `apikey:${req.apiKey!.id}`,
+        )
+        if (selected) finalMap = selected
+        // A good basemap clears stale ingest-failure tombstones so the admin
+        // panels stop flagging the game as unmapped (mirrors admin upload).
+        await db('geo_ingest_failure')
+          .where({ game_id: gameId })
+          .whereIn('source', ['registry', 'fandom', 'strategywiki', 'fextralife', 'wand', 'wikidata'])
+          .del()
+      }
+
+      await adminAuditRepository.record({
+        adminId: `apikey:${req.apiKey!.id}`,
+        action: 'geo-agent.create_map',
+        targetKind: 'geo_map',
+        targetId: String(map.id),
+        after: { gameId, imageUrl: body.imageUrl, source: 'manual', makeCanonical },
+        ip: req.ip ?? null,
+      })
+
+      res.status(201).json({ success: true, data: { map: finalMap, budget: budgetResult.budget } })
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
 // POST /games/:gameId/ingest — trigger the existing map-ingestion pipeline for
 // one game (phase 3). Pure enqueue: reuses `enqueueSingleTierImport`, so
 // tombstones/circuit-breakers, dedup, and license/attribution capture are

--- a/packages/geo-agent-mcp/src/server.test.ts
+++ b/packages/geo-agent-mcp/src/server.test.ts
@@ -73,6 +73,44 @@ describe('resolveToolPath', () => {
     assert.ok('error' in resolveToolPath('nope', {}))
   })
 
+  it('maps geo_create_map to a POST with the map body', () => {
+    assert.deepEqual(
+      resolveToolPath('geo_create_map', {
+        gameId: 38,
+        imageUrl: 'https://example.com/map.jpg',
+        widthPx: 1920,
+        heightPx: 1920,
+        license: 'CC-BY-SA-3.0',
+        attribution: 'Someone',
+        makeCanonical: true,
+      }),
+      {
+        path: '/api/agent/v1/geo/games/38/maps',
+        method: 'POST',
+        body: {
+          imageUrl: 'https://example.com/map.jpg',
+          widthPx: 1920,
+          heightPx: 1920,
+          license: 'CC-BY-SA-3.0',
+          attribution: 'Someone',
+          makeCanonical: true,
+        },
+      },
+    )
+  })
+
+  it('rejects geo_create_map missing required fields', () => {
+    assert.ok('error' in resolveToolPath('geo_create_map', { gameId: 1, widthPx: 10, heightPx: 10, license: 'x' })) // no imageUrl
+    assert.ok(
+      'error' in
+        resolveToolPath('geo_create_map', { gameId: 1, imageUrl: 'https://e.com/m.png', heightPx: 10, license: 'x' }),
+    ) // no widthPx
+    assert.ok(
+      'error' in
+        resolveToolPath('geo_create_map', { gameId: 1, imageUrl: 'https://e.com/m.png', widthPx: 10, heightPx: 10 }),
+    ) // no license
+  })
+
   it('maps geo_list_games with a validated limit', () => {
     assert.deepEqual(resolveToolPath('geo_list_games', {}), { path: '/api/agent/v1/geo/games' })
     assert.deepEqual(resolveToolPath('geo_list_games', { limit: 50 }), {

--- a/packages/geo-agent-mcp/src/server.ts
+++ b/packages/geo-agent-mcp/src/server.ts
@@ -159,6 +159,31 @@ export const TOOLS: ToolDef[] = [
     },
   },
   {
+    name: 'geo_create_map',
+    description:
+      'Create a basemap for a game from a hosted image URL and (by default) promote it to canonical (needs a geo-agent:curate key). Use when a game has no usable map or only a wrong/prop/cropped candidate — first host a full-world image at a publicly reachable, hotlink-friendly URL (external CDNs that block cross-origin referers will not render). Subject to the per-key daily map-action budget.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'number', description: 'Game id (required)' },
+        imageUrl: { type: 'string', description: 'Publicly reachable map image URL (required)' },
+        widthPx: { type: 'number', description: 'Image width in px (required)' },
+        heightPx: { type: 'number', description: 'Image height in px (required)' },
+        license: { type: 'string', description: 'License string (required, e.g. "CC-BY-SA-3.0")' },
+        attribution: { type: 'string', description: 'Attribution text' },
+        sourceUrl: { type: 'string', description: 'Source page URL' },
+        consensusRadius: { type: 'number', description: 'Optional consensus radius override (0.001–1)' },
+        region: { type: 'string', description: 'Optional region label for multi-map games' },
+        makeCanonical: {
+          type: 'boolean',
+          description: 'Enable + select the new map as capture-default, demoting the old one (default true)',
+        },
+      },
+      required: ['gameId', 'imageUrl', 'widthPx', 'heightPx', 'license'],
+      additionalProperties: false,
+    },
+  },
+  {
     name: 'geo_propose_pin',
     description:
       "Propose a location pin for a capture (needs a geo-agent:propose key). The pin is DOWNWEIGHTED and can never promote ground truth on its own — it joins consensus as one flagged voter, reviewed by humans. `rationale` is required. Propose only when confident; a wrong pin poisons the centroid.",
@@ -277,6 +302,31 @@ export function resolveToolPath(
       if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
       if (mapId === null) return { error: 'mapId is required and must be a positive integer' }
       return { path: `/api/agent/v1/geo/games/${gameId}/maps/${mapId}/reject`, method: 'POST', body: {} }
+    }
+    case 'geo_create_map': {
+      const gameId = asPositiveInt(a['gameId'])
+      if (gameId === null) return { error: 'gameId is required and must be a positive integer' }
+      const widthPx = asPositiveInt(a['widthPx'])
+      const heightPx = asPositiveInt(a['heightPx'])
+      if (widthPx === null || heightPx === null) {
+        return { error: 'widthPx and heightPx are required positive integers' }
+      }
+      if (typeof a['imageUrl'] !== 'string' || a['imageUrl'].trim() === '') {
+        return { error: 'imageUrl is required' }
+      }
+      if (typeof a['license'] !== 'string' || a['license'].trim() === '') {
+        return { error: 'license is required' }
+      }
+      const body: Record<string, unknown> = {
+        imageUrl: a['imageUrl'],
+        widthPx,
+        heightPx,
+        license: a['license'],
+      }
+      for (const k of ['attribution', 'sourceUrl', 'consensusRadius', 'region', 'makeCanonical'] as const) {
+        if (a[k] !== undefined) body[k] = a[k]
+      }
+      return { path: `/api/agent/v1/geo/games/${gameId}/maps`, method: 'POST', body }
     }
     case 'geo_propose_pin': {
       const candidateId = asPositiveInt(a['candidateId'])


### PR DESCRIPTION
## What
Adds a curate-scoped agent capability to register a game basemap from a hosted image URL and promote it to canonical in one call — the agent-facing analogue of the admin *manual map upload*.

- `POST /api/agent/v1/geo/games/:gameId/maps` — behind `geo-agent:curate` scope + the curate kill switch + the shared per-key map-action budget, audited as `geo-agent.create_map`. Reuses the same `geoMapRepository.create` primitive an operator uses; `makeCanonical` (default true) enables+selects the new row, demoting the old crop/prop.
- `geo_create_map` MCP tool (+ unit tests, 25/25 pass).

## Why
Games with no map or only a wrong/prop/cropped ingest candidate (GTA:SA/VC got MapGenie preview crops; Ocarina got a NES-Zelda dungeon map) could not be repaired through the agent surface — map creation was admin-session-only. Closes that gap without loosening the admin guardrail.

## Test
- MCP: node --test → 25/25 (incl. new create_map mapping + validation).
- Backend: mirrors adjacent select/reject handlers; validated via CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)