### PR TITLE
fix(pwa): stop changelog dialog reopening after every deploy

### DIFF
--- a/packages/frontend/src/components/pwa/ChangelogDialog.tsx
+++ b/packages/frontend/src/components/pwa/ChangelogDialog.tsx
@@ -24,15 +24,11 @@ import { useChangelogStore } from '@/stores/changelogStore'
 import {
   CHANGELOG,
   CHANGELOG_SECTIONS,
-  compareVersions,
   getLatestRelease,
+  resolveChangelogAutoOpen,
   type ChangelogRelease,
   type ChangelogSection,
 } from '@/data/changelog'
-
-/** Build-time version of the running bundle (see vite.config.ts). */
-const APP_VERSION =
-  typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'
 
 /** Localized i18n shape for a single release block. */
 interface ReleaseContent {
@@ -55,8 +51,8 @@ const SECTION_ACCENT: Record<ChangelogSection, string> = {
 }
 
 /**
- * "What's New" dialog. Auto-opens the newest release's notes once after the app
- * updates to that version, and opens on demand from the footer version chip.
+ * "What's New" dialog. Auto-opens the newest announced release's notes once
+ * per release, and opens on demand from the footer version chip.
  *
  * Releases are laid out on a *horizontal timeline* (newest first, left to
  * right): each version is a tappable stop, and the body shows one release at a
@@ -122,30 +118,17 @@ export function ChangelogDialog(): ReactElement | null {
     return () => window.removeEventListener('resize', updateFades)
   }, [open, activeIndex, updateFades, i18n.language])
 
-  // Auto-open the changelog the first time a player runs a build newer than the
-  // one this browser last acknowledged. Brand-new visitors (no recorded version)
-  // are marked seen silently so they aren't greeted by release notes for a build
-  // they never "upgraded" from. Runs once on mount.
-  //
-  // We intentionally do NOT require the running build to exactly match the newest
-  // changelog entry: if a release ships without a matching changelog bump, the
-  // dialog degrades gracefully to the latest notes on record instead of being
-  // silently disabled until the registry catches up.
+  // Auto-open the newest announced release's notes once, the first time a
+  // player loads the app after that release lands in the changelog registry.
+  // The seen-marker tracks the registry — NOT the build version, which bumps
+  // on every deploy and would re-open the dialog with the same stale notes
+  // after each one. Brand-new visitors (no recorded marker) are marked seen
+  // silently so they aren't greeted by notes for a release they never
+  // "upgraded" from. Runs once on mount.
   useEffect(() => {
-    if (!release) return
-    if (APP_VERSION === 'dev') return
-    if (lastSeenVersion === APP_VERSION) return
-
-    if (lastSeenVersion === null) {
-      markSeen(APP_VERSION)
-      return
-    }
-
-    if (compareVersions(APP_VERSION, lastSeenVersion) > 0) {
-      openChangelog()
-    } else {
-      markSeen(APP_VERSION)
-    }
+    const decision = resolveChangelogAutoOpen(release?.version, lastSeenVersion)
+    if (decision === 'open') openChangelog()
+    else if (decision === 'mark-seen' && release) markSeen(release.version)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -166,7 +149,7 @@ export function ChangelogDialog(): ReactElement | null {
   const activeEntry = CHANGELOG[activeIndex] ?? release
 
   const handleClose = (next: boolean): void => {
-    if (!next) markSeen(APP_VERSION === 'dev' ? release.version : APP_VERSION)
+    if (!next) markSeen(release.version)
   }
 
   const formatDate = (iso: string): string => {

--- a/packages/frontend/src/data/changelog.test.ts
+++ b/packages/frontend/src/data/changelog.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { compareVersions, resolveChangelogAutoOpen } from './changelog'
+
+describe('compareVersions', () => {
+  it('orders numeric major.minor.patch versions', () => {
+    assert.ok(compareVersions('2.142.0', '2.135.0') > 0)
+    assert.ok(compareVersions('2.135.0', '2.142.0') < 0)
+    assert.equal(compareVersions('2.142.0', '2.142.0'), 0)
+  })
+
+  it('compares numerically, not lexicographically', () => {
+    assert.ok(compareVersions('2.10.0', '2.9.0') > 0)
+  })
+
+  it('treats missing segments as zero', () => {
+    assert.equal(compareVersions('2.142', '2.142.0'), 0)
+    assert.ok(compareVersions('2.142.1', '2.142') > 0)
+  })
+
+  it('ignores pre-release suffixes and sorts non-numeric input lowest', () => {
+    assert.equal(compareVersions('2.142.0-beta.1', '2.142.0'), 0)
+    assert.ok(compareVersions('dev', '0.0.1') < 0)
+  })
+})
+
+describe('resolveChangelogAutoOpen', () => {
+  it('does nothing when no release is announced', () => {
+    assert.equal(resolveChangelogAutoOpen(null, null), 'none')
+    assert.equal(resolveChangelogAutoOpen(undefined, '2.142.0'), 'none')
+  })
+
+  it('silently marks brand-new visitors instead of greeting them with notes', () => {
+    assert.equal(resolveChangelogAutoOpen('2.142.0', null), 'mark-seen')
+  })
+
+  it('opens once when a release newer than the marker is announced', () => {
+    assert.equal(resolveChangelogAutoOpen('2.142.0', '2.135.0'), 'open')
+  })
+
+  it('stays closed once the newest announced release is acknowledged', () => {
+    assert.equal(resolveChangelogAutoOpen('2.142.0', '2.142.0'), 'none')
+  })
+
+  // Regression: markers written by the pre-fix code hold a *build* version,
+  // which runs ahead of the changelog registry (builds bump on every deploy).
+  // Those must read as already-seen — the old code compared the marker to the
+  // build version instead, so every deploy re-opened the dialog with the same
+  // stale notes.
+  it('treats a marker ahead of the registry (legacy build-version marker) as seen', () => {
+    assert.equal(resolveChangelogAutoOpen('2.142.0', '2.154.0'), 'none')
+  })
+})

--- a/packages/frontend/src/data/changelog.ts
+++ b/packages/frontend/src/data/changelog.ts
@@ -8,9 +8,11 @@
  * renders in the player's language. Keep this list ordered newest-first and
  * add an entry only for releases worth announcing in-app.
  *
- * The running app's version comes from the build-time `__APP_VERSION__`
- * constant (see `vite.config.ts`). The dialog shows a release's notes once,
- * the first time a player runs that version.
+ * The dialog auto-opens a release's notes once, the first time a player loads
+ * the app after that release is announced here. The persisted seen-marker
+ * tracks *this registry* — not the build version — so routine version bumps
+ * that ship without a changelog entry never re-trigger the dialog (see
+ * `resolveChangelogAutoOpen`).
  */
 
 export type ChangelogSection = 'features' | 'improvements' | 'fixes'
@@ -74,4 +76,33 @@ export function compareVersions(a: string, b: string): number {
     if (diff !== 0) return diff
   }
   return 0
+}
+
+/** What the changelog dialog should do when the app starts. */
+export type ChangelogAutoOpenDecision = 'open' | 'mark-seen' | 'none'
+
+/**
+ * Decide whether the dialog auto-opens, given the newest announced release and
+ * the seen-marker persisted in this browser.
+ *
+ * - `mark-seen`: brand-new visitor (no marker yet). Don't greet them with
+ *   notes for a release they never "upgraded" from — record the latest
+ *   announced version silently so only future releases pop.
+ * - `open`: a release newer than the marker has been announced.
+ * - `none`: the player already acknowledged the newest announced release.
+ *
+ * Both inputs are announced-release versions. Comparing against the *build*
+ * version instead is the historical bug this function replaces: builds bump on
+ * every deploy, so each deploy re-opened the dialog with the same stale notes.
+ * (Markers written by that older code hold a build version; since builds only
+ * ever run ahead of the registry, they compare as already-seen and heal on the
+ * next `markSeen`.)
+ */
+export function resolveChangelogAutoOpen(
+  latestVersion: string | null | undefined,
+  lastSeenVersion: string | null,
+): ChangelogAutoOpenDecision {
+  if (!latestVersion) return 'none'
+  if (lastSeenVersion === null) return 'mark-seen'
+  return compareVersions(latestVersion, lastSeenVersion) > 0 ? 'open' : 'none'
 }

