### PR TITLE
feat(geo): 5-round scored runs with recap (revamp phase 4)

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2555,6 +2555,21 @@
         "correctMap": "The correct map was: {{map}}"
       },
       "progressAria": "{{played}} of {{total}} screenshots played",
+      "run": {
+        "start": "Start a run",
+        "chip": "Run {{current}}/{{total}}",
+        "abandon": "Abandon the run",
+        "total": "Run total: {{score}}",
+        "recapCta": "See the recap",
+        "recapTitle": "Run complete!",
+        "recapAria": "Total score {{score}} out of {{max}}",
+        "roundAria": "Round {{round}}: {{score}} points",
+        "share": "Share",
+        "shareText": "I scored {{score}}/{{max}} in a {{rounds}}-round Geo run on The Box! {{url}}",
+        "copied": "Copied!",
+        "again": "New run",
+        "close": "Back to free play"
+      },
       "next": "Next round",
       "reroll": "New screenshot",
       "shuffleAllGames": "Random game",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2555,6 +2555,21 @@
         "correctMap": "La bonne carte était : {{map}}"
       },
       "progressAria": "{{played}} captures jouées sur {{total}}",
+      "run": {
+        "start": "Lancer un run",
+        "chip": "Run {{current}}/{{total}}",
+        "abandon": "Abandonner le run",
+        "total": "Total du run : {{score}}",
+        "recapCta": "Voir le récap",
+        "recapTitle": "Run terminé !",
+        "recapAria": "Score total {{score}} sur {{max}}",
+        "roundAria": "Manche {{round}} : {{score}} points",
+        "share": "Partager",
+        "shareText": "J'ai marqué {{score}}/{{max}} sur un run Géo de {{rounds}} manches sur The Box ! {{url}}",
+        "copied": "Copié !",
+        "again": "Nouveau run",
+        "close": "Continuer en mode libre"
+      },
       "next": "Suivant",
       "reroll": "Nouvelle capture",
       "shuffleAllGames": "Jeu aléatoire",

--- a/packages/frontend/src/components/geo/GeoPlayDeck.tsx
+++ b/packages/frontend/src/components/geo/GeoPlayDeck.tsx
@@ -3,12 +3,13 @@ import { useTranslation } from 'react-i18next'
 import { Home } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import type { GeoPoint } from '@the-box/types'
