### PR TITLE
fix(billing): past_due grace window, deletion Stripe cleanup, stripe:check CI gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,22 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Stripe price sync check
+        # Pre-release gate: asserts the live Stripe catalog still matches
+        # BILLING_CATALOG (currency / amount / interval / active product) so a
+        # renamed or archived price breaks CI before it reaches prod. Skips
+        # automatically when no STRIPE_SECRET_KEY secret is configured (forks,
+        # or before live mode is set up) rather than failing the release.
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${STRIPE_SECRET_KEY:-}" ]; then
+            echo "STRIPE_SECRET_KEY not configured — skipping stripe:check"
+            exit 0
+          fi
+          npm run stripe:check --workspace @the-box/backend -- --live
+
   build:
     # Split the multi-arch Docker build across native runners — arm64 via
     # QEMU emulation on an amd64 runner is roughly 5-10x slower than native

--- a/packages/backend/src/domain/services/billing.service.test.ts
+++ b/packages/backend/src/domain/services/billing.service.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { SubscriptionStatus } from '@the-box/types'
+import type { DomainLogger } from '../ports/logger.js'
+import {
+  createBillingService,
+  isSubscriptionEntitled,
+  type BillingServiceDeps,
+} from './billing.service.js'
+
+const UNCONDITIONAL: ReadonlySet<SubscriptionStatus> = new Set(['active', 'trialing'])
+const IN_ONE_HOUR = new Date(Date.now() + 60 * 60 * 1000)
+const ONE_HOUR_AGO = new Date(Date.now() - 60 * 60 * 1000)
+
+describe('isSubscriptionEntitled', () => {
+  it('grants active and trialing unconditionally, regardless of period end', () => {
+    assert.equal(isSubscriptionEntitled({ status: 'active', current_period_end: null }, UNCONDITIONAL), true)
+    assert.equal(isSubscriptionEntitled({ status: 'trialing', current_period_end: ONE_HOUR_AGO }, UNCONDITIONAL), true)
+  })
+
+  it('grants past_due only while the paid period is still running (grace window)', () => {
+    assert.equal(
+      isSubscriptionEntitled({ status: 'past_due', current_period_end: IN_ONE_HOUR }, UNCONDITIONAL),
+      true,
+      'past_due within period keeps premium so a transient failure does not revoke mid-cycle',
+    )
+    assert.equal(
+      isSubscriptionEntitled({ status: 'past_due', current_period_end: ONE_HOUR_AGO }, UNCONDITIONAL),
+      false,
+      'past_due after the paid period expired is no longer entitled',
+    )
+    assert.equal(
+      isSubscriptionEntitled({ status: 'past_due', current_period_end: null }, UNCONDITIONAL),
+      false,
+      'past_due with no known period end is not entitled',
+    )
+  })
+
+  it('never grants canceled / unpaid / incomplete', () => {
+    for (const status of ['canceled', 'unpaid', 'incomplete', 'incomplete_expired', 'paused'] as SubscriptionStatus[]) {
+      assert.equal(
+        isSubscriptionEntitled({ status, current_period_end: IN_ONE_HOUR }, UNCONDITIONAL),
+        false,
+        `${status} must be free`,
+      )
+    }
+  })
+})
+
+// ---- getEntitlement end-to-end (with fakes) ----------------------------
+
+const noopLogger = {
+  child: () => noopLogger,
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+} as unknown as DomainLogger
+
+function makeService(row: {
+  status: SubscriptionStatus
+  current_period_end: Date | null
+} | null): ReturnType<typeof createBillingService> {
+  const deps: BillingServiceDeps = {
+    logger: noopLogger,
+    entitledStatuses: UNCONDITIONAL,
+    userRepository: {
+      getSupporterLifetimeAt: async () => null,
+      getStripeCustomerId: async () => null,
+      setStripeCustomerId: async () => {},
+      findByStripeCustomerId: async () => null,
+    },
+    subscriptionRepository: {
+      findActiveByUserId: async () =>
+        row
+          ? {
+              stripe_price_id: 'price_test',
+              status: row.status,
+              current_period_end: row.current_period_end,
+              cancel_at_period_end: false,
+            }
+          : null,
+    },
+    stripe: {
+      createCustomer: async () => ({ id: 'cus_test' }),
+      retrieveCustomer: async () => ({ deleted: false, userId: null }),
+    },
+    catalog: {
+      tierFromPriceId: async () => 'premium_monthly',
+      snapshotResolvedCatalog: async () => ({ byLookupKey: new Map() }),
+    },
+  }
+  return createBillingService(deps)
+}
+
+describe('billingService.getEntitlement — grace window', () => {
+  it('keeps premium for a past_due subscription still inside its paid period', async () => {
+    const svc = makeService({ status: 'past_due', current_period_end: IN_ONE_HOUR })
+    const entitlement = await svc.getEntitlement('u1')
+    assert.equal(entitlement.isPremium, true)
+    assert.equal(entitlement.source, 'subscription')
+    assert.equal(entitlement.tier, 'premium_monthly')
+  })
+
+  it('drops premium once a past_due subscription is past its paid period', async () => {
+    const svc = makeService({ status: 'past_due', current_period_end: ONE_HOUR_AGO })
+    const entitlement = await svc.getEntitlement('u1')
+    assert.equal(entitlement.isPremium, false)
+  })
+
+  it('grants premium for a normal active subscription', async () => {
+    const svc = makeService({ status: 'active', current_period_end: IN_ONE_HOUR })
+    const entitlement = await svc.getEntitlement('u1')
+    assert.equal(entitlement.isPremium, true)
+  })
+
+  it('returns free when there is no subscription row', async () => {
+    const svc = makeService(null)
+    const entitlement = await svc.getEntitlement('u1')
+    assert.equal(entitlement.isPremium, false)
+    assert.equal(entitlement.source, null)
+  })
+})

