### PR TITLE
feat(frontend): use thinking-orbs loaders for page load and guess check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17866,6 +17866,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/thinking-orbs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/thinking-orbs/-/thinking-orbs-0.1.1.tgz",
+      "integrity": "sha512-nLvLTGJtk74K13MmP7XiRdzFiQx7UsoZAIyBZNgXyl7Q3h2mdz0r3eKn9LCsuzb3DGOVjwDvMhtnAkIqJJRVQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -19732,6 +19742,7 @@
         "socket.io-client": "^4.8.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
+        "thinking-orbs": "^0.1.1",
         "three": "^0.182.0",
         "zod": "^4.3.5",
         "zustand": "^5.0.9"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -60,6 +60,7 @@
     "socket.io-client": "^4.8.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
+    "thinking-orbs": "^0.1.1",
     "three": "^0.182.0",
     "zod": "^4.3.5",
     "zustand": "^5.0.9"

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { BottomNav } from '@/components/layout/BottomNav'
 import { Toaster } from '@/components/ui/sonner'
+import { ThinkingOrb } from '@/components/ui/thinking-orb'
 import { cn } from '@/lib/utils'
 import { ErrorBoundary, LazyComponentErrorBoundary } from '@/components/ErrorBoundary'
 import { RouteSeo } from '@/components/RouteSeo'
@@ -62,9 +63,10 @@ const PricingPage = lazy(() => import('@/pages/PricingPage'))
 const TwoFactorChallengePage = lazy(() => import('@/pages/TwoFactorChallengePage'))
 
 function LoadingSpinner() {
+  const { t } = useTranslation()
   return (
     <div className="flex items-center justify-center min-h-screen">
-      <div className="size-12 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+      <ThinkingOrb state="searching" size={64} aria-label={t('common.loading')} />
     </div>
   )
 }

--- a/packages/frontend/src/components/game/GuessInput.tsx
+++ b/packages/frontend/src/components/game/GuessInput.tsx
@@ -5,7 +5,8 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Tooltip } from '@/components/ui/tooltip'
 import { useGameStore } from '@/stores/gameStore'
-import { SkipForward, SkipBack, Loader2, Send } from 'lucide-react'
+import { SkipForward, SkipBack, Send } from 'lucide-react'
+import { ThinkingOrb } from '@/components/ui/thinking-orb'
 import { createGuessSubmissionService } from '@/services'
 import { LetterRevealBar } from '@/components/game/LetterRevealBar'
 import { ProximityHintBanner } from '@/components/game/ProximityHintBanner'
@@ -261,7 +262,15 @@ export function GuessInput() {
                 )}
               >
                 {isSubmitting ? (
-                  <Loader2 className={cn('size-4 sm:size-5 animate-spin', query.trim() && 'text-white')} />
+                  // `solving` reads as "checking your guess". Decorative here —
+                  // the Button already carries the `game.submit` aria-label, so
+                  // the orb is hidden from assistive tech to avoid a double read.
+                  <ThinkingOrb
+                    state="solving"
+                    size={20}
+                    role="presentation"
+                    aria-hidden
+                  />
                 ) : (
                   <Send className={cn('size-4 sm:size-5', query.trim() && 'text-white')} />
                 )}

--- a/packages/frontend/src/components/ui/thinking-orb.tsx
+++ b/packages/frontend/src/components/ui/thinking-orb.tsx
@@ -1,0 +1,24 @@
+import { ThinkingOrb as BaseThinkingOrb } from 'thinking-orbs'
+import type { ThinkingOrbProps } from 'thinking-orbs'
+
+export type { OrbState, OrbSize } from 'thinking-orbs'
+
+/**
+ * Thin wrapper around `thinking-orbs`' <ThinkingOrb> — Jakub Antalik's dotted
+ * thought-orb loaders (https://orbs.jakubantalik.com). It exists to pin the
+ * theme once, app-wide.
+ *
+ * The Box is dark-only (`color-scheme: dark` in index.css) and its
+ * `data-theme` attribute carries *accent* names (`neon_pink`, `cyber_blue`…),
+ * not `dark`/`light`. The library's default `theme="auto"` therefore never
+ * matches a dark/light ancestor and falls through to `prefers-color-scheme`,
+ * which would paint dark (invisible) ink on our dark surfaces for anyone whose
+ * OS is in light mode. Pinning `dark` keeps the light-ink orb visible
+ * everywhere. Callers can still override `theme` for a light surface.
+ *
+ * Reduced-motion, offscreen/hidden-tab pausing and DPR capping are handled by
+ * the library itself, so there is nothing to add here.
+ */
+export function ThinkingOrb({ theme = 'dark', ...props }: ThinkingOrbProps) {
+  return <BaseThinkingOrb theme={theme} {...props} />
+}


### PR DESCRIPTION
## Summary

Integrates [thinking-orbs](https://orbs.jakubantalik.com) — Jakub Antalik's dotted "thought-orb" loading indicators — into the app, replacing two generic spinners with state-matched orbs.

- **New wrapper** `components/ui/thinking-orb.tsx` — re-exports the library's `<ThinkingOrb>` but **pins `theme="dark"` once, app-wide**. The Box is dark-only (`color-scheme: dark`), and its `data-theme` attribute carries *accent* names (`neon_pink`, `cyber_blue`…), not `dark`/`light`. The library's default `theme="auto"` therefore never matches a dark/light ancestor and would fall through to `prefers-color-scheme`, painting invisible dark ink on our dark surfaces for anyone whose OS is in light mode. Pinning `dark` keeps the light-ink orb visible everywhere.
- **Route Suspense fallback** (`App.tsx`) → `searching` orb at size 64, with a localized `common.loading` aria-label.
- **Guess submit button** (`GuessInput.tsx`) → `solving` orb at size 20 while a guess is being checked (semantically "solving your guess"). Kept decorative (`role="presentation"` + `aria-hidden`) since the button already carries the `game.submit` aria-label.

## Why these spots

The two swaps map the library's animation vocabulary onto real app states: a page loading is *searching*, checking a guess is *solving*. Both are drop-in replacements for existing spinners — no layout or behavior change beyond the visual.

## Notes

- Peer dep is React ≥18; the app runs React 19. ✅
- Reduced-motion, offscreen/hidden-tab pausing and DPR capping are handled inside the library.
- Plain 2D canvas (no WebGL/filters), so no bundle-size or cross-browser concern.

## Testing

- `npm run build` (types + frontend) — passes
- `npm run lint` — no new warnings (one pre-existing unrelated warning in an e2e spec)
- `npm test` — 30/30 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7Ya6NXtszVhg91aVLPapF

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7Ya6NXtszVhg91aVLPapF)_