-import { useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
+import { RUN_LENGTH, useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { ImmersiveLayout } from '@/components/geo/ImmersiveLayout'
 import { FullscreenToggle } from '@/components/geo/FullscreenToggle'
 import { GamePicker } from '@/components/geo/GamePicker'
 import { MapPicker } from '@/components/geo/MapPicker'
+import { RunRecap } from '@/components/geo/RunRecap'
 import {
     ScreenshotPanel,
     MapChunkLoader,
@@ -98,6 +99,7 @@ export function GeoPlayDeck({
         ignoredGameIds,
         hasEverPlacedPin,
         previousBestScore,
+        run,
         history: roundHistory,
         historyIndex,
         selectGame,
@@ -107,6 +109,8 @@ export function GeoPlayDeck({
         goPrevious,
         goNext,
         nextRound,
+        startRun,
+        endRun,
         checkForNewScreenshots,
         toggleIgnoreGame,
     } = store
@@ -231,6 +235,9 @@ export function GeoPlayDeck({
         ],
     )
 
+    const runActive = run != null
+    const runComplete = run != null && run.scores.length >= RUN_LENGTH
+
     const bottomDockSlot: ReactNode = useMemo(
         () => (
             <Dock
@@ -241,10 +248,18 @@ export function GeoPlayDeck({
                 canGoNext={historyIndex < roundHistory.length - 1 || currentGameId != null}
                 onSubmit={onSubmit}
                 onNextRound={() => void nextRound()}
-                onSkip={() => void rerollScreenshot()}
+                // During a run, skip re-rolls across the whole catalog —
+                // the run owns game selection, so a same-game re-roll
+                // would fight it.
+                onSkip={() =>
+                    void (runActive ? pickRandomAcrossGames() : rerollScreenshot())
+                }
                 onClearPin={() => onMapPin(null)}
+                onStartRun={() => void startRun()}
                 onPlaceByCoords={onMapPin}
                 canSubmit={canSubmit}
+                runActive={runActive}
+                runComplete={runComplete}
                 phase={phase}
             />
         ),
@@ -259,7 +274,10 @@ export function GeoPlayDeck({
             nextRound,
             rerollScreenshot,
             onMapPin,
+            startRun,
             canSubmit,
+            runActive,
+            runComplete,
             phase,
         ],
     )
@@ -297,6 +315,11 @@ export function GeoPlayDeck({
                             language={language}
                             correctMapLabel={correctMap?.region ?? null}
                             previousBest={previousBestScore}
+                            runTotal={
+                                run
+                                    ? run.scores.reduce((sum, s) => sum + s, 0)
+                                    : null
+                            }
                         />
                     ) : null
                 }
@@ -312,12 +335,33 @@ export function GeoPlayDeck({
                         }
                         totalCount={currentGame?.screenshotCount ?? null}
                         language={language}
+                        run={
+                            run
+                                ? {
+                                      current: Math.min(
+                                          run.roundIndex + 1,
+                                          RUN_LENGTH,
+                                      ),
+                                      total: RUN_LENGTH,
+                                  }
+                                : null
+                        }
                         onChangeGame={() => setGamePickerOpen(true)}
                         onChangeMap={() => setMapPickerOpen(true)}
+                        onEndRun={endRun}
                     />
                 }
                 bottomDock={bottomDockSlot}
             />
+
+            {run?.finished && (
+                <RunRecap
+                    scores={run.scores}
+                    language={language}
+                    onNewRun={() => void startRun()}
+                    onClose={endRun}
+                />
+            )}
 
             <GamePicker
                 open={gamePickerOpen}

--- a/packages/frontend/src/components/geo/GeoPlaySlots.tsx
+++ b/packages/frontend/src/components/geo/GeoPlaySlots.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from 'react'
+import { useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
     TransformComponent,
@@ -23,11 +23,13 @@ import {
     Sparkles,
     Trophy,
     X,
+    Zap,
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { StatePanel } from '@/components/geo/StatePanel'
 import { useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
+import { useCountUp } from '@/hooks/useCountUp'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
 import { geoScoreTier } from '@/lib/geo-score-tiers'
 import { cn } from '@/lib/utils'
@@ -363,34 +365,6 @@ export function MapPlaceholder({
     )
 }
 
-// Count-up for the reveal score. Ease-out cubic over `durationMs`
-// (--duration-slow). Under prefers-reduced-motion the final value
-// renders immediately — no intermediate frames.
-function useCountUp(target: number, durationMs: number): number {
-    const prefersReduced =
-        typeof window !== 'undefined' &&
-        !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
-    const [value, setValue] = useState(() => (prefersReduced ? target : 0))
-    useEffect(() => {
-        let raf = 0
-        const start = performance.now()
-        const tick = (now: number) => {
-            // Reduced motion: jump straight to the final value (still via
-            // rAF so the state write never happens synchronously in the
-            // effect body).
-            const t = prefersReduced
-                ? 1
-                : Math.min(1, (now - start) / durationMs)
-            const eased = 1 - Math.pow(1 - t, 3)
-            setValue(Math.round(target * eased))
-            if (t < 1) raf = requestAnimationFrame(tick)
-        }
-        raf = requestAnimationFrame(tick)
-        return () => cancelAnimationFrame(raf)
-    }, [target, durationMs, prefersReduced])
-    return value
-}
-
 const TIER_TEXT_CLASS = {
     high: 'text-score-high',
     mid: 'text-score-mid',
@@ -413,6 +387,7 @@ export function ResultSheet({
     language,
     correctMapLabel,
     previousBest,
+    runTotal,
 }: {
     score: number
     distance: number
@@ -421,6 +396,10 @@ export function ResultSheet({
     language: string
     correctMapLabel: string | null
     previousBest: number | null
+    // Cumulative run score including this round, or null in free browse.
+    // Takes the personal-best line's slot — during a run the session
+    // total is the context that matters.
+    runTotal: number | null
 }) {
     const { t } = useTranslation()
     const tier = geoScoreTier(score)
@@ -488,7 +467,14 @@ export function ResultSheet({
                         <MapPin className="size-3 text-neon-pink" />
                         {t('geo.daily.pinCount', { count: pinCount })}
                     </span>
-                    {isNewBest ? (
+                    {runTotal != null ? (
+                        <span className="font-medium text-neon-cyan">
+                            {t('geo.play.run.total', {
+                                defaultValue: 'Run total: {{score}}',
+                                score: runTotal.toLocaleString(language),
+                            })}
+                        </span>
+                    ) : isNewBest ? (
                         <span className="font-medium text-score-high">
                             {t('geo.play.result.newBest', 'New personal best!')}
                         </span>
@@ -586,8 +572,10 @@ export function ContextHeader({
     playedCount,
     totalCount,
     language,
+    run,
     onChangeGame,
     onChangeMap,
+    onEndRun,
 }: {
     gameLabel: string | null
     mapLabel: string | null
@@ -595,8 +583,12 @@ export function ContextHeader({
     playedCount: number | null
     totalCount: number | null
     language: string
+    // Active run progress (1-based round). Replaces the per-game ring —
+    // the game changes every round, so per-game progress is noise here.
+    run: { current: number; total: number } | null
     onChangeGame: () => void
     onChangeMap: () => void
+    onEndRun: () => void
 }) {
     const { t } = useTranslation()
     return (
@@ -623,12 +615,36 @@ export function ContextHeader({
                     </span>
                 </button>
             )}
-            {playedCount != null && totalCount != null && totalCount > 0 && (
-                <ProgressRing
-                    played={playedCount}
-                    total={totalCount}
-                    language={language}
-                />
+            {run ? (
+                <span className="inline-flex items-center gap-0.5 rounded-full border border-neon-cyan/40 bg-black/40 pl-3 pr-1 text-neon-cyan">
+                    <Zap className="size-3.5" aria-hidden />
+                    <span className="ml-1 tabular-nums">
+                        {t('geo.play.run.chip', {
+                            defaultValue: 'Run {{current}}/{{total}}',
+                            current: run.current,
+                            total: run.total,
+                        })}
+                    </span>
+                    <button
+                        type="button"
+                        onClick={onEndRun}
+                        aria-label={t('geo.play.run.abandon', 'Abandon the run')}
+                        title={t('geo.play.run.abandon', 'Abandon the run')}
+                        className="inline-flex size-9 items-center justify-center rounded-full text-neon-cyan/80 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+                    >
+                        <X className="size-3.5" aria-hidden />
+                    </button>
+                </span>
+            ) : (
+                playedCount != null &&
+                totalCount != null &&
+                totalCount > 0 && (
+                    <ProgressRing
+                        played={playedCount}
+                        total={totalCount}
+                        language={language}
+                    />
+                )
             )}
         </div>
     )
@@ -644,8 +660,11 @@ export function Dock({
     onNextRound,
     onSkip,
     onClearPin,
+    onStartRun,
     onPlaceByCoords,
     canSubmit,
+    runActive,
+    runComplete,
     phase,
 }: {
     onShuffleAllGames: () => void
@@ -657,8 +676,14 @@ export function Dock({
     onNextRound: () => void
     onSkip: () => void
     onClearPin: () => void
+    onStartRun: () => void
     onPlaceByCoords: (point: GeoPoint) => void
     canSubmit: boolean
+    // A scored run is in progress: history nav / shuffle / start-run
+    // leave the browse row (only skip remains — the run picks the games).
+    runActive: boolean
+    // Every run round is scored: the reveal CTA opens the recap.
+    runComplete: boolean
     phase: ReturnType<typeof useGeoFreePlayStore.getState>['phase']
 }) {
     const { t } = useTranslation()
@@ -673,13 +698,16 @@ export function Dock({
     return (
         <div className="flex flex-col gap-2">
             {revealed ? (
-                /* Revealed — one job: move on. */
+                /* Revealed — one job: move on (or open the run recap when
+                   the last run round just got scored). */
                 <Button
                     type="button"
                     onClick={onNextRound}
                     className="gradient-gaming hover:opacity-90 min-h-12 w-full"
                 >
-                    {t('geo.play.next', 'Next round')}
+                    {runComplete
+                        ? t('geo.play.run.recapCta', 'See the recap')
+                        : t('geo.play.next', 'Next round')}
                     <ArrowRight className="size-4 ml-2" aria-hidden />
                 </Button>
             ) : hasDraft ? (
@@ -714,39 +742,45 @@ export function Dock({
                     </Button>
                 </div>
             ) : (
-                /* Browsing — history nav, shuffle and the skip escape
-                   hatch. Skip is a real button (not a text link): a
-                   player who'd otherwise drop a random guess pollutes
+                /* Browsing — history nav, shuffle, run start and the skip
+                   escape hatch. Skip is a real button (not a text link):
+                   a player who'd otherwise drop a random guess pollutes
                    the contribution dataset more than a skip costs. The
                    old always-visible disabled "Drop pin" CTA is gone —
-                   its job (pointing at the map) moved to PinHintChip. */
+                   its job (pointing at the map) moved to PinHintChip.
+                   During a run only skip survives: the run owns game
+                   selection, and history nav would break its integrity. */
                 <div className="flex items-center justify-center gap-1.5">
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={onPrevious}
-                        className="size-12 min-h-12 min-w-12 text-white/80 hover:text-white"
-                        disabled={!canGoPrevious || loading}
-                        aria-label={t('geo.play.previous', 'Previous screenshot')}
-                        title={t('geo.play.previous', 'Previous screenshot')}
-                    >
-                        <ChevronLeft className="size-5" aria-hidden />
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        onClick={onShuffleAllGames}
-                        className="min-h-12 text-white/80 hover:text-white"
-                        disabled={loading}
-                        aria-label={t('geo.play.shuffleAllGames', 'Random game')}
-                        title={t('geo.play.shuffleAllGames', 'Random game')}
-                    >
-                        <Shuffle className="size-4 sm:mr-1.5" aria-hidden />
-                        <span className="hidden sm:inline">
-                            {t('geo.play.shuffleAllGames', 'Random game')}
-                        </span>
-                    </Button>
+                    {!runActive && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={onPrevious}
+                            className="size-12 min-h-12 min-w-12 text-white/80 hover:text-white"
+                            disabled={!canGoPrevious || loading}
+                            aria-label={t('geo.play.previous', 'Previous screenshot')}
+                            title={t('geo.play.previous', 'Previous screenshot')}
+                        >
+                            <ChevronLeft className="size-5" aria-hidden />
+                        </Button>
+                    )}
+                    {!runActive && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={onShuffleAllGames}
+                            className="min-h-12 text-white/80 hover:text-white"
+                            disabled={loading}
+                            aria-label={t('geo.play.shuffleAllGames', 'Random game')}
+                            title={t('geo.play.shuffleAllGames', 'Random game')}
+                        >
+                            <Shuffle className="size-4 sm:mr-1.5" aria-hidden />
+                            <span className="hidden sm:inline">
+                                {t('geo.play.shuffleAllGames', 'Random game')}
+                            </span>
+                        </Button>
+                    )}
                     <Button
                         type="button"
                         variant="ghost"
@@ -761,18 +795,36 @@ export function Dock({
                             {t('geo.play.skipShort', 'Skip')}
                         </span>
                     </Button>
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={onNext}
-                        className="size-12 min-h-12 min-w-12 text-white/80 hover:text-white"
-                        disabled={!canGoNext || loading}
-                        aria-label={t('geo.play.nextScreenshot', 'Next screenshot')}
-                        title={t('geo.play.nextScreenshot', 'Next screenshot')}
-                    >
-                        <ChevronRight className="size-5" aria-hidden />
-                    </Button>
+                    {!runActive && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={onStartRun}
+                            className="min-h-12 text-neon-cyan hover:text-white"
+                            disabled={loading}
+                            aria-label={t('geo.play.run.start', 'Start a run')}
+                            title={t('geo.play.run.start', 'Start a run')}
+                        >
+                            <Zap className="size-4 sm:mr-1.5" aria-hidden />
+                            <span className="hidden sm:inline">
+                                {t('geo.play.run.start', 'Start a run')}
+                            </span>
+                        </Button>
+                    )}
+                    {!runActive && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={onNext}
+                            className="size-12 min-h-12 min-w-12 text-white/80 hover:text-white"
+                            disabled={!canGoNext || loading}
+                            aria-label={t('geo.play.nextScreenshot', 'Next screenshot')}
+                            title={t('geo.play.nextScreenshot', 'Next screenshot')}
+                        >
+                            <ChevronRight className="size-5" aria-hidden />
+                        </Button>
+                    )}
                 </div>
             )}
 

--- a/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
+++ b/packages/frontend/src/components/geo/MapCanvasLeaflet.tsx
@@ -297,7 +297,17 @@ function RevealFocus({
             animate,
         })
         return () => {
-            map.fitBounds(worldBounds, { animate: false })
+            // Only restore the view when the map outlives the reveal
+            // (same game, next round). When the reveal ends because the
+            // whole MapContainer is unmounting (game/map switch), Leaflet
+            // is mid-teardown and fitBounds throws on removed panes.
+            const container = map.getContainer?.()
+            if (!container || !container.isConnected) return
+            try {
+                map.fitBounds(worldBounds, { animate: false })
+            } catch {
+                /* map mid-teardown — nothing left to restore */
+            }
         }
         // worldBounds is stable per map (memoized on widthPx/heightPx
         // upstream); listing scalars keeps the zoom from re-firing on

--- a/packages/frontend/src/components/geo/RunRecap.tsx
+++ b/packages/frontend/src/components/geo/RunRecap.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Check, Share2, X, Zap } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useCountUp } from '@/hooks/useCountUp'
+import { geoScoreTier } from '@/lib/geo-score-tiers'
+import { RUN_LENGTH } from '@/stores/geoFreePlayStore'
+import { cn } from '@/lib/utils'
+
+const TIER_TEXT_CLASS = {
+    high: 'text-score-high',
+    mid: 'text-score-mid',
+    low: 'text-score-low',
+} as const
+
+const TIER_BG_CLASS = {
+    high: 'bg-score-high',
+    mid: 'bg-score-mid',
+    low: 'bg-score-low',
+} as const
+
+// Per-round max from the scoring curve (docs/geo-mode.md).
+const ROUND_MAX = 2000
+
+/**
+ * End-of-run recap: total count-up colored by the run's average tier,
+ * one tier dot per round, and share / replay / back-to-browse actions.
+ * Sharing is client-only (Web Share API with a clipboard fallback) —
+ * an OG-image unfurl variant is a follow-up, not part of this slice.
+ */
+export function RunRecap({
+    scores,
+    language,
+    onNewRun,
+    onClose,
+}: {
+    scores: number[]
+    language: string
+    onNewRun: () => void
+    onClose: () => void
+}) {
+    const { t } = useTranslation()
+    const total = scores.reduce((sum, s) => sum + s, 0)
+    const max = RUN_LENGTH * ROUND_MAX
+    const tier = geoScoreTier(total / Math.max(1, scores.length))
+    const animatedTotal = useCountUp(total, 700)
+    const [copied, setCopied] = useState(false)
+
+    // Basic dialog behavior: focus lands on the primary action, Escape
+    // closes back to free browse.
+    const primaryRef = useRef<HTMLButtonElement>(null)
+    useEffect(() => {
+        primaryRef.current?.focus()
+    }, [])
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose()
+        }
+        window.addEventListener('keydown', onKey)
+        return () => window.removeEventListener('keydown', onKey)
+    }, [onClose])
+
+    const share = async () => {
+        const text = t('geo.play.run.shareText', {
+            defaultValue:
+                'I scored {{score}}/{{max}} in a {{rounds}}-round Geo run on The Box! {{url}}',
+            score: total.toLocaleString(language),
+            max: max.toLocaleString(language),
+            rounds: scores.length,
+            url: window.location.origin,
+        })
+        try {
+            if (navigator.share) {
+                await navigator.share({ text })
+                return
+            }
+            await navigator.clipboard.writeText(text)
+            setCopied(true)
+        } catch {
+            /* user cancelled the share sheet — nothing to do */
+        }
+    }
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="geo-run-recap-title"
+        >
+            <div
+                className="w-full max-w-sm rounded-2xl border border-neon-cyan/40 bg-card p-6 text-center motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-300"
+            >
+                <div className="mx-auto mb-3 w-fit rounded-full bg-neon-cyan/10 p-3">
+                    <Zap className="size-6 text-neon-cyan" aria-hidden />
+                </div>
+                <h2 id="geo-run-recap-title" className="text-lg font-semibold">
+                    {t('geo.play.run.recapTitle', 'Run complete!')}
+                </h2>
+
+                {/* Static sentence for AT; the count-up below is aria-hidden. */}
+                <p className="sr-only">
+                    {t('geo.play.run.recapAria', {
+                        defaultValue: 'Total score {{score}} out of {{max}}',
+                        score: total.toLocaleString(language),
+                        max: max.toLocaleString(language),
+                    })}
+                </p>
+                <p aria-hidden className="mt-2">
+                    <span
+                        className={cn(
+                            'text-4xl font-bold tabular-nums',
+                            TIER_TEXT_CLASS[tier],
+                        )}
+                    >
+                        {animatedTotal.toLocaleString(language)}
+                    </span>
+                    <span className="ml-1.5 text-sm text-muted-foreground">
+                        / {max.toLocaleString(language)}
+                    </span>
+                </p>
+
+                {/* One dot per round, colored by that round's tier. */}
+                <ul className="mt-4 flex items-center justify-center gap-3">
+                    {scores.map((score, i) => (
+                        <li
+                            key={i}
+                            className="flex flex-col items-center gap-1"
+                            aria-label={t('geo.play.run.roundAria', {
+                                defaultValue: 'Round {{round}}: {{score}} points',
+                                round: i + 1,
+                                score: score.toLocaleString(language),
+                            })}
+                        >
+                            <span
+                                className={cn(
+                                    'size-3 rounded-full',
+                                    TIER_BG_CLASS[geoScoreTier(score)],
+                                )}
+                                aria-hidden
+                            />
+                            <span
+                                className="text-[10px] tabular-nums text-muted-foreground"
+                                aria-hidden
+                            >
+                                {score.toLocaleString(language)}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+
+                <div className="mt-6 flex flex-col gap-2">
+                    <Button
+                        ref={primaryRef}
+                        type="button"
+                        onClick={onNewRun}
+                        className="gradient-gaming hover:opacity-90 min-h-12 w-full"
+                    >
+                        <Zap className="size-4 mr-2" aria-hidden />
+                        {t('geo.play.run.again', 'New run')}
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={share}
+                        className="min-h-12 w-full"
+                        aria-live="polite"
+                    >
+                        {copied ? (
+                            <>
+                                <Check className="size-4 mr-2" aria-hidden />
+                                {t('geo.play.run.copied', 'Copied!')}
+                            </>
+                        ) : (
+                            <>
+                                <Share2 className="size-4 mr-2" aria-hidden />
+                                {t('geo.play.run.share', 'Share')}
+                            </>
+                        )}
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={onClose}
+                        className="min-h-11 w-full text-white/80 hover:text-white"
+                    >
+                        <X className="size-4 mr-2" aria-hidden />
+                        {t('geo.play.run.close', 'Back to free play')}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/packages/frontend/src/hooks/useCountUp.ts
+++ b/packages/frontend/src/hooks/useCountUp.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Animated count-up toward `target` (ease-out cubic over `durationMs`).
+ * Under prefers-reduced-motion the final value renders immediately —
+ * no intermediate frames. Used by the geo reveal sheet and run recap.
+ */
+export function useCountUp(target: number, durationMs: number): number {
+    const prefersReduced =
+        typeof window !== 'undefined' &&
+        !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    const [value, setValue] = useState(() => (prefersReduced ? target : 0))
+    useEffect(() => {
+        let raf = 0
+        const start = performance.now()
+        const tick = (now: number) => {
+            // Reduced motion: jump straight to the final value (still via
+            // rAF so the state write never happens synchronously in the
+            // effect body).
+            const t = prefersReduced
+                ? 1
+                : Math.min(1, (now - start) / durationMs)
+            const eased = 1 - Math.pow(1 - t, 3)
+            setValue(Math.round(target * eased))
+            if (t < 1) raf = requestAnimationFrame(tick)
+        }
+        raf = requestAnimationFrame(tick)
+        return () => cancelAnimationFrame(raf)
+    }, [target, durationMs, prefersReduced])
+    return value
+}

--- a/packages/frontend/src/stores/geoFreePlayStore.ts
+++ b/packages/frontend/src/stores/geoFreePlayStore.ts
@@ -74,6 +74,23 @@ function isAuthError(err: unknown): boolean {
     return err.code === 'UNAUTHORIZED' || err.code === 'AUTH_ERROR'
 }
 
+// A "run" is a short scored session: RUN_LENGTH rounds picked randomly
+// across the catalog, cumulative score out of RUN_LENGTH × 2000. Purely
+// a client-side aggregation over normal free-play submits — no API
+// surface, no leaderboard writes, and intentionally not persisted (a
+// reload abandons the run; the round views can't be resurrected anyway).
+export const RUN_LENGTH = 5
+
+interface RunState {
+    // 0-based index of the round being played (== scores.length while a
+    // round is in progress).
+    roundIndex: number
+    // Confirmed score per completed round, in order.
+    scores: number[]
+    // True once all rounds are scored and the recap is showing.
+    finished: boolean
+}
+
 const GAMES_TTL_MS = 5 * 60 * 1000
 // WHERE NOT IN payload cap on the backend. Older plays simply roll off
 // the front of the array once we hit it — re-seeing the very oldest
@@ -133,6 +150,9 @@ interface GeoFreePlayState {
     // submit time so the reveal can show "new best" / the delta even
     // though bestScoreByGame has already been updated.
     previousBestScore: number | null
+    // Active scored run, or null in free browse. Transient (see
+    // RUN_LENGTH above for the lifecycle rationale).
+    run: RunState | null
     // In-memory navigation history (current session only). Each entry is
     // a fully-restorable round so prev/next can step through screenshots
     // the player has already seen — including across game switches.
@@ -158,6 +178,15 @@ interface GeoFreePlayState {
     // newly-promoted screenshots without a full page reload.
     checkForNewScreenshots(): Promise<void>
     toggleIgnoreGame(gameId: number): void
+    // Start a RUN_LENGTH-round scored session (first round rolls
+    // immediately, random across the catalog).
+    startRun(): Promise<void>
+    // Advance a run after a reveal: next random round, or mark the run
+    // finished (opens the recap) once every round is scored.
+    advanceRun(): Promise<void>
+    // Leave the run (abandon mid-way or close the recap) and return to
+    // free browse. Never touches played/best history.
+    endRun(): void
     reset(): void
 }
 
@@ -182,6 +211,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             hasEverPlacedPin: false,
             bestScoreByGame: {},
             previousBestScore: null,
+            run: null,
             history: [],
             historyIndex: -1,
 
@@ -456,7 +486,22 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                             bestScoreByGame,
                         })
                     }
-                    set({ result, correctMap, previousBestScore, phase: 'revealed' })
+                    // Fold the confirmed score into the active run. Guarded
+                    // on !finished so a stray submit after the recap opened
+                    // (shouldn't happen — the map is disabled) can't grow
+                    // the scores array past RUN_LENGTH.
+                    const { run } = get()
+                    const nextRun =
+                        run && !run.finished
+                            ? { ...run, scores: [...run.scores, result.score] }
+                            : run
+                    set({
+                        result,
+                        correctMap,
+                        previousBestScore,
+                        run: nextRun,
+                        phase: 'revealed',
+                    })
                     return result
                 } catch (err) {
                     set({
@@ -469,7 +514,35 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
             },
 
             async nextRound() {
+                // Inside a run, "next" advances the run instead of
+                // re-rolling within the current game.
+                if (get().run) {
+                    await get().advanceRun()
+                    return
+                }
                 await get().rerollScreenshot()
+            },
+
+            async startRun() {
+                set({ run: { roundIndex: 0, scores: [], finished: false } })
+                await get().pickRandomAcrossGames()
+            },
+
+            async advanceRun() {
+                const { run } = get()
+                if (!run) return
+                if (run.scores.length >= RUN_LENGTH) {
+                    // All rounds scored — open the recap. The round state
+                    // is left as-is (map disabled by phase 'revealed').
+                    set({ run: { ...run, finished: true } })
+                    return
+                }
+                set({ run: { ...run, roundIndex: run.scores.length } })
+                await get().pickRandomAcrossGames()
+            },
+
+            endRun() {
+                set({ run: null })
             },
 
             async checkForNewScreenshots() {
@@ -501,6 +574,7 @@ export const useGeoFreePlayStore = create<GeoFreePlayState>()(
                     phase: 'idle',
                     errorMessage: null,
                     errorCode: null,
+                    run: null,
                     history: [],
                     historyIndex: -1,
                 })


### PR DESCRIPTION
## What

Implements **Phase 4** of [`tasks/geo-play-revamp-proposal.html`](https://wifsimster.github.io/the-box/geo-play-revamp-proposal.html) — optional scored **runs** — following phases 1 (#347), 2 (#349) and 3 (#350). Purely a client-side aggregation over normal free-play submits: no API surface, no leaderboard writes.

## Changes

- **"Start a run"** button in the dock browse row begins a 5-round session (`RUN_LENGTH` in the store); each round is picked randomly across the catalog by the existing `pickRandomAcrossGames` (cold-start real-world bias reused untouched, per the proposal's open question).
- **Header run chip**: neon-cyan "Run n/5" with an abandon ✕, replacing the per-game progress ring while active (per-game progress is noise when the game changes each round). During a run the browse row keeps only **skip** — history nav and shuffle would break run integrity — and skip re-rolls across the whole catalog so it can't fight the run's game selection.
- **Reveal sheet** shows the cumulative "Run total" in place of the personal-best line. After the 5th score the CTA flips to **"See the recap"**.
- **`RunRecap`** (new component): total count-up out of 10 000 colored by the run's average tier, one tier dot per round with its score, **Share** (Web Share API, clipboard fallback with "Copied!" state), **New run**, and **Back to free play**. Escape closes; AT gets a static sr-only summary while the animated number is `aria-hidden`.
- `useCountUp` extracted to `hooks/useCountUp.ts` (shared by sheet + recap).
- Store: transient `run` slice (`roundIndex`, `scores`, `finished`) + `startRun`/`advanceRun`/`endRun`; `submitGuess` folds each confirmed score in. Deliberately **not persisted** — a reload abandons the run, since round views can't be resurrected.

### Bug fix (latent, exposed by runs)

`RevealFocus` (phase 2) restored the map view in its unmount cleanup — but when the reveal ends because the **whole `MapContainer` is unmounting** (game switch), Leaflet is mid-teardown and `fitBounds` throws `Cannot set properties of undefined (setting '_leaflet_pos')`, tripping the app error boundary. **Reachable on `main` today** by switching game via the header chip right after any reveal. The cleanup now skips when the map container is disconnected (plus a belt-and-braces try/catch).

## Scope notes

- The share OG-image unfurl variant (`og.routes.ts`) is a follow-up; sharing here is client-only text.
- If the catalog runs out of unplayed screenshots mid-run, the round simply doesn't advance (exhausted state + abandon ✕ remain available) — acceptable for the tiny-catalog edge.

## Verification

Driven end-to-end on the locally seeded stack (6 promoted screenshots, Playwright 412×915):

- Run start from the browse row → "Run 1/5" chip, shuffle/prev/next hidden, skip retained.
- 5 full rounds with the sheet showing accumulating run totals (840 → 1,232 → 2,593 → 3,078 → 3,258).
- Round 5 CTA reads "See the recap" → recap dialog with title, **3,258 / 10,000** total, 5 tier dots with per-round scores.
- Share → clipboard fallback → "Copied!" state.
- "New run" from the recap starts a fresh "Run 1/5"; mid-run abandon ✕ restores the free-browse row and ring.
- The `RevealFocus` crash reproduced before the fix (error boundary screen) and is gone after.

**Reviewer note:** geo visual-regression snapshots still need `npm run test:e2e:visual:update` (same batch as phases 1–3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2

---
_Generated by [Claude Code](https://claude.ai/code/session_019x8BuJCbmJeFS14tLjthc2)_