### PR TITLE
feat(geo): revamp free-play UX — welcome hero, tiered reveal, run recap bars

### DIFF
--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -2563,11 +2563,17 @@
         "fromTarget": "{{percent}}% from the target",
         "newBest": "New personal best!",
         "best": "Personal best: {{score}}",
-        "correctMap": "The correct map was: {{map}}"
+        "correctMap": "The correct map was: {{map}}",
+        "tierLabel": {
+          "high": "Excellent!",
+          "mid": "Nice one!",
+          "low": "Way off…"
+        }
       },
       "progressAria": "{{played}} of {{total}} screenshots played",
       "run": {
         "start": "Start a run",
+        "startShort": "Run",
         "chip": "Run {{current}}/{{total}}",
         "abandon": "Abandon the run",
         "total": "Run total: {{score}}",
@@ -2595,17 +2601,17 @@
       "deck": {
         "label": "Screenshot and map"
       },
-      "empty": {
-        "title": "Help us map the world of video games",
-        "body": "Look at a screenshot, then drop a pin where the scene takes place on the game world map. Every pin grows a shared atlas that powers future location-guessing modes.",
-        "steps": {
-          "one": "Pick a game from your catalog.",
-          "two": "Tap the map where you think the screenshot was taken.",
-          "three": "Confirm — your pin joins the dataset."
-        },
+      "welcome": {
+        "title": "Guess where every screenshot was taken",
+        "body": "Study the screenshot, then drop your pin on the exact spot on the game map. Every pin grows the community atlas.",
         "pinsToday_one": "{{formatted}} pin dropped today by the community",
         "pinsToday_other": "{{formatted}} pins dropped today by the community",
-        "cta": "Pick a game"
+        "quickPlay": "Quick play",
+        "quickPlaySub": "A random screenshot — play right away.",
+        "pickGame": "Pick a game",
+        "pickGameSub": "Browse the catalog at your own pace.",
+        "startRun": "Start a run",
+        "startRunSub": "{{count}} scored rounds, one total to share."
       },
       "map": {
         "empty": {

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -2563,11 +2563,17 @@
         "fromTarget": "à {{percent}} % de la cible",
         "newBest": "Nouveau record perso !",
         "best": "Record perso : {{score}}",
-        "correctMap": "La bonne carte était : {{map}}"
+        "correctMap": "La bonne carte était : {{map}}",
+        "tierLabel": {
+          "high": "Excellent !",
+          "mid": "Bien joué !",
+          "low": "À côté…"
+        }
       },
       "progressAria": "{{played}} captures jouées sur {{total}}",
       "run": {
         "start": "Lancer un run",
+        "startShort": "Run",
         "chip": "Run {{current}}/{{total}}",
         "abandon": "Abandonner le run",
         "total": "Total du run : {{score}}",
@@ -2595,17 +2601,17 @@
       "deck": {
         "label": "Capture et carte"
       },
-      "empty": {
-        "title": "Aide-nous à cartographier l'univers du jeu vidéo",
-        "body": "Regarde la capture d'écran, puis pose une épingle là où la scène se passe sur la carte du jeu. Chaque épingle enrichit un atlas partagé qui alimentera de futurs modes \"devine le lieu\".",
-        "steps": {
-          "one": "Choisis un jeu dans ton catalogue.",
-          "two": "Tape sur la carte là où tu penses que la capture a été prise.",
-          "three": "Confirme — ton épingle rejoint le dataset."
-        },
+      "welcome": {
+        "title": "Devine où chaque capture a été prise",
+        "body": "Observe la capture d'écran, puis pose ton épingle à l'endroit exact sur la carte du jeu. Chaque épingle enrichit l'atlas communautaire.",
         "pinsToday_one": "{{formatted}} épingle posée aujourd'hui par la communauté",
         "pinsToday_other": "{{formatted}} épingles posées aujourd'hui par la communauté",
-        "cta": "Choisir un jeu"
+        "quickPlay": "Partie rapide",
+        "quickPlaySub": "Une capture au hasard — joue tout de suite.",
+        "pickGame": "Choisir un jeu",
+        "pickGameSub": "Parcours le catalogue et joue à ton rythme.",
+        "startRun": "Lancer un run",
+        "startRunSub": "{{count}} manches notées, un total à partager."
       },
       "map": {
         "empty": {

--- a/packages/frontend/src/components/geo/GeoPlayDeck.tsx
+++ b/packages/frontend/src/components/geo/GeoPlayDeck.tsx
@@ -157,6 +157,8 @@ export function GeoPlayDeck({
                 }
                 errorMessage={phase === 'error' ? errorMessage : null}
                 onPickGame={() => setGamePickerOpen(true)}
+                onQuickPlay={() => void pickRandomAcrossGames()}
+                onStartRun={() => void startRun()}
                 onCheckForNew={() => void checkForNewScreenshots()}
                 onIgnoreCurrent={() => {
                     if (currentGameId != null) {
@@ -178,6 +180,8 @@ export function GeoPlayDeck({
             ignoredSet,
             errorMessage,
             setGamePickerOpen,
+            pickRandomAcrossGames,
+            startRun,
             checkForNewScreenshots,
             toggleIgnoreGame,
         ],
@@ -237,6 +241,14 @@ export function GeoPlayDeck({
 
     const runActive = run != null
     const runComplete = run != null && run.scores.length >= RUN_LENGTH
+
+    // Full-deck takeover: with no game selected the split layout has
+    // nothing to split (the map panel would only say "pick a game
+    // first"), and the auth wall deserves the whole stage rather than
+    // the top third. In both cases the screenshot slot already renders
+    // the right state screen — hand it to the layout's hero slot and
+    // drop the dock (the state screens carry their own CTAs).
+    const showHero = currentGameId == null || phase === 'authRequired'
 
     const bottomDockSlot: ReactNode = useMemo(
         () => (
@@ -303,6 +315,7 @@ export function GeoPlayDeck({
                 mapInert={gamePickerOpen || mapPickerOpen}
                 roundKey={`${currentGameId ?? 'none'}-${round}`}
                 topRight={topRightSlot}
+                hero={showHero ? screenshotSlot : undefined}
                 screenshot={screenshotSlot}
                 map={mapSlot}
                 resultOverlay={
@@ -324,6 +337,9 @@ export function GeoPlayDeck({
                     ) : null
                 }
                 topBar={
+                    // The welcome/auth hero carries its own entry points —
+                    // context chips on top of it would just duplicate them.
+                    showHero ? null : (
                     <ContextHeader
                         gameLabel={currentGame?.name ?? null}
                         mapLabel={selectedMap?.region ?? null}
@@ -350,8 +366,9 @@ export function GeoPlayDeck({
                         onChangeMap={() => setMapPickerOpen(true)}
                         onEndRun={endRun}
                     />
+                    )
                 }
-                bottomDock={bottomDockSlot}
+                bottomDock={showHero ? null : bottomDockSlot}
             />
 
             {run?.finished && (

--- a/packages/frontend/src/components/geo/GeoPlaySlots.tsx
+++ b/packages/frontend/src/components/geo/GeoPlaySlots.tsx
@@ -27,11 +27,12 @@ import {
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
+import { GeoWelcome } from '@/components/geo/GeoWelcome'
 import { StatePanel } from '@/components/geo/StatePanel'
-import { useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
+import { RUN_LENGTH, useGeoFreePlayStore } from '@/stores/geoFreePlayStore'
 import { useCountUp } from '@/hooks/useCountUp'
 import { isPlaceholderImageUrl } from '@/lib/geo-image'
-import { geoScoreTier } from '@/lib/geo-score-tiers'
+import { GEO_ROUND_MAX, geoScoreTier } from '@/lib/geo-score-tiers'
 import { cn } from '@/lib/utils'
 
 export function ScreenshotPanel({
@@ -49,6 +50,8 @@ export function ScreenshotPanel({
     canIgnoreCurrent,
     errorMessage,
     onPickGame,
+    onQuickPlay,
+    onStartRun,
     onCheckForNew,
     onIgnoreCurrent,
 }: {
@@ -66,6 +69,8 @@ export function ScreenshotPanel({
     canIgnoreCurrent: boolean
     errorMessage: string | null
     onPickGame: () => void
+    onQuickPlay: () => void
+    onStartRun: () => void
     onCheckForNew: () => void
     onIgnoreCurrent: () => void
 }) {
@@ -175,54 +180,18 @@ export function ScreenshotPanel({
     }
 
     if (empty) {
+        // Cold-start welcome — rendered full-deck via the layout's hero
+        // slot (see GeoPlayDeck), so it owns the pitch, social proof and
+        // all three entry points instead of auto-opening the picker.
         return (
-            <StatePanel
-                icon={<MapPin className="size-8 text-neon-pink" aria-hidden />}
-                title={t('geo.play.empty.title', 'Help us map the world of video games')}
-                body={t(
-                    'geo.play.empty.body',
-                    'Look at a screenshot, then drop a pin where the scene takes place on the game world map. Every pin grows a shared atlas that powers future location-guessing modes.',
-                )}
-                bodyMaxWidthClass="max-w-md space-y-2"
-                actions={
-                    <Button onClick={onPickGame} className="gradient-gaming hover:opacity-90 min-h-12">
-                        <Gamepad2 className="size-4 mr-2" aria-hidden />
-                        {t('geo.play.empty.cta', 'Pick a game')}
-                    </Button>
-                }
-            >
-                {/* Cold-start social proof: only render once we have a
-                    real number from the server, and only when there's
-                    actually been activity today (>0). A "0 pins today"
-                    chip would do the opposite of social proof. */}
-                {pinsToday != null && pinsToday > 0 && (
-                    <p
-                        className="inline-flex items-center gap-1.5 rounded-full bg-neon-pink/10 px-3 py-1 text-xs text-white/90"
-                        aria-live="polite"
-                    >
-                        <Sparkles className="size-3 text-neon-pink" aria-hidden />
-                        {t('geo.play.empty.pinsToday', {
-                            defaultValue: '{{count}} pins dropped today by the community',
-                            count: pinsToday,
-                            formatted: pinsToday.toLocaleString(language),
-                        })}
-                    </p>
-                )}
-                <ol className="text-left text-xs text-muted-foreground/90 space-y-1.5 max-w-xs">
-                    <li className="flex gap-2">
-                        <span className="font-semibold text-neon-pink">1.</span>
-                        <span>{t('geo.play.empty.steps.one', 'Pick a game from your catalog.')}</span>
-                    </li>
-                    <li className="flex gap-2">
-                        <span className="font-semibold text-neon-pink">2.</span>
-                        <span>{t('geo.play.empty.steps.two', 'Tap the map where you think the screenshot was taken.')}</span>
-                    </li>
-                    <li className="flex gap-2">
-                        <span className="font-semibold text-neon-pink">3.</span>
-                        <span>{t('geo.play.empty.steps.three', 'Confirm — your pin joins the dataset.')}</span>
-                    </li>
-                </ol>
-            </StatePanel>
+            <GeoWelcome
+                pinsToday={pinsToday}
+                language={language}
+                runLength={RUN_LENGTH}
+                onQuickPlay={onQuickPlay}
+                onPickGame={onPickGame}
+                onStartRun={onStartRun}
+            />
         )
     }
 
@@ -371,6 +340,20 @@ const TIER_TEXT_CLASS = {
     low: 'text-score-low',
 } as const
 
+const TIER_BG_CLASS = {
+    high: 'bg-score-high',
+    mid: 'bg-score-mid',
+    low: 'bg-score-low',
+} as const
+
+// Qualitative verdict per tier — gives the reveal a human read of the
+// bare number ("Excellent!" vs "Way off…") before the meter quantifies it.
+const TIER_LABEL_KEY = {
+    high: ['geo.play.result.tierLabel.high', 'Excellent!'],
+    mid: ['geo.play.result.tierLabel.mid', 'Nice one!'],
+    low: ['geo.play.result.tierLabel.low', 'Way off…'],
+} as const
+
 /**
  * Round-end reveal sheet. The score counts up in its tier color
  * (bands in lib/geo-score-tiers.ts), distance reads as "x% from the
@@ -451,8 +434,15 @@ export function ResultSheet({
                         >
                             {animated.toLocaleString(language)}
                         </span>
-                        <span className="text-xs text-white/70">
-                            {t('geo.daily.score', 'Score')}
+                        <span
+                            className={cn(
+                                'text-xs font-semibold',
+                                wrongMap ? 'text-white/70' : TIER_TEXT_CLASS[tier],
+                            )}
+                        >
+                            {wrongMap
+                                ? t('geo.daily.score', 'Score')
+                                : t(TIER_LABEL_KEY[tier][0], TIER_LABEL_KEY[tier][1])}
                         </span>
                     </div>
                     <span className="text-xs text-white/70">
@@ -461,6 +451,20 @@ export function ResultSheet({
                             percent: distancePct,
                         })}
                     </span>
+                </div>
+                {/* Score meter toward the 2000-point ceiling — quantifies
+                    the tier verdict at a glance. Purely decorative: the
+                    sr-only sentence above already carries the numbers. */}
+                <div className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+                    <div
+                        className={cn(
+                            'h-full rounded-full motion-safe:transition-[width] motion-safe:duration-500',
+                            TIER_BG_CLASS[tier],
+                        )}
+                        style={{
+                            width: `${Math.min(100, (score / GEO_ROUND_MAX) * 100)}%`,
+                        }}
+                    />
                 </div>
                 <div className="mt-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs text-white/70">
                     <span className="inline-flex items-center gap-1">
@@ -790,22 +794,23 @@ export function Dock({
                         aria-label={t('geo.play.skip', "I don't know — skip this one")}
                         title={t('geo.play.skip', "I don't know — skip this one")}
                     >
-                        <SkipForward className="size-4 sm:mr-1.5" aria-hidden />
-                        <span className="hidden sm:inline">
-                            {t('geo.play.skipShort', 'Skip')}
-                        </span>
+                        <SkipForward className="size-4 mr-1.5" aria-hidden />
+                        {t('geo.play.skipShort', 'Skip')}
                     </Button>
                     {!runActive && (
                         <Button
                             type="button"
-                            variant="ghost"
+                            variant="outline"
                             onClick={onStartRun}
-                            className="min-h-12 text-neon-cyan hover:text-white"
+                            className="min-h-12 rounded-full border-neon-cyan/50 bg-transparent text-neon-cyan hover:bg-neon-cyan/10 hover:text-neon-cyan"
                             disabled={loading}
                             aria-label={t('geo.play.run.start', 'Start a run')}
                             title={t('geo.play.run.start', 'Start a run')}
                         >
-                            <Zap className="size-4 sm:mr-1.5" aria-hidden />
+                            <Zap className="size-4 mr-1.5" aria-hidden />
+                            <span className="sm:hidden">
+                                {t('geo.play.run.startShort', 'Run')}
+                            </span>
                             <span className="hidden sm:inline">
                                 {t('geo.play.run.start', 'Start a run')}
                             </span>

--- a/packages/frontend/src/components/geo/GeoWelcome.tsx
+++ b/packages/frontend/src/components/geo/GeoWelcome.tsx
@@ -1,0 +1,167 @@
+import { type ComponentType, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronRight, Gamepad2, MapPin, Play, Sparkles, Zap } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Cold-start hero for the free-play geo deck. Rendered across the FULL
+ * deck (both panel slots) when no game is selected, replacing the old
+ * flow that auto-opened the game picker over a blank split screen. The
+ * player gets the pitch, social proof and three explicit entry points —
+ * quick play (zero decisions), the catalog picker, and the scored run —
+ * before any sheet is pushed in their face.
+ */
+export function GeoWelcome({
+    pinsToday,
+    language,
+    runLength,
+    onQuickPlay,
+    onPickGame,
+    onStartRun,
+}: {
+    pinsToday: number | null
+    language: string
+    runLength: number
+    onQuickPlay: () => void
+    onPickGame: () => void
+    onStartRun: () => void
+}) {
+    const { t } = useTranslation()
+    return (
+        <div className="relative size-full overflow-y-auto">
+            {/* Decorative depth — one soft radial glow, per the one-hero-
+                glow-per-screen token rule (the reveal owns the glow once
+                a round is running; here the welcome is the only screen). */}
+            <div
+                aria-hidden
+                className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_45%_at_50%_0%,var(--tw-gradient-stops))] from-neon-purple/20 via-transparent to-transparent"
+            />
+            <div className="relative mx-auto flex min-h-full w-full max-w-md flex-col items-center justify-center gap-5 px-6 py-10 text-center">
+                <div className="rounded-full bg-neon-pink/10 p-4">
+                    <MapPin className="size-8 text-neon-pink" aria-hidden />
+                </div>
+                <div className="space-y-2">
+                    <h2 className="text-xl font-bold leading-tight sm:text-2xl">
+                        {t('geo.play.welcome.title', 'Guess where every screenshot was taken')}
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                        {t(
+                            'geo.play.welcome.body',
+                            'Study the screenshot, then drop your pin on the exact spot on the game map. Every pin grows the community atlas.',
+                        )}
+                    </p>
+                </div>
+
+                {/* Social proof — render only once a real, non-zero number
+                    landed; a "0 pins today" chip would do the opposite. */}
+                {pinsToday != null && pinsToday > 0 && (
+                    <p
+                        className="inline-flex items-center gap-1.5 rounded-full bg-neon-pink/10 px-3 py-1 text-xs text-white/90"
+                        aria-live="polite"
+                    >
+                        <Sparkles className="size-3 text-neon-pink" aria-hidden />
+                        {t('geo.play.welcome.pinsToday', {
+                            defaultValue: '{{count}} pins dropped today by the community',
+                            count: pinsToday,
+                            formatted: pinsToday.toLocaleString(language),
+                        })}
+                    </p>
+                )}
+
+                <div className="flex w-full flex-col gap-2.5">
+                    <WelcomeAction
+                        icon={Play}
+                        title={t('geo.play.welcome.quickPlay', 'Quick play')}
+                        sub={t(
+                            'geo.play.welcome.quickPlaySub',
+                            'A random screenshot — play right away.',
+                        )}
+                        onClick={onQuickPlay}
+                        variant="primary"
+                    />
+                    <WelcomeAction
+                        icon={Gamepad2}
+                        title={t('geo.play.welcome.pickGame', 'Pick a game')}
+                        sub={t(
+                            'geo.play.welcome.pickGameSub',
+                            'Browse the catalog at your own pace.',
+                        )}
+                        onClick={onPickGame}
+                    />
+                    <WelcomeAction
+                        icon={Zap}
+                        title={t('geo.play.welcome.startRun', 'Start a run')}
+                        sub={t('geo.play.welcome.startRunSub', {
+                            defaultValue: '{{count}} scored rounds, one total to share.',
+                            count: runLength,
+                        })}
+                        onClick={onStartRun}
+                        variant="run"
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function WelcomeAction({
+    icon: Icon,
+    title,
+    sub,
+    onClick,
+    variant = 'default',
+}: {
+    icon: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>
+    title: ReactNode
+    sub: ReactNode
+    onClick: () => void
+    variant?: 'primary' | 'run' | 'default'
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={cn(
+                'group flex w-full items-center gap-3 rounded-xl border p-3.5 text-left transition',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                variant === 'primary' &&
+                    'gradient-gaming border-transparent text-white hover:opacity-90',
+                variant === 'run' &&
+                    'border-neon-cyan/40 bg-card hover:border-neon-cyan/70',
+                variant === 'default' &&
+                    'border-border bg-card hover:border-neon-pink/60',
+            )}
+        >
+            <span
+                className={cn(
+                    'flex size-10 shrink-0 items-center justify-center rounded-full',
+                    variant === 'primary' && 'bg-white/15 text-white',
+                    variant === 'run' && 'bg-neon-cyan/10 text-neon-cyan',
+                    variant === 'default' && 'bg-neon-pink/10 text-neon-pink',
+                )}
+            >
+                <Icon className="size-5" aria-hidden />
+            </span>
+            <span className="min-w-0 flex-1">
+                <span className="block text-sm font-semibold leading-tight">
+                    {title}
+                </span>
+                <span
+                    className={cn(
+                        'mt-0.5 block text-xs leading-snug',
+                        variant === 'primary' ? 'text-white/80' : 'text-muted-foreground',
+                    )}
+                >
+                    {sub}
+                </span>
+            </span>
+            <ChevronRight
+                className={cn(
+                    'size-4 shrink-0 transition-transform group-hover:translate-x-0.5',
+                    variant === 'primary' ? 'text-white/80' : 'text-muted-foreground',
+                )}
+                aria-hidden
+            />
+        </button>
+    )
+}

--- a/packages/frontend/src/components/geo/ImmersiveLayout.tsx
+++ b/packages/frontend/src/components/geo/ImmersiveLayout.tsx
@@ -6,6 +6,11 @@ import { cn } from '@/lib/utils'
 interface ImmersiveLayoutProps {
     screenshot: ReactNode
     map: ReactNode
+    // Full-deck takeover slot. When set, it replaces BOTH panels (the
+    // header and dock still render around it) — used for the cold-start
+    // welcome and the auth wall, where a split screenshot/map layout
+    // would just squeeze the message into the top third of the screen.
+    hero?: ReactNode
     // Right-aligned header actions (home link, fullscreen toggle).
     // Rendered inside the same header strip as `topBar` so the page has
     // a single top row instead of an absolute overlay racing the bar
@@ -40,6 +45,7 @@ interface ImmersiveLayoutProps {
 export function ImmersiveLayout({
     screenshot,
     map,
+    hero,
     topRight,
     topBar,
     bottomDock,
@@ -106,6 +112,9 @@ export function ImmersiveLayout({
                 Firefox and snaps elsewhere, which is an acceptable
                 fallback. */}
             <div className="flex-1 relative overflow-hidden">
+                {hero ? (
+                    <div className="absolute inset-0">{hero}</div>
+                ) : (
                 <div
                     className="absolute inset-0 grid grid-rows-[minmax(30%,1fr)_minmax(52%,1.6fr)] md:grid-rows-1 md:[grid-template-columns:var(--geo-desktop-cols)] md:transition-[grid-template-columns] md:duration-300 motion-reduce:md:transition-none"
                     style={deckStyle}
@@ -173,6 +182,7 @@ export function ImmersiveLayout({
                         {map}
                     </Panel>
                 </div>
+                )}
             </div>
 
             {/* Result overlay — sits above the deck but below the dock so

--- a/packages/frontend/src/components/geo/RunRecap.tsx
+++ b/packages/frontend/src/components/geo/RunRecap.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Check, Share2, X, Zap } from 'lucide-react'
+import { Check, Share2, Star, X, Zap } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useCountUp } from '@/hooks/useCountUp'
-import { geoScoreTier } from '@/lib/geo-score-tiers'
+import { GEO_ROUND_MAX, geoScoreTier } from '@/lib/geo-score-tiers'
 import { RUN_LENGTH } from '@/stores/geoFreePlayStore'
 import { cn } from '@/lib/utils'
 
@@ -18,9 +18,6 @@ const TIER_BG_CLASS = {
     mid: 'bg-score-mid',
     low: 'bg-score-low',
 } as const
-
-// Per-round max from the scoring curve (docs/geo-mode.md).
-const ROUND_MAX = 2000
 
 /**
  * End-of-run recap: total count-up colored by the run's average tier,
@@ -41,8 +38,12 @@ export function RunRecap({
 }) {
     const { t } = useTranslation()
     const total = scores.reduce((sum, s) => sum + s, 0)
-    const max = RUN_LENGTH * ROUND_MAX
+    const max = RUN_LENGTH * GEO_ROUND_MAX
     const tier = geoScoreTier(total / Math.max(1, scores.length))
+    // Index of the best round — starred in the bar chart. Only
+    // meaningful when at least one round actually scored points.
+    const bestScore = Math.max(...scores)
+    const bestIndex = bestScore > 0 ? scores.indexOf(bestScore) : -1
     const animatedTotal = useCountUp(total, 700)
     const [copied, setCopied] = useState(false)
 
@@ -126,33 +127,52 @@ export function RunRecap({
                     </span>
                 </p>
 
-                {/* One dot per round, colored by that round's tier. */}
-                <ul className="mt-4 flex items-center justify-center gap-3">
-                    {scores.map((score, i) => (
-                        <li
-                            key={i}
-                            className="flex flex-col items-center gap-1"
-                            aria-label={t('geo.play.run.roundAria', {
-                                defaultValue: 'Round {{round}}: {{score}} points',
-                                round: i + 1,
-                                score: score.toLocaleString(language),
-                            })}
-                        >
-                            <span
-                                className={cn(
-                                    'size-3 rounded-full',
-                                    TIER_BG_CLASS[geoScoreTier(score)],
-                                )}
-                                aria-hidden
-                            />
-                            <span
-                                className="text-[10px] tabular-nums text-muted-foreground"
-                                aria-hidden
+                {/* One bar per round — height scales with the score,
+                    color follows the round's tier, and the best round
+                    gets a star. Reads round-by-round at a glance where
+                    the old 3px dots only encoded the tier. */}
+                <ul className="mt-5 flex items-end justify-center gap-2.5">
+                    {scores.map((score, i) => {
+                        const isBest = i === bestIndex
+                        return (
+                            <li
+                                key={i}
+                                className="flex w-10 flex-col items-center gap-1"
+                                aria-label={t('geo.play.run.roundAria', {
+                                    defaultValue: 'Round {{round}}: {{score}} points',
+                                    round: i + 1,
+                                    score: score.toLocaleString(language),
+                                })}
                             >
-                                {score.toLocaleString(language)}
-                            </span>
-                        </li>
-                    ))}
+                                {isBest && (
+                                    <Star
+                                        className="size-3 fill-score-high text-score-high"
+                                        aria-hidden
+                                    />
+                                )}
+                                <span
+                                    aria-hidden
+                                    className="flex h-16 w-3 items-end overflow-hidden rounded-full bg-muted/40"
+                                >
+                                    <span
+                                        className={cn(
+                                            'block w-full rounded-full',
+                                            TIER_BG_CLASS[geoScoreTier(score)],
+                                        )}
+                                        style={{
+                                            height: `${Math.max(6, Math.min(100, (score / GEO_ROUND_MAX) * 100))}%`,
+                                        }}
+                                    />
+                                </span>
+                                <span
+                                    className="text-[10px] tabular-nums text-muted-foreground"
+                                    aria-hidden
+                                >
+                                    {score.toLocaleString(language)}
+                                </span>
+                            </li>
+                        )
+                    })}
                 </ul>
 
                 <div className="mt-6 flex flex-col gap-2">

--- a/packages/frontend/src/lib/geo-score-tiers.ts
+++ b/packages/frontend/src/lib/geo-score-tiers.ts
@@ -9,6 +9,11 @@ export const GEO_SCORE_TIER_BANDS = {
     mid: 500,
 } as const
 
+// Per-round score ceiling from the scoring curve (docs/geo-mode.md).
+// Shared by the reveal meter and the run recap bars so a "full" bar
+// means the same thing everywhere.
+export const GEO_ROUND_MAX = 2000
+
 export type GeoScoreTier = 'high' | 'mid' | 'low'
 
 export function geoScoreTier(score: number): GeoScoreTier {

--- a/packages/frontend/src/pages/GeoPlayPage.tsx
+++ b/packages/frontend/src/pages/GeoPlayPage.tsx
@@ -107,23 +107,9 @@ export default function GeoPlayPage() {
           })
         : ''
 
-    // Open the game picker for a fresh visitor with no selection — gives
-    // them an obvious "what do I do here" cue instead of a blank canvas.
-    // Guarded by a ref so a later catalog refresh can't yank the picker
-    // back open over the player.
-    const hasAutoOpenedPickerRef = useRef(false)
-    useEffect(() => {
-        if (
-            !hasAutoOpenedPickerRef.current &&
-            currentGameId == null &&
-            games.length > 0
-        ) {
-            hasAutoOpenedPickerRef.current = true
-            // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot opener that keys off games-list arrival; the ref ensures it fires at most once per session.
-            setGamePickerOpen(true)
-        }
-    }, [games.length, currentGameId])
-
+    // Fresh visitors with no selection land on the full-deck welcome
+    // hero (see GeoWelcome), which carries the pitch and the entry
+    // points — no picker sheet is auto-opened over them anymore.
     const isMultiMap = maps.length > 1
     const selectedMap = useMemo(
         () => maps.find((m) => m.id === currentMapId) ?? null,


### PR DESCRIPTION
## Summary

Second-pass UX revamp of the free-play geo page (`/fr/geo`), building on the phases already shipped from `tasks/geo-play-revamp-proposal.html`. Verified visually by driving the page in Chromium (mobile 390×844 + desktop 1440×900) against a stubbed geo API: welcome, deck, draft pin, reveal and run recap all exercised end-to-end.

### Cold-start welcome hero (biggest change)
- Fresh visitors no longer get the game picker sheet auto-opened over a blank split screen. A new `GeoWelcome` hero takes over the **full deck** (new `hero` slot in `ImmersiveLayout`) with the pitch, the community pins-today social proof, and three explicit entry points: **Partie rapide** (random game, zero decisions), **Choisir un jeu** (picker), **Lancer un run** (scored mode — previously only discoverable via a small dock icon).
- The auth wall also renders full-deck instead of being squeezed into the top third on mobile.
- Header context chips are hidden while the hero is up (they duplicated its CTAs); home/fullscreen stay.

### Reveal sheet
- Tier verdict label next to the score («&nbsp;Excellent !&nbsp;» / «&nbsp;Bien joué !&nbsp;» / «&nbsp;À côté…&nbsp;»), suppressed on wrong-map fails.
- Score meter bar toward the 2000-point ceiling, colored by tier (`GEO_ROUND_MAX` now shared from `geo-score-tiers.ts`).

### Dock
- Skip and Run labels are visible at all widths (were icon-only below `sm`).
- Run is now a cyan-outlined button instead of a ghost icon, making the scored mode legible.

### Run recap
- Per-round tier **bars** (height ∝ score) with a star on the best round, replacing the 3px dots; a11y labels unchanged.

### i18n
- `geo.play.welcome.*` replaces the old `geo.play.empty.*` copy (fr written first), plus `result.tierLabel.*` and `run.startShort` in both locales.

## Screens exercised
Welcome (mobile/desktop) → quick play deck → draft pin → reveal (tier + meter) → 5-round run → recap bars. A11y plumbing untouched: pin live region, coordinate-entry fallback, roving-tabindex pickers, `min-h-11/12` targets.

## Test plan
- [x] `npm run build` (all packages typecheck)
- [x] `npm run lint` (0 errors; 1 pre-existing warning in `e2e/iphone-compliance.spec.ts`)
- [x] `npm test` (480 passing)
- [x] Manual Chromium pass on mobile + desktop viewports via stubbed geo API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ni511Stz5v5sWdLrQr4T3o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ni511Stz5v5sWdLrQr4T3o)_