### PR TITLE
feat(geo): GEO_COMMUNITY_ENABLED sunset switch for the community geo surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,17 @@ VAPID_PRIVATE_KEY=
 VAPID_SUBJECT=mailto:no-reply@the-box.battistella.ovh
 
 # ============================================
+# COMMUNITY GEO SURFACE (free play + contribution)
+# ============================================
+# Player-facing /api/geo routes (Geo free play + crowdsourced pin
+# contribution). On by default. Set to false to sunset the community
+# dataset-building loop: the routes unmount (404) and the frontend hides the
+# Geo nav entry / home cards via /api/features. The geo data layer is NOT
+# affected — ingestion, the agent sourcing API, admin geo-fetch and GeoGamers
+# keep working.
+GEO_COMMUNITY_ENABLED=true
+
+# ============================================
 # GEO AGENT API (issue #331)
 # ============================================
 # Key-authenticated agent content-sourcing surface at /api/agent/v1/geo. Off by

--- a/docs/geo-mode.md
+++ b/docs/geo-mode.md
@@ -22,6 +22,10 @@ Trois activités cohabitent :
 - **Contribution** — le joueur place un pin sur une capture sans coordonnées canoniques. Le système agrège les pins (consensus) et promeut une position canonique au-delà d'un seuil de fiabilité.
 - **Pipeline d'ingestion** — un orchestrateur admin fait tourner plusieurs workers d'import pour rapatrier des cartes de jeu et des captures depuis des sources externes.
 