--- a/packages/frontend/src/stores/changelogStore.ts
+++ b/packages/frontend/src/stores/changelogStore.ts
@@ -4,10 +4,15 @@ import { persist, createJSONStorage } from 'zustand/middleware'
 /**
  * Drives the "What's New" changelog dialog.
  *
- * `lastSeenVersion` is persisted to localStorage so a release's notes auto-open
- * exactly once — the first time a player runs that build. `open` is ephemeral
- * UI state: the dialog flips it on automatically after an update, and the footer
- * version chip can flip it on manually to re-read the latest notes any time.
+ * `lastSeenVersion` is the newest *announced* release (a `CHANGELOG` registry
+ * entry, not the build version) this browser has acknowledged. It is persisted
+ * to localStorage so a release's notes auto-open exactly once — the first load
+ * after that release is announced. Build versions bump on every deploy, so
+ * keying on them would re-open the dialog after each deploy; the registry only
+ * moves when there is genuinely something new to read. `open` is ephemeral UI
+ * state: the dialog flips it on automatically after a new announcement, and
+ * the footer version chip can flip it on manually to re-read the notes any
+ * time.
  *
  * `null` for `lastSeenVersion` means "this browser has never recorded a
  * version" (a brand-new visitor). We intentionally don't pop the changelog at


### PR DESCRIPTION
## Problem

Players see the "Nouveautés" dialog on (seemingly) every refresh instead of once per release.

**Root cause:** the auto-open check compared the persisted seen-marker against the **build version** (`__APP_VERSION__`), and dismissing the dialog stamped the build version too. Builds bump on every deploy — a dozen times between 2.142.0 (July 10) and 2.154.0 (today) — so each silently auto-updated PWA bundle made `APP_VERSION` newer than the marker again and re-opened the dialog with the same stale v2.142.0 notes.

## Fix

Key the seen-marker to the newest **announced changelog entry** (`CHANGELOG` registry) instead of the build version:

- The dialog auto-opens exactly once per release added to the registry.
- Version bumps that ship without changelog notes never re-trigger it.
- Markers already written by the old code hold a build version that runs ahead of the registry, so they compare as already-seen — affected users heal immediately, no migration needed.
- New-visitor silent marking and the footer version-chip manual open are unchanged.

The decision now lives in a pure `resolveChangelogAutoOpen()` helper in `data/changelog.ts`, with unit tests including a regression case for the legacy build-version marker.

## Verification

Drove the real app (Vite dev server + Chromium) through all paths:

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| Legacy build-version marker (2.148.0), no new notes | dialog re-opens (the bug) | stays closed ✅ |
| New announced release (marker 2.135.0 < 2.142.0) | — | opens once, dismiss stamps `2.142.0`, closed on two subsequent refreshes ✅ |
| Brand-new visitor | — | no dialog, marker silently set ✅ |
| Footer version-chip manual open, Esc, refresh | — | opens on demand, stays closed after ✅ |

`npm run build`, `npm run lint`, and `npm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jAwSPC4Qhq4XBnr2gXWfM

---
_Generated by [Claude Code](https://claude.ai/code/session_016jAwSPC4Qhq4XBnr2gXWfM)_