--- a/packages/backend/src/domain/services/billing.service.ts
+++ b/packages/backend/src/domain/services/billing.service.ts
@@ -30,6 +30,25 @@ export function toSubscriptionStatus(raw: string): SubscriptionStatus {
     : 'incomplete'
 }
 
+// Entitlement decision for a subscription row. `active`/`trialing` (the
+// `unconditionalStatuses` set) grant premium outright; `past_due` grants only
+// while the already-paid period is still running — a grace window so a
+// transient renewal failure doesn't revoke access mid-cycle while Stripe
+// retries. Everything else is free. Kept pure (now is injectable) so it's the
+// single source of truth shared by getEntitlement below and testable in
+// isolation.
+export function isSubscriptionEntitled(
+  row: { status: SubscriptionStatus; current_period_end: Date | null },
+  unconditionalStatuses: ReadonlySet<SubscriptionStatus>,
+  now: Date = new Date(),
+): boolean {
+  if (unconditionalStatuses.has(row.status)) return true
+  if (row.status === 'past_due') {
+    return row.current_period_end != null && row.current_period_end.getTime() > now.getTime()
+  }
+  return false
+}
+
 // Narrow domain-facing gateway over the Stripe customer API. The composition
 // root adapts the concrete Stripe SDK to this; the service file never imports
 // the Stripe client, so it stays a pure domain unit.
@@ -119,7 +138,10 @@ export function createBillingService(deps: BillingServiceDeps): BillingService {
       }
     }
     const tier = await deps.catalog.tierFromPriceId(row.stripe_price_id)
