### PR TITLE
fix(design-system): close token-lint gap and migrate 3 raw glow shadows

### DIFF
--- a/docs/ui-tokens.md
+++ b/docs/ui-tokens.md
@@ -115,6 +115,8 @@ Toute valeur `box-shadow` dans un composant doit référencer un de ces tokens.
 | `--glow-success` | `0 0 20px oklch(0.75 0.2 145 / 0.5)` | Correct-guess pulse, success input state |
 | `--glow-warning` | `0 0 20px oklch(0.8 0.15 85 / 0.5)` | Cautionary progress bars, pending warnings |
 | `--glow-error` | `0 0 20px oklch(0.7 0.22 25 / 0.5)` | Wrong-guess shake, error input state |
+| `--glow-pink-sm` | `0 0 12px oklch(0.72 0.2 350 / 0.4)` | Pink selection ring (selected map tile) |
+| `--glow-pink-lg` | `0 0 40px -12px oklch(0.72 0.2 350 / 0.45)` | Diffuse pink card halo (highlighted pricing card) |
 | `--text-shadow-neon` | stacked neon text shadow | Hero titles (TierIntro, landing heroes) |
 
 **Classes utilitaires déjà câblées :**

--- a/packages/frontend/eslint-local/no-raw-design-tokens.js
+++ b/packages/frontend/eslint-local/no-raw-design-tokens.js
@@ -17,7 +17,13 @@
  */
 
 const HEX_COLOR_RE = /#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?\b/
