### PR TITLE
fix(geo-agent): promote endpoints violated promoted_by FK (INTERNAL_ERROR)

### DIFF
--- a/packages/backend/src/domain/ports/repositories.ts
+++ b/packages/backend/src/domain/ports/repositories.ts
@@ -843,7 +843,7 @@ export interface GeoScreenshotRepository {
     confidence: number
     consensusVersion: number
     promotedVia: 'consensus' | 'admin' | 'agent_override'
-    promotedBy?: string
+    promotedBy?: string | null
   }): Promise<GeoScreenshotMeta>
   countPromotedForGame(gameId: number): Promise<number>
   pickRandomPromotedForGame(

--- a/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/geo-screenshot.repository.ts
@@ -188,7 +188,7 @@ export const geoScreenshotRepository = {
     confidence: number
     consensusVersion: number
     promotedVia: 'consensus' | 'admin' | 'agent_override'
-    promotedBy?: string
+    promotedBy?: string | null
   }): Promise<GeoScreenshotMeta> {
     log.info({ candidateId: data.candidateId, via: data.promotedVia }, 'promoteCandidateToMeta')
 

--- a/packages/backend/src/presentation/routes/agent-geo.routes.ts
+++ b/packages/backend/src/presentation/routes/agent-geo.routes.ts
@@ -1080,7 +1080,10 @@ router.post(
         confidence: consensus.confidence,
         consensusVersion: GEO_CONSENSUS_VERSION,
         promotedVia: 'consensus',
-        promotedBy: `apikey:${keyId}`,
+        // promoted_by is a FK to user.id; agent promotions have no user, so
+        // NULL it and rely on the admin_audit row (adminId = apikey:<id>) for
+        // provenance. Passing "apikey:<id>" here violated the FK (INTERNAL_ERROR).
+        promotedBy: null,
       })
 
       await adminAuditRepository.record({
@@ -1199,7 +1202,10 @@ router.post(
         confidence: 1.0,
         consensusVersion: GEO_CONSENSUS_VERSION,
         promotedVia: 'agent_override',
-        promotedBy: `apikey:${keyId}`,
+        // promoted_by is a FK to user.id; agent promotions have no user, so
+        // NULL it and rely on the admin_audit row (adminId = apikey:<id>) for
+        // provenance. Passing "apikey:<id>" here violated the FK (INTERNAL_ERROR).
+        promotedBy: null,
       })
 
       await adminAuditRepository.record({


### PR DESCRIPTION
## Bug
Every agent promotion (both `POST /candidates/:id/promote-override` from #346 and the consensus `promote`) returns **500 INTERNAL_ERROR**.

`geo_screenshot_meta.promoted_by` is a **FK to `user.id`** (migration `20260419_add_geolocation_mode.ts` L61), but both handlers passed `promotedBy: \`apikey:${keyId}\`` — not a user id → foreign-key violation.

This blocks the whole point of #345/#346: an agent cannot create a canonical pin, so GeoGamers can't be flipped on via the MCP (repro: `promote-override` on Bloodborne candidate 1312 → 500).

## Fix
Agent promotions have no user → store `NULL` in `promoted_by` and rely on the `admin_audit` row (`adminId = apikey:<id>`) for provenance. Widen `promotedBy` to `string | null` in the repo + port signatures.

## Verification
- Backend build/typecheck via CI.
- Post-deploy: `promote-override` on candidate 1312 returns 200 and creates a meta with `promoted_via = 'agent_override'`, `promoted_by = NULL`; `geo_health.eligibleGames` increments.

Refs #345, follow-up to #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)