### PR TITLE
fix(game): show last-round result before completion-choice modal

### DIFF
--- a/packages/frontend/e2e/completion-choice-order.spec.ts
+++ b/packages/frontend/e2e/completion-choice-order.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Regression: end-of-game dialog ordering on the last-needed screenshot.
+ *
+ * Bug: when the player made the final correct guess while skipped positions
+ * still remained, the game set `gamePhase='result'` (the per-screenshot
+ * ResultCard, z-40) AND `showCompletionChoice=true` (the CompletionChoiceModal,
+ * a z-50 portal) at the same time. The modal rendered on top of the result
+ * card, so the player could never see whether that last guess was correct.
+ *
+ * Fix: the result card is shown FIRST (queued via `pendingCompletionChoice`);
+ * the completion-choice modal only opens once the player advances from the
+ * result. This spec asserts that ordering.
+ *
+ * The daily-game backend (challenge / session / screenshot / guess) is fully
+ * network-mocked so the test is deterministic and runs against the frontend
+ * dev server alone — no Postgres/Redis/backend required. The completion-choice
+ * scenario ("visited all positions, one still skipped, last guess correct") is
+ * seeded through the dev-only `window.__gameStore` test seam.
+ */
+
+const TRANSPARENT_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+
+const FAKE_USER = {
+  id: 'e2e-completion-user',
+  email: 'completion@test.local',
+  name: 'Completion Tester',
+  username: 'completion',
+  displayName: 'Completion Tester',
+  emailVerified: true,
+  image: null,
+  role: 'user',
+  createdAt: '2020-01-01T00:00:00.000Z',
+  updatedAt: '2020-01-01T00:00:00.000Z',
+}
+
+const CORRECT_GAME = {
+  id: 42,
+  name: 'The Witcher 3: Wild Hunt',
+  slug: 'the-witcher-3',
+  aliases: ['Witcher 3'],
+  releaseYear: 2015,
+  developer: 'CD Projekt Red',
+  publisher: 'CD Projekt',
+}
+
+function jsonOk(data: unknown) {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ success: true, data }),
+  }
+}
+
+async function mockDailyGameBackend(page: Page) {
+  const today = new Date().toISOString().slice(0, 10)
+
+  // Better Auth session — a logged-in user so the guest gate never appears.
+  await page.route('**/api/auth/get-session*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session: {
+          id: 'sess-1',
+          userId: FAKE_USER.id,
+          token: 'tok',
+          expiresAt: '2999-01-01T00:00:00.000Z',
+        },
+        user: FAKE_USER,
+      }),
+    })
+  )
+
+  // Today's challenge exists; no prior session → fresh start via the intro.
+  await page.route('**/api/game/today*', (route) =>
+    route.fulfill(
+      jsonOk({
+        challengeId: 1,
+        date: today,
+        totalScreenshots: 10,
+        hasPlayed: false,
+        userSession: null,
+      })
+    )
+  )
+
+  // Start the challenge session.
+  await page.route('**/api/game/start/*', (route) =>
+    route.fulfill(
+      jsonOk({
+        sessionId: 'sid-1',
+        tierSessionId: 'tsid-1',
+        totalScreenshots: 10,
+        sessionStartedAt: `${today}T00:00:00.000Z`,
+      })
+    )
+  )
+
+  // Any screenshot request → a valid response for the requested position.
+  await page.route('**/api/game/screenshot*', (route) => {
+    const url = new URL(route.request().url())
+    const position = Number(url.searchParams.get('position') ?? '1')
+    route.fulfill(
+      jsonOk({
+        screenshotId: 1000 + position,
+        position,
+        imageUrl: TRANSPARENT_PNG,
+        timeLimitSeconds: 45,
+      })
+    )
+  })
+
+  // Every guess is correct but the session is NOT complete (a skipped position
+  // still remains) — exactly the state that used to stack the two dialogs.
+  await page.route('**/api/game/guess', (route) =>
+    route.fulfill(
+      jsonOk({
+        isCorrect: true,
+        correctGame: CORRECT_GAME,
+        scoreEarned: 100,
+        totalScore: 900,
+        screenshotsFound: 9,
+        nextPosition: 10,
+        isCompleted: false,
+        matchPrecision: 'exact',
+      })
+    )
+  )
+}
+
+/**
+ * Seed the "visited all positions, one still skipped" state directly on the
+ * store, keeping the CURRENT position (1) in progress so the next guess is the
+ * final correct one that triggers the completion choice.
+ */
+async function seedAllVisitedOneSkipped(page: Page) {
+  await page.evaluate(() => {
+    const store = (
+      window as unknown as {
+        __gameStore?: { setState: (s: Record<string, unknown>) => void }
+      }
+    ).__gameStore
+    if (!store) throw new Error('window.__gameStore is not exposed')
+
+    const positionStates: Record<number, unknown> = {
+      1: { position: 1, status: 'in_progress', isCorrect: false },
+      10: { position: 10, status: 'skipped', isCorrect: false },
+    }
+    for (let i = 2; i <= 9; i++) {
+      positionStates[i] = { position: i, status: 'correct', isCorrect: true }
+    }
+
+    store.setState({
+      currentPosition: 1,
+      totalScreenshots: 10,
+      positionStates,
+    })
+  })
+}
+
+test.describe('End-of-game dialog ordering', () => {
+  test('shows the last result before the completion choice (not stacked)', async ({
+    page,
+  }) => {
+    await mockDailyGameBackend(page)
+
+    await page.goto('/en/play')
+
+    // Start the daily game from the intro screen.
+    const startButton = page.getByRole('button', {
+      name: /start|commencer|play/i,
+    })
+    await expect(startButton).toBeVisible({ timeout: 15000 })
+    await startButton.click()
+
+    // Wait until we're actually in the playing phase with a screenshot loaded.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              (
+                window as unknown as {
+                  __gameStore?: { getState: () => { gamePhase: string } }
+                }
+              ).__gameStore?.getState().gamePhase
+          ),
+        { timeout: 15000 }
+      )
+      .toBe('playing')
+
+    // Seed the completion-choice scenario, then make the final correct guess.
+    await seedAllVisitedOneSkipped(page)
+
+    const guessInput = page.getByPlaceholder(/game name/i).first()
+    await expect(guessInput).toBeEnabled()
+    await guessInput.fill('The Witcher 3')
+    await page.getByRole('button', { name: /submit guess/i }).click()
+
+    // 1) The per-screenshot result appears first and clearly shows the outcome.
+    const resultDialog = page.getByRole('dialog', { name: /round result/i })
+    await expect(resultDialog).toBeVisible()
+    await expect(resultDialog.getByText(/correct/i).first()).toBeVisible()
+
+    // 2) The completion-choice modal is NOT stacked on top of the result — the
+    //    regression assertion: its title must be absent while the result shows.
+    const completionTitle = page.getByText('Nice Work!', { exact: true })
+    await expect(completionTitle).toBeHidden()
+
+    // 3) Advancing from the result reveals the completion-choice modal.
+    await resultDialog.getByRole('button', { name: /continue/i }).click()
+
+    await expect(completionTitle).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /see results/i })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /continue playing/i })
+    ).toBeVisible()
+
+    // 4) The result card is gone once the choice modal is up (clean hand-off).
+    await expect(resultDialog).toBeHidden()
+  })
+})

