### PR TITLE
feat(geo): tiered reveal sheet with map focus (revamp phase 2)

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2547,6 +2547,13 @@
       "hint": {
         "tapMap": "Tap the map to place your pin"
       },
+      "result": {
+        "announce": "Score {{score}} — {{percent}}% from the target",
+        "fromTarget": "{{percent}}% from the target",
+        "newBest": "New personal best!",
+        "best": "Personal best: {{score}}",
+        "correctMap": "The correct map was: {{map}}"
+      },
       "next": "Next round",
       "reroll": "New screenshot",
       "shuffleAllGames": "Random game",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2547,6 +2547,13 @@
       "hint": {
         "tapMap": "Touchez la carte pour placer l'épingle"
       },
+      "result": {
+        "announce": "Score {{score}} — à {{percent}} % de la cible",
+        "fromTarget": "à {{percent}} % de la cible",
+        "newBest": "Nouveau record perso !",
+        "best": "Record perso : {{score}}",
+        "correctMap": "La bonne carte était : {{map}}"
+      },
       "next": "Suivant",
       "reroll": "Nouvelle capture",
       "shuffleAllGames": "Jeu aléatoire",

--- a/packages/frontend/src/components/geo/GeoPlayDeck.tsx
+++ b/packages/frontend/src/components/geo/GeoPlayDeck.tsx
@@ -14,7 +14,7 @@ import {
     MapChunkLoader,
     MapPlaceholder,
     PinHintChip,
-    ResultOverlay,
+    ResultSheet,
     ContextHeader,
     Dock,
 } from '@/components/geo/GeoPlaySlots'