+### Kill switch de la surface communautaire
+
+Les deux premières activités (free play + contribution, servies par `/api/geo`) sont gouvernées par `GEO_COMMUNITY_ENABLED` (défaut `true`). À `false`, les routes joueur sont démontées (404) et le frontend masque l'entrée de navigation Géo et les cartes d'accueil (via `GET /api/features`) — le mode peut donc être mis en sommeil si la constitution du dataset passe au sourcing agent (voir `docs/geo-agent-api.md`) plutôt qu'au crowdsourcing. La **couche de données géo n'est pas touchée** : pipeline d'ingestion, API agent, panel admin Geo-Fetch et GeoGamers continuent de fonctionner (ils ne passent pas par `/api/geo`), et le worker de consensus reste actif car les propositions de pins agent l'alimentent toujours.
+
 ## Mécanique de jeu (free play)
 
 ### Scoring

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -40,6 +40,15 @@ export const env = {
   // Public-facing frontend URL (used in marketing email CTAs)
   FRONTEND_URL: process.env['FRONTEND_URL'] || 'https://the-box.battistella.ovh',
 
+  // Community geo surface (free play + crowdsourced contribution) at /api/geo.
+  // On by default. Flipping it off unmounts the player-facing routes (they 404
+  // like a dark-shipped feature) so the community dataset-building loop can be
+  // sunset without touching the geo data layer — ingestion pipeline, agent
+  // sourcing API, admin geo-fetch and GeoGamers all keep running: they don't go
+  // through /api/geo. The consensus worker also stays registered because agent
+  // pin proposals (/api/agent/v1/geo) still feed it.
+  GEO_COMMUNITY_ENABLED: process.env['GEO_COMMUNITY_ENABLED'] || 'true',
+
   // GeoGamers mode (guess-the-game + geolocate). Off by default: the routes
   // 404 and the daily-challenge scheduler doesn't register until enabled, so
   // the feature can ship dark and be turned on once enough consensus-confirmed

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -23,6 +23,7 @@ import rewardsRoutes from './presentation/routes/rewards.routes.js'
 import referralRoutes from './presentation/routes/referral.routes.js'
 import ogRoutes, { parseGeoRunScores } from './presentation/routes/og.routes.js'
 import geoRoutes from './presentation/routes/geo.routes.js'
+import featuresRoutes from './presentation/routes/features.routes.js'
 import geoGamersRoutes from './presentation/routes/geogamers.routes.js'
 import screenshotReportRoutes from './presentation/routes/screenshot-report.routes.js'
 import pushRoutes from './presentation/routes/push.routes.js'
@@ -243,7 +244,14 @@ app.use('/api/inventory', dailyLoginRoutes)
 app.use('/api/rewards', rewardsRoutes)
 app.use('/api/referral', referralRoutes)
 app.use('/api/og', ogRoutes)
-app.use('/api/geo', geoRoutes)
+app.use('/api/features', featuresRoutes)
+// Community geo surface (free play + contribution) — mounted only while the
+// community dataset-building loop is active. Unmounting sunsets the player
+// routes without touching the geo data layer: ingestion, the agent sourcing
+// API and GeoGamers don't go through /api/geo.
+if (env.GEO_COMMUNITY_ENABLED === 'true') {
+  app.use('/api/geo', geoRoutes)
+}
 // GeoGamers mode — mounted only when enabled so the API surface stays dark
 // until there's enough consensus-confirmed content to schedule challenges.
 if (env.GEOGAMERS_ENABLED === 'true') {

--- a/packages/backend/src/presentation/routes/features.routes.ts
+++ b/packages/backend/src/presentation/routes/features.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express'
+import { env } from '../../config/env.js'
+
+const router = Router()
+
+/**
+ * GET /api/features
+ *
+ * Public, unauthenticated runtime feature flags for the frontend. The SPA is
+ * built once into the Docker image, so build-time VITE_ vars can't reflect
+ * per-deployment env flips — this endpoint is how the client learns which
+ * optional surfaces (nav entries, home-page cards) to render. Only booleans
+ * derived from env flags cross this surface; nothing user- or session-scoped.
+ */
+router.get('/', (_req, res) => {
+    res.set('Cache-Control', 'public, max-age=60')
+    res.json({
+        success: true,
+        data: {
+            geoCommunity: env.GEO_COMMUNITY_ENABLED === 'true',
+            geogamers: env.GEOGAMERS_ENABLED === 'true',
+        },
+    })
+})
+
+export default router

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2699,6 +2699,7 @@
   "apiErrors": {
     "default": "Something went wrong. Please try again.",
     "GEOGAMERS_UNAVAILABLE": "GeoGamers isn't available right now.",
+    "GEO_COMMUNITY_DISABLED": "Geo mode isn't available on this deployment.",
     "NETWORK_ERROR": "Network error. Please check your connection.",
     "VALIDATION_ERROR": "The information you entered is invalid.",
     "UNAUTHORIZED": "Please sign in to continue.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2699,6 +2699,7 @@
   "apiErrors": {
     "default": "Une erreur est survenue. Veuillez réessayer.",
     "GEOGAMERS_UNAVAILABLE": "GeoGamers n'est pas disponible pour le moment.",
+    "GEO_COMMUNITY_DISABLED": "Le mode Géo n'est pas disponible sur ce déploiement.",
     "NETWORK_ERROR": "Erreur réseau. Vérifiez votre connexion.",
     "VALIDATION_ERROR": "Les informations saisies sont invalides.",
     "UNAUTHORIZED": "Veuillez vous connecter pour continuer.",

--- a/packages/frontend/src/components/home/HomeDailyCta.tsx
+++ b/packages/frontend/src/components/home/HomeDailyCta.tsx
@@ -5,6 +5,7 @@ import { Play, Trophy, History, Clock, CalendarDays, MapPin } from 'lucide-react
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
+import { useFeatures } from '@/hooks/useFeatures'
 
 interface YesterdayChallenge {
   challengeId: number
@@ -53,6 +54,7 @@ export function HomeDailyCta({
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { localizedPath } = useLocalizedPath()
+  const { geoCommunity } = useFeatures()
   const { isLoading, isTodayCompleted, isOnline, hasSession, previewAvailable } = status
 
   return (
@@ -140,22 +142,24 @@ export function HomeDailyCta({
               </Button>
             )}
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate(localizedPath('/geo'))}
-            data-tour="geo-cta"
-            className="gap-1.5 text-xs sm:text-sm text-muted-foreground hover:text-neon-pink"
-          >
-            <MapPin className="size-4" />
-            {t('home.geoCta')}
-            <Badge
-              variant="outline"
-              className="ml-1 h-4 px-1 text-[9px] font-semibold uppercase tracking-wide border-neon-pink/40 text-neon-pink"
+          {geoCommunity && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate(localizedPath('/geo'))}
+              data-tour="geo-cta"
+              className="gap-1.5 text-xs sm:text-sm text-muted-foreground hover:text-neon-pink"
             >
-              {t('common.alpha')}
-            </Badge>
-          </Button>
+              <MapPin className="size-4" />
+              {t('home.geoCta')}
+              <Badge
+                variant="outline"
+                className="ml-1 h-4 px-1 text-[9px] font-semibold uppercase tracking-wide border-neon-pink/40 text-neon-pink"
+              >
+                {t('common.alpha')}
+              </Badge>
+            </Button>
+          )}
           {!isTodayCompleted && !hasSession && (
             <p className="text-xs sm:text-sm text-muted-foreground">
               {t('home.guestHint')}

--- a/packages/frontend/src/components/home/HomeModesShowcase.tsx
+++ b/packages/frontend/src/components/home/HomeModesShowcase.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { GradientIcon } from '@/components/ui/gradient-icon'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe'
+import { useFeatures, type RuntimeFeatures } from '@/hooks/useFeatures'
 
 interface ModeCard {
   key: string
@@ -19,6 +20,8 @@ interface ModeCard {
   descriptionKey: string
   /** i18n key for the small status badge (alpha / new). */
   badgeKey: string
+  /** Runtime feature flag gating this card. Cards without one always show. */
+  feature?: keyof RuntimeFeatures
 }
 
 const MODES: ModeCard[] = [
@@ -29,6 +32,7 @@ const MODES: ModeCard[] = [
     titleKey: 'common.geo',
     descriptionKey: 'home.modes.geo.description',
     badgeKey: 'common.alpha',
+    feature: 'geoCommunity',
   },
   {
     key: 'geogamers',
@@ -50,8 +54,12 @@ export function HomeModesShowcase() {
   const { t } = useTranslation()
   const { localizedPath } = useLocalizedPath()
   const reducedMotion = useReducedMotionSafe()
+  const features = useFeatures()
   const motionProps = (props: MotionProps): MotionProps =>
     reducedMotion ? {} : props
+
+  const modes = MODES.filter((mode) => !mode.feature || features[mode.feature])
+  if (modes.length === 0) return null
 
   return (
     <m.section
@@ -83,7 +91,7 @@ export function HomeModesShowcase() {
       </div>
 
       <div className="grid gap-4 sm:gap-5 sm:grid-cols-2">
-        {MODES.map((mode) => {
+        {modes.map((mode) => {
           const Icon = mode.icon
           return (
             <Link

--- a/packages/frontend/src/components/layout/Header.tsx
+++ b/packages/frontend/src/components/layout/Header.tsx
@@ -23,6 +23,7 @@ import { Menu, User, ChevronDown, LogOut, Settings, Sparkles, LifeBuoy, Compass 
 import { PRIMARY_NAV, type NavLinkItem } from '@/components/layout/nav-items'
 import { useLocalizedPath } from '@/hooks/useLocalizedPath'
 import { useAuth } from '@/hooks/useAuth'
+import { useFeatures } from '@/hooks/useFeatures'
 import { DailyRewardBadge } from '@/components/daily-login'
 import { RewardsInboxBell } from '@/components/rewards'
 import { useDailyLoginStore } from '@/stores/dailyLoginStore'
@@ -272,6 +273,12 @@ export function Header() {
   const { localizedPath } = useLocalizedPath()
   const navigate = useNavigate()
   const { session, isPending, signOut } = useAuth()
+  const features = useFeatures()
+  // Drop nav entries whose runtime feature flag is off (e.g. the Geo entry on
+  // a deployment that sunset the community geo surface).
+  const primaryNav = PRIMARY_NAV.filter(
+    (item) => !item.feature || features[item.feature],
+  )
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const isScrolled = useSyncExternalStore(
     subscribeScrolled,
@@ -347,7 +354,7 @@ export function Header() {
               </SheetHeader>
 
               <nav aria-label={t('nav.mobile')} className="mt-6 flex flex-col gap-1">
-                {PRIMARY_NAV.map((item) => (
+                {primaryNav.map((item) => (
                   <NavItemLink
                     key={item.key}
                     item={item}
@@ -402,7 +409,7 @@ export function Header() {
 
         {/* Desktop primary navigation — shown at md and up */}
         <nav aria-label={t('nav.primary')} className="hidden items-center gap-1 md:flex lg:gap-2">
-          {PRIMARY_NAV.map((item) => (
+          {primaryNav.map((item) => (
             <NavItemLink key={item.key} item={item} variant="desktop" />
           ))}
           {showPremiumUpsell && <NavItemLink item={PREMIUM_NAV_ITEM} variant="desktop" accent />}

--- a/packages/frontend/src/components/layout/nav-items.ts
+++ b/packages/frontend/src/components/layout/nav-items.ts
@@ -22,6 +22,11 @@ export interface NavLinkItem {
   badgeKey?: string
   /** Optional `data-tour` anchor id for the onboarding tour. */
   dataTour?: string
+  /**
+   * Runtime feature flag (from `useFeatures()`) gating this entry. Entries
+   * without a flag are always shown.
+   */
+  feature?: 'geoCommunity' | 'geogamers'
 }
 
 /**
@@ -45,6 +50,7 @@ export const PRIMARY_NAV: NavLinkItem[] = [
     icon: MapPin,
     path: '/geo',
     badgeKey: 'common.alpha',
+    feature: 'geoCommunity',
   },
   {
     key: 'geogamers',

--- a/packages/frontend/src/hooks/useFeatures.ts
+++ b/packages/frontend/src/hooks/useFeatures.ts
@@ -1,0 +1,66 @@
+import { useEffect, useSyncExternalStore } from 'react'
+
+/**
+ * Runtime feature flags served by `GET /api/features`. The SPA bundle is built
+ * once into the Docker image, so build-time VITE_ vars can't reflect
+ * per-deployment env flips — the backend tells us which optional surfaces to
+ * render.
+ */
+export interface RuntimeFeatures {
+  /** Community geo surface (free play + contribution) — GEO_COMMUNITY_ENABLED. */
+  geoCommunity: boolean
+  /** GeoGamers daily mode — GEOGAMERS_ENABLED. */
+  geogamers: boolean
+}
+
+// Optimistic defaults matching the backend flag defaults: geoCommunity ships
+// on. A deployment that turned it off hides the entries right after the
+// (cached, 60s) fetch resolves; a failed fetch keeps current behavior rather
+// than blanking navigation.
+const DEFAULT_FEATURES: RuntimeFeatures = { geoCommunity: true, geogamers: true }
+
+let snapshot: RuntimeFeatures = DEFAULT_FEATURES
+let fetchStarted = false
+const listeners = new Set<() => void>()
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function getSnapshot(): RuntimeFeatures {
+  return snapshot
+}
+
+async function fetchFeatures(): Promise<void> {
+  try {
+    const res = await fetch('/api/features', { credentials: 'include' })
+    if (!res.ok) return
+    const json = (await res.json()) as {
+      success?: boolean
+      data?: Partial<RuntimeFeatures>
+    }
+    if (!json.success || !json.data) return
+    snapshot = {
+      geoCommunity: json.data.geoCommunity ?? DEFAULT_FEATURES.geoCommunity,
+      geogamers: json.data.geogamers ?? DEFAULT_FEATURES.geogamers,
+    }
+    listeners.forEach((l) => l())
+  } catch {
+    // Network failure: keep the optimistic defaults.
+  }
+}
+
+/**
+ * Subscribe to the runtime feature flags. Fetched once per page load, shared
+ * across every consumer (Header, home cards, …).
+ */
+export function useFeatures(): RuntimeFeatures {
+  useEffect(() => {
+    if (!fetchStarted) {
+      fetchStarted = true
+      void fetchFeatures()
+    }
+  }, [])
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}

--- a/packages/frontend/src/lib/api/geo.ts
+++ b/packages/frontend/src/lib/api/geo.ts
@@ -38,11 +38,30 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
             ...(init?.headers ?? {}),
         },
     })
-    const json = (await res.json()) as ApiEnvelope<T>
-    if (!res.ok || !json.success) {
+    // Guard the parse: when the community geo surface is disabled
+    // (GEO_COMMUNITY_ENABLED=false) the routes are unmounted and a request can
+    // come back as a non-JSON body. Treat any unparseable body as a failure
+    // instead of surfacing a raw parser error.
+    let json: ApiEnvelope<T> | undefined
+    try {
+        json = (await res.json()) as ApiEnvelope<T>
+    } catch {
+        json = undefined
+    }
+
+    if (!res.ok || !json || !json.success) {
+        // A 404 NOT_FOUND (routes unmounted) or a non-JSON body both mean the
+        // community geo surface isn't available on this deployment — map them
+        // to a single friendly, localized code. Endpoint-specific 404s carry
+        // their own codes (CANDIDATE_NOT_FOUND, NO_FREE_PLAY_CANDIDATE, …) and
+        // are passed through untouched.
+        const unavailable =
+            !json || (res.status === 404 && (json.error?.code ?? 'NOT_FOUND') === 'NOT_FOUND')
         throw new GeoApiError(
-            json.error?.code ?? 'GEO_REQUEST_FAILED',
-            json.error?.message ?? `Request to ${path} failed`,
+            unavailable
+                ? 'GEO_COMMUNITY_DISABLED'
+                : (json?.error?.code ?? 'GEO_REQUEST_FAILED'),
+            json?.error?.message ?? `Request to ${path} failed`,
             res.status,
         )
     }

--- a/tasks/prd-geo-community-sunset.md
+++ b/tasks/prd-geo-community-sunset.md
@@ -1,0 +1,119 @@
+# PRD: Geo Community Sunset & Agent-First Content Sourcing
+
+## Introduction
+
+The community geo surface (Geo Free Play + Geo Contribute) exists to build the
+dataset GeoGamers runs on: screenshot ↔ map-coordinate pairs, promoted to
+canonical ground truth by crowd consensus. Since issue #331/#345 shipped, the
+same dataset can be built by an LLM agent over MCP: the Geo Agent API
+(`docs/geo-agent-api.md`) can enroll games, trigger ingestion, top up captures,
+curate maps, and — with `geo-agent:promote-override` — assert canonical pins
+directly, with no crowd involved.
+
+This PRD answers "can we remove the geo feature and go straight to GeoGamers?"
+and ships the first step: a sunset switch.
+
+**What cannot be removed** (GeoGamers hard dependencies):
+
+- Tables `geo_screenshot_meta`, `geo_screenshot_candidate`, `geo_maps` — every
+  GeoGamers challenge joins them.
+- The ingestion pipeline (map/capture importers, metadata resolver, geo-fetch
+  admin panel) — it is how maps and candidates exist at all.
+- `geo-scoring.service` (GeoGamers phase 2 reuses its decay curve) and the
+  Leaflet map components under `components/geo/` (GeoGamers pages import them).
+- The Geo Agent API + `@the-box/geo-agent-mcp` — the replacement sourcing path.
+
+**What is community-only** (candidates for sunset):
+
+- `/api/geo` routes: free-play pick/guess, contribute pick/pin, contributor
+  stats, playable-games catalog.
+- `GeoPlayPage`, `GeoContributePage`, `geoStore`, `geoFreePlayStore`.
+- Contributor progression (`geo-contributor.service`, tiers, shadow-ban),
+  first-pin/accuracy rewards (`geo-reward.service`).
+- The crowd half of `geo-consensus.service` (the ≥5-human-pins promote gate).
+
+## Goals
+
+- Allow a deployment to turn off the community surface without code changes,
+  losing nothing GeoGamers needs.
+- Keep the default behavior identical (flag defaults on) — no product decision
+  is forced by this PR.
+- Document the agent-first bootstrap runbook so GeoGamers can launch without
+  waiting for crowd consensus.
+- Defer physical deletion until the agent pipeline has proven itself in
+  production (phase 2, separate PR).
+
+## Non-Goals
+
+- Deleting any code, table, or migration in this phase.
+- Changing GeoGamers eligibility rules or consensus math.
+- Turning the flag off anywhere — that is an ops decision.
+
+## What shipped in this PR (phase 1 — the switch)
+
+- `GEO_COMMUNITY_ENABLED` (default `true`). When `false`:
+  - `/api/geo` is not mounted; requests get the JSON 404
+    (`NOT_FOUND`), which the frontend geo client maps to a localized
+    `GEO_COMMUNITY_DISABLED` message on the Geo pages.
+  - `GET /api/features` (new, public, cacheable) reports
+    `{ geoCommunity, geogamers }`; the frontend hides the Geo nav entry, the
+    home-page mode card, and the home hero's Geo CTA.
+- The geo data layer is untouched: ingestion workers, consensus worker (agent
+  pin proposals still feed it), admin geo-fetch, the agent API, and GeoGamers
+  all run regardless of the flag.
+
+## Agent-first bootstrap runbook (GeoGamers launch without the crowd)
+
+Preconditions: an admin-minted geo-agent key with the needed scopes
+(Admin → Géo → Clés agent), `RAWG_API_KEY` set, and the MCP server
+(`@the-box/geo-agent-mcp`) configured against prod.
+
+1. Flip the surface on: `GEO_AGENT_API_ENABLED=true`, then per stage
+   `GEO_AGENT_CURATE_ENABLED=true` and (deliberately last)
+   `GEO_AGENT_PROMOTE_OVERRIDE_ENABLED=true`.
+2. `GET /health` → `starved`/`eligibleGames` tells the agent how far from
+   `GEOGAMERS_MIN_ELIGIBLE_GAMES` (default 10) the pool is.
+3. Per missing game: `POST /games` (enroll by `rawgId`) → `POST /games/:id/ingest`
+   → inspect `GET /games/:id/maps`, `select`/`reject`/upload a manual map →
+   `POST /games/:id/captures` for geolocatable stills.
+4. Ground truth: prefer `POST /candidates/:id/pins` multi-pass proposals
+   (`visionPass` 0–2) so the consensus math cross-checks locations; use
+   `POST /candidates/:id/promote-override` (budget: 5/day/key) only for
+   captures the agent can localize against a structured source (e.g. a wiki
+   marker), never from vision alone while `GEO_AGENT_VISION_ENABLED` is off.
+5. Verify with `GET /api/admin/geogamers/health`, create the first challenge
+   via the admin card, set `GEOGAMERS_ENABLED=true`, launch at a month
+   boundary.
+
+Quality bar before trusting vision pins at scale: `npm run eval:geo-vision`
+must clear ≥40% of predictions within the map's consensus radius and median
+normalized error < 0.1 on ≥50 known-truth metas.
+
+## Phase 2 (separate PR, only after agent sourcing is proven)
+
+Once the flag has been `false` in production for a full season with no content
+starvation and no bad-pin incidents:
+
+- Delete `GeoPlayPage`, `GeoContributePage`, `geoStore`, `geoFreePlayStore`,
+  the `/geo` and `/geo/contribute` routes, and `lib/api/geo.ts`.
+- Delete the community endpoints from `geo.routes.ts` (or the file) and
+  `geo-contributor.service` / `geo-reward.service` + their repositories.
+- Keep `geo-consensus.service` — repurposed as the multi-pass agent-pin
+  validation harness (centroid + σ-rejection over `visionPass` voters).
+- Keep `geo_pins` (agent pins land there) and every `geo_*` content table.
+- Re-point the `/share/geo-run` OG route or retire it with the pages.
+- Drop the `geo-play`/`geo-contribute` e2e specs; add an agent-sourcing smoke
+  test against a seeded DB instead.
+
+## Risks
+
+- **Wrong canonical pins with no crowd to catch them.** Mitigation: prefer
+  consensus-validated multi-pass proposals over overrides; keep
+  `promoted_via = 'agent_override'` metas filterable and reversible; keep the
+  override budget tight.
+- **Losing a retention loop.** Contribute/free-play engagement should be
+  measured before phase 2 deletes them; the flag makes an A/B or staged
+  rollout trivial.
+- **Source licensing.** Agent-sourced locations lean on wiki/MapGenie-style
+  references; keep the provenance rules from `docs/geo-mode.md` (prefer
+  Wikidata/CC sources, identify the crawler, respect rate limits).


### PR DESCRIPTION
## Context

Follow-up to the "can we remove the geo feature and go straight to GeoGamers?" analysis. Short answer: the geo **data layer** (tables, ingestion pipeline, scoring, map components, agent API) is a hard dependency of GeoGamers and stays; the **community surface** (Geo Free Play + Contribute) is the only removable part, and the agent-driven sourcing path that replaces it already exists (`docs/geo-agent-api.md` + `@the-box/geo-agent-mcp`).

This PR ships the reversible first step: a sunset switch, defaulting to current behavior.

## Changes

**Backend**
- New `GEO_COMMUNITY_ENABLED` env flag (default `true`). When `false`, `/api/geo` is not mounted (mirrors the `GEOGAMERS_ENABLED` gate) and requests get the JSON 404. The geo data layer is untouched: ingestion workers, consensus worker (agent pin proposals still feed it), admin geo-fetch, the agent API and GeoGamers all run regardless.
- New public `GET /api/features` endpoint (`{ geoCommunity, geogamers }`, `Cache-Control: public, max-age=60`) — the SPA is built once into the Docker image, so runtime flags can't travel via `VITE_` vars.

**Frontend**
- `useFeatures()` hook (module-level cache + `useSyncExternalStore`, optimistic defaults so a failed fetch keeps current behavior).
- When `geoCommunity` is off: the Geo nav entry (Header desktop + drawer), the home-page Geo mode card, and the home hero's quiet Geo CTA are hidden.
- `lib/api/geo.ts` maps the unmounted-route 404 / non-JSON body to `GEO_COMMUNITY_DISABLED`, rendered by the existing `apiErrors.*` i18n mapping (fr + en strings added), so deep links to `/geo` show a friendly localized message.

**Docs**
- Kill-switch section in `docs/geo-mode.md`, `.env.example` entry.
- `tasks/prd-geo-community-sunset.md`: dependency analysis (what GeoGamers needs vs. what's community-only), the agent-first bootstrap runbook for launching GeoGamers without crowd consensus, the phase-2 deletion plan, and risks (ground-truth quality without a crowd, retention loop, source licensing).

## Verification

- `npm run build`, `npm run lint` (one pre-existing warning), `npm test` (416 + 25 + 30 pass).
- Smoke-tested the compiled features route + mount gate with both flag values: on → `geoCommunity: true` and `/api/geo` responds; off → `geoCommunity: false` and `/api/geo` returns `404 NOT_FOUND` JSON.
- Default-on means no behavior change for existing deployments and e2e (`geo-play`, `geo-contribute`) specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UHf24ihLPbtUcKBLwCAHn

---
_Generated by [Claude Code](https://claude.ai/code/session_014UHf24ihLPbtUcKBLwCAHn)_