### PR TITLE
fix(security): let password managers autofill the 2FA code field

### DIFF
--- a/packages/frontend/src/pages/TwoFactorChallengePage.tsx
+++ b/packages/frontend/src/pages/TwoFactorChallengePage.tsx
@@ -79,12 +79,17 @@ export default function TwoFactorChallengePage() {
 
             <form onSubmit={handleSubmit} className="space-y-5">
               <div>
-                <label className="text-sm font-medium text-foreground/80">
+                <label
+                  htmlFor="two-factor-code"
+                  className="text-sm font-medium text-foreground/80"
+                >
                   {mode === 'totp'
                     ? t('security.challenge.codeLabel')
                     : t('security.challenge.backupCodeLabel')}
                 </label>
                 <Input
+                  id="two-factor-code"
+                  name={mode === 'totp' ? 'totp' : 'backup-code'}
                   type="text"
                   inputMode={mode === 'totp' ? 'numeric' : 'text'}
                   autoComplete="one-time-code"


### PR DESCRIPTION
## Problem

On the two-factor challenge page, Bitwarden (and similar password managers) never offered to autofill the 6-digit TOTP code. The input only carried an `autocomplete="one-time-code"` hint — it had **no `name`, no `id`, and the `<label>` wasn't associated with it**. Bitwarden's TOTP field-detection scans `name` / `id` / linked-label / placeholder for tokens like `totp`, `otp`, `code`, `verification`; with none present, it didn't classify the box as a fillable code field, so the inline autofill menu never appeared.

## Change

`packages/frontend/src/pages/TwoFactorChallengePage.tsx`:

- Added `id="two-factor-code"` and a matching `<label htmlFor="two-factor-code">` so the label text is read as a field hint.
- Added `name="totp"` in TOTP mode (a first-class Bitwarden TOTP token), switching to `name="backup-code"` in backup-code mode so managers don't try to fill a TOTP into the recovery-code field.
- Kept `autocomplete="one-time-code"` so native iOS/Android/Chrome code suggestion still works.

## Notes

- Purely additive DOM attributes; no behavior change to submission/validation logic.
- Bitwarden will still only fill when the matching vault item for the site actually stores a TOTP secret.

## Verification

- `tsc --noEmit` on the frontend passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKDegssDw8vjrRE5VwrvnM)_