### PR TITLE
feat(geo): reclaim the free-play viewport (revamp phase 1)

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2532,8 +2532,10 @@
       "changeMap": "Choose map",
       "submit": "Drop pin",
       "confirm": "Confirm pin",
+      "clearPin": "Remove pin",
       "pinPlacedAria": "Pin placed at {{x}}%, {{y}}%",
       "skip": "I don't know — skip this one",
+      "skipShort": "Skip",
       "coords": {
         "toggle": "Place pin by coordinates",
         "formLabel": "Place a pin using x/y coordinates",
@@ -2541,6 +2543,9 @@
         "y": "Y (%)",
         "place": "Place pin",
         "hint": "0% is the top-left corner of the map, 100% is the bottom-right."
+      },
+      "hint": {
+        "tapMap": "Tap the map to place your pin"
       },
       "next": "Next round",
       "reroll": "New screenshot",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2532,8 +2532,10 @@
       "changeMap": "Changer de carte",
       "submit": "Placer l'épingle",
       "confirm": "Confirmer la position",
+      "clearPin": "Retirer l'épingle",
       "pinPlacedAria": "Épingle posée à {{x}} %, {{y}} %",
       "skip": "Je ne sais pas — passer celle-ci",
+      "skipShort": "Passer",
       "coords": {
         "toggle": "Placer l'épingle par coordonnées",
         "formLabel": "Placer une épingle avec des coordonnées x/y",
@@ -2541,6 +2543,9 @@
         "y": "Y (%)",
         "place": "Placer l'épingle",
         "hint": "0 % correspond au coin haut-gauche de la carte, 100 % au coin bas-droit."
+      },
+      "hint": {
+        "tapMap": "Touchez la carte pour placer l'épingle"
       },
       "next": "Suivant",
       "reroll": "Nouvelle capture",

