### PR TITLE
fix(game): center daily screenshot in viewer and re-anchor zoom

### DIFF
--- a/packages/frontend/src/components/ui/carousel.tsx
+++ b/packages/frontend/src/components/ui/carousel.tsx
@@ -179,7 +179,12 @@ const CarouselContent = ({ className, ref, ...props }: CarouselContentProps) => 
   const { carouselRef, orientation } = useCarousel()
 
   return (
-    <div ref={carouselRef} className="overflow-hidden">
+    // The embla viewport wrapper must inherit the section's height so a
+    // full-height carousel (e.g. the game screenshot viewer) keeps its vertical
+    // centering. Without `h-full` here the wrapper collapses to content height,
+    // pushing the image off-centre and breaking zoom geometry. `h-full` is a
+    // no-op for auto-height (horizontal card) carousels.
+    <div ref={carouselRef} className="h-full overflow-hidden">
       <div
         ref={ref}
         className={cn(

--- a/packages/frontend/src/components/ui/game-carousel.tsx
+++ b/packages/frontend/src/components/ui/game-carousel.tsx
@@ -245,6 +245,7 @@ export function GameCarousel({
     const [api, setApi] = useState<CarouselApi>()
     const [loadedImages, setLoadedImages] = useState<Set<number>>(new Set())
     const hasUserInteractedRef = useRef(false)
+    const rootRef = useRef<HTMLDivElement | null>(null)
 
     const zoom = useImageZoom(images[currentIndex]?.url ?? currentIndex)
     const { view } = zoom
@@ -316,6 +317,24 @@ export function GameCarousel({
         }
     }, [api])
 
+    // Re-measure embla whenever the viewer's box size settles or changes.
+    // Embla computes its snap positions once at init; if that happens before
+    // the flex height resolves (the screenshot frame is `flex-1 min-h-0`) its
+    // built-in resize watcher never fires — it only reacts to width changes —
+    // so the centered slide can land dozens of pixels off-centre and stay there.
+    // A ResizeObserver fires on the first real layout (and any later resize),
+    // letting us reInit and re-anchor the active slide exactly centered.
+    useEffect(() => {
+        const el = rootRef.current
+        if (!api || !el) return
+        const ro = new ResizeObserver(() => {
+            api.reInit()
+            api.scrollTo(currentIndex, false)
+        })
+        ro.observe(el)
+        return () => ro.disconnect()
+    }, [api, currentIndex])
+
     // Sync the embla carousel (an external, imperative system) to the
     // controlled `currentIndex` prop. This is the React-endorsed "synchronizing
     // with an external system" effect — there is no user event to hang it on,
@@ -340,7 +359,7 @@ export function GameCarousel({
     )
 
     return (
-        <div className={cn('relative size-full', className)}>
+        <div ref={rootRef} className={cn('relative size-full', className)}>
             <Carousel
                 setApi={setApi}
                 opts={{

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -362,11 +362,6 @@ html {
   }
 }
 
-/* Ensure CarouselContent wrapper takes full height for vertical centering */
-[role="region"][aria-roledescription="carousel"] > div {
-  height: 100% !important;
-}
-
 /* =====================================================================
    Premium themes
    ---------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On the Daily screenshot-guessing mode, the screenshot was not centered in the viewer depending on its dimensions (portrait/landscape), and the zoom feature did not re-center the image on zoom in/out — it stayed low and partly hidden.

## Root cause

The screenshot viewer relied on a **global CSS rule** to give the embla carousel's viewport wrapper its height:

```css
[role="region"][aria-roledescription="carousel"] > div { height: 100% !important; }
```

But the carousel renders a `<section aria-roledescription="carousel">` **without** a literal `role="region"` attribute (a `<section>` only gets an implicit `region` role when it has an accessible name, and attribute selectors don't match implicit roles anyway). So the selector never matched the game carousel:

- the embla viewport wrapper collapsed to content height → the whole `flex-1 min-h-0` height chain broke;
- the `object-contain` image no longer filled the frame, rendering off-centre (stuck low);
- the zoom `fit`/clamp math ran against a wrong-height frame, so zoom in/out never re-centered.

A secondary issue: even with height fixed, embla computes its snap positions **once at init** — before the flex height resolves — and its built-in resize watcher only reacts to **width** changes. So the "current" slide could land dozens of pixels off-centre horizontally and stay there.

## Changes

- **`carousel.tsx`** — give the embla viewport wrapper `h-full` so it inherits the section height. This is a no-op for auto-height horizontal carousels (e.g. `HomeAchievementTeaser`).
- **`index.css`** — remove the dead, never-matching height hack.
- **`game-carousel.tsx`** — observe the viewer box with a `ResizeObserver` and `reInit()` + `scrollTo()` embla on first real layout (and any later resize, e.g. mobile keyboard open/close), re-anchoring the active slide exactly centered.

## Validation

Validated with Playwright driving the **real `GameCarousel`** component mounted in isolation (no backend needed), across portrait and landscape screenshots on both desktop and mobile viewports:

- the `<img>` fills the frame and its centre coincides with the frame centre within 2px (X and Y);
- zoom **in** grows the image while keeping it centered;
- zoom **out** below fit shrinks it while keeping it centered (no longer stuck low).

Before the fix these assertions failed (image height collapsed to ~320px vs a ~592px frame; centre off by 120–160px). After the fix, all pass consistently with no flakiness. `npm run build`, `npm run lint`, and `npm test` are green.

> Note: the Playwright harness used for validation was intentionally not committed — it required a dev-only route and a lint exception. The change is a self-contained layout/geometry fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZf5Pd6UUnzb5Wazq1jwuK)_