--- a/packages/frontend/public/locales/en/translation.json
+++ b/packages/frontend/public/locales/en/translation.json
@@ -340,6 +340,7 @@
     "time": "Time",
     "guessPlaceholder": "Game name...",
     "nextRound": "Next Round",
+    "continue": "Continue",
     "correct": "Correct!",
     "partialMatch": "Franchise recognised!",
     "partialMatchHint": "You named the series but not the full title — partial points awarded.",

--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -340,6 +340,7 @@
     "time": "Temps",
     "guessPlaceholder": "Nom du jeu...",
     "nextRound": "Round Suivant",
+    "continue": "Continuer",
     "correct": "Correct !",
     "partialMatch": "Licence reconnue !",
     "partialMatchHint": "Tu as trouvé la série mais pas le titre complet — points partiels accordés.",

--- a/packages/frontend/src/components/game/ResultCard.tsx
+++ b/packages/frontend/src/components/game/ResultCard.tsx
@@ -35,6 +35,9 @@ export function ResultCard() {
     challengeId,
     isSessionCompleted,
     showCompletionChoice,
+    pendingCompletionChoice,
+    setPendingCompletionChoice,
+    setShowCompletionChoice,
   } = useGameStore()
 
   // Auto-close countdown state (must be before early return)
@@ -50,6 +53,17 @@ export function ResultCard() {
   const nextPosition = lastResult ? findNextUnfinished(currentPosition) : null
 
   const handleNext = useCallback(() => {
+    // A completion-choice prompt was queued behind this result (the last correct
+    // guess with skipped positions still remaining). Now that the player has seen
+    // whether that guess was correct, reveal the choice modal. Switching to
+    // 'playing' unmounts this ResultCard so the modal shows over the game surface
+    // instead of stacking on top of the (now hidden) result card.
+    if (pendingCompletionChoice) {
+      setPendingCompletionChoice(false)
+      setGamePhase('playing')
+      setShowCompletionChoice(true)
+      return
+    }
     if (nextPosition) {
       // Navigate to next unfinished position
       navigateToPosition(nextPosition)
@@ -85,7 +99,16 @@ export function ResultCard() {
         setGamePhase('challenge_complete')
       }
     }
-  }, [nextPosition, navigateToPosition, positionStates, setGamePhase, challengeId])
+  }, [
+    nextPosition,
+    navigateToPosition,
+    positionStates,
+    setGamePhase,
+    challengeId,
+    pendingCompletionChoice,
+    setPendingCompletionChoice,
+    setShowCompletionChoice,
+  ])
 
   // Auto-navigation fires from the timer when it reaches zero. Wrapped as an
   // Effect Event so it always reads the latest state without being a reactive