-    const isPremium = deps.entitledStatuses.has(row.status)
+    // past_due rows only reach here within their grace window (the repository
+    // filters expired ones out), but re-run the pure check so the service
+    // owns the entitlement decision rather than trusting the query shape.
+    const isPremium = isSubscriptionEntitled(row, deps.entitledStatuses)
     return {
       isPremium,
       tier,

--- a/packages/backend/src/infrastructure/repositories/subscription.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/subscription.repository.ts
@@ -25,12 +25,22 @@ export interface UpsertSubscriptionInput {
   cancelAtPeriodEnd: boolean
 }
 
-// Statuses that grant premium entitlement. `trialing` is included so a Stripe
-// trial without payment still unlocks features; everything else (past_due,
-// canceled, incomplete, ...) treats the user as free.
+// Statuses that grant premium entitlement unconditionally. `trialing` is
+// included so a Stripe trial without payment still unlocks features.
 export const ENTITLED_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
   'active',
   'trialing',
+])
+
+// Statuses that grant a *time-limited* grace entitlement: the user keeps
+// premium only while the already-paid period hasn't ended. `past_due` means a
+// renewal charge failed and Stripe is still retrying (smart retries run for
+// days) — revoking on the first failure would punish a transient card decline,
+// so we hold entitlement until current_period_end and let the eventual
+// unpaid/canceled transition (or period expiry) drop it. Everything not in
+// either set (canceled, incomplete, unpaid, ...) is treated as free.
+export const GRACE_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
+  'past_due',
 ])
 
 export const subscriptionRepository = {
@@ -68,13 +78,23 @@ export const subscriptionRepository = {
   },
 
   async findActiveByUserId(userId: string): Promise<SubscriptionRow | null> {
-    // Most recent entitled-status subscription wins. A user shouldn't have
-    // multiple active subs at once, but checkout idempotency in the wild
-    // means we sometimes see two — pick the one with the latest period end
-    // so the UI's "Premium until …" reflects the actual grant.
+    // Most recent entitled subscription wins. Entitled = an unconditional
+    // status (active/trialing) OR a grace status (past_due) whose already-paid
+    // period hasn't ended yet. A user shouldn't have multiple active subs at
+    // once, but checkout idempotency in the wild means we sometimes see two —
+    // ordering by current_period_end desc picks the latest grant (and prefers
+    // a genuine active sub over a lapsing past_due one) so the UI's "Premium
+    // until …" reflects reality.
+    const now = new Date()
     const row = await db('subscriptions')
       .where({ user_id: userId })
-      .whereIn('status', Array.from(ENTITLED_STATUSES))
+      .andWhere((qb) => {
+        qb.whereIn('status', Array.from(ENTITLED_STATUSES)).orWhere((grace) => {
+          grace
+            .whereIn('status', Array.from(GRACE_STATUSES))
+            .andWhere('current_period_end', '>', now)
+        })
+      })
       .orderBy('current_period_end', 'desc')
       .first<SubscriptionRow>()
     return row ?? null

--- a/packages/backend/src/presentation/routes/billing-webhook.routes.ts
+++ b/packages/backend/src/presentation/routes/billing-webhook.routes.ts
@@ -204,10 +204,14 @@ async function dispatch(deps: BillingWebhookDeps, log: DomainLogger, event: Stri
 
     case 'invoice.payment_failed': {
       const invoice = event.data.object as Stripe.Invoice
-      // Just log for now — the subsequent customer.subscription.updated
-      // event from Stripe carries the new status (past_due/unpaid), and
-      // that's where we adjust entitlement. Email notifications belong in
-      // a later iteration.
+      // Don't revoke here. The paired customer.subscription.updated carries the
+      // new status (past_due), and the entitlement layer treats past_due as a
+      // grace window (see GRACE_STATUSES / isSubscriptionEntitled) — the user
+      // keeps premium until current_period_end while Stripe retries. Access is
+      // only dropped when Stripe finally transitions the sub to unpaid/canceled
+      // (or the paid period expires).
+      // TODO(notification): a Resend "payment failed, we'll retry" email
+      // belongs here once the lifecycle email worker covers billing.
       log.warn(
         {
           invoiceId: invoice.id,
@@ -217,7 +221,24 @@ async function dispatch(deps: BillingWebhookDeps, log: DomainLogger, event: Stri
           // SDK's discriminated union.
           subscriptionId: (invoice as unknown as { subscription?: string }).subscription,
         },
-        'invoice payment failed',
+        'invoice payment failed — entering grace window until current_period_end',
+      )
+      return
+    }
+
+    case 'invoice.paid': {
+      // Successful (re)payment. The paired customer.subscription.updated flips
+      // the status back to active, which the subscription-sync path above
+      // applies — so entitlement recovery from a prior past_due grace window is
+      // automatic. Logged here purely for a clean recovery trail.
+      const invoice = event.data.object as Stripe.Invoice
+      log.info(
+        {
+          invoiceId: invoice.id,
+          customerId: invoice.customer,
+          subscriptionId: (invoice as unknown as { subscription?: string }).subscription,
+        },
+        'invoice paid — entitlement recovered via subscription.updated',
       )
       return
     }

--- a/packages/backend/src/presentation/routes/user.routes.ts
+++ b/packages/backend/src/presentation/routes/user.routes.ts
@@ -9,6 +9,7 @@ import { isDisplayNameSafe } from '../../domain/services/display-name-safety.js'
 import { avatarUpload, getAvatarUrl, deleteAvatarFile } from '../middleware/upload.middleware.js'
 import { logger } from '../../infrastructure/logger/logger.js'
 import { db } from '../../infrastructure/database/connection.js'
+import { getStripe, isStripeConfigured } from '../../infrastructure/stripe/stripe.client.js'
 import { PREMIUM_THEME_KEYS, DEFAULT_THEME_KEY, isValidThemeKey } from '../../config/themes.js'
 import type { AdvancedStats, PublicProfile } from '@the-box/types'
 
@@ -554,11 +555,58 @@ router.delete('/account', authMiddleware, async (req, res, next) => {
       })
     }
 
+    // Block deletion while a live recurring subscription is still billing, so
+    // we never orphan an active subscription in Stripe (the user row — and its
+    // stripe_customer_id — is about to be hard-deleted). Supporter-lifetime
+    // (source 'supporter') is one-time and doesn't block; a subscription
+    // already set to cancel at period end doesn't either, since the cleanup
+    // below cancels the remainder.
+    const entitlement = await billingService.getEntitlement(req.userId!)
+    if (
+      entitlement.source === 'subscription' &&
+      entitlement.isPremium &&
+      !entitlement.cancelAtPeriodEnd
+    ) {
+      return res.status(409).json({
+        success: false,
+        error: {
+          code: 'SUBSCRIPTION_ACTIVE',
+          message:
+            'Cancel your active subscription in the billing portal before deleting your account.',
+        },
+      })
+    }
+
+    // Capture the Stripe customer id before the row (and the id with it) is
+    // deleted so the cleanup below can remove the customer.
+    const stripeCustomerId = await userRepository.getStripeCustomerId(req.userId!)
+
     // CASCADE removes sessions / accounts / game data, mirroring the admin
     // delete path. The cascaded `session` rows are enough to log the user out.
     await db('user').where('id', req.userId).del()
 
     logger.info({ userId: req.userId }, 'user self-deleted account')
+
+    // Best-effort Stripe customer cleanup. Done after the DB delete so a Stripe
+    // outage can't block account deletion; deleting the customer also cancels
+    // any lingering (cancel-at-period-end) subscription. Log-and-continue on
+    // failure — the account is already gone and a stale Stripe customer is
+    // harmless (and re-reconciled via the customer.deleted webhook otherwise).
+    if (stripeCustomerId && isStripeConfigured()) {
+      try {
+        await getStripe().customers.del(stripeCustomerId)
+        logger.info(
+          { userId: req.userId, stripeCustomerId },
+          'stripe customer deleted after account deletion',
+        )
+      } catch (err) {
+        logger.error(
+          { userId: req.userId, stripeCustomerId, err: String(err) },
+          'failed to delete stripe customer after account deletion',
+        )
+      }
+    }
+
     res.json({ success: true, data: { deleted: true } })
   } catch (error) {
     next(error)


### PR DESCRIPTION
Follow-up fixes from the review of #115. Scopes to the genuinely-open **code** defects; the remaining items on #115 are either Stripe live-mode ops (dashboard actions, no code) or already shipped (theme switcher, advanced stats, profile premium badge, Terms/Privacy legal content — see the reconciliation note on the issue).

## What changed

### 1. Keep premium during the `past_due` grace window (bug)
`ENTITLED_STATUSES` was `{ active, trialing }`, so a single failed renewal — which Stripe surfaces as `past_due` via `customer.subscription.updated` — revoked premium **immediately**, before Stripe's smart retries had a chance to recover the payment.

- New `GRACE_STATUSES = { past_due }`: entitlement now holds until `current_period_end`, then lapses.
- `subscription.repository.findActiveByUserId` returns `past_due` rows only while still inside the paid period.
- New pure `isSubscriptionEntitled()` in `billing.service` is the single source of truth for the decision (repo + service agree).
- `invoice.payment_failed` handler reworded to reflect grace behavior; added an `invoice.paid` handler that logs the recovery trail (recovery itself is automatic via the `subscription.updated → active` sync).
- New unit tests in `billing.service.test.ts` cover the grace boundary (in-period vs expired vs null period end) both at the pure-function and `getEntitlement` level.

### 2. Clean up Stripe on account deletion (correctness / compliance)
`DELETE /api/user/account` hard-deleted the user row (and its `stripe_customer_id`) without telling Stripe, orphaning any live subscription/customer.

- Blocks deletion while a live recurring subscription is still billing (prompts the user to cancel via the portal first). Supporter-lifetime and already-`cancel_at_period_end` subs don't block.
- Best-effort `stripe.customers.del()` after the DB delete (also cancels any remainder). Log-and-continue so a Stripe outage can't block account deletion.

### 3. Gate release on `stripe:check` (CI hardening)
Added a `stripe:check --live` step to the pre-release `checks` job in `release.yml` so a renamed/archived live price fails CI before it reaches prod. Skips automatically when no `STRIPE_SECRET_KEY` secret is configured (forks / pre-live-mode).

## Testing
- `npm test` — all workspaces green (backend 416, frontend 25, geo-agent-mcp 30), including the new grace-window tests and the existing webhook dispatch tests.
- `npm run build` (backend) typechecks clean.
- `release.yml` validated as well-formed YAML.

## Not included (tracked on #115)
- **Failed-payment notification email** — the grace window is the correctness half; the Resend template + worker is a separate follow-up (marked with a `TODO(notification)` in the webhook handler).
- **Leaderboard premium badge** — `LeaderboardEntry` carries no `tier`; needs backend payload plumbing (real cosmetic feature, not a quick fix).
- **Stripe live-mode ops** and **day-zero early access** (`release_at`) — ops / net-new feature respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191hawuZ5Pw5KxVPYAwJBTt

---
_Generated by [Claude Code](https://claude.ai/code/session_0191hawuZ5Pw5KxVPYAwJBTt)_