### PR TITLE
fix(geo-agent-mcp): require Node 24 LTS and derive version from package.json

### DIFF
--- a/packages/geo-agent-mcp/package.json
+++ b/packages/geo-agent-mcp/package.json
@@ -14,7 +14,7 @@
     "test": "node --import tsx --test 'src/**/*.test.ts'"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24.0.0"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/packages/geo-agent-mcp/src/index.ts
+++ b/packages/geo-agent-mcp/src/index.ts
@@ -10,10 +10,25 @@
 // Wire into Claude Code (see README.md) with an `mcpServers` entry pointing at
 // this file and the two env vars.
 
-import { handleRpc, type ApiRequest, type JsonRpcMessage } from './server.js'
+import { readFileSync } from 'node:fs'
+import { handleRpc, SERVER_INFO, type ApiRequest, type JsonRpcMessage } from './server.js'
 
 const API_URL = (process.env['THE_BOX_API_URL'] ?? 'http://localhost:3000').replace(/\/+$/, '')
 const AGENT_KEY = process.env['THE_BOX_AGENT_KEY'] ?? ''
+
+// Advertise the package.json version so it tracks the release workflow's
+// version bumps instead of a hand-synced constant that silently drifts.
+const SERVER_VERSION = ((): string => {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as { version?: string }
+    return pkg.version ?? SERVER_INFO.version
+  } catch {
+    return SERVER_INFO.version
+  }
+})()
+const serverInfo = { name: SERVER_INFO.name, version: SERVER_VERSION }
 
 function log(msg: string): void {
   process.stderr.write(`[geo-agent-mcp] ${msg}\n`)
@@ -67,7 +82,7 @@ async function main(): Promise<void> {
         log(`skipping unparseable line: ${line.slice(0, 120)}`)
         continue
       }
-      void handleRpc(msg, { callApi })
+      void handleRpc(msg, { callApi, serverInfo })
         .then((response) => {
           if (response) write(response)
         })

--- a/packages/geo-agent-mcp/src/server.ts
+++ b/packages/geo-agent-mcp/src/server.ts
@@ -3,7 +3,10 @@
 // is fully unit-testable. `index.ts` wires this to a newline-delimited stdio
 // transport and a real HTTP client.
 
-export const SERVER_INFO = { name: 'the-box-geo-agent', version: '2.139.0' } as const
+// Server identity. `version` here is only a fallback: the stdio entrypoint
+// (index.ts) injects the real version read from package.json at startup, so the
+// advertised version tracks the release-bumped package.json instead of drifting.
+export const SERVER_INFO = { name: 'the-box-geo-agent', version: '0.0.0-dev' } as const
 export const DEFAULT_PROTOCOL_VERSION = '2024-11-05'
 
 export interface ToolDef {
@@ -435,6 +438,9 @@ export interface RpcDeps {
   // JSON. Defaults to GET; the ingest tool issues a POST with a JSON body.
   callApi: (req: ApiRequest) => Promise<unknown>
   protocolVersion?: string
+  // Overrides SERVER_INFO for the initialize reply (index.ts passes the
+  // package.json version). Falls back to SERVER_INFO when omitted (tests).
+  serverInfo?: { name: string; version: string }
 }
 
 function result(id: JsonRpcMessage['id'], value: unknown) {
@@ -466,7 +472,7 @@ export async function handleRpc(
           deps.protocolVersion ??
           DEFAULT_PROTOCOL_VERSION,
         capabilities: { tools: {} },
-        serverInfo: SERVER_INFO,
+        serverInfo: deps.serverInfo ?? SERVER_INFO,
       })
     case 'ping':
       return result(msg.id, {})


### PR DESCRIPTION
## Why

Two small correctness issues in `packages/geo-agent-mcp`, surfaced while getting the geo-agent MCP tools running:

1. **Node version mismatch.** The package declared `engines.node ">=20"`, but the repo **root** requires `">=24.0.0"` and CI runs on **Node 24**. On top of that, the test script's `node --test 'src/**/*.test.ts'` glob only resolves on **Node 21+** — so the declared floor (20) couldn't even run the tests. Aligning the package to **Node 24 LTS** removes the inconsistency and keeps `npm test` working.

2. **Advertised version drifted.** `SERVER_INFO.version` was hand-frozen at `2.139.0`, while the release workflow keeps auto-bumping `package.json` (`chore: bump version …`, now `2.152.1`). So the MCP server reported a stale version on `initialize`, and any manual re-sync would drift again on the next release.

## What

- `engines.node`: `>=20` → `>=24.0.0` (matches root + CI).
- `index.ts` now reads the version from `package.json` at startup and injects it into the `initialize` reply. `SERVER_INFO.version` becomes a `0.0.0-dev` fallback used only when not injected (tests). The advertised version now **tracks releases automatically** — no more hand-syncing.

## Testing

Verified on **Node 24.18.0** (the CI version):

- `npm run build` — clean (`tsc`).
- `npm test` — **30/30 pass** (the `src/**/*.test.ts` glob resolves natively).
- Live stdio `initialize` — `serverInfo` reports `2.152.1`, exactly matching `package.json`.

No behavior change to any tool; `dist/` is gitignored and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