@@ -174,6 +197,10 @@ export function ResultCard() {
 
   // Determine button text
   const getButtonText = () => {
+    // A completion choice is queued behind this result — advancing opens it.
+    if (pendingCompletionChoice) {
+      return t('game.continue', 'Continue')
+    }
     // Show "View Results" only when session is completed
     if (isSessionCompleted) {
       return t('game.viewResults')

--- a/packages/frontend/src/hooks/useGameGuess.ts
+++ b/packages/frontend/src/hooks/useGameGuess.ts
@@ -153,9 +153,14 @@ export function useGameGuess(submissionService: GuessSubmissionService) {
           const hasSkipped = store.hasSkippedPositions()
 
           if (result.isCorrect && hasVisitedAll && hasSkipped) {
-            // Show completion choice modal instead of auto-navigating
+            // Show the per-screenshot result FIRST so the player can clearly see
+            // whether this last guess was correct. The completion-choice modal is
+            // only queued here (pendingCompletionChoice) and opened once the
+            // player dismisses/advances from the result card — otherwise the
+            // modal (z-50 portal) would render on top of the result card (z-40)
+            // and hide the outcome. See ResultCard.handleNext.
             store.setGamePhase('result')
-            store.setShowCompletionChoice(true)
+            store.setPendingCompletionChoice(true)
           } else {
             // Show result screen before advancing to next screenshot
             store.setGamePhase('result')

--- a/packages/frontend/src/stores/gameStore.ts
+++ b/packages/frontend/src/stores/gameStore.ts
@@ -65,6 +65,12 @@ interface GameState {
   lastResult: GuessResult | null
   isSessionCompleted: boolean // Tracks if backend has marked session as complete
   showCompletionChoice: boolean // Controls visibility of the completion choice modal
+  // When true, a completion-choice prompt is queued but intentionally NOT shown
+  // yet: the per-screenshot ResultCard is displayed first so the player can see
+  // whether their last guess was correct. The choice modal only opens once they
+  // dismiss/advance from that result (see ResultCard.handleNext). This prevents
+  // the modal (a z-50 portal) from covering the result card (z-40).
+  pendingCompletionChoice: boolean
 
   // Actions
   setSessionId: (id: string, tierSessionId: string) => void
@@ -79,6 +85,7 @@ interface GameState {
   setLoading: (loading: boolean) => void
   setIsSessionCompleted: (completed: boolean) => void
   setShowCompletionChoice: (value: boolean) => void
+  setPendingCompletionChoice: (value: boolean) => void
 
   addGuessResult: (result: GuessResult) => void
   recordAttempt: (position: number, attempt: GuessAttempt) => void
@@ -170,6 +177,7 @@ const initialState = {
   lastResult: null,
   isSessionCompleted: false,
   showCompletionChoice: false,
+  pendingCompletionChoice: false,
 }
 
 export const useGameStore = create<GameState>()(
@@ -243,6 +251,7 @@ export const useGameStore = create<GameState>()(
         setGamePhase: (phase) => set({ gamePhase: phase }),
         setIsSessionCompleted: (completed) => set({ isSessionCompleted: completed }),
         setShowCompletionChoice: (value) => set({ showCompletionChoice: value }),
+        setPendingCompletionChoice: (value) => set({ pendingCompletionChoice: value }),
 
         setLoading: (loading) => set({ isLoading: loading }),
 
@@ -775,3 +784,12 @@ export const useGameStore = create<GameState>()(
     { name: 'GameStore' }
   )
 )
+
+// Dev-only test seam: expose the store on `window` so E2E specs can set up
+// deterministic game states (e.g. the "visited all + skipped" completion-choice
+// scenario) without a live backend. Guarded by `import.meta.env.DEV`, so it is
+// stripped from production builds and never widens the app's runtime surface.
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __gameStore?: typeof useGameStore }).__gameStore =
+    useGameStore
+}


### PR DESCRIPTION
## Problème

Dans le jeu quotidien, à la dernière étape, lorsque le joueur devinait correctement la dernière capture **alors que des positions étaient encore passées (skipped)**, la boîte de dialogue de fin de partie (**CompletionChoiceModal**, un portail `z-50`) s'ouvrait **en même temps** que la carte de résultat de la manche (**ResultCard**, `z-40`).

Résultat : le modal recouvrait la carte de résultat, et le joueur ne voyait **jamais** si sa dernière capture avait été devinée ou non — exactement le symptôme signalé (« la dialogue est en dessous de la dialogue de fin de partie »).

## Correctif

Le résultat de la manche est désormais affiché **d'abord**, puis le choix de fin de partie est proposé **ensuite** :

- Ajout d'un drapeau `pendingCompletionChoice` dans le `gameStore`. Sur la dernière bonne réponse avec positions passées restantes, `useGameGuess` met la partie en phase `result` et **met en file d'attente** le choix (au lieu d'ouvrir le modal immédiatement).
- Dans `ResultCard.handleNext`, une fois que le joueur avance depuis le résultat (bouton « Continuer » / Entrée / auto-avance), on repasse en phase `playing` — ce qui **démonte** la carte de résultat — puis on ouvre le modal de choix, qui s'affiche proprement au-dessus de la surface de jeu.
- Nouveau libellé i18n `game.continue` (fr : « Continuer », en : « Continue ») pour le bouton d'avancement dans ce cas.

Le time-out de manche reste inoffensif pendant l'ouverture du modal : son effet est déjà protégé par `status !== 'in_progress'`, et la position venant d'être devinée est `'correct'`.

## Séquence après correctif

1. **Résultat** de la dernière capture (Correct / Incorrect) clairement visible.
2. Le joueur avance → **modal de fin de partie** (« Continuer à jouer » / « Voir les résultats »).

## Validation Playwright

Nouveau spec `e2e/completion-choice-order.spec.ts` :

- Mocke entièrement le backend du jeu quotidien (auth, challenge, session, screenshot, guess) via `page.route`, donc il s'exécute contre le **serveur de dev frontend seul** (pas de Postgres/Redis/backend requis) et de façon déterministe.
- Reproduit le scénario « toutes les positions visitées + une passée » via un point de test `window.__gameStore` exposé **uniquement en DEV** (`import.meta.env.DEV`, absent des builds de production).
- Assertions : (1) la carte de résultat s'affiche et montre l'issue, (2) le modal de fin de partie **n'est pas** empilé par-dessus, (3) après avancement le modal apparaît, (4) la carte de résultat a disparu.

✅ Passe sur les projets `chromium` et `Mobile Chrome`.

## Fichiers modifiés

- `src/stores/gameStore.ts` — état `pendingCompletionChoice` + action, et point de test DEV `window.__gameStore`.
- `src/hooks/useGameGuess.ts` — met en file d'attente le choix au lieu d'ouvrir le modal en même temps que le résultat.
- `src/components/game/ResultCard.tsx` — révèle le modal à l'avancement ; libellé de bouton dédié.
- `public/locales/{en,fr}/translation.json` — clé `game.continue`.
- `e2e/completion-choice-order.spec.ts` — nouveau test de régression.

## Tests

- `tsc -b` (typecheck) ✅
- `npm test` (unitaires, tous workspaces) ✅ — également exécuté par le hook pre-commit
- `npx playwright test completion-choice-order.spec.ts` ✅ (chromium + Mobile Chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XifoEbhQM9tHitdipEajqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01XifoEbhQM9tHitdipEajqs)_