### PR TITLE
feat(geo): per-game progress + unified state screens (revamp phase 3)

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2554,6 +2554,7 @@
         "best": "Personal best: {{score}}",
         "correctMap": "The correct map was: {{map}}"
       },
+      "progressAria": "{{played}} of {{total}} screenshots played",
       "next": "Next round",
       "reroll": "New screenshot",
       "shuffleAllGames": "Random game",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2554,6 +2554,7 @@
         "best": "Record perso : {{score}}",
         "correctMap": "La bonne carte était : {{map}}"
       },
+      "progressAria": "{{played}} captures jouées sur {{total}}",
       "next": "Suivant",
       "reroll": "Nouvelle capture",
       "shuffleAllGames": "Jeu aléatoire",

--- a/packages/frontend/src/components/geo/GamePicker.tsx
+++ b/packages/frontend/src/components/geo/GamePicker.tsx
@@ -180,6 +180,7 @@ export function GamePicker({
                                             {...getItemProps(index)}
                                             game={g}
                                             selected={selectedGameId === g.id}
+                                            played={played}
                                             newCount={hasNew ? newCount : 0}
                                             completed={completed}
                                             ignored={ignored}
@@ -207,6 +208,9 @@ export function GamePicker({
 interface GameCardProps {
     game: GeoPlayableGame
     selected: boolean
+    // Screenshots the player has already guessed in this game — drives
+    // the completion bar under the count badges.
+    played: number
     newCount: number
     completed: boolean
     ignored: boolean
@@ -220,6 +224,7 @@ interface GameCardProps {
 function GameCard({
     game,
     selected,
+    played,
     newCount,
     completed,
     ignored,
@@ -312,6 +317,30 @@ function GameCard({
                             })}
                         </span>
                     </div>
+                    {/* Completion bar — only once the player has started
+                        the game, so untouched catalog entries stay clean.
+                        Full bar flips to the success color. */}
+                    {game.screenshotCount > 0 && played > 0 && (
+                        <div
+                            role="img"
+                            aria-label={t('geo.play.progressAria', {
+                                defaultValue: '{{played}} of {{total}} screenshots played',
+                                played: Math.min(played, game.screenshotCount),
+                                total: game.screenshotCount,
+                            })}
+                            className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-muted/40"
+                        >
+                            <div
+                                className={cn(
+                                    'h-full rounded-full',
+                                    completed ? 'bg-success' : 'bg-neon-cyan',
+                                )}
+                                style={{
+                                    width: `${Math.min(100, (played / game.screenshotCount) * 100)}%`,
+                                }}
+                            />
+                        </div>
+                    )}
                 </div>
             </button>
             {onToggleIgnore && (

--- a/packages/frontend/src/components/geo/GeoPlayDeck.tsx
+++ b/packages/frontend/src/components/geo/GeoPlayDeck.tsx
@@ -305,6 +305,13 @@ export function GeoPlayDeck({
                         gameLabel={currentGame?.name ?? null}
                         mapLabel={selectedMap?.region ?? null}
                         showMapButton={isMultiMap || currentGameId == null}
+                        playedCount={
+                            currentGameId != null
+                                ? playedByGame[currentGameId]?.length ?? 0
+                                : null
+                        }
+                        totalCount={currentGame?.screenshotCount ?? null}
+                        language={language}
                         onChangeGame={() => setGamePickerOpen(true)}
                         onChangeMap={() => setMapPickerOpen(true)}
                     />

--- a/packages/frontend/src/components/geo/GeoPlaySlots.tsx
+++ b/packages/frontend/src/components/geo/GeoPlaySlots.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-zoom-pan-pinch'
 import type { GeoPoint } from '@the-box/types'
 import {
+    AlertTriangle,
     ArrowRight,
     Check,
     ChevronLeft,
@@ -25,6 +26,7 @@ import {
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
+import { StatePanel } from '@/components/geo/StatePanel'
 import { useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
 import { geoScoreTier } from '@/lib/geo-score-tiers'
@@ -70,140 +72,123 @@ export function ScreenshotPanel({
 
     if (exhausted && allCompleted) {
         return (
-            <output
-                className="flex size-full flex-col items-center justify-center px-6 text-center gap-4"
-            >
-                <div className="rounded-full bg-neon-pink/10 p-4">
-                    <Sparkles className="size-8 text-neon-pink" aria-hidden />
-                </div>
-                <div className="space-y-1 max-w-sm">
-                    <h2 className="text-lg font-semibold">
-                        {t('geo.play.allDone.title', "You've completed The Box!")}
-                    </h2>
-                    <p className="text-sm text-muted-foreground">
-                        {t(
-                            'geo.play.allDone.body',
-                            "Bravo! You've guessed every screenshot in every game in your catalog. We'll ping you when new ones are added.",
-                        )}
-                    </p>
-                </div>
-                <Button onClick={onCheckForNew} variant="outline">
-                    <RefreshCw className="size-4 mr-2" aria-hidden />
-                    {t('geo.play.exhausted.checkForNew', 'Check for new screenshots')}
-                </Button>
-            </output>
+            <StatePanel
+                icon={<Sparkles className="size-8 text-neon-pink" aria-hidden />}
+                title={t('geo.play.allDone.title', "You've completed The Box!")}
+                body={t(
+                    'geo.play.allDone.body',
+                    "Bravo! You've guessed every screenshot in every game in your catalog. We'll ping you when new ones are added.",
+                )}
+                actions={
+                    <Button onClick={onCheckForNew} variant="outline">
+                        <RefreshCw className="size-4 mr-2" aria-hidden />
+                        {t('geo.play.exhausted.checkForNew', 'Check for new screenshots')}
+                    </Button>
+                }
+            />
         )
     }
 
     if (exhausted) {
         return (
-            <output
-                className="flex size-full flex-col items-center justify-center px-6 text-center gap-4"
-            >
-                <div className="rounded-full bg-neon-pink/10 p-4">
-                    <Trophy className="size-8 text-neon-pink" aria-hidden />
-                </div>
-                <div className="space-y-1 max-w-xs">
-                    <h2 className="text-lg font-semibold">
-                        {t('geo.play.exhausted.title', "You've seen every screenshot")}
-                    </h2>
-                    <p className="text-sm text-muted-foreground">
-                        {t(
-                            'geo.play.exhausted.body',
-                            "Nice run! You've guessed every available screenshot for this game. We'll let you know when new ones are added.",
-                        )}
-                    </p>
-                </div>
-                <div className="flex flex-wrap items-center justify-center gap-2">
-                    <Button onClick={onPickGame} className="gradient-gaming hover:opacity-90">
-                        <Gamepad2 className="size-4 mr-2" aria-hidden />
-                        {t('geo.play.exhausted.pickAnother', 'Pick another game')}
-                    </Button>
-                    <Button onClick={onCheckForNew} variant="outline">
-                        <RefreshCw className="size-4 mr-2" aria-hidden />
-                        {t('geo.play.exhausted.checkForNew', 'Check for new screenshots')}
-                    </Button>
-                </div>
-                {canIgnoreCurrent && (
-                    <button
-                        type="button"
-                        onClick={onIgnoreCurrent}
-                        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground underline-offset-4 hover:underline"
-                    >
-                        <EyeOff className="size-3.5" aria-hidden />
-                        {t(
-                            'geo.play.exhausted.markIgnored',
-                            "I don't want to see this game again",
-                        )}
-                    </button>
+            <StatePanel
+                icon={<Trophy className="size-8 text-neon-pink" aria-hidden />}
+                title={t('geo.play.exhausted.title', "You've seen every screenshot")}
+                body={t(
+                    'geo.play.exhausted.body',
+                    "Nice run! You've guessed every available screenshot for this game. We'll let you know when new ones are added.",
                 )}
-            </output>
+                bodyMaxWidthClass="max-w-xs"
+                actions={
+                    <>
+                        <Button onClick={onPickGame} className="gradient-gaming hover:opacity-90">
+                            <Gamepad2 className="size-4 mr-2" aria-hidden />
+                            {t('geo.play.exhausted.pickAnother', 'Pick another game')}
+                        </Button>
+                        <Button onClick={onCheckForNew} variant="outline">
+                            <RefreshCw className="size-4 mr-2" aria-hidden />
+                            {t('geo.play.exhausted.checkForNew', 'Check for new screenshots')}
+                        </Button>
+                    </>
+                }
+                footnote={
+                    canIgnoreCurrent ? (
+                        <button
+                            type="button"
+                            onClick={onIgnoreCurrent}
+                            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground underline-offset-4 hover:underline"
+                        >
+                            <EyeOff className="size-3.5" aria-hidden />
+                            {t(
+                                'geo.play.exhausted.markIgnored',
+                                "I don't want to see this game again",
+                            )}
+                        </button>
+                    ) : undefined
+                }
+            />
         )
     }
 
     if (authRequired) {
         return (
-            <output
-                className="flex size-full flex-col items-center justify-center px-6 text-center gap-4"
-            >
-                <div className="rounded-full bg-neon-pink/10 p-4">
-                    <MapPin className="size-8 text-neon-pink" aria-hidden />
-                </div>
-                <div className="space-y-1 max-w-sm">
-                    <h2 className="text-lg font-semibold">
-                        {t('geo.play.auth.title', 'Sign in to drop pins')}
-                    </h2>
-                    <p className="text-sm text-muted-foreground">
-                        {t(
-                            'geo.play.auth.body',
-                            'Help us map the world of video games — drop a pin where each scene takes place.',
-                        )}
-                    </p>
-                </div>
-                <div className="flex flex-wrap items-center justify-center gap-2">
-                    <Button asChild className="gradient-gaming hover:opacity-90 min-h-12">
-                        <Link to={loginHref}>
-                            {t('geo.play.auth.login', 'Sign in')}
-                        </Link>
-                    </Button>
-                    <Button asChild variant="outline" className="min-h-12">
-                        <Link to={registerHref}>
-                            {t('geo.play.auth.register', 'Create account')}
-                        </Link>
-                    </Button>
-                </div>
-            </output>
+            <StatePanel
+                icon={<MapPin className="size-8 text-neon-pink" aria-hidden />}
+                title={t('geo.play.auth.title', 'Sign in to drop pins')}
+                body={t(
+                    'geo.play.auth.body',
+                    'Help us map the world of video games — drop a pin where each scene takes place.',
+                )}
+                // When a round was already on screen (e.g. the session
+                // expired mid-play), keep its screenshot visible behind a
+                // blur — the game itself is the strongest signup nudge.
+                backdropUrl={safeUrl}
+                actions={
+                    <>
+                        <Button asChild className="gradient-gaming hover:opacity-90 min-h-12">
+                            <Link to={loginHref}>
+                                {t('geo.play.auth.login', 'Sign in')}
+                            </Link>
+                        </Button>
+                        <Button asChild variant="outline" className="min-h-12">
+                            <Link to={registerHref}>
+                                {t('geo.play.auth.register', 'Create account')}
+                            </Link>
+                        </Button>
+                    </>
+                }
+            />
         )
     }
 
     if (errorMessage) {
         return (
-            <div
-                className="flex size-full items-center justify-center px-6 text-center"
+            <StatePanel
                 role="alert"
-            >
-                <p className="text-sm text-destructive">{errorMessage}</p>
-            </div>
+                icon={<AlertTriangle className="size-8 text-destructive" aria-hidden />}
+                title={t('common.error', 'Error')}
+                body={errorMessage}
+            />
         )
     }
 
     if (empty) {
         return (
-            <div className="flex size-full flex-col items-center justify-center px-6 text-center gap-4">
-                <div className="rounded-full bg-neon-pink/10 p-4">
-                    <MapPin className="size-8 text-neon-pink" aria-hidden />
-                </div>
-                <div className="space-y-2 max-w-md">
-                    <h2 className="text-lg font-semibold">
-                        {t('geo.play.empty.title', 'Help us map the world of video games')}
-                    </h2>
-                    <p className="text-sm text-muted-foreground">
-                        {t(
-                            'geo.play.empty.body',
-                            'Look at a screenshot, then drop a pin where the scene takes place on the game world map. Every pin grows a shared atlas that powers future location-guessing modes.',
-                        )}
-                    </p>
-                </div>
+            <StatePanel
+                icon={<MapPin className="size-8 text-neon-pink" aria-hidden />}
+                title={t('geo.play.empty.title', 'Help us map the world of video games')}
+                body={t(
+                    'geo.play.empty.body',
+                    'Look at a screenshot, then drop a pin where the scene takes place on the game world map. Every pin grows a shared atlas that powers future location-guessing modes.',
+                )}
+                bodyMaxWidthClass="max-w-md space-y-2"
+                actions={
+                    <Button onClick={onPickGame} className="gradient-gaming hover:opacity-90 min-h-12">
+                        <Gamepad2 className="size-4 mr-2" aria-hidden />
+                        {t('geo.play.empty.cta', 'Pick a game')}
+                    </Button>
+                }
+            >
                 {/* Cold-start social proof: only render once we have a
                     real number from the server, and only when there's
                     actually been activity today (>0). A "0 pins today"
@@ -235,11 +220,7 @@ export function ScreenshotPanel({
                         <span>{t('geo.play.empty.steps.three', 'Confirm — your pin joins the dataset.')}</span>
                     </li>
                 </ol>
-                <Button onClick={onPickGame} className="gradient-gaming hover:opacity-90 min-h-12">
-                    <Gamepad2 className="size-4 mr-2" aria-hidden />
-                    {t('geo.play.empty.cta', 'Pick a game')}
-                </Button>
-            </div>
+            </StatePanel>
         )
     }
 
@@ -539,16 +520,81 @@ export function ResultSheet({
     )
 }
 
+/**
+ * Per-game completion ring for the context header. Turns the invisible
+ * march toward the "exhausted" state into a visible collection
+ * mechanic — the data (playedByGame × screenshotCount) already existed
+ * in the store. Counters use neon-cyan per the token contract.
+ */
+function ProgressRing({
+    played,
+    total,
+    language,
+}: {
+    played: number
+    total: number
+    language: string
+}) {
+    const { t } = useTranslation()
+    const fraction = Math.min(1, played / total)
+    const r = 7
+    const circumference = 2 * Math.PI * r
+    return (
+        <span
+            role="img"
+            aria-label={t('geo.play.progressAria', {
+                defaultValue: '{{played}} of {{total}} screenshots played',
+                played,
+                total,
+            })}
+            className="inline-flex shrink-0 items-center gap-1.5 text-neon-cyan"
+        >
+            <svg viewBox="0 0 20 20" className="size-4 -rotate-90" aria-hidden>
+                <circle
+                    cx="10"
+                    cy="10"
+                    r={r}
+                    fill="none"
+                    stroke="currentColor"
+                    strokeOpacity="0.25"
+                    strokeWidth="2.5"
+                />
+                {fraction > 0 && (
+                    <circle
+                        cx="10"
+                        cy="10"
+                        r={r}
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2.5"
+                        strokeLinecap="round"
+                        strokeDasharray={`${fraction * circumference} ${circumference}`}
+                    />
+                )}
+            </svg>
+            <span className="tabular-nums" aria-hidden>
+                {played.toLocaleString(language)}/{total.toLocaleString(language)}
+            </span>
+        </span>
+    )
+}
+
 export function ContextHeader({
     gameLabel,
     mapLabel,
     showMapButton,
+    playedCount,
+    totalCount,
+    language,
     onChangeGame,
     onChangeMap,
 }: {
     gameLabel: string | null
     mapLabel: string | null
     showMapButton: boolean
+    playedCount: number | null
+    totalCount: number | null
+    language: string
     onChangeGame: () => void
     onChangeMap: () => void
 }) {
@@ -576,6 +622,13 @@ export function ContextHeader({
                         {mapLabel ?? t('geo.play.changeMap', 'Choose map')}
                     </span>
                 </button>
+            )}
+            {playedCount != null && totalCount != null && totalCount > 0 && (
+                <ProgressRing
+                    played={playedCount}
+                    total={totalCount}
+                    language={language}
+                />
             )}
         </div>
     )

--- a/packages/frontend/src/components/geo/StatePanel.tsx
+++ b/packages/frontend/src/components/geo/StatePanel.tsx
@@ -1,0 +1,81 @@
+import { type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+interface StatePanelProps {
+    // 'status' renders an <output> (polite live region, matching the
+    // previous hand-rolled states); 'alert' renders a div[role=alert]
+    // for the error state.
+    role?: 'status' | 'alert'
+    icon: ReactNode
+    title: string
+    body: string
+    // Width cap for the title/body block — the empty state historically
+    // ran wider than the others.
+    bodyMaxWidthClass?: string
+    // Primary action buttons, laid out as a wrapping centered row.
+    actions?: ReactNode
+    // De-emphasized trailing affordance (e.g. "never show this game").
+    footnote?: ReactNode
+    // Extra content between body and actions (steps list, social proof).
+    children?: ReactNode
+    // Blurred backdrop image — used by the auth state to keep the round's
+    // screenshot visible behind the sign-in prompt (the game itself is
+    // the best signup nudge). Purely decorative.
+    backdropUrl?: string | null
+}
+
+/**
+ * Shared full-panel state screen for the geo deck (empty / exhausted /
+ * all-done / auth-required / error). One layout, expressed as data, so
+ * the five states can't drift apart visually.
+ */
+export function StatePanel({
+    role = 'status',
+    icon,
+    title,
+    body,
+    bodyMaxWidthClass = 'max-w-sm',
+    actions,
+    footnote,
+    children,
+    backdropUrl,
+}: StatePanelProps) {
+    const content = (
+        <>
+            {backdropUrl && (
+                <>
+                    <img
+                        src={backdropUrl}
+                        alt=""
+                        aria-hidden
+                        className="absolute inset-0 size-full scale-105 object-cover opacity-50 blur-md"
+                    />
+                    <div className="absolute inset-0 bg-black/60" aria-hidden />
+                </>
+            )}
+            <div className="relative flex flex-col items-center gap-4">
+                <div className="rounded-full bg-neon-pink/10 p-4">{icon}</div>
+                <div className={cn('space-y-1', bodyMaxWidthClass)}>
+                    <h2 className="text-lg font-semibold">{title}</h2>
+                    <p className="text-sm text-muted-foreground">{body}</p>
+                </div>
+                {children}
+                {actions && (
+                    <div className="flex flex-wrap items-center justify-center gap-2">
+                        {actions}
+                    </div>
+                )}
+                {footnote}
+            </div>
+        </>
+    )
+    const className =
+        'relative flex size-full flex-col items-center justify-center overflow-hidden px-6 text-center'
+    return role === 'alert' ? (
+        <div role="alert" className={className}>
+            {content}
+        </div>
+    ) : (
+        <output className={className}>{content}</output>
+    )
+}


### PR DESCRIPTION
## What

Implements **Phase 3** of [`tasks/geo-play-revamp-proposal.html`](https://wifsimster.github.io/the-box/geo-play-revamp-proposal.html) — progress + state unification — following phases 1 (#347) and 2 (#349).

## Changes

- **Per-game progress ring** in the context header (`ProgressRing` in `GeoPlaySlots.tsx`): a neon-cyan ring + "12/58" counter fed by `playedByGame[gameId].length / game.screenshotCount` — data the store already held. Exposed to AT via one `aria-label` ("x of y screenshots played"); the SVG and raw numbers are `aria-hidden`.
- **Completion bars in `GamePicker`**: each started game's card gets a thin progress bar under its count badges (cyan while in progress, `success` when complete, hidden for untouched games so the catalog stays clean).
- **`StatePanel`** (new `components/geo/StatePanel.tsx`): the five hand-rolled state screens in `ScreenshotPanel` — empty, exhausted, all-done, auth-required, error — are now one layout expressed as data (icon / title / body / actions / footnote / children slots, `role="status"` or `"alert"`). The error state gains the shared icon+title treatment (`common.error`).
- **Blurred-screenshot auth state**: when a session expires mid-round, the auth prompt now renders over the round's screenshot behind a blur + dark overlay — the game itself is the signup nudge. Purely presentational; when no screenshot is on screen (cold 401) the state renders as before.
- New i18n key (fr + en): `geo.play.progressAria`.

No backend changes; store untouched.

## Verification

Driven end-to-end on the locally seeded stack (Playwright, 412×915 mobile viewport):

- Empty state renders via the unified panel (title, 1-2-3 steps, CTA).
- Header ring reads "0 of 1 screenshots played" before the submit and "1 of 1" after (visible as cyan `1/1` next to the game chip).
- Exhausted state renders via the unified panel after next-round.
- Game picker shows the full success-colored bar plus the existing "All seen" badge with correct aria-label.
- Clearing session cookies mid-round then confirming a pin lands on the auth state **with the blurred screenshot backdrop** (probed: backdrop `img` present, "Sign in to drop pins" over it).

**Reviewer note:** geo visual-regression snapshots still need `npm run test:e2e:visual:update` (header + state screens changed intentionally; same batch as phases 1–2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2

---
_Generated by [Claude Code](https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2)_