@@ -97,6 +97,7 @@ export function GeoPlayDeck({
         playedByGame,
         ignoredGameIds,
         hasEverPlacedPin,
+        previousBestScore,
         history: roundHistory,
         historyIndex,
         selectGame,
@@ -288,12 +289,14 @@ export function GeoPlayDeck({
                 map={mapSlot}
                 resultOverlay={
                     phase === 'revealed' && result ? (
-                        <ResultOverlay
+                        <ResultSheet
                             score={result.score}
                             distance={result.distance}
                             wrongMap={!!result.wrongMap}
                             pinCount={result.pinCount}
                             language={language}
+                            correctMapLabel={correctMap?.region ?? null}
+                            previousBest={previousBestScore}
                         />
                     ) : null
                 }

--- a/packages/frontend/src/components/geo/GeoPlaySlots.tsx
+++ b/packages/frontend/src/components/geo/GeoPlaySlots.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
     TransformComponent,
@@ -27,6 +27,7 @@ import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
+import { geoScoreTier } from '@/lib/geo-score-tiers'
 import { cn } from '@/lib/utils'
 
 export function ScreenshotPanel({
@@ -381,52 +382,159 @@ export function MapPlaceholder({
     )
 }
 
-export function ResultOverlay({
+// Count-up for the reveal score. Ease-out cubic over `durationMs`
+// (--duration-slow). Under prefers-reduced-motion the final value
+// renders immediately — no intermediate frames.
+function useCountUp(target: number, durationMs: number): number {
+    const prefersReduced =
+        typeof window !== 'undefined' &&
+        !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    const [value, setValue] = useState(() => (prefersReduced ? target : 0))
+    useEffect(() => {
+        let raf = 0
+        const start = performance.now()
+        const tick = (now: number) => {
+            // Reduced motion: jump straight to the final value (still via
+            // rAF so the state write never happens synchronously in the
+            // effect body).
+            const t = prefersReduced
+                ? 1
+                : Math.min(1, (now - start) / durationMs)
+            const eased = 1 - Math.pow(1 - t, 3)
+            setValue(Math.round(target * eased))
+            if (t < 1) raf = requestAnimationFrame(tick)
+        }
+        raf = requestAnimationFrame(tick)
+        return () => cancelAnimationFrame(raf)
+    }, [target, durationMs, prefersReduced])
+    return value
+}
+
+const TIER_TEXT_CLASS = {
+    high: 'text-score-high',
+    mid: 'text-score-mid',
+    low: 'text-score-low',
+} as const
+
+/**
+ * Round-end reveal sheet. The score counts up in its tier color
+ * (bands in lib/geo-score-tiers.ts), distance reads as "x% from the
+ * target", and a personal-best line gives the round context beyond a
+ * bare number. Screen readers get one static sentence via the sr-only
+ * span — the animated markup is aria-hidden so the count-up can't spam
+ * the live region.
+ */
+export function ResultSheet({
     score,
     distance,
     wrongMap,
     pinCount,
     language,
+    correctMapLabel,
+    previousBest,
 }: {
     score: number
     distance: number
     wrongMap: boolean
     pinCount: number
     language: string
+    correctMapLabel: string | null
+    previousBest: number | null
 }) {
     const { t } = useTranslation()
+    const tier = geoScoreTier(score)
+    const animated = useCountUp(score, 500)
+    const distancePct = (distance * 100).toLocaleString(language, {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+    })
+    // A floored wrong-map score is a fail state, not an achievement —
+    // never celebrate it as a personal best (the store still records it).
+    const isNewBest = !wrongMap && (previousBest == null || score > previousBest)
     return (
         <output
             aria-live="polite"
             aria-atomic="true"
             className={cn(
-                'block mx-auto max-w-md rounded-2xl border bg-black/70 px-4 py-3 backdrop-blur',
-                wrongMap ? 'border-destructive/50' : 'border-neon-pink/50',
+                'block mx-auto max-w-md rounded-2xl border bg-black/80 px-4 py-3.5 backdrop-blur',
+                'motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 motion-safe:duration-300',
+                wrongMap
+                    ? 'border-destructive/60'
+                    : tier === 'high'
+                      ? 'border-success/50'
+                      : 'border-white/15',
             )}
+            style={
+                !wrongMap && tier === 'high'
+                    ? { boxShadow: 'var(--glow-success)' }
+                    : undefined
+            }
         >
-            <div className="flex items-center justify-between gap-3 text-white">
-                <div className="flex items-center gap-2">
-                    <Trophy className="size-4 text-neon-pink" aria-hidden />
-                    <span className="font-semibold text-lg">
-                        {score.toLocaleString(language)}
-                    </span>
+            <span className="sr-only">
+                {t('geo.play.result.announce', {
+                    defaultValue: 'Score {{score}} — {{percent}}% from the target',
+                    score: score.toLocaleString(language),
+                    percent: distancePct,
+                })}
+            </span>
+            <div aria-hidden className="text-white">
+                <div className="flex items-end justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                        <Trophy
+                            className={cn('size-5', TIER_TEXT_CLASS[tier])}
+                        />
+                        <span
+                            className={cn(
+                                'text-3xl font-bold tabular-nums leading-none',
+                                TIER_TEXT_CLASS[tier],
+                            )}
+                        >
+                            {animated.toLocaleString(language)}
+                        </span>
+                        <span className="text-xs text-white/70">
+                            {t('geo.daily.score', 'Score')}
+                        </span>
+                    </div>
                     <span className="text-xs text-white/70">
-                        {t('geo.daily.score', 'Score')}
+                        {t('geo.play.result.fromTarget', {
+                            defaultValue: '{{percent}}% from the target',
+                            percent: distancePct,
+                        })}
                     </span>
                 </div>
-                <span className="text-xs text-white/70">
-                    {t('geo.daily.distance', 'Distance')}: {(distance * 100).toFixed(1)}%
-                </span>
+                <div className="mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs text-white/70">
+                    <span className="inline-flex items-center gap-1">
+                        <MapPin className="size-3 text-neon-pink" />
+                        {t('geo.daily.pinCount', { count: pinCount })}
+                    </span>
+                    {isNewBest ? (
+                        <span className="font-medium text-score-high">
+                            {t('geo.play.result.newBest', 'New personal best!')}
+                        </span>
+                    ) : previousBest != null ? (
+                        <span>
+                            {t('geo.play.result.best', {
+                                defaultValue: 'Personal best: {{score}}',
+                                score: previousBest.toLocaleString(language),
+                            })}
+                        </span>
+                    ) : null}
+                </div>
+                {wrongMap && (
+                    <p className="mt-2 text-xs text-destructive">
+                        {t('geo.daily.wrongMap.banner', 'Wrong map — score floored.')}
+                        {correctMapLabel && (
+                            <>
+                                {' '}
+                                {t('geo.play.result.correctMap', {
+                                    defaultValue: 'The correct map was: {{map}}',
+                                    map: correctMapLabel,
+                                })}
+                            </>
+                        )}
+                    </p>
+                )}
             </div>
-            <div className="mt-1 flex items-center gap-1 text-xs text-white/70">
-                <MapPin className="size-3 text-neon-pink" aria-hidden />
-                <span>{t('geo.daily.pinCount', { count: pinCount })}</span>
-            </div>
-            {wrongMap && (
-                <p className="mt-1 text-xs text-destructive">
-                    {t('geo.daily.wrongMap.banner', 'Wrong map — score floored.')}
-                </p>
-            )}
         </output>
     )
 }

--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -177,10 +177,17 @@ export function MapCanvasLeaflet({
                     <Marker position={canonicalLatLng} icon={EMERALD_DIVICON} />
                 )}
                 {showGuessLine && pinLatLng && canonicalLatLng && (
-                    <Polyline
-                        positions={[pinLatLng, canonicalLatLng]}
-                        pathOptions={{ color: 'var(--foreground)', weight: 2, dashArray: '6 4', opacity: 0.9 }}
-                    />
+                    <>
+                        <Polyline
+                            positions={[pinLatLng, canonicalLatLng]}
+                            pathOptions={{ color: 'var(--foreground)', weight: 2, dashArray: '6 4', opacity: 0.9 }}
+                        />
+                        <RevealFocus
+                            guess={pinLatLng}
+                            canonical={canonicalLatLng}
+                            worldBounds={bounds}
+                        />
+                    </>
                 )}
             </MapContainer>
         </div>
@@ -253,6 +260,49 @@ function TilePyramidLayer({
             layer.remove()
         }
     }, [map, scheme, urlTemplate, tileSize, minZoom, maxZoom, widthPx, heightPx])
+    return null
+}
+
+/**
+ * On reveal, glide the viewport to frame the guess→answer segment so the
+ * payoff (how far off was I?) is visible without hunting for the line.
+ * On unmount (next round / result dismissed) the full map view is
+ * restored so a fresh round never starts zoomed into last round's
+ * corner. Both moves respect prefers-reduced-motion by snapping
+ * instead of animating.
+ */
+function RevealFocus({
+    guess,
+    canonical,
+    worldBounds,
+}: {
+    guess: LatLngExpression
+    canonical: LatLngExpression
+    worldBounds: LatLngBoundsExpression
+}) {
+    const map = useMap()
+    // Depend on the scalar coordinates, not the array identities — the
+    // parent rebuilds those tuples every render and the effect must fire
+    // exactly once per (guess, canonical) pair.
+    const [gLat, gLng] = guess as [number, number]
+    const [cLat, cLng] = canonical as [number, number]
+    useEffect(() => {
+        const animate = !window.matchMedia?.('(prefers-reduced-motion: reduce)')
+            .matches
+        map.fitBounds(L.latLngBounds([gLat, gLng], [cLat, cLng]), {
+            padding: [48, 48],
+            // Near-perfect guesses collapse the bounds to a point;
+            // without a cap fitBounds would zoom in absurdly far.
+            maxZoom: map.getZoom() + 3,
+            animate,
+        })
+        return () => {
+            map.fitBounds(worldBounds, { animate: false })
+        }
+        // worldBounds is stable per map (memoized on widthPx/heightPx
+        // upstream); listing scalars keeps the zoom from re-firing on
+        // unrelated parent renders.
+    }, [map, gLat, gLng, cLat, cLng, worldBounds])
     return null
 }
 

--- a/packages/frontend/src/lib/geo-score-tiers.ts
+++ b/packages/frontend/src/lib/geo-score-tiers.ts
@@ -1,0 +1,18 @@
+// Qualitative bands for free-play geo scores (max 2000, exponential
+// decay — see docs/geo-mode.md). The thresholds map back onto the
+// scoring curve: ≥1500 ≈ within ~3.6% of the target, ≥500 ≈ within
+// ~17%. Provisional until validated against real pin distributions
+// (tasks/geo-play-revamp-proposal.html §11) — which is exactly why
+// they live in this single constant.
+export const GEO_SCORE_TIER_BANDS = {
+    high: 1500,
+    mid: 500,
+} as const
+
+export type GeoScoreTier = 'high' | 'mid' | 'low'
+
+export function geoScoreTier(score: number): GeoScoreTier {
+    if (score >= GEO_SCORE_TIER_BANDS.high) return 'high'
+    if (score >= GEO_SCORE_TIER_BANDS.mid) return 'mid'
+    return 'low'
+}

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -125,6 +125,14 @@ interface GeoFreePlayState {
     // Gates the "tap the map" onboarding hint chip so it only ever shows
     // to players who haven't discovered the core gesture yet.
     hasEverPlacedPin: boolean
+    // Highest confirmed score per game (persisted). Feeds the reveal
+    // sheet's personal-best line.
+    bestScoreByGame: Record<number, number>
+    // The personal best as it stood BEFORE the round currently revealed
+    // (null = first scored round on this game). Transient — captured at
+    // submit time so the reveal can show "new best" / the delta even
+    // though bestScoreByGame has already been updated.
+    previousBestScore: number | null
     // In-memory navigation history (current session only). Each entry is
     // a fully-restorable round so prev/next can step through screenshots
     // the player has already seen — including across game switches.
@@ -172,6 +180,8 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             playedByGame: {},
             ignoredGameIds: [],
             hasEverPlacedPin: false,
+            bestScoreByGame: {},
+            previousBestScore: null,
             history: [],
             historyIndex: -1,
 
@@ -420,19 +430,33 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                     // Record this metaId as played so the next reroll
                     // (and every future session — see persist config)
                     // excludes it from the random pool.
+                    let previousBestScore: number | null = null
                     if (currentGameId != null) {
                         const prev = get().playedByGame[currentGameId] ?? []
                         const next = prev.includes(view.meta.id)
                             ? prev
                             : [...prev, view.meta.id].slice(-MAX_PLAYED_PER_GAME)
+                        // Capture the pre-round personal best for the reveal
+                        // sheet, then fold this round's score into the
+                        // persisted best when it improves on it.
+                        previousBestScore =
+                            get().bestScoreByGame[currentGameId] ?? null
+                        const bestScoreByGame =
+                            previousBestScore == null || result.score > previousBestScore
+                                ? {
+                                      ...get().bestScoreByGame,
+                                      [currentGameId]: result.score,
+                                  }
+                                : get().bestScoreByGame
                         set({
                             playedByGame: {
                                 ...get().playedByGame,
                                 [currentGameId]: next,
                             },
+                            bestScoreByGame,
                         })
                     }
-                    set({ result, correctMap, phase: 'revealed' })
+                    set({ result, correctMap, previousBestScore, phase: 'revealed' })
                     return result
                 } catch (err) {
                     set({
@@ -496,6 +520,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                 playedByGame: state.playedByGame,
                 ignoredGameIds: state.ignoredGameIds,
                 hasEverPlacedPin: state.hasEverPlacedPin,
+                bestScoreByGame: state.bestScoreByGame,
             }),
             version: 3,
         },


### PR DESCRIPTION
## What

Implements **Phase 2** of [`tasks/geo-play-revamp-proposal.html`](https://wifsimster.github.io/the-box/geo-play-revamp-proposal.html) — "make the reveal the reward" — following phase 1 (#347).

## Changes

- **`ResultSheet`** replaces `ResultOverlay` (`GeoPlaySlots.tsx`): score counts up (ease-out cubic over `--duration-slow`) in its **tier color** — `score-high` ≥1500 / `score-mid` ≥500 / `score-low` below — with the bands in one exported constant (`src/lib/geo-score-tiers.ts`, flagged provisional per the proposal §11). Distance reads as "*x*% from the target" (locale-aware decimals) instead of "Distance: x%". High tier carries the page's single hero glow (`--glow-success`); wrong-map rounds get destructive styling and name the correct map.
- **Personal best**: `geoFreePlayStore` persists a new `bestScoreByGame` map and captures the pre-round best (`previousBestScore`) at submit time, so the sheet shows "New personal best!" or "Personal best: N". Wrong-map floored scores are never celebrated as a best (though still recorded).
- **`RevealFocus`** in `MapCanvasLeaflet.tsx`: on reveal, the viewport `fitBounds` the guess→answer segment (48px padding, zoom capped at +3 so near-perfect guesses don't zoom into pixel soup) and **restores the full map view** when the round ends, so the next round never starts zoomed into last round's corner.
- **A11y**: the live region announces one static sentence via an `sr-only` span; the animated markup is `aria-hidden` so the count-up cannot spam screen readers. Count-up, `fitBounds`, and the view restore all collapse to instant under `prefers-reduced-motion`.
- New i18n keys (fr + en): `geo.play.result.{announce, fromTarget, newBest, best, correctMap}`.

No backend changes.

## Verification

Driven end-to-end on a locally seeded stack (Postgres 16 + Redis + dev servers) with Playwright at 412×915:

- **High-tier round** (0.6% off): green count-up to 1,905, success glow, "New personal best!", sr-announce sentence correct, and the map visibly zoomed onto the guess→answer line.
- **Next round**: map restored to the full view.
- **Mid-tier round** (9.2% off, after clearing only `playedByGame` so the persisted best survived): amber 957, "Personal best: 1,905", no glow.
- **Reduced-motion context**: the visible number equals the final score immediately after reveal (no count-up frames).

Not exercised live: the **wrong-map path** — the seed has a single map, so it can't be triggered; that branch is code-only (destructive border + correct-map line).

**Reviewer note:** geo visual-regression snapshots need `npm run test:e2e:visual:update` (reveal appearance intentionally changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2

---
_Generated by [Claude Code](https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2)_