### PR TITLE
feat(home): explain Geo and GeoGamers modes on the homepage

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -571,6 +571,17 @@
       "subheading": "Three trophies you don't have yet. Yet.",
       "cta": "See all achievements"
     },
+    "modes": {
+      "heading": "Explore the other game modes",
+      "subheading": "Beyond the daily challenge, two more ways to test your gaming knowledge.",
+      "cta": "Discover",
+      "geo": {
+        "description": "Pinpoint where a screenshot was taken on the game's map — the closer you land, the more you score."
+      },
+      "geogamers": {
+        "description": "A daily two-phase run: guess the hidden game, then locate the scene on its map."
+      }
+    },
     "completionMessages": {
       "perfect": [
         "Absolute perfection! You're a living legend! 🏆",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -571,6 +571,17 @@
       "subheading": "Trois trophées que tu n'as pas encore. Encore.",
       "cta": "Voir tous les succès"
     },
+    "modes": {
+      "heading": "Explore les autres modes de jeu",
+      "subheading": "Au-delà du défi quotidien, deux façons de tester ta culture gaming.",
+      "cta": "Découvrir",
+      "geo": {
+        "description": "Repère où une capture a été prise sur la carte du jeu — plus tu vises juste, plus tu marques."
+      },
+      "geogamers": {
+        "description": "Un run quotidien en deux temps : devine le jeu caché, puis localise la scène sur sa carte."
+      }
+    },
     "completionMessages": {
       "perfect": [
         "Perfection absolue ! Tu es une légende vivante ! 🏆",

--- a/packages/frontend/src/components/home/HomeModesShowcase.tsx
+++ b/packages/frontend/src/components/home/HomeModesShowcase.tsx
@@ -1,0 +1,131 @@
+import type { ComponentType } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { m, type MotionProps } from 'framer-motion'
+import { ArrowRight, Crosshair, Gamepad2, MapPin, type LucideProps } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { GradientIcon } from '@/components/ui/gradient-icon'
+import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe'
+
+interface ModeCard {
+  key: string
+  /** Unlocalized route the card links to. */
+  path: string
+  icon: ComponentType<LucideProps>
+  /** i18n key for the visible mode title. */
+  titleKey: string
+  /** i18n key for the one-sentence description. */
+  descriptionKey: string
+  /** i18n key for the small status badge (alpha / new). */
+  badgeKey: string
+}
+
+const MODES: ModeCard[] = [
+  {
+    key: 'geo',
+    path: '/geo',
+    icon: MapPin,
+    titleKey: 'common.geo',
+    descriptionKey: 'home.modes.geo.description',
+    badgeKey: 'common.alpha',
+  },
+  {
+    key: 'geogamers',
+    path: '/geogamers',
+    icon: Crosshair,
+    titleKey: 'common.geogamers',
+    descriptionKey: 'home.modes.geogamers.description',
+    badgeKey: 'common.new',
+  },
+]
+
+/**
+ * Home-page showcase for the app's secondary game modes. The daily challenge
+ * gets the loud hero CTA above; this section answers "what are Geo and
+ * GeoGamers?" with a one-sentence pitch and an explicit link into each mode,
+ * so visitors aren't left guessing what the nav badges mean.
+ */
+export function HomeModesShowcase() {
+  const { t } = useTranslation()
+  const { localizedPath } = useLocalizedPath()
+  const reducedMotion = useReducedMotionSafe()
+  const motionProps = (props: MotionProps): MotionProps =>
+    reducedMotion ? {} : props
+
+  return (
+    <m.section
+      {...motionProps({
+        initial: { opacity: 0, y: 20 },
+        animate: { opacity: 1, y: 0 },
+        transition: { duration: 0.5, delay: 0.45 },
+      })}
+      aria-labelledby="home-modes-heading"
+      className="max-w-4xl mx-auto mb-8 sm:mb-10 md:mb-12 lg:mb-16"
+    >
+      <div className="flex items-center gap-3 mb-4 sm:mb-6">
+        <GradientIcon
+          size="sm"
+          icon={<Gamepad2 className="size-4 text-white" />}
+          className="shrink-0"
+        />
+        <div className="min-w-0">
+          <h2
+            id="home-modes-heading"
+            className="text-lg sm:text-xl md:text-2xl font-bold leading-tight gradient-gaming-title"
+          >
+            {t('home.modes.heading')}
+          </h2>
+          <p className="text-xs sm:text-sm text-muted-foreground mt-0.5">
+            {t('home.modes.subheading')}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:gap-5 sm:grid-cols-2">
+        {MODES.map((mode) => {
+          const Icon = mode.icon
+          return (
+            <Link
+              key={mode.key}
+              to={localizedPath(mode.path)}
+              className="group relative flex flex-col overflow-hidden rounded-xl border border-neon-purple/30 bg-card/60 backdrop-blur-sm p-5 sm:p-6 transition-colors hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            >
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute -top-12 -right-12 size-32 rounded-full bg-neon-pink/20 blur-3xl opacity-50 group-hover:opacity-70 transition-opacity"
+              />
+              <div className="relative flex items-center gap-3 mb-3">
+                <GradientIcon
+                  icon={<Icon className="size-6 text-white" />}
+                  className="shrink-0"
+                />
+                <div className="flex flex-wrap items-center gap-2 min-w-0">
+                  <h3 className="text-base sm:text-lg font-bold leading-tight text-foreground">
+                    {t(mode.titleKey)}
+                  </h3>
+                  <Badge
+                    variant="outline"
+                    className="border-neon-pink/40 bg-neon-pink/10 text-[10px] uppercase tracking-wide text-neon-pink"
+                  >
+                    {t(mode.badgeKey)}
+                  </Badge>
+                </div>
+              </div>
+              <p className="relative text-sm text-muted-foreground flex-1">
+                {t(mode.descriptionKey)}
+              </p>
+              <span className="relative mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-foreground group-hover:text-neon-pink transition-colors">
+                {t('home.modes.cta')}
+                <ArrowRight
+                  className="size-4 transition-transform group-hover:translate-x-0.5"
+                  aria-hidden="true"
+                />
+              </span>
+            </Link>
+          )
+        })}
+      </div>
+    </m.section>
+  )
+}

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -12,6 +12,7 @@ import { consumeTourPending, hasCompletedTour, TOUR_REPLAY_EVENT } from '@/compo
 import { StreakRiskBanner } from '@/components/daily-login/StreakRiskBanner'
 import { HomeAchievementTeaser } from '@/components/home/HomeAchievementTeaser'
 import { HomeDailyCta } from '@/components/home/HomeDailyCta'
+import { HomeModesShowcase } from '@/components/home/HomeModesShowcase'
 import { HomePremiumTeaser } from '@/components/home/HomePremiumTeaser'
 import { HomeSocialProof } from '@/components/home/HomeSocialProof'
 import { useBillingStore } from '@/stores/billingStore'
@@ -286,6 +287,11 @@ export default function HomePage() {
           yesterdayChallenge={yesterdayChallenge}
           motionProps={motionProps}
         />
+
+        {/* Game-modes showcase — explains the secondary modes (Geo,
+            GeoGamers) in one sentence each with a direct link, so the nav
+            badges aren't the only hint that these modes exist. */}
+        <HomeModesShowcase />
 
         {/* Premium teaser — surfaces subscriptions now that paid features
             are live. Hidden once the visitor already has Premium so we don't


### PR DESCRIPTION
## Problem

On the homepage, Geo and GeoGamers appear only as navigation entries with small `Alpha` / `Nouveau` badges. A visitor has no way to tell what these modes are or why they'd play them — there's no description and no explicit call-to-action explaining the app's secondary game modes.

## Change

Add a **game-modes showcase** section to the homepage that pitches each secondary mode in one sentence with a direct link into it:

- **New component** `HomeModesShowcase.tsx` — two cards (Geo, GeoGamers), each with the mode's icon, its status badge (`Alpha` / `Nouveau`), a one-sentence description, and a "Discover / Découvrir" CTA. Mirrors the existing `HomeAchievementTeaser` / `HomePremiumTeaser` design language (neon cards, `GradientIcon`, motion, reduced-motion safe, focus-visible rings).
- **Wired into** `HomePage.tsx`, placed right after the daily-challenge CTA and before the premium teaser.
- **i18n**: added a `home.modes.*` block (heading, subheading, per-mode one-sentence descriptions, CTA) to both `fr` and `en`. Mode titles/badges reuse the existing `common.geo` / `common.geogamers` / `common.alpha` / `common.new` strings.

The loud hero CTA still belongs to the daily challenge; this section is a lower-emphasis explainer so visitors understand the other modes exist and what they do. The existing quiet "Mode Géo" shortcut in the daily CTA block is left untouched (the onboarding tour anchors to it).

## Copy

- **Geo** — "Repère où une capture a été prise sur la carte du jeu — plus tu vises juste, plus tu marques." / "Pinpoint where a screenshot was taken on the game's map — the closer you land, the more you score."
- **GeoGamers** — "Un run quotidien en deux temps : devine le jeu caché, puis localise la scène sur sa carte." / "A daily two-phase run: guess the hidden game, then locate the scene on its map."

## Verification

- `tsc --noEmit` (frontend) — passes
- `npm run lint` — passes (0 errors)
- `npm run build:frontend` — builds
- `npm test` (pre-commit hook) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W77G7Kh7bAPGhK5mK8C8M9

---
_Generated by [Claude Code](https://claude.ai/code/session_01W77G7Kh7bAPGhK5mK8C8M9)_