--- a/packages/frontend/src/components/geo/GeoPlayDeck.tsx
+++ b/packages/frontend/src/components/geo/GeoPlayDeck.tsx
@@ -13,6 +13,7 @@ import {
     ScreenshotPanel,
     MapChunkLoader,
     MapPlaceholder,
+    PinHintChip,
     ResultOverlay,
     ContextHeader,
     Dock,
@@ -95,6 +96,7 @@ export function GeoPlayDeck({
         round,
         playedByGame,
         ignoredGameIds,
+        hasEverPlacedPin,
         history: roundHistory,
         historyIndex,
         selectGame,
@@ -179,26 +181,34 @@ export function GeoPlayDeck({
     const mapSlot: ReactNode = useMemo(
         () =>
             selectedMap ? (
-                <Suspense fallback={<MapChunkLoader />}>
-                    <GeoMapCanvas
-                        imageUrl={selectedMap.imageUrl}
-                        widthPx={selectedMap.widthPx}
-                        heightPx={selectedMap.heightPx}
-                        tiles={selectedMap.tiles}
-                        pin={pendingGuess ?? result?.guess ?? null}
-                        canonical={
-                            phase === 'revealed' && correctMap && selectedMap.id === correctMap.id
-                                ? result?.canonical ?? null
-                                : null
-                        }
-                        disabled={phase !== 'ready'}
-                        onPin={onMapPin}
-                        showGuessLine={
-                            phase === 'revealed' && !!correctMap && selectedMap.id === correctMap.id
-                        }
-                        className="!rounded-none h-full"
-                    />
-                </Suspense>
+                <>
+                    <Suspense fallback={<MapChunkLoader />}>
+                        <GeoMapCanvas
+                            imageUrl={selectedMap.imageUrl}
+                            widthPx={selectedMap.widthPx}
+                            heightPx={selectedMap.heightPx}
+                            tiles={selectedMap.tiles}
+                            pin={pendingGuess ?? result?.guess ?? null}
+                            canonical={
+                                phase === 'revealed' && correctMap && selectedMap.id === correctMap.id
+                                    ? result?.canonical ?? null
+                                    : null
+                            }
+                            disabled={phase !== 'ready'}
+                            onPin={onMapPin}
+                            showGuessLine={
+                                phase === 'revealed' && !!correctMap && selectedMap.id === correctMap.id
+                            }
+                            className="!rounded-none h-full"
+                        />
+                    </Suspense>
+                    {/* First-run onboarding: the tap-the-map gesture has no
+                        visible affordance of its own, so point at it until
+                        the player's first-ever draft pin. */}
+                    {phase === 'ready' && !pendingGuess && !hasEverPlacedPin && (
+                        <PinHintChip />
+                    )}
+                </>
             ) : (
                 <MapPlaceholder
                     hasGame={currentGameId != null}
@@ -216,6 +226,7 @@ export function GeoPlayDeck({
             currentGameId,
             isMultiMap,
             setMapPickerOpen,
+            hasEverPlacedPin,
         ],
     )
 
@@ -230,6 +241,7 @@ export function GeoPlayDeck({
                 onSubmit={onSubmit}
                 onNextRound={() => void nextRound()}
                 onSkip={() => void rerollScreenshot()}
+                onClearPin={() => onMapPin(null)}
                 onPlaceByCoords={onMapPin}
                 canSubmit={canSubmit}
                 phase={phase}

--- a/packages/frontend/src/components/geo/GeoPlaySlots.tsx
+++ b/packages/frontend/src/components/geo/GeoPlaySlots.tsx
@@ -18,8 +18,10 @@ import {
     MapPin,
     RefreshCw,
     Shuffle,
+    SkipForward,
     Sparkles,
     Trophy,
+    X,
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
@@ -480,6 +482,7 @@ export function Dock({
     onSubmit,
     onNextRound,
     onSkip,
+    onClearPin,
     onPlaceByCoords,
     canSubmit,
     phase,
@@ -492,6 +495,7 @@ export function Dock({
     onSubmit: () => void
     onNextRound: () => void
     onSkip: () => void
+    onClearPin: () => void
     onPlaceByCoords: (point: GeoPoint) => void
     canSubmit: boolean
     phase: ReturnType<typeof useGeoFreePlayStore.getState>['phase']
@@ -500,55 +504,15 @@ export function Dock({
     const submitting = phase === 'submitting'
     const revealed = phase === 'revealed'
     const loading = phase === 'loading'
+    // A draft pin exists (or is being submitted). The dock renders only
+    // the controls valid for the current phase, in a single constant-
+    // height row, so the map above never shifts.
+    const hasDraft = canSubmit || submitting
+
     return (
         <div className="flex flex-col gap-2">
-            {/* Secondary row — navigation through history + shuffle. Compact
-                so the primary CTA below it gets full visual weight. */}
-            <div className="flex items-center justify-center gap-1.5">
-                <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={onPrevious}
-                    className="size-12 min-h-12 min-w-12 text-white/80 hover:text-white"
-                    disabled={!canGoPrevious || submitting || loading}
-                    aria-label={t('geo.play.previous', 'Previous screenshot')}
-                    title={t('geo.play.previous', 'Previous screenshot')}
-                >
-                    <ChevronLeft className="size-5" aria-hidden />
-                </Button>
-                <Button
-                    type="button"
-                    variant="ghost"
-                    onClick={onShuffleAllGames}
-                    className="min-h-12 text-white/80 hover:text-white"
-                    disabled={submitting || loading}
-                    aria-label={t('geo.play.shuffleAllGames', 'Random game')}
-                    title={t('geo.play.shuffleAllGames', 'Random game')}
-                >
-                    <Shuffle className="size-4 sm:mr-1.5" aria-hidden />
-                    <span className="hidden sm:inline">
-                        {t('geo.play.shuffleAllGames', 'Random game')}
-                    </span>
-                </Button>
-                <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={onNext}
-                    className="size-12 min-h-12 min-w-12 text-white/80 hover:text-white"
-                    disabled={!canGoNext || submitting || loading}
-                    aria-label={t('geo.play.nextScreenshot', 'Next screenshot')}
-                    title={t('geo.play.nextScreenshot', 'Next screenshot')}
-                >
-                    <ChevronRight className="size-5" aria-hidden />
-                </Button>
-            </div>
-
-            {/* Primary row — single full-width CTA. Fills the thumb-zone on
-                mobile and matches Fitts: bigger target, no neighbours
-                competing for taps. */}
             {revealed ? (
+                /* Revealed — one job: move on. */
                 <Button
                     type="button"
                     onClick={onNextRound}
@@ -557,57 +521,136 @@ export function Dock({
                     {t('geo.play.next', 'Next round')}
                     <ArrowRight className="size-4 ml-2" aria-hidden />
                 </Button>
+            ) : hasDraft ? (
+                /* Draft pin placed — confirm is the only primary action;
+                   the ✕ clears the draft and returns to the browse row. */
+                <div className="flex items-center gap-2">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={onClearPin}
+                        disabled={submitting}
+                        className="size-12 min-h-12 min-w-12 text-white/80 hover:text-white"
+                        aria-label={t('geo.play.clearPin', 'Remove pin')}
+                        title={t('geo.play.clearPin', 'Remove pin')}
+                    >
+                        <X className="size-5" aria-hidden />
+                    </Button>
+                    <Button
+                        type="button"
+                        onClick={onSubmit}
+                        disabled={submitting}
+                        className="gradient-gaming hover:opacity-90 min-h-12 flex-1"
+                        aria-live="polite"
+                    >
+                        {submitting ? (
+                            <Loader2 className="size-4 mr-2 animate-spin" aria-hidden />
+                        ) : (
+                            <Check className="size-4 mr-2" aria-hidden />
+                        )}
+                        {t('geo.play.confirm', 'Confirm pin')}
+                    </Button>
+                </div>
             ) : (
-                <Button
-                    type="button"
-                    onClick={onSubmit}
-                    disabled={!canSubmit || submitting}
-                    className="gradient-gaming hover:opacity-90 min-h-12 w-full"
-                    aria-live="polite"
-                >
-                    {submitting ? (
-                        <Loader2 className="size-4 mr-2 animate-spin" aria-hidden />
-                    ) : canSubmit ? (
-                        <Check className="size-4 mr-2" aria-hidden />
-                    ) : (
-                        <MapPin className="size-4 mr-2" aria-hidden />
-                    )}
-                    {canSubmit
-                        ? t('geo.play.confirm', 'Confirm pin')
-                        : t('geo.play.submit', 'Drop pin')}
-                </Button>
-            )}
-
-            {/* Skip affordance — shown only while waiting for a pin (no
-                draft, not yet revealed). A discoverable "I don't know"
-                escape hatch protects dataset quality: a player who'd
-                otherwise drop a random guess can roll forward instead.
-                Hidden once a pin is placed so it doesn't fight the
-                primary "Confirm pin" CTA for attention. */}
-            {!revealed && !canSubmit && (
-                <button
-                    type="button"
-                    onClick={onSkip}
-                    disabled={submitting || loading}
-                    className="self-center text-xs text-white/80 underline-offset-4 hover:text-white hover:underline disabled:opacity-40 min-h-11 px-2"
-                >
-                    {t('geo.play.skip', "I don't know — skip this one")}
-                </button>
+                /* Browsing — history nav, shuffle and the skip escape
+                   hatch. Skip is a real button (not a text link): a
+                   player who'd otherwise drop a random guess pollutes
+                   the contribution dataset more than a skip costs. The
+                   old always-visible disabled "Drop pin" CTA is gone —
+                   its job (pointing at the map) moved to PinHintChip. */
+                <div className="flex items-center justify-center gap-1.5">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={onPrevious}
+                        className="size-12 min-h-12 min-w-12 text-white/80 hover:text-white"
+                        disabled={!canGoPrevious || loading}
+                        aria-label={t('geo.play.previous', 'Previous screenshot')}
+                        title={t('geo.play.previous', 'Previous screenshot')}
+                    >
+                        <ChevronLeft className="size-5" aria-hidden />
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={onShuffleAllGames}
+                        className="min-h-12 text-white/80 hover:text-white"
+                        disabled={loading}
+                        aria-label={t('geo.play.shuffleAllGames', 'Random game')}
+                        title={t('geo.play.shuffleAllGames', 'Random game')}
+                    >
+                        <Shuffle className="size-4 sm:mr-1.5" aria-hidden />
+                        <span className="hidden sm:inline">
+                            {t('geo.play.shuffleAllGames', 'Random game')}
+                        </span>
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={onSkip}
+                        className="min-h-12 text-white/80 hover:text-white"
+                        disabled={loading}
+                        aria-label={t('geo.play.skip', "I don't know — skip this one")}
+                        title={t('geo.play.skip', "I don't know — skip this one")}
+                    >
+                        <SkipForward className="size-4 sm:mr-1.5" aria-hidden />
+                        <span className="hidden sm:inline">
+                            {t('geo.play.skipShort', 'Skip')}
+                        </span>
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={onNext}
+                        className="size-12 min-h-12 min-w-12 text-white/80 hover:text-white"
+                        disabled={!canGoNext || loading}
+                        aria-label={t('geo.play.nextScreenshot', 'Next screenshot')}
+                        title={t('geo.play.nextScreenshot', 'Next screenshot')}
+                    >
+                        <ChevronRight className="size-5" aria-hidden />
+                    </Button>
+                </div>
             )}
 
             {/* Non-tap pin-placement alternative for keyboard, switch
                 control and screen-reader users — Leaflet's keyboard
                 pan doesn't synthesize a click on Enter, so without
                 this they can't drop a pin at all. Native <details>
-                gives full keyboard support out of the box and stays
-                collapsed for sighted/touch users so it doesn't add
-                visual noise. WCAG 2.1.1 (Keyboard). */}
-            {!revealed && !canSubmit && (
+                gives full keyboard support out of the box. Visually
+                hidden until keyboard focus reaches it (skip-link
+                pattern) so touch users don't pay a dock row for an
+                affordance they never use. WCAG 2.1.1 (Keyboard). */}
+            {!revealed && !hasDraft && (
                 <CoordinateInput
                     onPlace={onPlaceByCoords}
-                    disabled={submitting || loading}
+                    disabled={loading}
                 />
             )}
+        </div>
+    )
+}
+
+/**
+ * Onboarding hint anchored to the map panel: tells first-time players
+ * the core gesture is tapping the map. Rendered only until the player's
+ * first-ever draft pin (persisted flag in the free-play store), and
+ * purely decorative for AT — the dock CTA and the pin live region
+ * already carry the state for screen readers.
+ */
+export function PinHintChip() {
+    const { t } = useTranslation()
+    return (
+        <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-3 bottom-3 z-20 flex justify-center"
+        >
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-black/60 px-3 py-1.5 text-center text-xs font-medium text-white shadow-lg backdrop-blur">
+                <MapPin className="size-3.5 shrink-0 text-neon-pink" aria-hidden />
+                {t('geo.play.hint.tapMap', 'Tap the map to place your pin')}
+            </span>
         </div>
     )
 }
@@ -635,7 +678,10 @@ function CoordinateInput({
     }
 
     return (
-        <details className="self-center text-xs text-white/80">
+        // Skip-link pattern: sr-only until the summary receives keyboard
+        // focus or the details is open, then it pops into the layout.
+        // Keeps the control in DOM/tab order right after the dock row.
+        <details className="self-center text-xs text-white/80 [&:not([open]):not(:focus-within)]:sr-only">
             <summary className="cursor-pointer underline-offset-4 hover:text-white hover:underline min-h-11 inline-flex items-center px-2">
                 {t('geo.play.coords.toggle', 'Place pin by coordinates')}
             </summary>

--- a/packages/frontend/src/components/geo/ImmersiveLayout.tsx
+++ b/packages/frontend/src/components/geo/ImmersiveLayout.tsx
@@ -6,12 +6,14 @@ import { cn } from '@/lib/utils'
 interface ImmersiveLayoutProps {
     screenshot: ReactNode
     map: ReactNode
-    // Top-right overlay (the fullscreen toggle, plus optional report button).
+    // Right-aligned header actions (home link, fullscreen toggle).
+    // Rendered inside the same header strip as `topBar` so the page has
+    // a single top row instead of an absolute overlay racing the bar
+    // for z-order.
     topRight?: ReactNode
-    // Top header strip rendered above the deck. Used for context
-    // metadata that isn't itself an action — game/map labels, alpha
-    // banner, etc. Sized by its own intrinsic height so passing null
-    // collapses cleanly.
+    // Left side of the header strip. Used for context metadata —
+    // game/map chips etc. Sized by its own intrinsic height so passing
+    // null collapses cleanly.
     topBar?: ReactNode
     // Sticky bottom dock (skip / submit / next).
     bottomDock?: ReactNode
@@ -31,9 +33,9 @@ interface ImmersiveLayoutProps {
 
 /**
  * Split-panel layout for the screenshot + map flow. Both panels are
- * always visible — stacked vertically on mobile, side-by-side on desktop —
- * and each carries a corner type-tag badge so the player can tell them
- * apart at a glance without a Photo/Map toggle.
+ * always visible — stacked vertically on mobile (map dominant),
+ * side-by-side on desktop, where each carries a corner type-tag badge
+ * so the player can tell them apart at a glance.
  */
 export function ImmersiveLayout({
     screenshot,
@@ -57,43 +59,38 @@ export function ImmersiveLayout({
             )}
             data-immersive={isImmersive ? 'true' : 'false'}
         >
-            {/* Top-right overlay (fullscreen toggle, etc.). Needs to sit above
-                the `topBar` strip — both used to share `z-30`, but the topBar's
-                `backdrop-filter` makes z-index apply to it as a non-positioned
-                element, so equal z-index would let the later sibling (topBar)
-                intercept clicks over this overlay. Bumped to z-40 so the Home
-                and fullscreen buttons stay clickable across the topBar's
-                right padding. */}
-            {topRight && (
+            {/* Single header strip — context chips on the left, home /
+                fullscreen actions on the right. One row, one z-index:
+                replaces the old absolute top-right overlay that needed a
+                z-40 bump to stay clickable over the bar's backdrop-filter. */}
+            {(topBar || topRight) && (
                 <div
-                    className="absolute right-3 top-3 z-40 flex items-center gap-2"
+                    className="z-30 border-b border-white/10 bg-black/70 backdrop-blur"
                     style={{
                         paddingTop: 'env(safe-area-inset-top, 0px)',
+                        paddingLeft: 'env(safe-area-inset-left, 0px)',
                         paddingRight: 'env(safe-area-inset-right, 0px)',
                     }}
                 >
-                    {topRight}
-                </div>
-            )}
-
-            {/* Top context bar — game/map labels and any informational
-                copy. Sits above the deck so the dock can stay focused on
-                actions. Collapses to nothing when no children are passed. */}
-            {topBar && (
-                <div
-                    className="z-30 border-b border-white/10 bg-black/70 backdrop-blur"
-                    style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
-                >
-                    <div className="px-3 py-2 pr-16">{topBar}</div>
+                    <div className="flex items-center gap-2 px-3 py-2">
+                        <div className="min-w-0 flex-1">{topBar}</div>
+                        {topRight && (
+                            <div className="flex shrink-0 items-center gap-2">
+                                {topRight}
+                            </div>
+                        )}
+                    </div>
                 </div>
             )}
 
             {/* Deck — both panels are always visible. On mobile the map gets
                 visual priority (the user's active surface) with the photo
                 kept reference-sized above; on tablet/desktop they go
-                side-by-side at equal width. */}
+                side-by-side at equal width. Row split favors the map hard:
+                the dock is now a single row, and the reclaimed space
+                belongs to the surface the player acts on. */}
             <div className="flex-1 relative overflow-hidden">
-                <div className="absolute inset-0 grid grid-rows-[minmax(38%,1fr)_minmax(45%,1.2fr)] md:grid-rows-1 md:grid-cols-2">
+                <div className="absolute inset-0 grid grid-rows-[minmax(30%,1fr)_minmax(52%,1.6fr)] md:grid-rows-1 md:grid-cols-2">
                     <Panel
                         id="geo-panel-photo"
                         tag={
@@ -125,14 +122,13 @@ export function ImmersiveLayout({
 
             {/* Result overlay — sits above the deck but below the dock so
                 the dock's Next button is always reachable. The bottom
-                offset clears the redesigned two-row dock (secondary
-                actions + primary CTA). */}
+                offset clears the single-row dock (padding + one 3rem row). */}
             {resultOverlay && (
                 <div
                     className="absolute left-0 right-0 z-30 px-3"
                     style={{
                         bottom:
-                            'calc(env(safe-area-inset-bottom, 0px) + 7.5rem)',
+                            'calc(env(safe-area-inset-bottom, 0px) + 5.5rem)',
                     }}
                 >
                     {resultOverlay}
@@ -179,7 +175,10 @@ function Panel({
             inert={inertProp || undefined}
         >
             {children}
-            <div className="pointer-events-none absolute left-3 top-3 z-20 inline-flex items-center gap-1.5 rounded-full bg-black/55 px-2.5 py-1 text-xs font-medium text-white shadow backdrop-blur">
+            {/* Type-tag badge — desktop only. On mobile the panels are
+                self-evident (a screenshot vs a map with zoom controls)
+                and every overlay pill costs scarce panel real estate. */}
+            <div className="pointer-events-none absolute left-3 top-3 z-20 hidden items-center gap-1.5 rounded-full bg-black/55 px-2.5 py-1 text-xs font-medium text-white shadow backdrop-blur md:inline-flex">
                 {tag}
             </div>
         </div>

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -121,6 +121,10 @@ interface GeoFreePlayState {
     // They're hidden from completion math so the all-time "done" message
     // can fire even if the catalog has games the player will never touch.
     ignoredGameIds: number[]
+    // True once the player has ever dropped a draft pin (any session).
+    // Gates the "tap the map" onboarding hint chip so it only ever shows
+    // to players who haven't discovered the core gesture yet.
+    hasEverPlacedPin: boolean
     // In-memory navigation history (current session only). Each entry is
     // a fully-restorable round so prev/next can step through screenshots
     // the player has already seen — including across game switches.
@@ -167,6 +171,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             round: 0,
             playedByGame: {},
             ignoredGameIds: [],
+            hasEverPlacedPin: false,
             history: [],
             historyIndex: -1,
 
@@ -388,7 +393,11 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                 // one to trigger a re-render of the map canvas.
                 if (prev && p && prev.x === p.x && prev.y === p.y) return
                 if (!prev && !p) return
-                set({ pendingGuess: p })
+                set(
+                    p
+                        ? { pendingGuess: p, hasEverPlacedPin: true }
+                        : { pendingGuess: p },
+                )
             },
 
             async submitGuess() {
@@ -486,6 +495,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                 currentMapId: state.currentMapId,
                 playedByGame: state.playedByGame,
                 ignoredGameIds: state.ignoredGameIds,
+                hasEverPlacedPin: state.hasEverPlacedPin,
             }),
             version: 3,
         },


### PR DESCRIPTION
## What

Implements **Phase 1** of [`tasks/geo-play-revamp-proposal.html`](https://wifsimster.github.io/the-box/geo-play-revamp-proposal.html) (merged in #344): reclaim the mobile viewport on the Geo free-play page (`/:lng/geo`).

## Changes

- **Single-row, phase-driven dock** (`GeoPlaySlots.tsx`): browse row (prev · shuffle · **skip, promoted to a real button** · next) while waiting for a pin; clear-pin ✕ + full-width "Confirm pin" once a draft exists; full-width "Next round" when revealed. The always-visible *disabled* "Drop pin" gradient CTA is removed — it advertised the wrong next action.
- **`PinHintChip`**: a floating "Tap the map to place your pin" chip on the map panel takes over the onboarding job. Shown only until the player's first-ever draft pin, tracked by a new persisted `hasEverPlacedPin` flag in `geoFreePlayStore` (decorative/`aria-hidden`; the live region still announces pin state).
- **Coordinate entry focus-reveal**: the keyboard/switch/SR fallback keeps its exact DOM and tab position (WCAG 2.1.1) but is `sr-only` until it receives keyboard focus or is open — touch users no longer pay a dock row for it.
- **Merged header** (`ImmersiveLayout.tsx`): context chips and home/fullscreen actions now share one header strip, removing the old absolute overlay and its z-40 workaround.
- **Map gets the reclaimed space**: mobile deck rows retuned from `minmax(38%,1fr)/minmax(45%,1.2fr)` to `minmax(30%,1fr)/minmax(52%,1.6fr)`; Photo/Map corner badges are now desktop-only.
- New i18n keys (fr + en): `geo.play.hint.tapMap`, `geo.play.clearPin`, `geo.play.skipShort`.

Store contract is otherwise untouched; no backend changes.

## Verification

Beyond `npm run build` / `lint` / `npm test` (all green; pre-commit hook re-ran the suite), the change was exercised end-to-end against a locally seeded stack (Postgres 16 + Redis + both dev servers) with Playwright on a 412×915 mobile viewport:

- Idle state shows the hint chip and the single browse row; no confirm CTA before a pin exists.
- Coordinate entry is `sr-only` (computed `absolute/1px×1px`) until focused, then reveals (`static/163px×44px`); placing by coordinates flips the dock to Confirm + ✕.
- Clearing the draft returns the browse row; the hint chip stays dismissed (persisted flag).
- Map tap → Confirm → score reveal → Next round all work; result overlay clears the single-row dock.
- Desktop (1280×800) shows the Photo/Map corner badges again.

One bug was caught and fixed during verification: the hint chip's `-translate-x-1/2` centering didn't apply, leaving it clipped at the viewport edge — replaced with a flex-centered wrapper.

**Note for reviewers:** visual-regression snapshots for the geo page will need `npm run test:e2e:visual:update` — the mobile layout intentionally changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2

---
_Generated by [Claude Code](https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2)_