### PR TITLE
feat(geogamers): keep the capture visible while locating on the map

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2688,6 +2688,12 @@
       "zoomIn": "Zoom in",
       "zoomOut": "Zoom out",
       "zoomReset": "Reset zoom"
+    },
+    "pip": {
+      "show": "Show the capture",
+      "hide": "Hide the capture",
+      "expand": "Enlarge the capture",
+      "shrink": "Shrink the capture"
     }
   },
   "apiErrors": {
@@ -2991,7 +2997,8 @@
     },
     "locate": {
       "banner": "Drop your marker on the map of",
-      "confirm": "Confirm location"
+      "confirm": "Confirm location",
+      "changeMap": "Change map"
     },
     "result": {
       "breakdown": "{{game}} (game) + {{location}} (precision)",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2688,6 +2688,12 @@
       "zoomIn": "Zoom avant",
       "zoomOut": "Zoom arrière",
       "zoomReset": "Réinitialiser le zoom"
+    },
+    "pip": {
+      "show": "Afficher la capture",
+      "hide": "Masquer la capture",
+      "expand": "Agrandir la capture",
+      "shrink": "Réduire la capture"
     }
   },
   "apiErrors": {
@@ -2991,7 +2997,8 @@
     },
     "locate": {
       "banner": "Place ton marqueur sur la carte de",
-      "confirm": "Confirmer l'emplacement"
+      "confirm": "Confirmer l'emplacement",
+      "changeMap": "Changer de carte"
     },
     "result": {
       "breakdown": "{{game}} (jeu) + {{location}} (précision)",

--- a/packages/frontend/src/components/geo/ScreenshotPip.tsx
+++ b/packages/frontend/src/components/geo/ScreenshotPip.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Image as ImageIcon, Maximize2, Minimize2, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface ScreenshotPipProps {
+    imageUrl: string
+    alt: string
+    className?: string
+}
+
+/**
+ * Picture-in-picture reference card for the capture being located. Floats
+ * over the map (anchored to the top-right of the nearest relative ancestor)
+ * so the player can keep the screenshot in view while dropping a pin: tap
+ * the image to enlarge / shrink it, or dismiss it behind a recoverable
+ * "show capture" pill when it gets in the way of the pin spot.
+ */
+export function ScreenshotPip({ imageUrl, alt, className }: ScreenshotPipProps) {
+    const { t } = useTranslation()
+    const [expanded, setExpanded] = useState(false)
+    const [hidden, setHidden] = useState(false)
+
+    if (hidden) {
+        return (
+            <button
+                type="button"
+                onClick={() => setHidden(false)}
+                className={cn(
+                    'absolute right-2 top-2 z-20 inline-flex items-center gap-1.5 rounded-full bg-black/60 px-3 py-1.5 text-xs font-medium text-white shadow-lg backdrop-blur hover:bg-black/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink',
+                    className,
+                )}
+            >
+                <ImageIcon className="size-3.5" aria-hidden />
+                {t('geo.pip.show', 'Show the capture')}
+            </button>
+        )
+    }
+
+    const toggleLabel = expanded
+        ? t('geo.pip.shrink', 'Shrink the capture')
+        : t('geo.pip.expand', 'Enlarge the capture')
+
+    return (
+        <div
+            className={cn(
+                'absolute right-2 top-2 z-20 overflow-hidden rounded-lg border border-white/20 bg-black/70 shadow-lg backdrop-blur transition-[width] duration-200 motion-reduce:transition-none',
+                expanded ? 'w-[min(80%,26rem)]' : 'w-28 sm:w-40',
+                className,
+            )}
+        >
+            <button
+                type="button"
+                onClick={() => setExpanded((e) => !e)}
+                aria-expanded={expanded}
+                aria-label={toggleLabel}
+                title={toggleLabel}
+                className={cn(
+                    'block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-neon-pink',
+                    expanded ? 'cursor-zoom-out' : 'cursor-zoom-in',
+                )}
+            >
+                <img
+                    src={imageUrl}
+                    alt={alt}
+                    className="block w-full object-contain"
+                    draggable={false}
+                />
+                {/* Affordance hint — decorative, the button above carries the
+                    accessible name. */}
+                <span
+                    aria-hidden
+                    className="pointer-events-none absolute bottom-1 right-1 inline-flex size-6 items-center justify-center rounded-full bg-black/55 text-white"
+                >
+                    {expanded ? (
+                        <Minimize2 className="size-3.5" />
+                    ) : (
+                        <Maximize2 className="size-3.5" />
+                    )}
+                </span>
+            </button>
+            <button
+                type="button"
+                onClick={() => {
+                    setHidden(true)
+                    setExpanded(false)
+                }}
+                aria-label={t('geo.pip.hide', 'Hide the capture')}
+                title={t('geo.pip.hide', 'Hide the capture')}
+                className="absolute right-1 top-1 inline-flex size-6 items-center justify-center rounded-full bg-black/55 text-white hover:bg-black/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink"
+            >
+                <X className="size-3.5" aria-hidden />
+            </button>
+        </div>
+    )
+}

--- a/packages/frontend/src/pages/GeoGamersPartyPage.tsx
+++ b/packages/frontend/src/pages/GeoGamersPartyPage.tsx
@@ -4,6 +4,7 @@ import { Loader2, Users, Crown, Copy, Check } from 'lucide-react'
 import { useGeoGamersPartyStore } from '@/stores/geoGamersPartyStore'
 import { useAuth } from '@/hooks/useAuth'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
+import { ScreenshotPip } from '@/components/geo/ScreenshotPip'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
@@ -250,14 +251,21 @@ export default function GeoGamersPartyPage() {
                                     {view.round.gameName}
                                 </span>
                             </div>
-                            <GeoMapCanvas
-                                imageUrl={selectedMap.imageUrl}
-                                widthPx={selectedMap.widthPx}
-                                heightPx={selectedMap.heightPx}
-                                tiles={selectedMap.tiles}
-                                pin={pendingPin}
-                                onPin={setPendingPin}
-                            />
+                            {/* Keep the capture in view while pinning. */}
+                            <div className="relative">
+                                <GeoMapCanvas
+                                    imageUrl={selectedMap.imageUrl}
+                                    widthPx={selectedMap.widthPx}
+                                    heightPx={selectedMap.heightPx}
+                                    tiles={selectedMap.tiles}
+                                    pin={pendingPin}
+                                    onPin={setPendingPin}
+                                />
+                                <ScreenshotPip
+                                    imageUrl={view.round.screenshotUrl}
+                                    alt={t('geogamers.identify.screenshotAlt')}
+                                />
+                            </div>
                             <Button
                                 className="mt-4 w-full"
                                 disabled={!pendingPin}

--- a/packages/frontend/src/pages/GeoGamersPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoGamersPlayPage.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import { Loader2, MapPin, Sparkles, Trophy, Users } from 'lucide-react'
+import { ChevronDown, Loader2, Map, MapPin, Sparkles, Trophy, Users } from 'lucide-react'
 import { useGeoGamersStore } from '@/stores/geoGamersStore'
 import { useAuth } from '@/hooks/useAuth'
 import { GeoMapCanvas } from '@/components/geo/GeoMapCanvas'
 import { MapPicker } from '@/components/geo/MapPicker'
+import { ScreenshotPip } from '@/components/geo/ScreenshotPip'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
@@ -42,6 +43,8 @@ export default function GeoGamersPlayPage() {
         useJoker: applyJoker,
         reset,
     } = useGeoGamersStore()
+
+    const [mapPickerOpen, setMapPickerOpen] = useState(false)
 
     const startedRef = useRef(false)
     useEffect(() => {
@@ -187,33 +190,50 @@ export default function GeoGamersPlayPage() {
             {/* ---------------- LOCATE ---------------- */}
             {phase === 'locate' && run && selectedMap && (
                 <section>
-                    <div className="mb-3 rounded-lg bg-primary/15 px-4 py-2 text-center">
-                        <span className="text-sm text-muted-foreground">
-                            {t('geogamers.locate.banner')}{' '}
-                        </span>
-                        <span className="font-semibold text-neon-purple">{run.game?.name}</span>
+                    <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-lg bg-primary/15 px-4 py-2">
+                        <p className="min-w-0 flex-1 text-center sm:text-left">
+                            <span className="text-sm text-muted-foreground">
+                                {t('geogamers.locate.banner')}{' '}
+                            </span>
+                            <span className="font-semibold text-neon-purple">
+                                {run.game?.name}
+                            </span>
+                        </p>
+                        {mapPickerNeeded && (
+                            <button
+                                type="button"
+                                onClick={() => setMapPickerOpen(true)}
+                                aria-label={t('geogamers.locate.changeMap')}
+                                title={t('geogamers.locate.changeMap')}
+                                className="mx-auto inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium hover:border-neon-pink/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink sm:mx-0"
+                            >
+                                <Map className="size-3.5 text-neon-purple" aria-hidden />
+                                <span className="max-w-40 truncate">
+                                    {selectedMap.region ??
+                                        t('geo.daily.chooseMap.worldFallback', 'World map')}
+                                </span>
+                                <ChevronDown className="size-3.5 text-muted-foreground" aria-hidden />
+                            </button>
+                        )}
                     </div>
 
-                    {mapPickerNeeded && (
-                        <div className="mb-3">
-                            <MapPicker
-                                open={false}
-                                onOpenChange={() => {}}
-                                maps={asGeoMaps(run.maps ?? [])}
-                                selectedMapId={selectedMapId}
-                                onSelect={(id) => selectMap(id ?? run.maps![0]!.id)}
-                            />
-                        </div>
-                    )}
-
-                    <GeoMapCanvas
-                        imageUrl={selectedMap.imageUrl}
-                        widthPx={selectedMap.widthPx}
-                        heightPx={selectedMap.heightPx}
-                        tiles={selectedMap.tiles}
-                        pin={pendingPin}
-                        onPin={setPendingPin}
-                    />
+                    {/* Map + floating capture: the screenshot stays in view as
+                        a picture-in-picture card while the player pins, instead
+                        of vanishing when the map appears. */}
+                    <div className="relative">
+                        <GeoMapCanvas
+                            imageUrl={selectedMap.imageUrl}
+                            widthPx={selectedMap.widthPx}
+                            heightPx={selectedMap.heightPx}
+                            tiles={selectedMap.tiles}
+                            pin={pendingPin}
+                            onPin={setPendingPin}
+                        />
+                        <ScreenshotPip
+                            imageUrl={run.screenshotUrl}
+                            alt={t('geogamers.identify.screenshotAlt')}
+                        />
+                    </div>
 
                     <Button
                         className="mt-4 w-full"
@@ -222,13 +242,23 @@ export default function GeoGamersPlayPage() {
                     >
                         {t('geogamers.locate.confirm')}
                     </Button>
+
+                    {mapPickerNeeded && (
+                        <MapPicker
+                            open={mapPickerOpen}
+                            onOpenChange={setMapPickerOpen}
+                            maps={asGeoMaps(run.maps ?? [])}
+                            selectedMapId={selectedMapId}
+                            onSelect={(id) => selectMap(id ?? run.maps![0]!.id)}
+                        />
+                    )}
                 </section>
             )}
 
             {/* ---------------- RESULT ---------------- */}
             {phase === 'result' && run && result && selectedMap && (
                 <section>
-                    <div className="mb-4">
+                    <div className="relative mb-4">
                         <GeoMapCanvas
                             imageUrl={selectedMap.imageUrl}
                             widthPx={selectedMap.widthPx}
@@ -238,6 +268,10 @@ export default function GeoGamersPlayPage() {
                             canonical={result.canonical}
                             showGuessLine
                             disabled
+                        />
+                        <ScreenshotPip
+                            imageUrl={run.screenshotUrl}
+                            alt={t('geogamers.identify.screenshotAlt')}
                         />
                     </div>
 

--- a/packages/frontend/src/stores/geoGamersStore.ts
+++ b/packages/frontend/src/stores/geoGamersStore.ts
@@ -129,7 +129,11 @@ export const useGeoGamersStore = create<GeoGamersState>()(
             },
 
             selectMap(id) {
-                set({ selectedMapId: id })
+                // A pin is expressed in the coordinate space of its map, so a
+                // draft pin can't survive a map switch.
+                if (id !== get().selectedMapId) {
+                    set({ selectedMapId: id, pendingPin: null })
+                }
             },
 
             setPendingPin(p) {


### PR DESCRIPTION
## Problem

In GeoGamers, the locate phase replaced the screenshot with the map: the moment the map appeared, the capture was gone, so players had to pin the location from memory. There was no way to see both at the same time.

Two related defects in the same section:
- The multi-map `MapPicker` was rendered with `open={false}` and no trigger, so on games with several maps the picker was permanently unreachable.
- Switching maps kept the draft pin, even though pin coordinates are relative to the map they were placed on.

## Changes

- **New `ScreenshotPip` component** (`components/geo/ScreenshotPip.tsx`): a picture-in-picture card of the capture floating over the map, anchored top-right. Tap to enlarge (up to 26rem / 80% of the map width), tap again to shrink, or dismiss it behind a recoverable "Show the capture" pill. Keyboard accessible (`aria-expanded`, focus rings), reduced-motion friendly, styled like the other geo overlays (black/blur pills).
- **GeoGamersPlayPage — locate phase**: the map canvas is wrapped in a relative container with the PiP capture on top; the banner now hosts a map chip (region name + chevron) that opens the `MapPicker` sheet properly.
- **GeoGamersPlayPage — result phase**: the capture is also shown as a PiP over the reveal map so players can compare the scene with the actual location.
- **GeoGamersPartyPage**: same PiP treatment in the party locate phase.
- **`geoGamersStore.selectMap`**: clears the pending pin when the selected map actually changes.
- **i18n**: new `geo.pip.*` keys and `geogamers.locate.changeMap` in both `en` and `fr`.

## Verification

- `npm run build:frontend`, `npm run lint` (no new warnings), all unit tests pass (pre-commit hook runs the full suite).
- Rendered the real `GeoMapCanvas` + `ScreenshotPip` composition in a throwaway Vite harness and screenshotted thumbnail / expanded / hidden states on desktop (1280px) and mobile (390px) — all states render and toggle correctly over the Leaflet map without blocking pinning.

Note: `npm run build` (full workspace) fails on a pre-existing, unrelated TS 6 `baseUrl` deprecation in the backend/sw tsconfigs; frontend build itself is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017R35NTrEmdqJwaR1Ph7gad

---
_Generated by [Claude Code](https://claude.ai/code/session_017R35NTrEmdqJwaR1Ph7gad)_