-const RAW_COLOR_FN_RE = /\b(?:rgba?|oklch|oklab|hsla?|color)\(/
+// NB: a leading `\b` here would MISS the most common offender —
+// `shadow-[0_0_20px_rgba(...)]` — because Tailwind joins arbitrary-value
+// tokens with `_`, and `_` is a word char, so there is no word boundary
+// between `_` and `rgba`. Use a negative lookbehind that only rejects an
+// alphabetic prefix (so `bgcolor(` stays un-matched) while still catching
+// the function after `_`, `(`, `,` or whitespace.
+const RAW_COLOR_FN_RE = /(?<![a-zA-Z])(?:rgba?|oklch|oklab|hsla?|color)\(/
 const PALETTE_CLASS_RE = /\b(?:bg|text|border|ring|from|to|via|fill|stroke|decoration|outline|divide|placeholder|caret|accent|shadow)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\d{2,3}/g
 const ARBITRARY_CLASS_RE = /\b(?:bg|text|border|ring|shadow|from|to|via|fill|stroke|decoration|outline)-\[([^[\]]+)\]/g
 const VAR_RE = /\bvar\(--/

--- a/packages/frontend/src/components/geo/MapPicker.tsx
+++ b/packages/frontend/src/components/geo/MapPicker.tsx
@@ -190,7 +190,7 @@ function MapCard({ map, selected, tabIndex, onKeyDown, onSelect, ref }: MapCardP
                 'group relative aspect-square w-full overflow-hidden rounded-lg border bg-muted/30 text-left transition',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-pink',
                 selected
-                    ? 'border-neon-pink ring-2 ring-neon-pink/60 shadow-[0_0_12px_rgba(236,72,153,0.4)]'
+                    ? 'border-neon-pink ring-2 ring-neon-pink/60 shadow-[var(--glow-pink-sm)]'
                     : 'border-muted/40 hover:border-neon-pink/60',
             )}
         >

--- a/packages/frontend/src/components/onboarding/TourGuide.tsx
+++ b/packages/frontend/src/components/onboarding/TourGuide.tsx
@@ -326,7 +326,7 @@ function TourGuideContent({ onClose }: { onClose: () => void }) {
       {!showFallback && rect && (
         <div
           aria-hidden="true"
-          className="absolute pointer-events-none rounded-xl ring-2 ring-neon-purple shadow-[0_0_24px_rgba(168,85,247,0.55)]"
+          className="absolute pointer-events-none rounded-xl ring-2 ring-neon-purple shadow-[var(--glow-lg)]"
           style={{
             top: rect.top - PADDING,
             left: rect.left - PADDING,

--- a/packages/frontend/src/components/pricing/PricingCard.tsx
+++ b/packages/frontend/src/components/pricing/PricingCard.tsx
@@ -73,7 +73,7 @@ export function PricingCard({
       <Card
         className={cn(
           'h-full flex flex-col relative overflow-hidden',
-          highlight && 'border-neon-pink/60 shadow-[0_0_40px_-12px_rgba(244,114,182,0.45)]',
+          highlight && 'border-neon-pink/60 shadow-[var(--glow-pink-lg)]',
         )}
       >
         {highlight && (

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -157,6 +157,13 @@
   --glow-warning: 0 0 20px oklch(0.8 0.15 85 / 0.5);
   --glow-error: 0 0 20px oklch(0.7 0.22 25 / 0.5);
 
+  /* Neon-pink emphasis glows — pink-hued counterpart to --glow-* for
+     selection/highlight accents that read pink (selected map tile, the
+     highlighted pricing card). --glow-pink-lg uses a soft negative spread
+     for a diffuse card halo. */
+  --glow-pink-sm: 0 0 12px oklch(0.72 0.2 350 / 0.4);
+  --glow-pink-lg: 0 0 40px -12px oklch(0.72 0.2 350 / 0.45);
+
   /* Neon text-shadow stack for hero titles */
   --text-shadow-neon:
     0 0 10px oklch(0.65 0.2 293 / 0.8),


### PR DESCRIPTION
## Context

Audit of the design system (`docs/oxygen-design-system.md` + `docs/ui-tokens.md` + the `design-tokens/no-raw-design-tokens` ESLint rule that enforces them) surfaced a linked pair of discrepancies.

## The bug

The lint rule detected raw color functions with `\b(?:rgba?|oklch|…)\(`. Tailwind joins arbitrary-value tokens with `_`, and `_` is a word character — so there is **no word boundary** between `_` and `rgba`, and the rule silently missed `shadow-[0_0_20px_rgba(...)]`. That is the exact pattern `docs/ui-tokens.md` (line 220) claims the rule catches, so the enforcement layer was not enforcing its headline case.

As a result, three raw-color glow shadows had slipped past CI into `src/`:

| File | Raw value |
|------|-----------|
| `components/geo/MapPicker.tsx` | `shadow-[0_0_12px_rgba(236,72,153,0.4)]` |
| `components/onboarding/TourGuide.tsx` | `shadow-[0_0_24px_rgba(168,85,247,0.55)]` |
| `components/pricing/PricingCard.tsx` | `shadow-[0_0_40px_-12px_rgba(244,114,182,0.45)]` |

## Changes

- **Rule fix** — replace the leading `\b` with a `(?<[a-zA-Z])` lookbehind, so raw color functions are caught after `_`, `(`, `,` or whitespace while alphabetic prefixes like `bgcolor(` stay un-matched. `shadow-[var(--glow-md)]` references remain allowed.
- **New tokens** — add `--glow-pink-sm` / `--glow-pink-lg` (pink counterpart to the purple glow scale) in `src/index.css` and document them in `docs/ui-tokens.md`.
- **Migrate the three violations** — MapPicker selected tile → `--glow-pink-sm`, PricingCard highlight halo → `--glow-pink-lg`, TourGuide spotlight ring → existing `--glow-lg`.

## Verification

- Added a synthetic case to confirm the fixed rule now flags underscore-preceded `rgba(`/`oklch(` while still permitting `shadow-[var(--glow-md)]`.
- `eslint .` clean over `src/` (0 errors).
- `npm run build:frontend` passes; unit test suite passes (husky pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAHH9LRqJ2WDUgctKewJx4)_