### PR TITLE
docs(geo): full revamp proposal for the free-play page

### DIFF
--- a/tasks/geo-play-revamp-proposal.html
+++ b/tasks/geo-play-revamp-proposal.html
@@ -1,0 +1,487 @@
+<!-- SUMMARY:
+Full revamp proposal for the Geo free-play page (/geo, GeoPlayPage). Audit of the
+current mobile layout finds the action dock eating ~30% of the viewport, a
+disabled-looking primary CTA, a flat reveal moment and no feedback loop. Proposes
+a contextual one-row dock, guided pin flow, tiered score reveal sheet, per-game
+progress, optional 5-round runs, and a 5-phase file-level delivery plan.
+-->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Geo Play Page — Revamp Proposal</title>
+<style>
+  :root {
+    --bg: #0a0a0f;
+    --panel: #12121a;
+    --panel-2: #17171f;
+    --border: #26263a;
+    --text: #d6d6e0;
+    --muted: #8b8b9e;
+    --primary: #a855f7;
+    --primary-dim: #7c3aed;
+    --pink: #ec4899;
+    --ok: #34d399;
+    --warn: #fbbf24;
+    --bad: #f87171;
+    --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 16px/1.65 Inter, system-ui, -apple-system, "Segoe UI", sans-serif;
+    padding: 2.5rem 1.25rem 6rem;
+  }
+  main { max-width: 72ch; margin: 0 auto; }
+  h1, h2, h3 { line-height: 1.25; color: #fff; }
+  h1 { font-size: 1.7rem; margin: 0 0 .25rem; }
+  h1 .accent {
+    background: linear-gradient(90deg, var(--primary), var(--pink));
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  h2 {
+    font-size: 1.25rem; margin: 3rem 0 .75rem;
+    padding-top: 1.5rem; border-top: 1px solid var(--border);
+  }
+  h2 .num { color: var(--primary); font-family: var(--mono); font-size: 1rem; margin-right: .5rem; }
+  h3 { font-size: 1.02rem; margin: 1.75rem 0 .5rem; }
+  p { margin: .7rem 0; }
+  a { color: var(--primary); }
+  a:focus-visible, summary:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+  code, pre {
+    font-family: var(--mono); font-size: .84em;
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px;
+  }
+  code { padding: .1em .35em; }
+  pre { padding: .9rem 1rem; overflow-x: auto; line-height: 1.55; margin: .9rem 0; }
+  pre code { background: none; border: none; padding: 0; }
+  table {
+    width: 100%; border-collapse: collapse; margin: 1rem 0;
+    font-size: .88rem; display: block; overflow-x: auto;
+  }
+  th, td { text-align: left; padding: .5rem .65rem; border: 1px solid var(--border); vertical-align: top; }
+  th { background: var(--panel); color: #fff; white-space: nowrap; }
+  td code { white-space: nowrap; }
+  .meta { color: var(--muted); font-size: .85rem; margin-bottom: 2rem; font-family: var(--mono); }
+  .badge {
+    display: inline-block; font-family: var(--mono); font-size: .72rem;
+    padding: .1rem .5rem; border-radius: 999px; border: 1px solid var(--border);
+    vertical-align: middle; margin-left: .35rem;
+  }
+  .badge.ship { color: var(--ok); border-color: var(--ok); }
+  .badge.risk { color: var(--bad); border-color: var(--bad); }
+  .badge.gate { color: var(--warn); border-color: var(--warn); }
+  .callout {
+    border-left: 3px solid var(--primary); background: var(--panel);
+    padding: .75rem 1rem; border-radius: 0 6px 6px 0; margin: 1rem 0;
+  }
+  .callout.danger { border-left-color: var(--bad); }
+  .callout.ok { border-left-color: var(--ok); }
+  .callout strong:first-child { color: #fff; }
+  .tldr {
+    background: var(--panel); border: 1px solid var(--primary-dim);
+    border-radius: 8px; padding: 1rem 1.25rem; margin: 1.5rem 0;
+    box-shadow: 0 0 24px rgba(168, 85, 247, .12);
+  }
+  .tldr h2 { border: none; margin: 0 0 .5rem; padding: 0; font-size: 1.05rem; }
+  ul, ol { padding-left: 1.4rem; }
+  li { margin: .3rem 0; }
+  li::marker { color: var(--primary); }
+  .phase {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+    padding: 1rem 1.25rem; margin: 1.25rem 0;
+  }
+  .phase h3 { margin-top: 0; }
+  .files { font-family: var(--mono); font-size: .78rem; color: var(--muted); margin-top: .6rem; }
+  .files b { color: var(--text); font-weight: 500; }
+  figure { margin: 1.5rem 0; }
+  figcaption { color: var(--muted); font-size: .82rem; text-align: center; margin-top: .4rem; }
+  svg text { font-family: var(--mono); }
+  .small { font-size: .85rem; color: var(--muted); }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { transition: none !important; animation: none !important; }
+  }
+</style>
+
+<main>
+<h1>Geo Play Page — <span class="accent">Revamp Proposal</span></h1>
+<p class="meta">route <code>/:lng/geo</code> · rev 1 · 2026-07-12 · grounded in code as of <code>ce1af2e</code> (v2.145.1) · audited from a live mobile capture (Half-Life, fr)</p>
+
+<div class="tldr">
+  <h2>TL;DR</h2>
+  <p>The free-play geo page has a solid engine (store, history, a11y plumbing, exclusion
+  lists) wrapped in a layout that fights itself on mobile: <strong>four stacked dock rows eat
+  roughly a third of the viewport</strong>, the primary CTA is a big gradient button that does
+  nothing until you tap the map, and the reveal — the entire payoff of the loop — is a
+  small transient card. The revamp keeps the store and the a11y guarantees intact and
+  reworks the presentation in five phases: <strong>(1)</strong> collapse the dock into one contextual
+  row and give the reclaimed space to the map, <strong>(2)</strong> turn the reveal into a tiered
+  bottom sheet with a score count-up and guess→answer line focus, <strong>(3)</strong> add per-game
+  progress and unify the five state screens, <strong>(4)</strong> add an optional 5-round scored
+  "run" with a shareable recap, <strong>(5)</strong> desktop polish. Phases 1–3 are pure presentation
+  changes; only phase 4 touches the store.</p>
+</div>
+
+<h2><span class="num">1</span>Current state — what's on screen today</h2>
+
+<p>The page is <code>GeoPlayPage.tsx</code> → <code>GeoPlayDeck.tsx</code> → <code>ImmersiveLayout.tsx</code>, with all
+visual slots in <code>GeoPlaySlots.tsx</code> and state in <code>geoFreePlayStore.ts</code>. On mobile it renders,
+top to bottom:</p>
+
+<table>
+  <tr><th>Zone</th><th>Component</th><th>Contents</th></tr>
+  <tr><td>Top bar</td><td><code>ContextHeader</code></td><td>Game chip ("Half-Life"), map chip when multi-map</td></tr>
+  <tr><td>Top-right overlay</td><td><code>topRightSlot</code></td><td>Home button + fullscreen toggle (z-40, floats over the top bar)</td></tr>
+  <tr><td>Photo panel</td><td><code>ScreenshotPanel</code> / <code>ZoomablePhoto</code></td><td>Screenshot, pinch-zoomable, "Photo" corner badge — <code>minmax(38%,1fr)</code> of the deck</td></tr>
+  <tr><td>Map panel</td><td><code>GeoMapCanvas</code> (Leaflet, lazy)</td><td>Tap-to-pin map, +/− zoom, "Carte" corner badge — <code>minmax(45%,1.2fr)</code></td></tr>
+  <tr><td>Dock row 1</td><td><code>Dock</code></td><td>Previous · Random game (shuffle) · Next</td></tr>
+  <tr><td>Dock row 2</td><td><code>Dock</code></td><td>Full-width gradient CTA — "Placer l'épingle" / "Confirmer"</td></tr>
+  <tr><td>Dock row 3</td><td><code>Dock</code></td><td>"Je ne sais pas — passer celle-ci" text link</td></tr>
+  <tr><td>Dock row 4</td><td><code>CoordinateInput</code></td><td>"Placer l'épingle par coordonnées" <code>&lt;details&gt;</code> toggle</td></tr>
+</table>
+
+<p>What already works well and must survive the revamp untouched:</p>
+<ul>
+  <li><strong>The store.</strong> <code>geoFreePlayStore</code> handles catalog TTL, per-game played-exclusion,
+  prev/next history (50 entries), ignore lists, real-world cold-start bias, and persists the
+  right subset. Nothing in this proposal changes its shape until phase 4.</li>
+  <li><strong>A11y plumbing.</strong> Live-region pin announcements, the coordinate-entry fallback
+  (WCAG 2.1.1 — Leaflet can't synthesize a click on Enter), 44px targets, roving-tabindex
+  game picker, <code>inert</code> map under open sheets.</li>
+  <li><strong>Performance choices.</strong> Lazy Leaflet chunk, keyed transform reset on the zoomable
+  photo, memoized slots.</li>
+  <li><strong>Haptics + two-step pin</strong> (draft tick, confirm pulse).</li>
+</ul>
+
+<h2><span class="num">2</span>Problems <span class="badge risk">evidence-based</span></h2>
+
+<h3>P1 — The dock taxes the play surface</h3>
+<p>On the captured 780-CSS-px-tall phone, the dock (4 rows + safe-area padding) plus the top
+bar consume ≈240px, leaving the map — the surface the player actually acts on — about 45%
+of the deck. Leaflet then overlays its own zoom control on top of that. The photo panel is
+similarly squeezed, so both halves of the core comparison task (look at photo ↔ scan map)
+are cramped. The dock's height is constant even though at most one of its rows is
+relevant at any instant: before a pin exists the CTA is disabled; after a pin exists the
+skip link and coordinate toggle are hidden anyway (<code>!revealed && !canSubmit</code> gating in
+<code>Dock</code>).</p>
+
+<h3>P2 — The primary CTA lies about the next action</h3>
+<p>"Placer l'épingle" is rendered as the full-width <code>gradient-gaming</code> hero button, but it is
+<code>disabled</code> until a draft pin exists — the actual next action is <em>tap the map</em>. A saturated
+gradient button reads as "tap me"; a first-time player taps it, nothing happens, and there is
+no visible hint pointing at the map. The label then flips to "Confirmer" once a pin lands —
+two different actions time-sharing one button slot with no transition cue.</p>
+
+<h3>P3 — The keyboard fallback is promoted to primary navigation</h3>
+<p>"Placer l'épingle par coordonnées" exists for keyboard/switch/SR users and is deliberately
+collapsed — but its summary line is permanently visible in the dock, adding a fourth row and
+competing with the skip link. Sighted touch users pay the space cost of an affordance
+they will never use.</p>
+
+<h3>P4 — The reveal moment is flat</h3>
+<p>The entire loop exists for the reveal, and today it's a <code>max-w-md</code> card floating above the
+dock: static score number, "Distance : 12,3 %", pin count. No tier feedback (the design
+system's <code>score-high/mid/low</code> tokens are unused here), no count-up, no focus animation on
+the guess→canonical line that <code>MapCanvasLeaflet</code> already draws, no personal-best context.
+Compare the classic mode's tier reveals, which use <code>--glow-*</code> and count-ups.</p>
+
+<h3>P5 — No feedback loop across rounds</h3>
+<p>Free play is unranked by design, but it currently has <em>zero</em> session structure: no
+running total, no round counter, no per-game progress ("12/58 screenshots"), no best-score
+memory — even though <code>playedByGame</code> and <code>screenshotCount</code> already contain the progress
+data. The only long-horizon feedback is the terminal "exhausted" screen.</p>
+
+<h3>P6 — Chrome duplication on tiny panels</h3>
+<p>Three overlay layers stack on the panels: "Photo"/"Carte" corner badges, the top bar
+chips, and the top-right home/fullscreen cluster (which needed a z-index bump comment in
+<code>ImmersiveLayout</code> to stay clickable over the top bar — a smell that the header zone is
+overloaded). On a 380px-wide screen this is a lot of pills.</p>
+
+<h3>P7 — Desktop is an unexamined 50/50 split</h3>
+<p><code>md:grid-cols-2</code> gives photo and map equal width regardless of task phase. While scanning
+the map you want the map big; while studying the screenshot you want the photo big. Every
+comparable product (GeoGuessr et al.) solves this with an expandable secondary surface.</p>
+
+<h2><span class="num">3</span>Design principles for the revamp</h2>
+<ol>
+  <li><strong>The map is the stage.</strong> Every pixel not doing work goes to the map (mobile) or the
+  active surface (desktop).</li>
+  <li><strong>Show one action at a time.</strong> The dock renders exactly the controls valid in the
+  current phase, in one row.</li>
+  <li><strong>Make the reveal the reward.</strong> Spend the animation/glow budget on the result sheet,
+  nowhere else (ui-tokens rule: one hero glow per screen).</li>
+  <li><strong>Presentation-only until phase 4.</strong> The store contract, a11y fallbacks and E2E
+  selectors (<code>geo-panel-photo</code>/<code>geo-panel-map</code>) are load-bearing; keep them.</li>
+  <li><strong>Tokens, not raw values.</strong> Everything maps to <code>docs/ui-tokens.md</code>; the
+  <code>design-tokens/no-raw-design-tokens</code> lint rule is at <code>error</code> for <code>src/**</code>.</li>
+</ol>
+
+<h2><span class="num">4</span>Proposed layout</h2>
+
+<figure>
+<svg viewBox="0 0 640 420" role="img" aria-label="Before and after mobile wireframes. Before: photo and map panels squeezed by a four-row dock. After: larger map, one-row contextual dock, floating hint chip.">
+  <!-- BEFORE phone -->
+  <rect x="40" y="20" width="200" height="380" rx="14" fill="#12121a" stroke="#26263a"/>
+  <text x="140" y="14" fill="#8b8b9e" font-size="11" text-anchor="middle">BEFORE (today)</text>
+  <rect x="52" y="32" width="176" height="24" rx="4" fill="#17171f" stroke="#26263a"/>
+  <text x="60" y="48" fill="#8b8b9e" font-size="9">game chip · map chip · 🏠 ⤢</text>
+  <rect x="52" y="60" width="176" height="110" rx="4" fill="#1c1c26" stroke="#26263a"/>
+  <text x="140" y="118" fill="#d6d6e0" font-size="10" text-anchor="middle">PHOTO (~38%)</text>
+  <rect x="52" y="174" width="176" height="120" rx="4" fill="#1a2030" stroke="#26263a"/>
+  <text x="140" y="236" fill="#d6d6e0" font-size="10" text-anchor="middle">MAP (~45%)</text>
+  <rect x="52" y="298" width="176" height="22" rx="4" fill="#17171f" stroke="#26263a"/>
+  <text x="140" y="313" fill="#8b8b9e" font-size="9" text-anchor="middle">‹  shuffle  ›</text>
+  <rect x="52" y="324" width="176" height="24" rx="12" fill="#7c3aed"/>
+  <text x="140" y="340" fill="#fff" font-size="9" text-anchor="middle">Placer l'épingle (disabled!)</text>
+  <rect x="52" y="352" width="176" height="16" rx="4" fill="none"/>
+  <text x="140" y="363" fill="#8b8b9e" font-size="8" text-anchor="middle">Je ne sais pas — passer</text>
+  <text x="140" y="381" fill="#8b8b9e" font-size="8" text-anchor="middle">Placer l'épingle par coordonnées</text>
+
+  <!-- arrow -->
+  <path d="M262 210 L 358 210" stroke="#a855f7" stroke-width="2" marker-end="url(#arr)"/>
+  <defs><marker id="arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 z" fill="#a855f7"/></marker></defs>
+
+  <!-- AFTER phone -->
+  <rect x="380" y="20" width="200" height="380" rx="14" fill="#12121a" stroke="#a855f7"/>
+  <text x="480" y="14" fill="#a855f7" font-size="11" text-anchor="middle">AFTER (proposed)</text>
+  <rect x="392" y="32" width="176" height="24" rx="4" fill="#17171f" stroke="#26263a"/>
+  <text x="400" y="48" fill="#8b8b9e" font-size="9">Half-Life · ◔ 12/58 · 🏠 ⤢</text>
+  <rect x="392" y="60" width="176" height="104" rx="4" fill="#1c1c26" stroke="#26263a"/>
+  <text x="480" y="115" fill="#d6d6e0" font-size="10" text-anchor="middle">PHOTO (~32%)</text>
+  <rect x="392" y="168" width="176" height="176" rx="4" fill="#1a2030" stroke="#26263a"/>
+  <text x="480" y="246" fill="#d6d6e0" font-size="10" text-anchor="middle">MAP (~55%)</text>
+  <rect x="424" y="316" width="112" height="20" rx="10" fill="#0a0a0f" stroke="#a855f7" opacity=".95"/>
+  <text x="480" y="329" fill="#d6d6e0" font-size="8" text-anchor="middle">Touchez la carte 📍</text>
+  <rect x="392" y="348" width="176" height="30" rx="6" fill="#17171f" stroke="#26263a"/>
+  <text x="480" y="367" fill="#8b8b9e" font-size="9" text-anchor="middle">‹ · shuffle · passer ▸ · ›</text>
+</svg>
+<figcaption>Fig. 1 — Mobile: the four-row dock collapses to one; the hint chip floats on the
+map and morphs into the confirm CTA; the map gains ≈25% height.</figcaption>
+</figure>
+
+<h3>4.1 The contextual dock (mobile)</h3>
+<p>One 56px row, phase-driven — the row's <em>contents</em> change, its height never does (no
+layout shift):</p>
+<table>
+  <tr><th>Store phase</th><th>Dock contents</th></tr>
+  <tr><td><code>ready</code>, no draft pin</td><td>‹ prev · shuffle · <strong>passer</strong> (skip, promoted from text link to ghost button) · next ›</td></tr>
+  <tr><td><code>ready</code>, draft pin placed</td><td>Full-width gradient <strong>"Confirmer l'épingle"</strong> + small ✕ to clear the draft</td></tr>
+  <tr><td><code>submitting</code></td><td>Same CTA, spinner, disabled</td></tr>
+  <tr><td><code>revealed</code></td><td>Full-width <strong>"Capture suivante"</strong> (the result sheet sits above it)</td></tr>
+  <tr><td><code>loading</code></td><td>Row skeleton</td></tr>
+</table>
+<p>The disabled gradient button disappears entirely. Its job — telling the player what to do
+first — moves to a <strong>floating hint chip</strong> anchored bottom-center of the map panel:
+"Touchez la carte pour placer l'épingle" with a pin icon. It fades out on first pin of the
+session (persisted flag) and never returns for experienced players. When a draft pin
+lands, the chip position is where the confirm CTA slides in from, visually linking pin → confirm.</p>
+
+<h3>4.2 Where the removed controls go</h3>
+<ul>
+  <li><strong>Skip</strong> — promoted into the idle dock row as a real button. It was a
+  dataset-quality escape hatch hidden in 12px text; making it a peer of shuffle is
+  deliberate (a random guess pollutes contribution data more than a skip costs).</li>
+  <li><strong>Coordinate entry</strong> — stays in the DOM for WCAG 2.1.1 but becomes visually hidden
+  until keyboard-focused (<code>sr-only focus-within:not-sr-only</code> pattern on the details
+  summary), the same trick as skip-links. Touch users never see it; keyboard users hit it
+  in tab order right after the map, exactly where they need it.</li>
+  <li><strong>Prev/next history</strong> — stay as icon buttons flanking the idle row. Disabled states
+  unchanged.</li>
+  <li><strong>Corner badges "Photo"/"Carte"</strong> — dropped on mobile (the panels are
+  self-evident: one is a screenshot, one is a map with zoom controls); kept on desktop where
+  panels are peers. Removes one overlay layer from each panel.</li>
+</ul>
+
+<h3>4.3 Context header merge</h3>
+<p>The top bar and the top-right overlay merge into a single header row (fixes the z-40
+band-aid): game chip (opens picker) · map chip (multi-map only) · <strong>progress ring</strong>
+(new, §6) · spacer · home · fullscreen. One strip, one z-index, safe-area padded.</p>
+
+<h3>4.4 Desktop <span class="badge gate">phase 5</span></h3>
+<p>Keep the split but make it 60/40 photo-dominant, with the map panel expanding to 65% on
+hover/focus-within and pinnable via a corner toggle (CSS grid-template-columns transition,
+<code>--duration-normal</code>). This is the low-risk version of the GeoGuessr overlay pattern — no
+absolute-positioned mini-map, no drag-resize, works with the existing panel DOM. The
+corner badges and expand affordance live in the panel headers.</p>
+
+<h2><span class="num">5</span>The reveal sheet</h2>
+
+<figure>
+<svg viewBox="0 0 640 300" role="img" aria-label="Reveal sheet wireframe: map shows guess-to-answer line; bottom sheet shows tiered score count-up, distance, best delta, and next CTA.">
+  <rect x="200" y="10" width="240" height="280" rx="14" fill="#12121a" stroke="#26263a"/>
+  <rect x="212" y="22" width="216" height="150" rx="4" fill="#1a2030" stroke="#26263a"/>
+  <circle cx="268" cy="70" r="5" fill="#f87171"/>
+  <circle cx="360" cy="130" r="5" fill="#34d399"/>
+  <path d="M268 70 L360 130" stroke="#fbbf24" stroke-width="2" stroke-dasharray="5 4"/>
+  <text x="268" y="58" fill="#f87171" font-size="9" text-anchor="middle">vous</text>
+  <text x="360" y="148" fill="#34d399" font-size="9" text-anchor="middle">réponse</text>
+  <rect x="212" y="180" width="216" height="100" rx="10" fill="#17171f" stroke="#a855f7"/>
+  <text x="320" y="205" fill="#34d399" font-size="18" font-weight="bold" text-anchor="middle">1 730 pts</text>
+  <text x="320" y="222" fill="#8b8b9e" font-size="9" text-anchor="middle">à 4,2 % de la cible · record perso +180</text>
+  <rect x="230" y="236" width="180" height="26" rx="13" fill="#7c3aed"/>
+  <text x="320" y="253" fill="#fff" font-size="10" text-anchor="middle">Capture suivante →</text>
+</svg>
+<figcaption>Fig. 2 — Reveal: the map auto-fits the guess→answer segment, the sheet counts
+the score up in the tier color, and "next" is the only button.</figcaption>
+</figure>
+
+<p>Replaces <code>ResultOverlay</code> with a non-modal bottom sheet (Radix primitives already in the
+tree via <code>Sheet</code>, or a plain fixed div — no new dependency):</p>
+<ul>
+  <li><strong>Map focus.</strong> On reveal, <code>MapCanvasLeaflet</code> gets a <code>fitBounds</code> call over
+  the guess + canonical points (it already draws the line; today the player has to find it).
+  Wrong-map case: flash the map chip in <code>--destructive</code> and show the correct map name.</li>
+  <li><strong>Tiered score.</strong> Count-up over <code>--duration-slow</code>, colored by band:
+  ≥1500 → <code>score-high</code> + <code>--glow-success</code>; 500–1499 → <code>score-mid</code>;
+  &lt;500 → <code>score-low</code>. Bands align with the scoring curve in <code>docs/geo-mode.md</code>
+  (2000 × e<sup>−8d</sup>: 1500 ≈ within 3.6% of target, 500 ≈ within 17%).</li>
+  <li><strong>Human distance.</strong> "à 4,2 % de la cible" instead of "Distance : 4,2 %" — plus the
+  existing pin-count line ("N joueurs ont placé cette capture").</li>
+  <li><strong>Personal best delta</strong> per game, from a new persisted <code>bestScoreByGame</code> map
+  (tiny, additive store field — the one phase-2 store touch, purely local).</li>
+  <li><strong>A11y:</strong> keeps <code>aria-live="polite" aria-atomic</code>; count-up is skipped under
+  <code>prefers-reduced-motion</code> (final value rendered immediately).</li>
+</ul>
+
+<h2><span class="num">6</span>Progress &amp; session structure</h2>
+
+<h3>6.1 Per-game progress <span class="badge ship">data already exists</span></h3>
+<p><code>playedByGame[gameId].length / game.screenshotCount</code> is already in the store. Surface it
+as a small ring + "12/58" in the context header and as a progress bar per game inside
+<code>GamePicker</code> (which already computes <code>playedCountByGame</code>). This turns the invisible
+march toward "exhausted" into a collection mechanic for free.</p>
+
+<h3>6.2 Runs — optional 5-round scored session <span class="badge gate">phase 4</span></h3>
+<p>Free browse stays the default. A "Lancer un run" chip (header or empty state) starts a
+5-round run: random screenshots across the catalog (reusing <code>pickRandomAcrossGames</code>),
+cumulative score out of 10 000, round counter "3/5" in the header, recap screen with
+per-round tier dots and total, and a share CTA reusing the OG-image infrastructure
+(<code>og.routes.ts</code>) so a run result unfurls nicely in Discord/X. Store gets a small
+<code>run: { active, roundIndex, scores[] } | null</code> slice; guest-visible but submit still
+requires auth (unchanged backend contract — runs are a client-side aggregation, zero API
+work).</p>
+<p class="small">Why bother, if GeoGamers daily mode exists? Runs answer "one more go" retention in the
+unranked sandbox without touching leaderboards, and they create the first shareable artifact
+from free play. Cut this phase first if scope pressure hits.</p>
+
+<h2><span class="num">7</span>Unified state screens</h2>
+<p><code>ScreenshotPanel</code> currently hand-rolls five sibling states (all-done, exhausted,
+auth-required, error, empty) with copy-pasted icon-circle + title + body + actions markup.
+Extract one <code>StatePanel</code> (icon, title, body, actions, footnote slots) and express the five
+states as data. The empty state keeps its social-proof pins counter and 1-2-3 steps; the
+auth state gains the same screenshot <em>behind</em> a blur overlay ("sign in to play this one")
+instead of a bare panel — the strongest signup nudge is the game itself, one
+presentational div, no API change.</p>
+
+<h2><span class="num">8</span>Accessibility &amp; i18n checklist</h2>
+<ul>
+  <li>Coordinate entry: keep the form and its focus-reveal in tab order directly after the map
+  panel; E2E-assert it still works (it's the only non-pointer pin path — WCAG 2.1.1).</li>
+  <li>Pin live region (<code>output aria-live</code>) unchanged; add a reveal announcement
+  ("Score 1 730, à 4,2 % de la cible") to the sheet's existing live region.</li>
+  <li>All dock buttons keep <code>min-h-11/12</code>; the hint chip is <code>pointer-events-none</code>
+  (decorative, <code>aria-hidden</code> — the live region already announces state).</li>
+  <li>Phase-driven dock keeps a stable DOM order: history buttons, skip, CTA — visibility
+  toggles, not reordering, so focus never teleports.</li>
+  <li>Reduced motion: count-up, sheet slide-in and map <code>fitBounds</code> animation all collapse
+  to instant under <code>prefers-reduced-motion</code> (Leaflet: <code>animate: false</code>).</li>
+  <li>New i18n keys (fr + en): <code>geo.play.hint.tapMap</code>, <code>geo.play.clearPin</code>,
+  <code>geo.play.result.*</code> (tier lines, best delta), <code>geo.play.progress</code>,
+  <code>geo.play.run.*</code>. French is primary — write fr first.</li>
+</ul>
+
+<h2><span class="num">9</span>Token mapping</h2>
+<table>
+  <tr><th>Surface</th><th>Tokens (per <code>docs/ui-tokens.md</code>)</th></tr>
+  <tr><td>Confirm CTA</td><td><code>gradient-gaming</code> (from-neon-purple to-neon-pink) — unchanged, but now only rendered when tappable</td></tr>
+  <tr><td>Hint chip</td><td><code>bg-black/60 backdrop-blur border-white/10</code>, icon <code>text-neon-pink</code></td></tr>
+  <tr><td>Reveal sheet</td><td><code>Card variant="neon"</code>; score text <code>text-score-high/mid/low</code>; glow <code>var(--glow-success)</code> on high tier only (the page's single hero glow)</td></tr>
+  <tr><td>Wrong map</td><td><code>Card variant="error"</code>, chip flash <code>text-destructive</code></td></tr>
+  <tr><td>Progress ring</td><td><code>text-neon-cyan</code> (stats/counters per token contract)</td></tr>
+  <tr><td>Run recap tier dots</td><td><code>bg-score-high/mid/low</code></td></tr>
+  <tr><td>Motion</td><td><code>--duration-fast</code> chip fade, <code>--duration-normal</code> sheet slide, <code>--duration-slow</code> count-up, all <code>--ease-smooth</code>/<code>--ease-out</code></td></tr>
+</table>
+
+<h2><span class="num">10</span>Delivery plan</h2>
+
+<div class="phase">
+<h3>Phase 1 — Reclaim the viewport <span class="badge ship">highest value / lowest risk</span></h3>
+<ul>
+  <li>Rework <code>Dock</code> into the phase-driven single row; promote skip to a button; add draft-pin clear ✕.</li>
+  <li>Focus-reveal the <code>CoordinateInput</code>; keep DOM/tab order.</li>
+  <li>Add the map hint chip with persisted first-pin dismissal (one boolean in the store partialize).</li>
+  <li>Merge top bar + top-right overlay into one header row; drop mobile corner badges.</li>
+  <li>Retune deck rows to <code>minmax(30%,1fr)_minmax(52%,1.6fr)</code> (exact values via device pass).</li>
+</ul>
+<p class="files"><b>Files:</b> components/geo/GeoPlaySlots.tsx · components/geo/ImmersiveLayout.tsx ·
+components/geo/GeoPlayDeck.tsx · stores/geoFreePlayStore.ts (hint flag only) ·
+public/locales/{fr,en}/translation.json · e2e/geo-play.spec.ts · e2e/visual-regression + a11y-smoke updates</p>
+</div>
+
+<div class="phase">
+<h3>Phase 2 — The reveal</h3>
+<ul>
+  <li>Replace <code>ResultOverlay</code> with the bottom sheet; tiered count-up; human-readable distance; reduced-motion paths.</li>
+  <li><code>fitBounds</code>-on-reveal in <code>MapCanvasLeaflet</code> (guess + canonical, padded).</li>
+  <li>Add <code>bestScoreByGame</code> to the store (persisted) + best-delta line.</li>
+</ul>
+<p class="files"><b>Files:</b> components/geo/GeoPlaySlots.tsx (ResultSheet) · components/geo/MapCanvasLeaflet.tsx ·
+stores/geoFreePlayStore.ts · locales · e2e/geo-play.spec.ts</p>
+</div>
+
+<div class="phase">
+<h3>Phase 3 — Progress + state unification</h3>
+<ul>
+  <li>Progress ring in header; progress bars in <code>GamePicker</code> rows.</li>
+  <li>Extract <code>StatePanel</code>; blurred-screenshot auth state.</li>
+</ul>
+<p class="files"><b>Files:</b> components/geo/GeoPlaySlots.tsx · components/geo/GamePicker.tsx ·
+new components/geo/StatePanel.tsx · locales</p>
+</div>
+
+<div class="phase">
+<h3>Phase 4 — Runs <span class="badge gate">cut first under scope pressure</span></h3>
+<ul>
+  <li><code>run</code> slice in the store; header round counter; recap screen with share via existing OG route.</li>
+</ul>
+<p class="files"><b>Files:</b> stores/geoFreePlayStore.ts · components/geo/RunRecap.tsx (new) ·
+presentation/routes/og.routes.ts (new variant) · locales · e2e</p>
+</div>
+
+<div class="phase">
+<h3>Phase 5 — Desktop polish</h3>
+<ul>
+  <li>60/40 split with focus-expand + pin toggle; desktop-only corner badges as panel headers.</li>
+</ul>
+<p class="files"><b>Files:</b> components/geo/ImmersiveLayout.tsx · e2e/visual-regression.spec.ts</p>
+</div>
+
+<p>Each phase is an independent PR passing the standard gate: <code>npm run build</code> ·
+<code>npm run lint</code> · <code>npm test</code> · <code>npm run test:e2e</code> (geo-play, a11y-smoke,
+visual-regression with snapshot updates called out in the PR body).</p>
+
+<h2><span class="num">11</span>Risks &amp; open questions</h2>
+<ul>
+  <li><strong>Visual-regression churn.</strong> Phases 1–2 invalidate every geo snapshot; batch the
+  <code>test:e2e:visual:update</code> into the same PR and flag it for reviewer eyes.</li>
+  <li><strong>Focus-reveal coordinate entry</strong> must be tested on VoiceOver/TalkBack, not just
+  desktop tab order — the <code>details/summary</code> + <code>sr-only</code> combo has browser quirks. If
+  it misbehaves, fallback: keep it always-visible but move it into the overflow of the game
+  chip menu.</li>
+  <li><strong>Score tier bands</strong> (1500/500) are proposed from the decay curve, not play data.
+  Validate against real pin distributions (admin has <code>geo_pins</code>) before hard-coding; keep
+  bands in one exported constant.</li>
+  <li><strong>Open:</strong> should the hint chip also localize for the two-step confirm ("Touchez ✓ pour
+  valider") after the first pin, or is the CTA morph enough? Proposal assumes the morph is
+  enough; cheap to add later.</li>
+  <li><strong>Open:</strong> run length (5 vs 10) and whether runs bias toward the real-world catalog the
+  way cold-start shuffle does. Proposal: reuse the same <code>weightedPick</code> untouched.</li>
+</ul>
+
+<p class="small">Grounding: <code>packages/frontend/src/pages/GeoPlayPage.tsx</code>,
+<code>components/geo/{GeoPlayDeck,GeoPlaySlots,ImmersiveLayout,GamePicker,MapCanvasLeaflet}.tsx</code>,
+<code>stores/geoFreePlayStore.ts</code>, <code>docs/geo-mode.md</code>, <code>docs/ui-tokens.md</code>, live mobile
+capture of <code>the-box.battistella.ovh/fr/geo</code> (Half-Life), 2026-07-12.</p>
+
+</main>


### PR DESCRIPTION
## What

Adds `tasks/geo-play-revamp-proposal.html` — a self-contained HTML design proposal (per the repo's HTML-first convention) for a full revamp of the Geo free-play page (`/:lng/geo`, `GeoPlayPage`), grounded in the current code (`ce1af2e`, v2.145.1) and a live mobile capture of the page.

## Audit findings

- The bottom dock stacks four rows (history nav, full-width CTA, skip link, coordinate toggle) and, with the top bar, consumes ~30% of a mobile viewport — squeezing the map, the surface the player actually acts on.
- The primary CTA ("Placer l'épingle") is a full gradient button rendered disabled until a pin exists; the real next action is tapping the map, but nothing points there.
- The keyboard-fallback coordinate entry is permanently visible, paying a whole dock row for an affordance touch users never use.
- The reveal — the payoff of the loop — is a small static card: no score tiering (the `score-high/mid/low` tokens go unused), no count-up, no focus on the guess→answer line.
- No feedback loop across rounds despite the store already holding per-game progress data.

## Proposal (5 phases, presentation-first)

1. **Reclaim the viewport** — phase-driven one-row dock, floating "tap the map" hint chip, focus-revealed coordinate entry (WCAG 2.1.1 path preserved), merged header, map gains ~25% height.
2. **The reveal** — tiered bottom sheet with score count-up, `fitBounds` on the guess→answer segment, personal-best delta.
3. **Progress + state unification** — per-game progress ring/bars, single `StatePanel` for the five hand-rolled state screens.
4. **Runs** — optional 5-round scored session with shareable recap (client-side only; flagged as first cut under scope pressure).
5. **Desktop polish** — 60/40 split with focus-expand map.

Phases 1–3 touch presentation only; the store contract, a11y plumbing and E2E anchors are explicitly preserved. Includes SVG before/after wireframes, a token mapping against `docs/ui-tokens.md`, file-level task lists per phase, and open questions.

No app code changes in this PR — document only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2

---
_Generated by [Claude Code](https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2)_